### PR TITLE
feat: captive portal auto-popup + LED status feedback

### DIFF
--- a/app/camera/camera_streamer/led.py
+++ b/app/camera/camera_streamer/led.py
@@ -1,0 +1,68 @@
+"""
+LED status indicator for camera.
+
+Controls the onboard ACT LED via sysfs to show device state.
+Silently fails if LED is not accessible (e.g. in tests or containers).
+
+Patterns:
+  setup_mode()  — slow blink (1s on / 1s off) — waiting for WiFi config
+  connecting()  — fast blink (200ms on / 200ms off) — trying to connect
+  connected()   — solid ON — running normally
+  error()       — very fast blink (100ms on / 100ms off) — something wrong
+  off()         — LED off
+"""
+import os
+import logging
+
+log = logging.getLogger("camera-streamer.led")
+
+# ACT LED sysfs path (standard on RPi 4B and Zero 2W)
+LED_PATH = "/sys/class/leds/ACT"
+
+
+def _write(filename, value):
+    """Write a value to an LED sysfs file. Fails silently."""
+    try:
+        path = os.path.join(LED_PATH, filename)
+        with open(path, "w") as f:
+            f.write(str(value))
+    except (OSError, IOError) as e:
+        log.debug("LED write failed (%s=%s): %s", filename, value, e)
+
+
+def setup_mode():
+    """Slow blink — hotspot active, waiting for user to configure."""
+    log.debug("LED: setup_mode (slow blink)")
+    _write("trigger", "timer")
+    _write("delay_on", "1000")
+    _write("delay_off", "1000")
+
+
+def connecting():
+    """Fast blink — attempting WiFi connection."""
+    log.debug("LED: connecting (fast blink)")
+    _write("trigger", "timer")
+    _write("delay_on", "200")
+    _write("delay_off", "200")
+
+
+def connected():
+    """Solid ON — connected and running normally."""
+    log.debug("LED: connected (solid on)")
+    _write("trigger", "none")
+    _write("brightness", "1")
+
+
+def error():
+    """Very fast blink — error state, needs attention."""
+    log.debug("LED: error (very fast blink)")
+    _write("trigger", "timer")
+    _write("delay_on", "100")
+    _write("delay_off", "100")
+
+
+def off():
+    """LED off."""
+    log.debug("LED: off")
+    _write("trigger", "none")
+    _write("brightness", "0")

--- a/app/camera/camera_streamer/main.py
+++ b/app/camera/camera_streamer/main.py
@@ -100,6 +100,9 @@ def main():
     health = HealthMonitor(config, capture, stream)
     health.start()
 
+    # LED: solid on = running
+    from camera_streamer import led
+    led.connected()
     log.info("Camera streamer running (camera=%s)", config.camera_id)
 
     # 7. Main loop — wait for shutdown

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -20,6 +20,8 @@ import threading
 import time
 import logging
 
+from camera_streamer import led
+
 log = logging.getLogger("camera-streamer.wifi-setup")
 
 HOTSPOT_SSID = "HomeCam-Setup"
@@ -72,6 +74,9 @@ class WifiSetupServer:
         if not self._start_hotspot():
             log.warning("Could not start hotspot — setup via ethernet")
 
+        # LED: slow blink = waiting for setup
+        led.setup_mode()
+
         # Start HTTP server
         handler = _make_handler(self._config, self)
         self._server = http.server.HTTPServer(("0.0.0.0", LISTEN_PORT), handler)
@@ -88,6 +93,7 @@ class WifiSetupServer:
             self._server.shutdown()
             self._server = None
         self._stop_hotspot()
+        led.off()
         log.info("Setup server stopped")
 
     def save_and_connect(self, ssid, password, server_ip, server_port="8554"):
@@ -111,6 +117,7 @@ class WifiSetupServer:
         time.sleep(CONNECT_DELAY)
 
         log.info("Tearing down hotspot, connecting to WiFi: %s", ssid)
+        led.connecting()
 
         # Tear down hotspot
         self._stop_hotspot()
@@ -126,12 +133,15 @@ class WifiSetupServer:
             self._config.update(SERVER_IP=server_ip, SERVER_PORT=server_port)
             mark_setup_complete(self._config.data_dir)
             self._connect_result = True
+            led.connected()
         else:
             log.error("WiFi connection failed: %s — restarting hotspot", err)
             self._connect_result = err or "Connection failed"
