### PR TITLE
Fix hotspot startup race condition — wait for WiFi readiness

### DIFF
--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -217,14 +217,31 @@ class WifiSetupServer:
         except Exception as e:
             return False, str(e)
 
+    def _wait_for_wifi(self, max_wait=30):
+        """Wait until wlan0 is recognized by NetworkManager as a wifi device."""
+        log.info("Waiting for WiFi interface %s to be ready...", IFACE)
+        for waited in range(max_wait):
+            try:
+                result = subprocess.run(
+                    ["nmcli", "-t", "-f", "DEVICE,TYPE", "device", "status"],
+                    capture_output=True, text=True, timeout=10,
+                )
+                for line in result.stdout.strip().splitlines():
+                    parts = line.split(":")
+                    if len(parts) >= 2 and parts[0] == IFACE and parts[1] == "wifi":
+                        log.info("WiFi interface %s ready after %ds", IFACE, waited)
+                        return True
+            except Exception:
+                pass
+            time.sleep(1)
+        log.warning("WiFi interface %s not ready after %ds", IFACE, max_wait)
+        return False
+
     def _start_hotspot(self):
         """Start WiFi AP via NetworkManager."""
         try:
-            result = subprocess.run(
-                ["nmcli", "-t", "-f", "DEVICE", "device", "status"],
-                capture_output=True, text=True, timeout=10,
-            )
-            if IFACE not in result.stdout:
+            # Wait for WiFi hardware to be ready (firmware may still load at boot)
+            if not self._wait_for_wifi():
                 log.warning("WiFi interface %s not found", IFACE)
                 return False
 
@@ -252,10 +269,27 @@ class WifiSetupServer:
                 capture_output=True, text=True, timeout=15, check=True,
             )
 
-            subprocess.run(
-                ["nmcli", "connection", "up", CONN_NAME],
-                capture_output=True, text=True, timeout=15, check=True,
-            )
+            # Activate with explicit interface binding + retry.
+            # Even after NM sees wlan0, AP mode can fail briefly while
+            # the driver finishes initialization.
+            max_retries = 5
+            for attempt in range(1, max_retries + 1):
+                try:
+                    subprocess.run(
+                        ["nmcli", "connection", "up", CONN_NAME,
+                         "ifname", IFACE],
+                        capture_output=True, text=True, timeout=15, check=True,
+                    )
+                    break  # success
+                except subprocess.CalledProcessError as e:
+                    log.warning(
+                        "Hotspot activation attempt %d/%d failed: %s",
+                        attempt, max_retries,
+                        e.stderr.strip() if e.stderr else str(e),
+                    )
+                    if attempt >= max_retries:
+                        raise
+                    time.sleep(2)
 
             self._hotspot_active = True
             log.info("Hotspot started: SSID=%s", HOTSPOT_SSID)

--- a/app/camera/config/camera-streamer.service
+++ b/app/camera/config/camera-streamer.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Camera RTSP Streamer
-After=network-online.target avahi-daemon.service local-fs.target NetworkManager.service
+After=network-online.target avahi-daemon.service local-fs.target NetworkManager.service sys-subsystem-net-devices-wlan0.device
 Wants=network-online.target NetworkManager.service
 
 [Service]

--- a/app/camera/tests/test_wifi_setup.py
+++ b/app/camera/tests/test_wifi_setup.py
@@ -293,25 +293,64 @@ class TestRescan:
         assert server.get_cached_networks()[0]["ssid"] == "NewNet"
 
 
