### PR TITLE
fix: rewrite camera WiFi setup for single-radio constraint

### DIFF
--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -4,18 +4,21 @@ WiFi setup for camera first boot.
 On first boot (when /data/.setup-done doesn't exist):
 1. Starts a WiFi hotspot "HomeCam-Setup"
 2. Runs a tiny HTTP server on port 80 with a setup page
-3. User connects, configures WiFi + server IP
-4. Camera connects to home WiFi and starts streaming
+3. User connects, enters WiFi SSID + password + server IP on ONE page
+4. Camera saves settings, tears down hotspot, connects to home WiFi
+5. If WiFi fails, hotspot comes back up for retry
 
-Uses the same NetworkManager shared-mode pattern as the server.
+Single-radio constraint: wlan0 can either be an AP or a client, not both.
+So we can't scan while hotspot is active. User types SSID manually or we
+do a quick scan BEFORE starting the hotspot.
 """
 import http.server
 import json
 import os
 import subprocess
 import threading
+import time
 import logging
-import urllib.parse
 
 log = logging.getLogger("camera-streamer.wifi-setup")
 
@@ -25,6 +28,8 @@ CONN_NAME = "HomeCam-Setup"
 IFACE = "wlan0"
 SETUP_STAMP = ".setup-done"
 LISTEN_PORT = 80
+# Seconds to wait after sending response before tearing down AP
+CONNECT_DELAY = 3
 
 
 def is_setup_complete(data_dir):
@@ -34,6 +39,7 @@ def is_setup_complete(data_dir):
 
 def mark_setup_complete(data_dir):
     """Write setup-done stamp file."""
+    os.makedirs(data_dir, exist_ok=True)
     with open(os.path.join(data_dir, SETUP_STAMP), "w") as f:
         f.write("1\n")
 
@@ -46,16 +52,22 @@ class WifiSetupServer:
         self._server = None
         self._thread = None
         self._hotspot_active = False
+        self._cached_networks = []
+        self._connect_result = None  # None=not tried, True=ok, str=error
 
     def needs_setup(self):
         """Return True if setup hasn't been completed."""
         return not is_setup_complete(self._config.data_dir)
 
     def start(self):
-        """Start hotspot and setup HTTP server."""
+        """Scan networks, start hotspot, then start HTTP server."""
         if not self.needs_setup():
             log.info("Setup already complete, skipping")
             return False
+
+        # Scan BEFORE starting hotspot (wlan0 is in client mode now)
+        self._cached_networks = self._scan_wifi()
+        log.info("Pre-scan found %d networks", len(self._cached_networks))
 
         if not self._start_hotspot():
             log.warning("Could not start hotspot — setup via ethernet")
@@ -78,16 +90,126 @@ class WifiSetupServer:
         self._stop_hotspot()
         log.info("Setup server stopped")
 
-    def complete_setup(self, server_ip, server_port="8554"):
-        """Finalize setup: save config, stop hotspot, mark done."""
-        self._config.update(SERVER_IP=server_ip, SERVER_PORT=server_port)
-        mark_setup_complete(self._config.data_dir)
-        log.info("Setup complete — server=%s:%s", server_ip, server_port)
+    def save_and_connect(self, ssid, password, server_ip, server_port="8554"):
+        """Save settings and attempt WiFi connection in background.
+
+        Returns immediately so the HTTP response reaches the phone
+        before the hotspot is torn down.
+        """
+        self._connect_result = None
+        t = threading.Thread(
+            target=self._do_connect,
+            args=(ssid, password, server_ip, server_port),
+            daemon=True,
+            name="wifi-connect",
+        )
+        t.start()
+
+    def _do_connect(self, ssid, password, server_ip, server_port):
+        """Background: wait for phone to get response, then connect."""
+        # Give the phone time to receive the HTTP response
+        time.sleep(CONNECT_DELAY)
+
+        log.info("Tearing down hotspot, connecting to WiFi: %s", ssid)
+
+        # Tear down hotspot
+        self._stop_hotspot()
+
+        # Short pause for interface to settle
+        time.sleep(2)
+
+        # Try to connect
+        ok, err = self._connect_wifi(ssid, password)
+
+        if ok:
+            log.info("WiFi connected! Saving config and completing setup.")
+            self._config.update(SERVER_IP=server_ip, SERVER_PORT=server_port)
+            mark_setup_complete(self._config.data_dir)
+            self._connect_result = True
+        else:
+            log.error("WiFi connection failed: %s — restarting hotspot", err)
+            self._connect_result = err or "Connection failed"
+            # Restart hotspot so user can retry
+            time.sleep(2)
+            self._start_hotspot()
+
+    def get_status(self):
+        """Return current connection attempt status."""
+        return self._connect_result
+
+    def get_cached_networks(self):
+        """Return networks from pre-hotspot scan."""
+        return list(self._cached_networks)
+
+    def rescan(self):
+        """Rescan by briefly dropping AP, scanning, then restarting AP.
+
+        This is disruptive — phone will disconnect briefly.
+        """
+        log.info("Rescan requested — dropping AP briefly")
+        self._stop_hotspot()
+        time.sleep(2)
+        self._cached_networks = self._scan_wifi()
+        log.info("Rescan found %d networks", len(self._cached_networks))
+        time.sleep(1)
+        self._start_hotspot()
+        return self._cached_networks
+
+    def _scan_wifi(self):
+        """Scan for WiFi networks (only works when NOT in AP mode)."""
+        try:
+            # Force a fresh scan
+            subprocess.run(
+                ["nmcli", "device", "wifi", "rescan", "ifname", IFACE],
+                capture_output=True, timeout=10,
+            )
+            time.sleep(3)  # Give scan time to complete
+
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "SSID,SIGNAL,SECURITY",
+                 "device", "wifi", "list", "ifname", IFACE],
+                capture_output=True, text=True, timeout=15,
+            )
+            networks = []
+            seen = set()
+            for line in result.stdout.strip().splitlines():
+                parts = line.split(":")
+                if len(parts) >= 3 and parts[0] and parts[0] not in seen:
+                    seen.add(parts[0])
+                    networks.append({
+                        "ssid": parts[0],
+                        "signal": int(parts[1]) if parts[1].isdigit() else 0,
+                        "security": parts[2],
+                    })
+            networks.sort(key=lambda n: n["signal"], reverse=True)
+            return networks
+        except Exception as e:
+            log.error("WiFi scan failed: %s", e)
+            return []
+
+    def _connect_wifi(self, ssid, password):
+        """Connect to a WiFi network (must NOT be in AP mode)."""
+        try:
+            result = subprocess.run(
+                [
+                    "nmcli", "device", "wifi", "connect", ssid,
+                    "password", password,
+                    "ifname", IFACE,
+                ],
+                capture_output=True, text=True, timeout=30,
+            )
+            if result.returncode == 0:
+                return True, ""
+            err = result.stderr.strip() or result.stdout.strip()
+            return False, err
+        except subprocess.TimeoutExpired:
+            return False, "Connection timed out"
+        except Exception as e:
+            return False, str(e)
 
     def _start_hotspot(self):
         """Start WiFi AP via NetworkManager."""
         try:
