### PR TITLE
fix: NGINX, Flask watchdog, boot ordering, debug logging

### DIFF
--- a/app/camera/camera_streamer/main.py
+++ b/app/camera/camera_streamer/main.py
@@ -16,8 +16,12 @@ import logging
 import time
 import os
 
+# LOG_LEVEL env controls verbosity:
+# Dev builds set LOG_LEVEL=DEBUG via systemd drop-in
+# Prod defaults to WARNING
+_log_level = os.environ.get("LOG_LEVEL", "WARNING").upper()
 logging.basicConfig(
-    level=logging.INFO,
+    level=getattr(logging, _log_level, logging.WARNING),
     format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
 )
 log = logging.getLogger("camera-streamer")
@@ -37,16 +41,19 @@ def main():
     """Entry point for camera-streamer service."""
     global _shutdown
 
-    log.info("Camera streamer starting...")
+    log.info("Camera streamer starting (log_level=%s)", _log_level)
 
     # Register signal handlers
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
 
     # 1. Load configuration
+    log.debug("Loading config...")
     from camera_streamer.config import ConfigManager
     config = ConfigManager()
     config.load()
+    log.debug("Config loaded: data_dir=%s server_ip=%s camera_id=%s",
+              config.data_dir, getattr(config, 'server_ip', 'N/A'), config.camera_id)
 
     # 2. Check if setup is needed (first boot)
     from camera_streamer.wifi_setup import WifiSetupServer

--- a/app/camera/config/camera-streamer.service
+++ b/app/camera/config/camera-streamer.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Camera RTSP Streamer
-After=network-online.target avahi-daemon.service
-Wants=network-online.target
+After=network-online.target avahi-daemon.service local-fs.target NetworkManager.service
+Wants=network-online.target NetworkManager.service
 
 [Service]
 Type=simple
@@ -11,7 +11,6 @@ WorkingDirectory=/opt/camera
 ExecStart=/usr/bin/python3 -m camera_streamer.main
 Restart=always
 RestartSec=5
-WatchdogSec=60
 Environment=PYTHONPATH=/opt/camera
 Environment=CAMERA_DATA_DIR=/data
 Environment=CAMERA_CONFIG_DIR=/data/config
@@ -25,7 +24,7 @@ ReadWritePaths=/data
 PrivateTmp=true
 # Camera device access
 SupplementaryGroups=video
-# Hotspot setup needs NetworkManager D-Bus access
+# Hotspot setup needs NetworkManager D-Bus access and port 80
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]

--- a/app/server/config/monitor-hotspot.service
+++ b/app/server/config/monitor-hotspot.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Home Monitor WiFi Setup Hotspot
-Documentation=https://github.com/your-org/rpi-home-monitor
-After=NetworkManager.service
+Documentation=https://github.com/vinu-engineer/rpi-home-monitor
+After=NetworkManager.service local-fs.target
 Wants=NetworkManager.service
 Before=monitor.service
 

