### PR TITLE
Fix /data partition mount and hotspot service ordering

### DIFF
--- a/app/server/config/monitor-hotspot.service
+++ b/app/server/config/monitor-hotspot.service
@@ -2,6 +2,7 @@
 Description=Home Monitor WiFi Setup Hotspot
 Documentation=https://github.com/your-org/rpi-home-monitor
 After=NetworkManager.service
+Wants=NetworkManager.service
 Before=monitor.service
 
 # Only start if initial setup has not been completed

--- a/meta-home-monitor/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-home-monitor/recipes-core/base-files/base-files_%.bbappend
@@ -1,5 +1,12 @@
 # =============================================================
-# base-files customization
+# base-files customization — add /data partition to fstab
 # =============================================================
 # OS branding is handled by os-release.bbappend — do not add
 # /etc/os-release here as it conflicts with the os-release package.
+
+# Mount the /data partition (label=data) at boot.
+# This partition holds recordings, config, certs, and logs.
+# It persists across OTA rootfs updates.
+do_install:append() {
+    echo "LABEL=data  /data  ext4  defaults,noatime  0  2" >> ${D}${sysconfdir}/fstab
+}


### PR DESCRIPTION
## Summary
- Add fstab entry for `/data` partition (LABEL=data) via base-files bbappend — partition existed in wks layout but was never mounted at boot, so all services wrote to an empty rootfs dir instead of the real partition
- Add `Wants=NetworkManager.service` to monitor-hotspot.service — ensures NM daemon is running before hotspot script calls nmcli

## Why
The /data partition is critical — it holds recordings, config, certs, and logs. Without mounting it, first-boot services (cert generation, setup stamp files) write to the rootfs instead. This likely caused the server hotspot to not appear because the boot sequence was broken.

## Test plan
- [ ] Flash server image, verify `/data` is mounted (`mount | grep /data`)
- [ ] Verify `HomeMonitor-Setup` hotspot is visible on first boot
- [ ] Flash camera image, verify `/data` is mounted
- [ ] Verify `HomeCam-Setup` hotspot is visible and connectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)