+            led.error()
             # Restart hotspot so user can retry
             time.sleep(2)
             self._start_hotspot()
+            led.setup_mode()
 
     def get_status(self):
         """Return current connection attempt status."""
@@ -307,7 +317,14 @@ def _make_handler(config, setup_server):
                     "camera_id": config.camera_id,
                 })
             else:
-                self.send_error(404)
+                # Captive portal: redirect ANY unknown path to setup page.
+                # When phone connects to hotspot and checks connectivity
+                # (Apple, Android, Windows all probe different URLs),
+                # this redirect triggers the "Sign in to network" popup.
+                log.debug("Captive portal redirect: %s → /setup", self.path)
+                self.send_response(302)
+                self.send_header("Location", "http://10.42.0.1/setup")
+                self.end_headers()
 
         def do_POST(self):
             content_len = int(self.headers.get("Content-Length", 0))

--- a/app/camera/config/camera-streamer.service
+++ b/app/camera/config/camera-streamer.service
@@ -8,6 +8,8 @@ Type=simple
 User=camera
 Group=camera
 WorkingDirectory=/opt/camera
+# Allow camera user to control the onboard ACT LED for status feedback
+ExecStartPre=+/bin/sh -c 'chmod 0666 /sys/class/leds/ACT/trigger /sys/class/leds/ACT/brightness /sys/class/leds/ACT/delay_on /sys/class/leds/ACT/delay_off 2>/dev/null || true'
 ExecStart=/usr/bin/python3 -m camera_streamer.main
 Restart=always
 RestartSec=5

--- a/app/camera/config/captive-portal-dnsmasq.conf
+++ b/app/camera/config/captive-portal-dnsmasq.conf
@@ -1,0 +1,5 @@
+# Redirect all DNS queries to the hotspot gateway IP.
+# This enables captive portal detection on phones — the setup
+# page auto-opens when connecting to the setup hotspot.
+# Only active when NetworkManager shared mode is running.
+address=/#/10.42.0.1

--- a/app/camera/tests/test_led.py
+++ b/app/camera/tests/test_led.py
@@ -1,0 +1,73 @@
+"""Tests for camera_streamer.led module."""
+import os
+import pytest
+from unittest.mock import patch, mock_open, call
+
+from camera_streamer import led
+
+
+class TestLedWrite:
+    """Test the low-level _write function."""
+
+    @patch("builtins.open", mock_open())
+    def test_write_success(self):
+        """Should write value to sysfs file."""
+        led._write("trigger", "timer")
+        open.assert_called_once_with(
+            os.path.join(led.LED_PATH, "trigger"), "w"
+        )
+
+    @patch("builtins.open", side_effect=OSError("Permission denied"))
+    def test_write_fails_silently(self, mock_file):
+        """Should not raise on permission error."""
+        led._write("trigger", "timer")  # No exception
+
+
+class TestLedPatterns:
+    """Test LED pattern functions."""
+
+    @patch("camera_streamer.led._write")
+    def test_setup_mode(self, mock_write):
+        """setup_mode should set slow blink."""
+        led.setup_mode()
+        mock_write.assert_any_call("trigger", "timer")
+        mock_write.assert_any_call("delay_on", "1000")
+        mock_write.assert_any_call("delay_off", "1000")
+
+    @patch("camera_streamer.led._write")
+    def test_connecting(self, mock_write):
+        """connecting should set fast blink."""
+        led.connecting()
+        mock_write.assert_any_call("trigger", "timer")
+        mock_write.assert_any_call("delay_on", "200")
+        mock_write.assert_any_call("delay_off", "200")
+
+    @patch("camera_streamer.led._write")
+    def test_connected(self, mock_write):
+        """connected should set solid on."""
+        led.connected()
+        mock_write.assert_any_call("trigger", "none")
+        mock_write.assert_any_call("brightness", "1")
+
+    @patch("camera_streamer.led._write")
+    def test_error(self, mock_write):
+        """error should set very fast blink."""
+        led.error()
+        mock_write.assert_any_call("trigger", "timer")
+        mock_write.assert_any_call("delay_on", "100")
+        mock_write.assert_any_call("delay_off", "100")
+
+    @patch("camera_streamer.led._write")
+    def test_off(self, mock_write):
+        """off should turn LED off."""
+        led.off()
+        mock_write.assert_any_call("trigger", "none")
+        mock_write.assert_any_call("brightness", "0")
+
+
+class TestLedConstants:
+    """Test LED configuration constants."""
+
+    def test_led_path(self):
+        """LED path should point to ACT LED."""
+        assert "ACT" in led.LED_PATH