--- a/app/server/config/monitor-hotspot.sh
+++ b/app/server/config/monitor-hotspot.sh
@@ -44,8 +44,9 @@ start_hotspot() {
     nmcli connection up "${CONN_NAME}"
 
     # Get the actual IP assigned (shared mode uses 10.42.0.1 by default)
-    ACTUAL_IP=$(nmcli -t -f IP4.ADDRESS dev show "${IFACE}" 2>/dev/null | head -1 | cut -d: -f2 | cut -d/ -f1)
-    echo "Hotspot active on ${IFACE} — SSID: ${HOTSPOT_SSID}, IP: ${ACTUAL_IP:-unknown}"
+    ACTUAL_IP=$(nmcli -t -f IP4.ADDRESS dev show "${IFACE}" 2>/dev/null | head -n 1 | cut -d: -f2 | cut -d/ -f1)
+    echo "Hotspot active on ${IFACE} — SSID: ${HOTSPOT_SSID}, IP: ${ACTUAL_IP:-10.42.0.1}"
+    echo "Setup wizard available at http://${ACTUAL_IP:-10.42.0.1}/"
 }
 
 stop_hotspot() {

--- a/app/server/config/monitor.service
+++ b/app/server/config/monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Home Monitor Server
-After=network-online.target nginx.service mediamtx.service
+After=network-online.target nginx.service mediamtx.service local-fs.target
 Wants=network-online.target mediamtx.service
 
 [Service]
@@ -11,7 +11,6 @@ WorkingDirectory=/opt/monitor
 ExecStart=/usr/bin/python3 -m flask --app monitor run --host=127.0.0.1 --port=5000
 Restart=always
 RestartSec=5
-WatchdogSec=60
 Environment=PYTHONPATH=/opt/monitor
 Environment=FLASK_APP=monitor
 Environment=MONITOR_DATA_DIR=/data

--- a/app/server/config/nginx-monitor.conf
+++ b/app/server/config/nginx-monitor.conf
@@ -1,3 +1,53 @@
+# HTTP — needed for setup wizard (phone on hotspot, no TLS)
+# Also serves normal traffic; users can bookmark HTTPS after setup.
+server {
+    listen 80;
+    server_name _;
+
+    # Proxy to Flask app
+    location / {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # HLS live segments — served directly by nginx (fast)
+    location /live/ {
+        alias /data/live/;
+        types {
+            application/vnd.apple.mpegurl m3u8;
+            video/mp2t ts;
+        }
+        add_header Cache-Control "no-cache";
+        add_header Access-Control-Allow-Origin *;
+    }
+
+    # Recorded clips
+    location /clips/ {
+        alias /data/recordings/;
+        autoindex off;
+    }
+
+    # Static assets
+    location /static/ {
+        alias /opt/monitor/monitor/static/;
+        expires 1d;
+        gzip on;
+        gzip_types text/css application/javascript;
+    }
+
+    # Upload size for OTA images
+    client_max_body_size 500M;
+
+    # Timeouts for streaming
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_send_timeout 300;
+}
+
+# HTTPS — secure access after setup
 server {
     listen 443 ssl;
     server_name _;
@@ -23,7 +73,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # HLS live segments — served directly by nginx (fast)
+    # HLS live segments
     location /live/ {
         alias /data/live/;
         types {
@@ -34,19 +84,15 @@ server {
         add_header Access-Control-Allow-Origin *;
     }
 
-    # Recorded clips — served directly by nginx with byte-range
+    # Recorded clips
     location /clips/ {
         alias /data/recordings/;
         autoindex off;
-        mp4;
-        mp4_buffer_size 1m;
-        mp4_max_buffer_size 5m;
     }
 
     # Thumbnails
     location /snapshots/ {
         alias /data/recordings/;
-        # Thumbnails are .thumb.jpg files alongside .mp4 clips
     }
 
     # Static assets
@@ -64,11 +110,4 @@ server {
     proxy_read_timeout 300;
     proxy_connect_timeout 300;
     proxy_send_timeout 300;
-}
-
-# Redirect HTTP to HTTPS
-server {
-    listen 80;
-    server_name _;
-    return 301 https://$host$request_uri;
 }

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -4,12 +4,16 @@ RPi Home Monitor - Server Application
 Flask-based web server that manages RTSP camera streams,
 records video clips, and provides a mobile-friendly web dashboard.
 """
+import logging
 import os
+
 from flask import Flask
 
 from monitor.services.audit import AuditLogger
 from monitor.services.streaming import StreamingService
 from monitor.store import Store
+
+log = logging.getLogger("monitor")
 
 
 def _load_or_create_secret_key(config_dir):
@@ -60,6 +64,16 @@ def create_app(config=None):
     Creates and configures the Flask application with all blueprints,
     background services, and security middleware.
     """
+    # Configure logging — LOG_LEVEL env controls verbosity
+    # Dev builds set LOG_LEVEL=DEBUG via systemd drop-in
+    # Prod defaults to WARNING
+    log_level = os.environ.get("LOG_LEVEL", "WARNING").upper()
+    logging.basicConfig(
+        level=getattr(logging, log_level, logging.WARNING),
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+    )
+    log.info("Monitor server starting (log_level=%s)", log_level)
+
     app = Flask(__name__)
 
     config_dir = os.environ.get("MONITOR_CONFIG_DIR", "/data/config")
@@ -80,11 +94,14 @@ def create_app(config=None):
     if config:
         app.config.update(config)
 
+    log.debug("Config: DATA_DIR=%s CONFIG_DIR=%s", app.config["DATA_DIR"], config_dir)
+
     # Load persistent secret key (unless overridden by test config)
     if not config or "SECRET_KEY" not in config:
         app.config["SECRET_KEY"] = _load_or_create_secret_key(app.config["CONFIG_DIR"])
 
     # Initialize data store and audit logger
+    log.debug("Initializing data store at %s", app.config["CONFIG_DIR"])
     app.store = Store(app.config["CONFIG_DIR"])
     logs_dir = os.path.join(app.config["DATA_DIR"], "logs")
     app.audit = AuditLogger(logs_dir)
@@ -92,6 +109,7 @@ def create_app(config=None):
     # Create default admin user on first boot (skip in test mode)
     if not app.config.get("TESTING"):
         _ensure_default_admin(app.store)
+        log.debug("Default admin user ensured")
 
     # Initialize streaming service (manages ffmpeg pipelines per camera)
     app.streaming = StreamingService(
@@ -127,6 +145,7 @@ def create_app(config=None):
     app.register_blueprint(users_bp, url_prefix="/api/v1/users")
     app.register_blueprint(ota_bp, url_prefix="/api/v1/ota")
 
+    log.info("Monitor server ready — blueprints registered")
     return app
 
 

--- a/app/server/monitor/provisioning.py
+++ b/app/server/monitor/provisioning.py
@@ -8,6 +8,7 @@ from their phone and configure WiFi credentials + admin password.
 All setup endpoints require that /data/.setup-done does NOT exist. Once setup
 is complete, the stamp file is written and all endpoints return 403.
 """
+import logging
 import os
 import subprocess
 
@@ -18,6 +19,8 @@ from flask import (
     render_template,
     request,
 )
+
+log = logging.getLogger("monitor.provisioning")
 
 provisioning_bp = Blueprint("provisioning", __name__)
 
@@ -32,7 +35,10 @@ def _setup_done_path():
 
 def _is_setup_complete():
     """Check whether initial setup has already been completed."""
-    return os.path.exists(_setup_done_path())
+    path = _setup_done_path()
+    done = os.path.exists(path)
+    log.debug("Setup complete check: %s exists=%s", path, done)
+    return done
 
 
 def _require_setup_mode():
@@ -63,9 +69,12 @@ def setup_status():
     No authentication required. Used by the setup wizard and the main
     dashboard to determine which mode to show.
     """
+    complete = _is_setup_complete()
+    hotspot = _is_hotspot_active()
+    log.debug("GET /status — setup_complete=%s hotspot_active=%s", complete, hotspot)
     return jsonify({
-        "setup_complete": _is_setup_complete(),
-        "hotspot_active": _is_hotspot_active(),
+        "setup_complete": complete,
+        "hotspot_active": hotspot,
     }), 200
 
 
@@ -80,6 +89,7 @@ def wifi_scan():
     if blocked:
         return blocked
 
+    log.info("WiFi scan requested")
     try:
         result = subprocess.run(
             ["nmcli", "-t", "-f", "SSID,SIGNAL,SECURITY", "dev", "wifi", "list",
@@ -89,11 +99,14 @@ def wifi_scan():
             timeout=30,
         )
     except subprocess.TimeoutExpired:
+        log.error("WiFi scan timed out")
         return jsonify({"error": "WiFi scan timed out"}), 504
     except (FileNotFoundError, OSError) as exc:
+        log.error("WiFi scan failed: %s", exc)
         return jsonify({"error": f"WiFi scan failed: {exc}"}), 500
 
     if result.returncode != 0:
+        log.error("WiFi scan nmcli error: %s", result.stderr.strip())
         return jsonify({"error": "WiFi scan failed", "detail": result.stderr.strip()}), 500
 
     # Parse nmcli output: "SSID:SIGNAL:SECURITY"
@@ -122,6 +135,8 @@ def wifi_scan():
     # Sort by signal strength descending
     network_list = sorted(networks.values(), key=lambda n: n["signal"], reverse=True)
 
+    log.info("WiFi scan found %d networks", len(network_list))
+    log.debug("Networks: %s", [n["ssid"] for n in network_list])
     return jsonify({"networks": network_list}), 200
 
 
@@ -148,6 +163,7 @@ def wifi_connect():
     if not password:
         return jsonify({"error": "Password is required"}), 400
 
+    log.info("WiFi connect requested: SSID=%s", ssid)
     try:
         result = subprocess.run(
             ["nmcli", "dev", "wifi", "connect", ssid,
@@ -157,17 +173,21 @@ def wifi_connect():
             timeout=30,
         )
     except subprocess.TimeoutExpired:
+        log.error("WiFi connect timed out for SSID=%s", ssid)
         return jsonify({"error": "WiFi connection timed out"}), 504
     except (FileNotFoundError, OSError) as exc:
+        log.error("WiFi connect failed for SSID=%s: %s", ssid, exc)
         return jsonify({"error": f"WiFi connection failed: {exc}"}), 500
 
     if result.returncode != 0:
         stderr = result.stderr.strip()
+        log.error("WiFi connect failed for SSID=%s: %s", ssid, stderr)
         # Common failure: wrong password
         if "secrets were required" in stderr.lower() or "no suitable" in stderr.lower():
             return jsonify({"error": "Incorrect WiFi password"}), 401
         return jsonify({"error": "WiFi connection failed", "detail": stderr}), 500
 
+    log.info("WiFi connected to %s", ssid)
     return jsonify({"message": f"Connected to {ssid}"}), 200
 
 
@@ -214,26 +234,31 @@ def setup_complete():
     if blocked:
         return blocked
 
+    log.info("Marking setup as complete")
+
     # Write the setup-done stamp file
     stamp = _setup_done_path()
     try:
         os.makedirs(os.path.dirname(stamp), exist_ok=True)
         with open(stamp, "w") as f:
             f.write("setup completed\n")
+        log.info("Stamp file written: %s", stamp)
     except OSError as exc:
+        log.error("Failed to write stamp file %s: %s", stamp, exc)
         return jsonify({"error": f"Failed to mark setup complete: {exc}"}), 500
 
     # Stop the hotspot
+    log.info("Stopping hotspot...")
     try:
-        subprocess.run(
+        result = subprocess.run(
             [HOTSPOT_SCRIPT, "stop"],
             capture_output=True,
             text=True,
             timeout=30,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        # Non-fatal: hotspot may already be stopped
-        pass
+        log.debug("Hotspot stop: rc=%d stdout=%s", result.returncode, result.stdout.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        log.warning("Hotspot stop failed (non-fatal): %s", exc)
 
     # Get the new WiFi IP address
     ip_address = ""
@@ -257,6 +282,7 @@ def setup_complete():
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         pass
 
+    log.info("Setup complete! New WiFi IP: %s", ip_address or "unknown")
     return jsonify({
         "message": "Setup complete",
         "ip": ip_address,
@@ -266,4 +292,5 @@ def setup_complete():
 @provisioning_bp.route("/wizard", methods=["GET"])
 def setup_wizard():
     """Serve the setup wizard HTML page."""
+    log.debug("Serving setup wizard")
     return render_template("setup.html")

--- a/meta-home-monitor/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-home-monitor/recipes-core/base-files/base-files_%.bbappend
@@ -1,12 +1,10 @@
 # =============================================================
-# base-files customization — add /data partition to fstab
+# base-files customization
 # =============================================================
 # OS branding is handled by os-release.bbappend — do not add
 # /etc/os-release here as it conflicts with the os-release package.
-
-# Mount the /data partition (label=data) at boot.
-# This partition holds recordings, config, certs, and logs.
-# It persists across OTA rootfs updates.
-do_install:append() {
-    echo "LABEL=data  /data  ext4  defaults,noatime  0  2" >> ${D}${sysconfdir}/fstab
-}
+#
+# NOTE: /data partition fstab entry is generated automatically by
+# wic from the "part /data" line in the .wks layout file.
+# Do NOT add a duplicate entry here — it causes systemd-fstab-generator
+# to fail with "Duplicate entry in /etc/fstab".

--- a/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
+++ b/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
@@ -14,9 +14,16 @@ if [ -f "$STAMP" ]; then
     exit 0
 fi
 
-echo "Running first boot setup..."
+echo "=== First boot setup starting ==="
+echo "Checking /data mount..."
+if mountpoint -q /data; then
+    echo "/data is mounted"
+else
+    echo "WARNING: /data is NOT mounted — dirs will be on rootfs"
+fi
 
 # Create directory structure
+echo "Creating /data directory structure..."
 mkdir -p /data/config
 mkdir -p /data/recordings
 mkdir -p /data/live
@@ -26,19 +33,29 @@ mkdir -p /data/logs
 
 # Set ownership — monitor user for server, camera user for camera
 if id monitor >/dev/null 2>&1; then
+    echo "Setting ownership for monitor user (server)"
+    chown monitor:monitor /data
     chown -R monitor:monitor /data/config /data/recordings /data/live /data/logs
     chown -R monitor:monitor /data/certs
 fi
 
 if id camera >/dev/null 2>&1; then
-    chown -R camera:camera /data/config /data/certs
+    echo "Setting ownership for camera user (camera)"
+    chown camera:camera /data
+    chown -R camera:camera /data/config /data/certs /data/logs
 fi
 
 # Permissions
+chmod 755 /data
 chmod 750 /data/config /data/certs /data/logs
 chmod 755 /data/recordings /data/live
 
 # Mark first boot as done
 touch "$STAMP"
 
-echo "First boot setup complete."
+echo "=== First boot setup complete ==="
+echo "  /data/config      — app configuration"
+echo "  /data/certs       — TLS certificates"
+echo "  /data/recordings  — video clips"
+echo "  /data/live        — HLS live segments"
+echo "  /data/logs        — app logs"

--- a/meta-home-monitor/recipes-core/first-boot/first-boot_1.0.bb
+++ b/meta-home-monitor/recipes-core/first-boot/first-boot_1.0.bb
@@ -20,7 +20,9 @@ do_install() {
     cat > ${D}${systemd_system_unitdir}/first-boot-setup.service << 'UNIT'
 [Unit]
 Description=First boot data directory setup
-Before=monitor.service camera-streamer.service monitor-certs.service
+After=local-fs.target
+Requires=local-fs.target
+Before=monitor.service camera-streamer.service monitor-certs.service monitor-hotspot.service
 ConditionPathExists=!/data/.first-boot-done
 
 [Service]

--- a/meta-home-monitor/recipes-core/images/home-camera-image-dev.bb
+++ b/meta-home-monitor/recipes-core/images/home-camera-image-dev.bb
@@ -16,3 +16,6 @@ IMAGE_INSTALL += " \
     strace \
     tcpdump \
     "
+
+# --- Debug logging (LOG_LEVEL=DEBUG for app services) ---
+IMAGE_INSTALL += "monitor-dev-config"

--- a/meta-home-monitor/recipes-core/images/home-monitor-image-dev.bb
+++ b/meta-home-monitor/recipes-core/images/home-monitor-image-dev.bb
@@ -21,3 +21,6 @@ IMAGE_INSTALL += " \
     strace \
     tcpdump \
     "
+
+# --- Debug logging (LOG_LEVEL=DEBUG for app services) ---
+IMAGE_INSTALL += "monitor-dev-config"

--- a/meta-home-monitor/recipes-core/monitor-dev-config/monitor-dev-config_1.0.bb
+++ b/meta-home-monitor/recipes-core/monitor-dev-config/monitor-dev-config_1.0.bb
@@ -1,0 +1,36 @@
+# =============================================================
+# monitor-dev-config — Debug logging for dev builds only
+#
+# Installs systemd drop-in overrides that set LOG_LEVEL=DEBUG
+# for both monitor.service and camera-streamer.service.
+#
+# Only included in -dev image variants. Prod images don't
+# include this, so apps default to LOG_LEVEL=WARNING.
+# =============================================================
+SUMMARY = "Development logging configuration for Home Monitor"
+DESCRIPTION = "Systemd drop-ins that enable DEBUG logging for dev builds."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+S = "${WORKDIR}"
+
+do_install() {
+    # Monitor server debug logging
+    install -d ${D}${sysconfdir}/systemd/system/monitor.service.d
+    cat > ${D}${sysconfdir}/systemd/system/monitor.service.d/10-dev-logging.conf << 'CONF'
+[Service]
+Environment=LOG_LEVEL=DEBUG
+CONF
+
+    # Camera streamer debug logging
+    install -d ${D}${sysconfdir}/systemd/system/camera-streamer.service.d
+    cat > ${D}${sysconfdir}/systemd/system/camera-streamer.service.d/10-dev-logging.conf << 'CONF'
+[Service]
+Environment=LOG_LEVEL=DEBUG
+CONF
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/systemd/system/monitor.service.d/10-dev-logging.conf \
+    ${sysconfdir}/systemd/system/camera-streamer.service.d/10-dev-logging.conf \
+    "

--- a/meta-home-monitor/recipes-security/monitor-certs/monitor-certs_1.0.bb
+++ b/meta-home-monitor/recipes-security/monitor-certs/monitor-certs_1.0.bb
@@ -24,6 +24,8 @@ do_install() {
     cat > ${D}${systemd_system_unitdir}/monitor-certs.service << 'UNIT'
 [Unit]
 Description=Generate TLS certificates on first boot
+After=local-fs.target first-boot-setup.service
+Requires=local-fs.target
 Before=nginx.service monitor.service
 ConditionPathExists=!/data/certs/ca.crt
 


### PR DESCRIPTION
## Summary
Fixes **all issues found from live RPi 4B boot logs**:

- **NGINX refused to start**: `unknown directive "mp4"` — module not compiled in. Removed mp4 directives. Also serve HTTP on port 80 directly (no redirect to HTTPS) so setup wizard works on hotspot
- **Flask killed every 60s**: `WatchdogSec=60` but Flask dev server doesn't support sd_notify → removed
- **Duplicate /data fstab**: wks + bbappend both created entries → systemd-fstab-generator failed. Removed bbappend entry
- **Service boot ordering**: first-boot, certs, hotspot, camera all needed `/data` but had no `After=local-fs.target`
- **BusyBox `head -1`**: changed to `head -n 1`
- **`/data` ownership**: camera/monitor user couldn't write `.setup-done` — first-boot now chowns /data itself
- **Debug logging**: apps read `LOG_LEVEL` env (default WARNING). New `monitor-dev-config` recipe installs systemd drop-ins for `LOG_LEVEL=DEBUG` — dev images only

## Files changed (15)
- `nginx-monitor.conf` — HTTP port 80 serves Flask directly; removed mp4 directives
- `monitor.service` — removed WatchdogSec, added After=local-fs.target
- `camera-streamer.service` — removed WatchdogSec, added After=local-fs.target
- `monitor-hotspot.service` — added After=local-fs.target
- `monitor-hotspot.sh` — BusyBox-compatible head
- `base-files_%.bbappend` — removed duplicate fstab entry
- `first-boot_1.0.bb` — After=local-fs.target, Requires=local-fs.target
- `first-boot-setup.sh` — chown /data, verbose logging
- `monitor-certs_1.0.bb` — After=local-fs.target, first-boot-setup.service
- `monitor/__init__.py` — LOG_LEVEL env support + debug logging
- `provisioning.py` — debug logging on all endpoints
- `camera main.py` — LOG_LEVEL env support
- `monitor-dev-config_1.0.bb` — NEW: systemd drop-ins for dev logging
- `home-monitor-image-dev.bb` — includes monitor-dev-config
- `home-camera-image-dev.bb` — includes monitor-dev-config

## Test plan
- [x] 127 camera tests pass (85% coverage)
- [x] 366 server tests pass (92% coverage)
- [ ] Flash server image → verify NGINX starts, setup wizard at http://10.42.0.1
- [ ] Flash camera image → verify setup page loads, scan button works
- [ ] Check `journalctl -u monitor` shows DEBUG logs on dev build
- [ ] Verify prod build does NOT show DEBUG logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)