-            # Check if wlan0 exists
             result = subprocess.run(
                 ["nmcli", "-t", "-f", "DEVICE", "device", "status"],
                 capture_output=True, text=True, timeout=10,
@@ -126,10 +248,11 @@ class WifiSetupServer:
             )
 
             self._hotspot_active = True
-            log.info("Hotspot started: SSID=%s, password=%s", HOTSPOT_SSID, HOTSPOT_PASS)
+            log.info("Hotspot started: SSID=%s", HOTSPOT_SSID)
             return True
 
-        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired) as e:
+        except (subprocess.CalledProcessError, FileNotFoundError,
+                subprocess.TimeoutExpired) as e:
             log.error("Failed to start hotspot: %s", e)
             return False
 
@@ -148,67 +271,9 @@ class WifiSetupServer:
             )
             self._hotspot_active = False
             log.info("Hotspot stopped")
-        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        except (subprocess.CalledProcessError, FileNotFoundError,
+                subprocess.TimeoutExpired):
             pass
-
-    def connect_wifi(self, ssid, password):
-        """Connect to a WiFi network."""
-        try:
-            # If hotspot is active, bring it down first
-            if self._hotspot_active:
-                subprocess.run(
-                    ["nmcli", "connection", "down", CONN_NAME],
-                    capture_output=True, timeout=10,
-                )
-
-            result = subprocess.run(
-                [
-                    "nmcli", "device", "wifi", "connect", ssid,
-                    "password", password,
-                    "ifname", IFACE,
-                ],
-                capture_output=True, text=True, timeout=30,
-            )
-            if result.returncode == 0:
-                log.info("Connected to WiFi: %s", ssid)
-                return True, ""
-            else:
-                err = result.stderr.strip() or result.stdout.strip()
-                log.error("WiFi connect failed: %s", err)
-                # Re-activate hotspot so user can retry
-                if self._hotspot_active:
-                    subprocess.run(
-                        ["nmcli", "connection", "up", CONN_NAME],
-                        capture_output=True, timeout=15,
-                    )
-                return False, err
-        except Exception as e:
-            log.error("WiFi connect error: %s", e)
-            return False, str(e)
-
-    def scan_wifi(self):
-        """Scan for available WiFi networks."""
-        try:
-            result = subprocess.run(
-                ["nmcli", "-t", "-f", "SSID,SIGNAL,SECURITY", "device", "wifi", "list"],
-                capture_output=True, text=True, timeout=15,
-            )
-            networks = []
-            seen = set()
-            for line in result.stdout.strip().splitlines():
-                parts = line.split(":")
-                if len(parts) >= 3 and parts[0] and parts[0] not in seen:
-                    seen.add(parts[0])
-                    networks.append({
-                        "ssid": parts[0],
-                        "signal": int(parts[1]) if parts[1].isdigit() else 0,
-                        "security": parts[2],
-                    })
-            networks.sort(key=lambda n: n["signal"], reverse=True)
-            return networks
-        except Exception as e:
-            log.error("WiFi scan failed: %s", e)
-            return []
 
 
 def _make_handler(config, setup_server):
@@ -221,11 +286,23 @@ def _make_handler(config, setup_server):
         def do_GET(self):
             if self.path == "/" or self.path == "/setup":
                 self._serve_setup_page()
-            elif self.path == "/api/wifi/scan":
-                networks = setup_server.scan_wifi()
+            elif self.path == "/api/networks":
+                networks = setup_server.get_cached_networks()
                 self._json_response({"networks": networks})
             elif self.path == "/api/status":
+                result = setup_server.get_status()
+                if result is None:
+                    status = "idle"
+                    error = ""
+                elif result is True:
+                    status = "connected"
+                    error = ""
+                else:
+                    status = "failed"
+                    error = str(result)
                 self._json_response({
+                    "status": status,
+                    "error": error,
                     "setup_complete": is_setup_complete(config.data_dir),
                     "camera_id": config.camera_id,
                 })