--- a/app/server/config/captive-portal-dnsmasq.conf
+++ b/app/server/config/captive-portal-dnsmasq.conf
@@ -1,0 +1,5 @@
+# Redirect all DNS queries to the hotspot gateway IP.
+# This enables captive portal detection on phones — the setup
+# page auto-opens when connecting to the setup hotspot.
+# Only active when NetworkManager shared mode is running.
+address=/#/10.42.0.1

--- a/app/server/config/monitor-hotspot.sh
+++ b/app/server/config/monitor-hotspot.sh
@@ -13,6 +13,32 @@ IFACE="wlan0"
 HOTSPOT_SSID="HomeMonitor-Setup"
 HOTSPOT_PASS="homemonitor"
 
+# --- LED control (ACT LED on RPi) ---
+LED_PATH="/sys/class/leds/ACT"
+
+led_write() {
+    echo "$2" > "${LED_PATH}/$1" 2>/dev/null || true
+}
+
+led_setup_mode() {
+    # Slow blink — waiting for setup
+    chmod 0666 ${LED_PATH}/trigger ${LED_PATH}/brightness ${LED_PATH}/delay_on ${LED_PATH}/delay_off 2>/dev/null || true
+    led_write trigger timer
+    led_write delay_on 1000
+    led_write delay_off 1000
+}
+
+led_connected() {
+    # Solid on — running normally
+    led_write trigger none
+    led_write brightness 1
+}
+
+led_off() {
+    led_write trigger none
+    led_write brightness 0
+}
+
 start_hotspot() {
     echo "Starting WiFi hotspot: ${HOTSPOT_SSID}"
 
@@ -47,6 +73,10 @@ start_hotspot() {
     ACTUAL_IP=$(nmcli -t -f IP4.ADDRESS dev show "${IFACE}" 2>/dev/null | head -n 1 | cut -d: -f2 | cut -d/ -f1)
     echo "Hotspot active on ${IFACE} — SSID: ${HOTSPOT_SSID}, IP: ${ACTUAL_IP:-10.42.0.1}"
     echo "Setup wizard available at http://${ACTUAL_IP:-10.42.0.1}/"
+    echo "Captive portal: phone should auto-open setup page on connect"
+
+    # LED: slow blink = setup mode
+    led_setup_mode
 }
 
 stop_hotspot() {
@@ -55,6 +85,9 @@ stop_hotspot() {
     # Bring down and remove the hotspot connection
     nmcli connection down "${CONN_NAME}" 2>/dev/null || true
     nmcli connection delete "${CONN_NAME}" 2>/dev/null || true
+
+    # LED: solid on = normal operation
+    led_connected
 
     echo "Hotspot stopped"
 }

--- a/app/server/config/nginx-monitor.conf
+++ b/app/server/config/nginx-monitor.conf
@@ -4,6 +4,22 @@ server {
     listen 80;
     server_name _;
 
+    # --- Captive portal detection ---
+    # Phones probe these URLs to detect captive portals.
+    # Redirecting to the setup wizard triggers the "Sign in to network" popup.
+    # iOS: captive.apple.com/hotspot-detect.html
+    location = /hotspot-detect.html { return 302 http://$host/api/v1/setup/wizard; }
+    # Android: connectivitycheck.gstatic.com/generate_204
+    location = /generate_204 { return 302 http://$host/api/v1/setup/wizard; }
+    # Windows: www.msftconnecttest.com/connecttest.txt
+    location = /connecttest.txt { return 302 http://$host/api/v1/setup/wizard; }
+    # Firefox: detectportal.firefox.com/canonical.html
+    location = /canonical.html { return 302 http://$host/api/v1/setup/wizard; }
+    # Firefox alt
+    location = /success.txt { return 302 http://$host/api/v1/setup/wizard; }
+    # Samsung
+    location = /gen_204 { return 302 http://$host/api/v1/setup/wizard; }
+
     # Proxy to Flask app
     location / {
         proxy_pass http://127.0.0.1:5000;

--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -15,6 +15,7 @@ SRC_URI = " \
     file://camera_streamer/ \
     file://config/camera-streamer.service \
     file://config/nftables-camera.conf \
+    file://config/captive-portal-dnsmasq.conf \
     file://config/camera.conf.default \
     file://setup.py \
     "
@@ -57,10 +58,15 @@ do_install() {
     # Firewall rules
     install -d ${D}${sysconfdir}/nftables.d
     install -m 0644 ${WORKDIR}/config/nftables-camera.conf ${D}${sysconfdir}/nftables.d/camera.conf
+
+    # Captive portal DNS redirect (NM shared-mode dnsmasq config)
+    install -d ${D}${sysconfdir}/NetworkManager/dnsmasq-shared.d
+    install -m 0644 ${WORKDIR}/config/captive-portal-dnsmasq.conf ${D}${sysconfdir}/NetworkManager/dnsmasq-shared.d/captive-portal.conf
 }
 
 FILES:${PN} = " \
     /opt/camera \
     ${systemd_system_unitdir}/camera-streamer.service \
     ${sysconfdir}/nftables.d/camera.conf \
+    ${sysconfdir}/NetworkManager/dnsmasq-shared.d/captive-portal.conf \
     "

--- a/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
+++ b/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
@@ -18,6 +18,7 @@ SRC_URI = " \
     file://config/monitor-hotspot.sh \
     file://config/nginx-monitor.conf \
     file://config/nftables-server.conf \
+    file://config/captive-portal-dnsmasq.conf \
     file://config/logrotate-monitor.conf \
     file://setup.py \
     file://requirements.txt \
@@ -81,6 +82,10 @@ do_install() {
     # Logrotate
     install -d ${D}${sysconfdir}/logrotate.d
     install -m 0644 ${WORKDIR}/config/logrotate-monitor.conf ${D}${sysconfdir}/logrotate.d/monitor
+
+    # Captive portal DNS redirect (NM shared-mode dnsmasq config)
+    install -d ${D}${sysconfdir}/NetworkManager/dnsmasq-shared.d
+    install -m 0644 ${WORKDIR}/config/captive-portal-dnsmasq.conf ${D}${sysconfdir}/NetworkManager/dnsmasq-shared.d/captive-portal.conf
 }
 
 FILES:${PN} = " \
@@ -90,4 +95,5 @@ FILES:${PN} = " \
     ${sysconfdir}/nginx/sites-enabled/monitor.conf \
     ${sysconfdir}/nftables.d/monitor.conf \
     ${sysconfdir}/logrotate.d/monitor \
+    ${sysconfdir}/NetworkManager/dnsmasq-shared.d/captive-portal.conf \
     "


### PR DESCRIPTION
## Summary
- **Captive portal**: phone auto-opens setup page when connecting to hotspot (like hotel WiFi)
- **LED feedback**: onboard ACT LED shows device state (slow blink=setup, fast blink=connecting, solid=running, very fast=error)
- **Both server and camera** get captive portal + LED support
- **Manual fallback**: typing `http://10.42.0.1` in browser always works (for when iPhone captive portal is flaky)

## How captive portal works
1. NM dnsmasq config: `address=/#/10.42.0.1` — all DNS queries resolve to hotspot IP
2. HTTP server redirects captive portal probe URLs to setup page:
   - iOS: `/hotspot-detect.html` → setup wizard
   - Android: `/generate_204` → setup wizard
   - Windows: `/connecttest.txt` → setup wizard
   - Firefox: `/canonical.html` → setup wizard

## New files
- `app/camera/camera_streamer/led.py` — LED control module (sysfs-based, fails silently)
- `app/*/config/captive-portal-dnsmasq.conf` — DNS redirect for NM shared mode
- `app/camera/tests/test_led.py` — 8 tests, 100% coverage

## Test plan
- [x] 135 camera tests pass (86% coverage)
- [x] 366 server tests pass (92% coverage)
- [ ] Connect phone to HomeMonitor-Setup hotspot → verify "Sign in to network" popup appears
- [ ] Connect phone to HomeCam-Setup hotspot → verify popup appears
- [ ] Verify manual http://10.42.0.1 still works when popup doesn't trigger
- [ ] Verify LED blinks slowly during setup mode
- [ ] Verify LED goes solid after successful WiFi connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)