+class TestWaitForWifi:
+    """Test WiFi interface readiness check."""
+
+    @patch("camera_streamer.wifi_setup.time.sleep")
+    @patch("subprocess.run")
+    def test_wait_immediate_ready(self, mock_run, mock_sleep, unconfigured_config):
+        """Should return True immediately if wlan0 is ready."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="wlan0:wifi\n"
+        )
+        server = WifiSetupServer(unconfigured_config)
+        assert server._wait_for_wifi(max_wait=5) is True
+        mock_sleep.assert_not_called()
+
+    @patch("camera_streamer.wifi_setup.time.sleep")
+    @patch("subprocess.run")
+    def test_wait_becomes_ready(self, mock_run, mock_sleep, unconfigured_config):
+        """Should retry until wlan0 appears."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="eth0:ethernet\n"),
+            MagicMock(returncode=0, stdout="eth0:ethernet\n"),
+            MagicMock(returncode=0, stdout="wlan0:wifi\neth0:ethernet\n"),
+        ]
+        server = WifiSetupServer(unconfigured_config)
+        assert server._wait_for_wifi(max_wait=5) is True
+        assert mock_sleep.call_count == 2
+
+    @patch("camera_streamer.wifi_setup.time.sleep")
+    @patch("subprocess.run")
+    def test_wait_timeout(self, mock_run, mock_sleep, unconfigured_config):
+        """Should return False after max_wait seconds."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="eth0:ethernet\n")
+        server = WifiSetupServer(unconfigured_config)
+        assert server._wait_for_wifi(max_wait=3) is False
+        assert mock_sleep.call_count == 3
+
+
 class TestHotspot:
     """Test hotspot start/stop."""
 
+    @patch("camera_streamer.wifi_setup.time.sleep")
     @patch("subprocess.run")
-    def test_start_hotspot_success(self, mock_run, unconfigured_config):
+    def test_start_hotspot_success(self, mock_run, mock_sleep, unconfigured_config):
         """Should start hotspot via nmcli."""
         mock_run.return_value = MagicMock(
-            returncode=0, stdout="wlan0\n", stderr=""
+            returncode=0, stdout="wlan0:wifi\n", stderr=""
         )
         server = WifiSetupServer(unconfigured_config)
         result = server._start_hotspot()
         assert result is True
         assert server._hotspot_active is True
 
+    @patch("camera_streamer.wifi_setup.time.sleep")
     @patch("subprocess.run")
-    def test_start_hotspot_no_wlan0(self, mock_run, unconfigured_config):
-        """Should return False when wlan0 missing."""
+    def test_start_hotspot_no_wlan0(self, mock_run, mock_sleep, unconfigured_config):
+        """Should return False when wlan0 never appears."""
         mock_run.return_value = MagicMock(
-            returncode=0, stdout="eth0\n", stderr=""
+            returncode=0, stdout="eth0:ethernet\n", stderr=""
         )
         server = WifiSetupServer(unconfigured_config)
         result = server._start_hotspot()
@@ -333,8 +372,9 @@ class TestHotspot:
         server._stop_hotspot()
         mock_run.assert_not_called()
 
+    @patch("camera_streamer.wifi_setup.time.sleep")
     @patch("subprocess.run")
-    def test_start_hotspot_nmcli_error(self, mock_run, unconfigured_config):
+    def test_start_hotspot_nmcli_error(self, mock_run, mock_sleep, unconfigured_config):
         """Should return False and not crash on nmcli error."""
         import subprocess
         mock_run.side_effect = subprocess.CalledProcessError(1, "nmcli")
@@ -342,6 +382,25 @@ class TestHotspot:
         result = server._start_hotspot()
         assert result is False
         assert server._hotspot_active is False
+
+    @patch("camera_streamer.wifi_setup.time.sleep")
+    @patch("subprocess.run")
+    def test_start_hotspot_retries_activation(self, mock_run, mock_sleep, unconfigured_config):
+        """Should retry connection up if first attempt fails."""
+        import subprocess as sp
+        # wait_for_wifi succeeds, delete succeeds, add succeeds,
+        # first 'up' fails, second 'up' succeeds
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="wlan0:wifi\n"),  # wait_for_wifi
+            MagicMock(returncode=0),  # delete
+            MagicMock(returncode=0),  # add
+            sp.CalledProcessError(1, "nmcli", stderr="No suitable device"),  # up attempt 1
+            MagicMock(returncode=0),  # up attempt 2
+        ]
+        server = WifiSetupServer(unconfigured_config)
+        result = server._start_hotspot()
+        assert result is True
+        assert server._hotspot_active is True
 
 
 class TestSetupHTTPHandler:

--- a/app/server/config/monitor-hotspot.service
+++ b/app/server/config/monitor-hotspot.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Home Monitor WiFi Setup Hotspot
 Documentation=https://github.com/vinu-engineer/rpi-home-monitor
-After=NetworkManager.service local-fs.target
+After=NetworkManager.service local-fs.target sys-subsystem-net-devices-wlan0.device
 Wants=NetworkManager.service
 Before=monitor.service
 
@@ -11,6 +11,7 @@ ConditionPathExists=!/data/.setup-done
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+TimeoutStartSec=90
 ExecStart=/opt/monitor/scripts/monitor-hotspot.sh start
 ExecStop=/opt/monitor/scripts/monitor-hotspot.sh stop
 

--- a/app/server/config/monitor-hotspot.sh
+++ b/app/server/config/monitor-hotspot.sh
@@ -39,11 +39,31 @@ led_off() {
     led_write brightness 0
 }
 
+wait_for_wifi() {
+    # Wait until wlan0 is recognized by NetworkManager as a wifi device.
+    # The WiFi firmware/driver may still be loading at early boot.
+    MAX_WAIT=30
+    WAITED=0
+    echo "Waiting for WiFi interface ${IFACE} to be ready..."
+    while [ "$WAITED" -lt "$MAX_WAIT" ]; do
+        # Check NM sees it as a wifi device (not just that the interface exists)
+        DEVTYPE=$(nmcli -t -f DEVICE,TYPE device status 2>/dev/null | grep "^${IFACE}:" | cut -d: -f2)
+        if [ "$DEVTYPE" = "wifi" ]; then
+            echo "WiFi interface ${IFACE} ready after ${WAITED}s"
+            return 0
+        fi
+        sleep 1
+        WAITED=$((WAITED + 1))
+    done
+    echo "WiFi interface ${IFACE} not ready after ${MAX_WAIT}s"
+    return 1
+}
+
 start_hotspot() {
     echo "Starting WiFi hotspot: ${HOTSPOT_SSID}"
 
-    # Check if WiFi interface exists
-    if ! nmcli -t -f DEVICE device status 2>/dev/null | grep -q "^${IFACE}$"; then
+    # Wait for WiFi hardware to be ready (firmware may still be loading)
+    if ! wait_for_wifi; then
         echo "WiFi interface ${IFACE} not found — skipping hotspot (ethernet-only setup)"
         exit 0
     fi
@@ -66,8 +86,32 @@ start_hotspot() {
         wifi-sec.psk "${HOTSPOT_PASS}" \
         ipv4.method shared
 
-    # Bring up the connection
-    nmcli connection up "${CONN_NAME}"
+    # Bring up the connection with explicit interface binding + retry.
+    # Even after NM sees wlan0, AP mode activation can fail briefly
+    # while the driver finishes initialization.
+    # Note: temporarily disable set -e for the retry loop.
+    MAX_RETRIES=5
+    RETRY=0
+    ACTIVATED=false
+    set +e
+    while [ "$RETRY" -lt "$MAX_RETRIES" ]; do
+        OUTPUT=$(nmcli connection up "${CONN_NAME}" ifname "${IFACE}" 2>&1)
+        if [ $? -eq 0 ]; then
+            echo "$OUTPUT"
+            ACTIVATED=true
+            break
+        fi
+        RETRY=$((RETRY + 1))
+        echo "Hotspot activation attempt ${RETRY}/${MAX_RETRIES} failed: ${OUTPUT}"
+        echo "Retrying in 2s..."
+        sleep 2
+    done
+    set -e
+
+    if [ "$ACTIVATED" = false ]; then
+        echo "ERROR: Failed to activate hotspot after ${MAX_RETRIES} attempts"
+        exit 1
+    fi
 
     # Get the actual IP assigned (shared mode uses 10.42.0.1 by default)
     ACTUAL_IP=$(nmcli -t -f IP4.ADDRESS dev show "${IFACE}" 2>/dev/null | head -n 1 | cut -d: -f2 | cut -d/ -f1)


### PR DESCRIPTION
## Summary
- **Root cause**: `nmcli connection up` was called before wlan0 was ready for AP mode at boot (~8.8s). NM fell back to eth0, which doesn't match the wifi profile → "No suitable device found"
- **Fix**: Added `wait_for_wifi()` that polls NetworkManager until wlan0 is recognized as a wifi device (up to 30s), then retries `connection up` with explicit `ifname wlan0` (5 attempts, 2s apart)
- **Both apps fixed**: Server (shell script) and camera (Python) have identical wait+retry logic
- **Systemd**: Added `sys-subsystem-net-devices-wlan0.device` to `After=` deps + 90s timeout

## Test plan
- [ ] Flash server image, verify hotspot starts on first boot (check `journalctl -u monitor-hotspot`)
- [ ] Verify "WiFi interface wlan0 ready after Xs" appears in logs
- [ ] Connect phone to HomeMonitor-Setup hotspot, confirm captive portal + web UI
- [ ] Run `pytest app/camera/tests/test_wifi_setup.py` — 38 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)