@@ -236,34 +313,40 @@ def _make_handler(config, setup_server):
             content_len = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(content_len) if content_len > 0 else b""
 
-            if self.path == "/api/wifi/connect":
+            if self.path == "/api/connect":
                 try:
                     data = json.loads(body)
-                    ssid = data.get("ssid", "")
+                    ssid = data.get("ssid", "").strip()
                     password = data.get("password", "")
-                    if not ssid:
-                        self._json_response({"error": "SSID required"}, 400)
-                        return
-                    ok, err = setup_server.connect_wifi(ssid, password)
-                    if ok:
-                        self._json_response({"status": "connected", "ssid": ssid})
-                    else:
-                        self._json_response({"error": err or "Connection failed"}, 400)
-                except json.JSONDecodeError:
-                    self._json_response({"error": "Invalid JSON"}, 400)
+                    server_ip = data.get("server_ip", "").strip()
+                    server_port = data.get("server_port", "8554").strip()
 
-            elif self.path == "/api/setup/complete":
-                try:
-                    data = json.loads(body)
-                    server_ip = data.get("server_ip", "")
-                    server_port = data.get("server_port", "8554")
-                    if not server_ip:
-                        self._json_response({"error": "server_ip required"}, 400)
+                    if not ssid:
+                        self._json_response({"error": "WiFi name required"}, 400)
                         return
-                    setup_server.complete_setup(server_ip, server_port)
-                    self._json_response({"status": "complete"})
+                    if not password:
+                        self._json_response({"error": "WiFi password required"}, 400)
+                        return
+                    if not server_ip:
+                        self._json_response({"error": "Server IP required"}, 400)
+                        return
+
+                    # Start connection in background
+                    setup_server.save_and_connect(
+                        ssid, password, server_ip, server_port
+                    )
+
+                    self._json_response({
+                        "status": "connecting",
+                        "message": "Settings saved. Connecting to WiFi...",
+                    })
                 except json.JSONDecodeError:
-                    self._json_response({"error": "Invalid JSON"}, 400)
+                    self._json_response({"error": "Invalid request"}, 400)
+
+            elif self.path == "/api/rescan":
+                # Disruptive — will briefly drop AP
+                networks = setup_server.rescan()
+                self._json_response({"networks": networks})
             else:
                 self.send_error(404)
 
@@ -276,7 +359,9 @@ def _make_handler(config, setup_server):
             self.wfile.write(body)
 
         def _serve_setup_page(self):
-            html = _SETUP_HTML.replace("{{CAMERA_ID}}", config.camera_id)
+            html = _SETUP_HTML.replace(
+                "{{CAMERA_ID}}", config.camera_id
+            )
             body = html.encode()
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
@@ -299,165 +384,217 @@ body { font-family: -apple-system, BlinkMacSystemFont, sans-serif;
        background: #1a1a2e; color: #eee; min-height: 100vh;
        display: flex; flex-direction: column; align-items: center; }
 .container { max-width: 400px; width: 100%; padding: 20px; }
