### PR TITLE
Fix 6 test failures from unhandled thread exceptions and unclosed resources

### DIFF
--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -74,6 +74,7 @@ class WifiSetupServer:
         """Stop HTTP server and hotspot."""
         if self._server:
             self._server.shutdown()
+            self._server.server_close()
             self._server = None
         self._stop_hotspot()
         log.info("Setup server stopped")

--- a/app/camera/tests/test_wifi_setup.py
+++ b/app/camera/tests/test_wifi_setup.py
@@ -47,14 +47,16 @@ class TestWifiSetupServer:
         server = WifiSetupServer(unconfigured_config)
         assert server.needs_setup() is False
 
+    @patch("http.server.HTTPServer")
     @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")
-    def test_start_when_needed(self, mock_hotspot, unconfigured_config):
+    def test_start_when_needed(self, mock_hotspot, mock_http_server, unconfigured_config):
         """start() should activate when setup needed."""
         mock_hotspot.return_value = True
         server = WifiSetupServer(unconfigured_config)
         result = server.start()
         assert result is True
         mock_hotspot.assert_called_once()
+        mock_http_server.assert_called_once()
         server.stop()
 
     @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")

--- a/app/server/tests/test_api_live.py
+++ b/app/server/tests/test_api_live.py
@@ -72,6 +72,7 @@ class TestHLSPlaylist:
         response = client.get("/api/v1/live/cam-001/stream.m3u8")
         assert response.status_code == 200
         assert b"#EXTM3U" in response.data
+        response.close()
 
 
 class TestSnapshot:
@@ -101,3 +102,4 @@ class TestSnapshot:
         response = client.get("/api/v1/live/cam-001/snapshot")
         assert response.status_code == 200
         assert response.content_type == "image/jpeg"
+        response.close()

--- a/app/server/tests/test_streaming.py
+++ b/app/server/tests/test_streaming.py
@@ -58,8 +58,9 @@ class TestStreamingService:
         assert mock_popen.call_count == 2
         svc.stop()
 
+    @patch("monitor.services.streaming.StreamingService._take_snapshot")
     @patch("subprocess.Popen")
-    def test_start_camera_creates_dirs(self, mock_popen, tmp_path):
+    def test_start_camera_creates_dirs(self, mock_popen, mock_snap, tmp_path):
         """start_camera should create live and recording directories."""
         proc = MagicMock()
         proc.pid = 1234
@@ -86,8 +87,9 @@ class TestStreamingService:
         result = svc.start_camera("cam-abc123")
         assert result is False
 
+    @patch("monitor.services.streaming.StreamingService._take_snapshot")
     @patch("subprocess.Popen")
-    def test_stop_camera(self, mock_popen, tmp_path):
+    def test_stop_camera(self, mock_popen, mock_snap, tmp_path):
         """stop_camera should terminate ffmpeg processes."""
         proc = MagicMock()
         proc.pid = 1234
@@ -107,8 +109,9 @@ class TestStreamingService:
         proc.terminate.assert_called()
         svc.stop()
 
+    @patch("monitor.services.streaming.StreamingService._take_snapshot")
     @patch("subprocess.Popen")
-    def test_is_camera_active(self, mock_popen, tmp_path):
+    def test_is_camera_active(self, mock_popen, mock_snap, tmp_path):
         """is_camera_active should reflect HLS process state."""
         proc = MagicMock()
         proc.pid = 1234
@@ -134,8 +137,9 @@ class TestStreamingService:
         )
         svc.stop_camera("nonexistent")  # Should not raise
 
+    @patch("monitor.services.streaming.StreamingService._take_snapshot")
     @patch("subprocess.Popen")
-    def test_stop_cleans_hls_segments(self, mock_popen, tmp_path):
+    def test_stop_cleans_hls_segments(self, mock_popen, mock_snap, tmp_path):
         """stop_camera should remove stale HLS segment files."""
         proc = MagicMock()
         proc.pid = 1234


### PR DESCRIPTION
## Summary
- Fix 4 streaming test failures by mocking `_take_snapshot` in tests that mock `subprocess.Popen` — the snapshot threads were crashing because the mocked Popen broke `subprocess.run`'s `communicate()` tuple unpacking
- Fix 2 live API test failures by closing `send_file()` responses to prevent unclosed file handle warnings
- Fix `WifiSetupServer.stop()` to call `server_close()` after `shutdown()`, preventing a socket leak (both a test fix and a production bug)

## Test plan
- [x] Server tests: 366 passed with `-W error`
- [x] Camera tests: 111 passed with `-W error`
- [x] Coverage: server 92%, camera 85% (both above 80% threshold)

https://claude.ai/code/session_01Ao9eghPnZZHqomgLTRFm5b