-h1 { text-align: center; color: #e94560; margin: 30px 0 10px; font-size: 1.4em; }
-h2 { text-align: center; color: #aaa; font-size: 0.9em; margin-bottom: 30px; }
-.step { display: none; }
-.step.active { display: block; }
-.card { background: #16213e; border-radius: 12px; padding: 20px; margin: 15px 0; }
-label { display: block; margin: 10px 0 5px; color: #aaa; font-size: 0.85em; }
+h1 { text-align: center; color: #e94560; margin: 30px 0 6px; font-size: 1.5em; }
+.cam-id { text-align: center; color: #666; font-size: 0.8em; margin-bottom: 24px; }
+.card { background: #16213e; border-radius: 12px; padding: 20px; margin: 12px 0; }
+.card h3 { margin-bottom: 12px; font-size: 1.1em; }
+label { display: block; margin: 12px 0 4px; color: #8090b0; font-size: 0.85em; }
 input[type=text], input[type=password] {
-  width: 100%; padding: 12px; border: 1px solid #333; border-radius: 8px;
-  background: #0f3460; color: #eee; font-size: 1em; }
-button { width: 100%; padding: 14px; border: none; border-radius: 8px;
-  background: #e94560; color: #fff; font-size: 1em; font-weight: 600;
-  cursor: pointer; margin-top: 15px; }
-button:disabled { opacity: 0.5; }
-.network-list { max-height: 250px; overflow-y: auto; }
-.network { padding: 12px; border-bottom: 1px solid #333; cursor: pointer;
-  display: flex; justify-content: space-between; }
-.network:hover { background: #0f3460; }
-.signal { color: #e94560; font-weight: bold; }
-.status { text-align: center; padding: 15px; color: #4CAF50; }
-.error { color: #e94560; text-align: center; padding: 10px; }
-.spinner { display: inline-block; width: 20px; height: 20px;
-  border: 3px solid #333; border-top: 3px solid #e94560;
-  border-radius: 50%; animation: spin 0.8s linear infinite; }
+  width: 100%; padding: 12px; border: 1px solid #2a3a5e; border-radius: 8px;
+  background: #0f3460; color: #eee; font-size: 1em; outline: none; }
+input:focus { border-color: #e94560; }
+.btn { display: block; width: 100%; padding: 14px; border: none; border-radius: 10px;
+  font-size: 1em; font-weight: 600; cursor: pointer; margin-top: 14px; }
+.btn-primary { background: #e94560; color: #fff; }
+.btn-primary:hover { background: #d63851; }
+.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-secondary { background: #0f3460; color: #b0b0c0; margin-top: 8px; }
+.btn-secondary:hover { background: #133a6a; }
+.hint { color: #506080; font-size: 0.8em; margin-top: 4px; }
+.network-list { max-height: 200px; overflow-y: auto; margin: 8px 0; }
+.net { padding: 10px 12px; border-bottom: 1px solid #0f3460; cursor: pointer;
+  display: flex; justify-content: space-between; align-items: center; }
+.net:hover { background: #0f3460; border-radius: 6px; }
+.net-ssid { font-weight: 500; }
+.net-signal { color: #4ade80; font-size: 0.85em; }
+.msg { text-align: center; padding: 16px; border-radius: 8px; margin: 12px 0; }
+.msg-info { background: #0f3460; color: #8090b0; }
+.msg-ok { background: #065f46; color: #d1fae5; }
+.msg-err { background: #7f1d1d; color: #fecaca; }
+.msg-warn { background: #78350f; color: #fde68a; }
+.spinner { display: inline-block; width: 18px; height: 18px;
+  border: 2px solid rgba(255,255,255,0.2); border-top-color: #fff;
+  border-radius: 50%; animation: spin 0.7s linear infinite;
+  vertical-align: middle; margin-right: 8px; }
 @keyframes spin { to { transform: rotate(360deg); } }
+#view-form, #view-connecting, #view-result { display: none; }
+#view-form.active, #view-connecting.active, #view-result.active { display: block; }
 </style>
 </head>
 <body>
 <div class="container">
   <h1>Camera Setup</h1>
-  <h2>{{CAMERA_ID}}</h2>
+  <p class="cam-id">{{CAMERA_ID}}</p>
 
-  <!-- Step 1: WiFi -->
-  <div class="step active" id="step-wifi">
+  <!-- FORM VIEW -->
+  <div id="view-form" class="active">
     <div class="card">
-      <h3>Connect to WiFi</h3>
-      <p style="color:#aaa;font-size:0.85em;margin:10px 0">
-        Select your home WiFi network.</p>
-      <div id="wifi-loading" style="text-align:center;padding:20px">
-        <div class="spinner"></div><p style="margin-top:10px;color:#aaa">Scanning...</p>
+      <h3>WiFi Network</h3>
+      <div id="net-section">
+        <div id="net-list-wrap" style="display:none">
+          <p style="color:#8090b0;font-size:0.85em;margin-bottom:6px">
+            Networks found before hotspot started. Tap to select:</p>
+          <div class="network-list" id="net-list"></div>
+        </div>
+        <label>WiFi Name (SSID)</label>
+        <input type="text" id="in-ssid" placeholder="Your WiFi network name">
+        <label>WiFi Password</label>
+        <input type="password" id="in-pass" placeholder="WiFi password">
       </div>
-      <div class="network-list" id="network-list" style="display:none"></div>
-      <div id="wifi-form" style="display:none">
-        <label>Network: <strong id="selected-ssid"></strong></label>
-        <label>Password</label>
-        <input type="password" id="wifi-pass" placeholder="WiFi password">
-        <button onclick="connectWifi()">Connect</button>
-        <button onclick="showNetworks()" style="background:#333;margin-top:8px">Back</button>
-      </div>
-      <div id="wifi-status"></div>
     </div>
-  </div>
 
-  <!-- Step 2: Server -->
-  <div class="step" id="step-server">
     <div class="card">
       <h3>Server Connection</h3>
-      <p style="color:#aaa;font-size:0.85em;margin:10px 0">
-        Enter your Home Monitor server IP address.</p>
-      <label>Server IP</label>
-      <input type="text" id="server-ip" placeholder="192.168.1.100">
-      <label>Port (default: 8554)</label>
-      <input type="text" id="server-port" value="8554">
-      <button onclick="completeSetup()">Complete Setup</button>
+      <label>Server IP Address</label>
+      <input type="text" id="in-server" placeholder="192.168.1.100">
+      <div class="hint">The IP of your RPi 4B running Home Monitor</div>
+      <label>RTSP Port</label>
+      <input type="text" id="in-port" value="8554">
+    </div>
+
+    <button class="btn btn-primary" id="btn-save" onclick="doConnect()">
+      Save &amp; Connect
+    </button>
+    <button class="btn btn-secondary" onclick="loadNetworks()">
+      Scan for Networks
+    </button>
+    <p class="hint" style="text-align:center;margin-top:8px">
+      Scanning will briefly drop the hotspot connection.</p>
+  </div>
+
+  <!-- CONNECTING VIEW -->
+  <div id="view-connecting">
+    <div class="card">
+      <div class="msg msg-info">
+        <div class="spinner"></div> Connecting to WiFi...
+      </div>
+      <p style="color:#8090b0;font-size:0.85em;text-align:center;margin-top:12px">
+        The hotspot will disappear now. This is normal.<br><br>
+        <strong>If it worked:</strong> the camera LED will go solid.
+        You can close this page.<br><br>
+        <strong>If it failed:</strong> the <em>HomeCam-Setup</em> hotspot
+        will reappear in about 30 seconds. Reconnect and try again.
+      </p>
     </div>
   </div>
 
-  <!-- Step 3: Done -->
-  <div class="step" id="step-done">
-    <div class="card">
-      <div class="status">
-        <h3 style="font-size:2em;margin-bottom:10px">&#10003;</h3>
-        <h3>Setup Complete!</h3>
-        <p style="margin-top:10px;color:#aaa">
-          Camera will now connect to the server and start streaming.
-          You can close this page.</p>
-      </div>
-    </div>
+  <!-- RESULT VIEW (shown if user reconnects after failure) -->
+  <div id="view-result">
+    <div id="result-msg" class="msg msg-err"></div>
+    <button class="btn btn-primary" onclick="showForm()">Try Again</button>
   </div>
 </div>
 
 <script>
-let selectedSSID = '';
+function $(id) { return document.getElementById(id); }
 
-async function scanWifi() {
-  try {
-    const r = await fetch('/api/wifi/scan');
-    const d = await r.json();
-    const list = document.getElementById('network-list');
-    list.innerHTML = '';
-    d.networks.forEach(n => {
-      const div = document.createElement('div');
-      div.className = 'network';
-      div.innerHTML = '<span>'+n.ssid+'</span><span class="signal">'+n.signal+'%</span>';
-      div.onclick = () => selectNetwork(n.ssid);
-      list.appendChild(div);
+function showView(name) {
+  ['view-form','view-connecting','view-result'].forEach(function(v) {
+    $(v).className = v === name ? 'active' : '';
+  });
+}
+
+function showForm() { showView('view-form'); }
+
+function loadNetworks() {
+  var wrap = $('net-list-wrap');
+  var list = $('net-list');
+  list.innerHTML = '<div class="msg msg-info"><div class="spinner"></div> Scanning...</div>';
+  wrap.style.display = 'block';
+
+  fetch('/api/networks')
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      var nets = d.networks || [];
+      if (nets.length === 0) {
+        list.innerHTML = '<div class="msg msg-info">No networks found. Type SSID manually.</div>';
+        return;
+      }
+      var html = '';
+      nets.forEach(function(n) {
+        html += '<div class="net" onclick="pickNet(\\''+esc(n.ssid)+'\\')"><span class="net-ssid">'
+          +esc(n.ssid)+'</span><span class="net-signal">'+n.signal+'%</span></div>';
+      });
+      list.innerHTML = html;
+    })
+    .catch(function() {
+      list.innerHTML = '<div class="msg msg-err">Scan failed. Type SSID manually.</div>';
     });
-    document.getElementById('wifi-loading').style.display = 'none';
-    list.style.display = 'block';
-  } catch(e) {
-    document.getElementById('wifi-loading').innerHTML =
-      '<p class="error">Scan failed. Retrying...</p>';
-    setTimeout(scanWifi, 3000);
-  }
 }
 
-function selectNetwork(ssid) {
-  selectedSSID = ssid;
-  document.getElementById('selected-ssid').textContent = ssid;
-  document.getElementById('network-list').style.display = 'none';
-  document.getElementById('wifi-form').style.display = 'block';
+function pickNet(ssid) {
+  $('in-ssid').value = ssid;
+  $('in-pass').focus();
 }
 
-function showNetworks() {
-  document.getElementById('wifi-form').style.display = 'none';
-  document.getElementById('network-list').style.display = 'block';
-}
+function doConnect() {
+  var ssid = $('in-ssid').value.trim();
+  var pass = $('in-pass').value;
+  var server = $('in-server').value.trim();
+  var port = $('in-port').value.trim() || '8554';
 
-async function connectWifi() {
-  const pass = document.getElementById('wifi-pass').value;
-  const status = document.getElementById('wifi-status');
-  status.innerHTML = '<div style="text-align:center;padding:10px"><div class="spinner"></div></div>';
-  try {
-    const r = await fetch('/api/wifi/connect', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({ssid: selectedSSID, password: pass})
-    });
-    const d = await r.json();
-    if (r.ok) {
-      status.innerHTML = '<p class="status">Connected to ' + selectedSSID + '</p>';
-      setTimeout(() => showStep('step-server'), 1000);
+  if (!ssid) { alert('Enter WiFi network name'); return; }
+  if (!pass) { alert('Enter WiFi password'); return; }
+  if (!server) { alert('Enter server IP address'); return; }
+
+  $('btn-save').disabled = true;
+
+  fetch('/api/connect', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ssid:ssid, password:pass, server_ip:server, server_port:port})
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(d) {
+    if (d.error) {
+      alert(d.error);
+      $('btn-save').disabled = false;
     } else {
-      status.innerHTML = '<p class="error">' + (d.error || 'Failed') + '</p>';
+      showView('view-connecting');
     }
-  } catch(e) {
-    status.innerHTML = '<p class="error">Connection error</p>';
-  }
+  })
+  .catch(function() {
+    showView('view-connecting');
+  });
 }
 
-async function completeSetup() {
-  const ip = document.getElementById('server-ip').value.trim();
-  const port = document.getElementById('server-port').value.trim() || '8554';
-  if (!ip) { alert('Server IP is required'); return; }
-  try {
-    const r = await fetch('/api/setup/complete', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({server_ip: ip, server_port: port})
-    });
-    if (r.ok) { showStep('step-done'); }
-  } catch(e) { alert('Error: ' + e); }
+function esc(s) {
+  var d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML.replace(/'/g, "\\\\'");
 }
 
-function showStep(id) {
-  document.querySelectorAll('.step').forEach(s => s.classList.remove('active'));
-  document.getElementById(id).classList.add('active');
-}
-
-scanWifi();
+// On page load: check if we're returning after a failed attempt
+fetch('/api/status')
+  .then(function(r) { return r.json(); })
+  .then(function(d) {
+    if (d.setup_complete) {
+      showView('view-result');
+      $('result-msg').className = 'msg msg-ok';
+      $('result-msg').textContent = 'Setup complete! Camera is connected.';
+    } else if (d.status === 'failed') {
+      showView('view-result');
+      $('result-msg').textContent = 'WiFi connection failed: ' + d.error + '. Try again.';
+    } else {
+      // Load cached networks
+      fetch('/api/networks')
+        .then(function(r) { return r.json(); })
+        .then(function(nd) {
+          var nets = nd.networks || [];
+          if (nets.length > 0) {
+            var list = $('net-list');
+            var html = '';
+            nets.forEach(function(n) {
+              html += '<div class="net" onclick="pickNet(\\''+esc(n.ssid)+'\\')"><span class="net-ssid">'
+                +esc(n.ssid)+'</span><span class="net-signal">'+n.signal+'%</span></div>';
+            });
+            list.innerHTML = html;
+            $('net-list-wrap').style.display = 'block';
+          }
+        });
+    }
+  })
+  .catch(function() {});
 </script>
 </body>
 </html>

--- a/app/camera/tests/test_wifi_setup.py
+++ b/app/camera/tests/test_wifi_setup.py
@@ -2,7 +2,7 @@
 import json
 import os
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 from http.client import HTTPConnection
 
 from camera_streamer.wifi_setup import (
@@ -12,6 +12,9 @@ from camera_streamer.wifi_setup import (
     _make_handler,
     HOTSPOT_SSID,
     HOTSPOT_PASS,
+    CONN_NAME,
+    IFACE,
+    CONNECT_DELAY,
 )
 
 
@@ -32,6 +35,12 @@ class TestSetupStamp:
         mark_setup_complete(str(data_dir))
         assert os.path.isfile(os.path.join(str(data_dir), ".setup-done"))
 
+    def test_mark_creates_data_dir(self, tmp_path):
+        """mark_setup_complete should create data dir if missing."""
+        new_dir = str(tmp_path / "nonexistent" / "data")
+        mark_setup_complete(new_dir)
+        assert is_setup_complete(new_dir) is True
+
 
 class TestWifiSetupServer:
     """Test WiFi setup server logic."""
@@ -48,80 +57,240 @@ class TestWifiSetupServer:
         assert server.needs_setup() is False
 
     @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")
-    def test_start_when_needed(self, mock_hotspot, unconfigured_config):
-        """start() should activate when setup needed."""
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._scan_wifi")
+    def test_start_when_needed(self, mock_scan, mock_hotspot, unconfigured_config):
+        """start() should pre-scan, start hotspot, and start HTTP server."""
+        mock_scan.return_value = [{"ssid": "TestNet", "signal": 80, "security": "WPA2"}]
         mock_hotspot.return_value = True
         server = WifiSetupServer(unconfigured_config)
         result = server.start()
         assert result is True
+        mock_scan.assert_called_once()
         mock_hotspot.assert_called_once()
+        # Verify cached networks from pre-scan
+        assert len(server.get_cached_networks()) == 1
+        assert server.get_cached_networks()[0]["ssid"] == "TestNet"
         server.stop()
 
     @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")
-    def test_start_skips_when_done(self, mock_hotspot, unconfigured_config):
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._scan_wifi")
+    def test_start_skips_when_done(self, mock_scan, mock_hotspot, unconfigured_config):
         """start() should skip when setup already done."""
         mark_setup_complete(unconfigured_config.data_dir)
         server = WifiSetupServer(unconfigured_config)
         result = server.start()
         assert result is False
         mock_hotspot.assert_not_called()
+        mock_scan.assert_not_called()
 
-    def test_complete_setup_saves_config(self, unconfigured_config):
-        """complete_setup should save server IP and mark done."""
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._scan_wifi")
+    def test_start_with_hotspot_failure(self, mock_scan, mock_hotspot, unconfigured_config):
+        """start() should still work if hotspot fails (e.g. no WiFi hw)."""
+        mock_scan.return_value = []
+        mock_hotspot.return_value = False
         server = WifiSetupServer(unconfigured_config)
-        server.complete_setup("10.0.0.5", "9999")
+        # Should not raise — logs a warning, HTTP server still starts
+        result = server.start()
+        assert result is True
+        server.stop()
 
-        assert is_setup_complete(unconfigured_config.data_dir)
-        # Reload and verify
-        from camera_streamer.config import ConfigManager
-        mgr = ConfigManager(data_dir=unconfigured_config.data_dir)
-        mgr.load()
-        assert mgr.server_ip == "10.0.0.5"
-        assert mgr.server_port == 9999
+    def test_get_status_initial(self, unconfigured_config):
+        """get_status should return None initially."""
+        server = WifiSetupServer(unconfigured_config)
+        assert server.get_status() is None
+
+    def test_get_cached_networks_empty(self, unconfigured_config):
+        """get_cached_networks returns empty list before scan."""
+        server = WifiSetupServer(unconfigured_config)
+        assert server.get_cached_networks() == []
+
+    def test_get_cached_networks_returns_copy(self, unconfigured_config):
+        """get_cached_networks should return a copy, not reference."""
+        server = WifiSetupServer(unconfigured_config)
+        server._cached_networks = [{"ssid": "Test", "signal": 50, "security": "WPA2"}]
+        nets = server.get_cached_networks()
+        nets.clear()  # Modifying copy shouldn't affect original
+        assert len(server.get_cached_networks()) == 1
+
+
+class TestScanWifi:
+    """Test WiFi scanning (private _scan_wifi)."""
 
     @patch("subprocess.run")
-    def test_scan_wifi(self, mock_run, unconfigured_config):
-        """scan_wifi should parse nmcli output."""
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="MyNetwork:85:WPA2\nGuest:60:WPA1\nMyNetwork:80:WPA2\n",
-        )
+    def test_scan_parses_nmcli(self, mock_run, unconfigured_config):
+        """_scan_wifi should parse nmcli output and deduplicate."""
+        # First call is rescan (no output needed), second is list
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # rescan
+            MagicMock(
+                returncode=0,
+                stdout="MyNetwork:85:WPA2\nGuest:60:WPA1\nMyNetwork:80:WPA2\n",
+            ),
+        ]
         server = WifiSetupServer(unconfigured_config)
-        networks = server.scan_wifi()
+        networks = server._scan_wifi()
         assert len(networks) == 2  # Deduplicated
         assert networks[0]["ssid"] == "MyNetwork"
         assert networks[0]["signal"] == 85
         assert networks[1]["ssid"] == "Guest"
 
     @patch("subprocess.run")
-    def test_scan_wifi_handles_error(self, mock_run, unconfigured_config):
-        """scan_wifi should return empty list on error."""
+    def test_scan_sorts_by_signal(self, mock_run, unconfigured_config):
+        """Networks should be sorted by signal strength descending."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(
+                returncode=0,
+                stdout="Weak:20:WPA2\nStrong:90:WPA2\nMedium:50:WPA2\n",
+            ),
+        ]
+        server = WifiSetupServer(unconfigured_config)
+        networks = server._scan_wifi()
+        assert networks[0]["ssid"] == "Strong"
+        assert networks[1]["ssid"] == "Medium"
+        assert networks[2]["ssid"] == "Weak"
+
+    @patch("subprocess.run")
+    def test_scan_handles_error(self, mock_run, unconfigured_config):
+        """_scan_wifi should return empty list on error."""
         mock_run.side_effect = Exception("nmcli failed")
         server = WifiSetupServer(unconfigured_config)
-        networks = server.scan_wifi()
+        networks = server._scan_wifi()
         assert networks == []
 
     @patch("subprocess.run")
-    def test_connect_wifi_success(self, mock_run, unconfigured_config):
-        """connect_wifi should return True on success."""
+    def test_scan_skips_empty_ssid(self, mock_run, unconfigured_config):
+        """_scan_wifi should skip entries with empty SSID."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout=":80:WPA2\nValid:70:WPA2\n"),
+        ]
+        server = WifiSetupServer(unconfigured_config)
+        networks = server._scan_wifi()
+        assert len(networks) == 1
+        assert networks[0]["ssid"] == "Valid"
+
+
+class TestConnectWifi:
+    """Test WiFi connection (private _connect_wifi)."""
+
+    @patch("subprocess.run")
+    def test_connect_success(self, mock_run, unconfigured_config):
+        """_connect_wifi should return True on success."""
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         server = WifiSetupServer(unconfigured_config)
-        ok, err = server.connect_wifi("TestNet", "password123")
+        ok, err = server._connect_wifi("TestNet", "password123")
         assert ok is True
         assert err == ""
 
     @patch("subprocess.run")
-    def test_connect_wifi_failure(self, mock_run, unconfigured_config):
-        """connect_wifi should return False with error on failure."""
+    def test_connect_failure(self, mock_run, unconfigured_config):
+        """_connect_wifi should return False with error on failure."""
         mock_run.return_value = MagicMock(
             returncode=1,
             stdout="",
             stderr="Error: Connection activation failed",
         )
         server = WifiSetupServer(unconfigured_config)
-        ok, err = server.connect_wifi("TestNet", "wrongpass")
+        ok, err = server._connect_wifi("TestNet", "wrongpass")
         assert ok is False
         assert "activation failed" in err
+
+    @patch("subprocess.run")
+    def test_connect_timeout(self, mock_run, unconfigured_config):
+        """_connect_wifi should handle timeout."""
+        import subprocess
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="nmcli", timeout=30)
+        server = WifiSetupServer(unconfigured_config)
+        ok, err = server._connect_wifi("TestNet", "pass")
+        assert ok is False
+        assert "timed out" in err
+
+
+class TestSaveAndConnect:
+    """Test the save_and_connect flow (background connection)."""
+
+    @patch("camera_streamer.wifi_setup.time.sleep")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._stop_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._connect_wifi")
+    def test_connect_success_saves_config(
+        self, mock_connect, mock_stop, mock_start, mock_sleep, unconfigured_config
+    ):
+        """Successful connect should save config and mark setup done."""
+        mock_connect.return_value = (True, "")
+        server = WifiSetupServer(unconfigured_config)
+
+        # Call _do_connect directly (skip threading)
+        server._do_connect("TestNet", "pass123", "192.168.1.100", "8554")
+
+        assert server.get_status() is True
+        assert is_setup_complete(unconfigured_config.data_dir)
+        mock_stop.assert_called_once()
+        mock_start.assert_not_called()  # No restart on success
+
+    @patch("camera_streamer.wifi_setup.time.sleep")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._stop_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._connect_wifi")
+    def test_connect_failure_restarts_hotspot(
+        self, mock_connect, mock_stop, mock_start, mock_sleep, unconfigured_config
+    ):
+        """Failed connect should restart hotspot for retry."""
+        mock_connect.return_value = (False, "No such network")
+        server = WifiSetupServer(unconfigured_config)
+
+        server._do_connect("BadNet", "pass", "192.168.1.100", "8554")
+
+        assert server.get_status() == "No such network"
+        assert not is_setup_complete(unconfigured_config.data_dir)
+        mock_stop.assert_called_once()
+        mock_start.assert_called_once()  # Hotspot restarted
+
+    @patch("camera_streamer.wifi_setup.time.sleep")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._stop_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._connect_wifi")
+    def test_connect_saves_server_port(
+        self, mock_connect, mock_stop, mock_start, mock_sleep, unconfigured_config
+    ):
+        """Server port should be saved to config on success."""
+        mock_connect.return_value = (True, "")
+        server = WifiSetupServer(unconfigured_config)
+
+        server._do_connect("TestNet", "pass", "10.0.0.5", "9999")
+
+        from camera_streamer.config import ConfigManager
+        mgr = ConfigManager(data_dir=unconfigured_config.data_dir)
+        mgr.load()
+        assert mgr.server_ip == "10.0.0.5"
+        assert mgr.server_port == 9999
+
+
+class TestRescan:
+    """Test the rescan flow (drops AP briefly)."""
+
+    @patch("camera_streamer.wifi_setup.time.sleep")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._start_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._stop_hotspot")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._scan_wifi")
+    def test_rescan_drops_and_restarts_ap(
+        self, mock_scan, mock_stop, mock_start, mock_sleep, unconfigured_config
+    ):
+        """rescan should stop AP, scan, then restart AP."""
+        mock_scan.return_value = [{"ssid": "NewNet", "signal": 75, "security": "WPA2"}]
+        server = WifiSetupServer(unconfigured_config)
+
+        networks = server.rescan()
+
+        mock_stop.assert_called_once()
+        mock_scan.assert_called_once()
+        mock_start.assert_called_once()
+        assert len(networks) == 1
+        assert networks[0]["ssid"] == "NewNet"
+        # Cached networks should be updated
+        assert server.get_cached_networks()[0]["ssid"] == "NewNet"
 
 
 class TestHotspot:
@@ -131,7 +300,7 @@ class TestHotspot:
     def test_start_hotspot_success(self, mock_run, unconfigured_config):
         """Should start hotspot via nmcli."""
         mock_run.return_value = MagicMock(
-            returncode=0, stdout=f"wlan0\n", stderr=""
+            returncode=0, stdout="wlan0\n", stderr=""
         )
         server = WifiSetupServer(unconfigured_config)
         result = server._start_hotspot()
@@ -156,6 +325,24 @@ class TestHotspot:
         server._stop_hotspot()
         assert server._hotspot_active is False
 
+    @patch("subprocess.run")
+    def test_stop_hotspot_noop_when_inactive(self, mock_run, unconfigured_config):
+        """Should not call nmcli when hotspot not active."""
+        server = WifiSetupServer(unconfigured_config)
+        server._hotspot_active = False
+        server._stop_hotspot()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_start_hotspot_nmcli_error(self, mock_run, unconfigured_config):
+        """Should return False and not crash on nmcli error."""
+        import subprocess
+        mock_run.side_effect = subprocess.CalledProcessError(1, "nmcli")
+        server = WifiSetupServer(unconfigured_config)
+        result = server._start_hotspot()
+        assert result is False
+        assert server._hotspot_active is False
+
 
 class TestSetupHTTPHandler:
     """Test the setup HTTP handler responses."""
@@ -163,11 +350,11 @@ class TestSetupHTTPHandler:
     def _make_handler_class(self, config):
         """Create handler class for testing."""
         server = WifiSetupServer(config)
-        return _make_handler(config, server)
+        return _make_handler(config, server), server
 
     def test_handler_class_created(self, unconfigured_config):
         """Should create a valid handler class."""
-        handler = self._make_handler_class(unconfigured_config)
+        handler, _ = self._make_handler_class(unconfigured_config)
         assert handler is not None
 
     def test_hotspot_ssid(self):
@@ -177,3 +364,15 @@ class TestSetupHTTPHandler:
     def test_hotspot_password(self):
         """Password should be homecamera."""
         assert HOTSPOT_PASS == "homecamera"
+
+    def test_connection_name(self):
+        """Connection name should match SSID."""
+        assert CONN_NAME == "HomeCam-Setup"
+
+    def test_interface(self):
+        """Interface should be wlan0."""
+        assert IFACE == "wlan0"
+
+    def test_connect_delay(self):
+        """Connect delay should be positive (give phone time to receive response)."""
+        assert CONNECT_DELAY > 0


### PR DESCRIPTION
## Summary
- **Rewrites camera WiFi setup** (`wifi_setup.py`) to handle the RPi Zero 2W single-radio constraint — wlan0 can be AP or client, not both
- **Pre-scans networks** before starting hotspot so user sees available SSIDs
- **Single-page form** with WiFi SSID, password, and server IP — replaces broken two-step flow that disconnected the phone mid-setup
- **Background connect with delay** — phone receives HTTP response before AP teardown
- **Auto-retry** — if WiFi fails, hotspot restarts automatically
- **Updated tests** — 34 tests covering scan, connect, save flow, rescan, hotspot, and status (127 total camera tests pass, 85% coverage)

## What was wrong
The old flow had two steps: (1) connect WiFi, (2) enter server IP. When step 1 tore down the hotspot, the phone lost connection and could never complete step 2. Also, WiFi scanning while in AP mode silently failed due to the single-radio constraint.

## Test plan
- [x] All 127 camera unit tests pass
- [x] Coverage 85% (above 80% threshold)
- [ ] Flash camera image and verify hotspot appears
- [ ] Connect phone, verify network list shows pre-scanned SSIDs
- [ ] Enter WiFi credentials + server IP, tap Save & Connect
- [ ] Verify camera connects to home WiFi and setup completes
- [ ] Verify hotspot restarts if wrong password entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)