### PR TITLE
Add mDNS server discovery (homemonitor.local)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to RPi Home Monitor are documented here.
+
+## [Unreleased]
+
+### Added
+- **mDNS server discovery** — Server advertises itself as `homemonitor.local` via Avahi. Cameras auto-discover the server without needing a manual IP address. Camera setup page defaults to `homemonitor.local`.
+- **Captive portal provisioning** — Both server and camera trigger the phone's "Sign in to network" popup on hotspot connect. Supports iOS, Android, Windows, Firefox, and Samsung captive portal detection. Manual fallback at `http://10.42.0.1` always works.
+- **LED status feedback** — Onboard ACT LED shows device state:
+  - Slow blink (1s) = setup mode, waiting for WiFi config
+  - Fast blink (200ms) = connecting to WiFi
+  - Very fast blink (100ms) = error, connection failed
+  - Solid on = running normally
+  - Off = service stopped
+- **WiFi rescan button** — Camera setup page can re-scan for networks (briefly drops hotspot).
+- **Avahi service file** for server — advertises `_homemonitor._tcp`, `_https._tcp`, and `_http._tcp` services.
+- **First-boot hostname** — Server hostname set to `homemonitor` on first boot for mDNS reachability.
+
+### Fixed
+- **Hotspot startup race condition** — `nmcli connection up` was called before wlan0 was ready at boot, causing "No suitable device found" error. Now waits for WiFi interface readiness (up to 30s) and retries activation (5 attempts). Explicit `ifname wlan0` passed to prevent NM from trying eth0.
+- **NGINX HTTP redirect loop** — Setup wizard was inaccessible because HTTP 80 redirected to HTTPS 443, but TLS certs don't exist during first boot. HTTP now serves directly.
+- **Camera WiFi scan** — Scan button now triggers a real WiFi rescan instead of showing cached results.
+
+### Changed
+- Server and camera systemd services now depend on `sys-subsystem-net-devices-wlan0.device` to ensure WiFi hardware is ready.
+- Server hotspot service has `TimeoutStartSec=90` to allow for WiFi retry loop.
+- Camera setup page server address field defaults to `homemonitor.local` instead of empty.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,38 @@ RPi Home Monitor runs **Home Monitor OS**, a custom Linux distribution built wit
 | **Camera Node** | Raspberry Pi Zero 2W + ZeroCam | Captures 1080p video, streams to server over RTSPS |
 | **Dashboard** | Any phone/laptop on LAN | Live view (HLS), clip playback, camera management, system admin |
 
+## First Boot Setup
+
+Both the server and camera use a **captive portal** for zero-config WiFi provisioning:
+
+1. **Power on** the device. The onboard LED starts **slow blinking** (1s on/off) = setup mode.
+2. **Connect your phone** to the WiFi hotspot:
+   - Server: `HomeMonitor-Setup` (password: `homemonitor`)
+   - Camera: `HomeCam-Setup` (password: `homecamera`)
+3. **Captive portal auto-opens** — your phone shows a "Sign in to network" popup with the setup wizard. If it doesn't, open `http://10.42.0.1` manually in a browser.
+4. **Configure WiFi** credentials and (for camera) the server address. Default server address is `homemonitor.local` (auto-discovery via mDNS).
+5. **Save & Connect** — the LED switches to **fast blinking** (connecting), then **solid on** (connected). The hotspot disappears.
+
+If WiFi connection fails, the LED blinks rapidly (error) and the hotspot restarts automatically for retry.
+
+### LED Status Indicators
+
+The onboard ACT LED provides visual feedback on both server and camera devices:
+
+| LED Pattern | Meaning |
+|-------------|---------|
+| **Slow blink** (1s on / 1s off) | Setup mode — waiting for WiFi configuration |
+| **Fast blink** (200ms on / 200ms off) | Connecting — attempting to join WiFi network |
+| **Very fast blink** (100ms on / 100ms off) | Error — WiFi connection failed, hotspot restarting |
+| **Solid on** | Running normally — connected and operational |
+| **Off** | Service stopped |
+
+### Server Discovery (mDNS)
+
+The server advertises itself as `homemonitor.local` on the local network using Avahi/mDNS. Cameras use this to find the server automatically — no need to know or type the server's IP address. The camera setup page pre-fills `homemonitor.local` as the default server address.
+
+If mDNS is not available on your network, you can enter the server's IP address manually during camera setup.
+
 ## Key Features
 
 | Feature | Details |

--- a/app/camera/camera_streamer/main.py
+++ b/app/camera/camera_streamer/main.py
@@ -37,6 +37,22 @@ def _handle_signal(signum, frame):
     _shutdown = True
 
 
+def _resolve_server(config):
+    """Resolve server address — handles mDNS names like homemonitor.local."""
+    import socket
+    addr = config.server_ip
+    if not addr:
+        return
+    try:
+        ip = socket.gethostbyname(addr)
+        log.info("Server address resolved: %s -> %s", addr, ip)
+    except socket.gaierror:
+        log.warning(
+            "Cannot resolve server address '%s' — mDNS may not be ready yet. "
+            "Will retry when streaming starts.", addr
+        )
+
+
 def main():
     """Entry point for camera-streamer service."""
     global _shutdown
@@ -75,6 +91,10 @@ def main():
         # Reload config after setup
         config.load()
         log.info("Setup complete, continuing with startup")
+
+    # 2b. Resolve server address (mDNS: homemonitor.local → IP)
+    if config.is_configured:
+        _resolve_server(config)
 
     # 3. Validate camera device
     from camera_streamer.capture import CaptureManager

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -496,9 +496,9 @@ input:focus { border-color: #e94560; }
 
     <div class="card">
       <h3>Server Connection</h3>
-      <label>Server IP Address</label>
-      <input type="text" id="in-server" placeholder="192.168.1.100">
-      <div class="hint">The IP of your RPi 4B running Home Monitor</div>
+      <label>Server Address</label>
+      <input type="text" id="in-server" value="homemonitor.local" placeholder="homemonitor.local or 192.168.1.x">
+      <div class="hint">Default: homemonitor.local (auto-discovery). Or enter server IP manually.</div>
       <label>RTSP Port</label>
       <input type="text" id="in-port" value="8554">
     </div>

--- a/app/camera/tests/test_main.py
+++ b/app/camera/tests/test_main.py
@@ -12,6 +12,7 @@ class TestMain:
     def test_main_callable(self):
         assert callable(main)
 
+    @patch("camera_streamer.main._resolve_server")
     @patch("camera_streamer.wifi_setup.WifiSetupServer")
     @patch("camera_streamer.health.HealthMonitor")
     @patch("camera_streamer.stream.StreamManager")
@@ -20,13 +21,14 @@ class TestMain:
     @patch("camera_streamer.config.ConfigManager")
     def test_main_startup_sequence(
         self, MockConfig, MockCapture, MockDiscovery,
-        MockStream, MockHealth, MockSetup
+        MockStream, MockHealth, MockSetup, mock_resolve
     ):
         """Main should initialize all components in order."""
         config = MagicMock()
         config.is_configured = True
         config.camera_id = "cam-test"
         config.data_dir = "/tmp/test"
+        config.server_ip = "homemonitor.local"
         MockConfig.return_value = config
         config.load.return_value = config
 
@@ -68,6 +70,7 @@ class TestMain:
         stream.stop.assert_called_once()
         discovery.stop.assert_called_once()
 
+    @patch("camera_streamer.main._resolve_server")
     @patch("camera_streamer.wifi_setup.WifiSetupServer")
     @patch("camera_streamer.health.HealthMonitor")
     @patch("camera_streamer.stream.StreamManager")
@@ -76,7 +79,7 @@ class TestMain:
     @patch("camera_streamer.config.ConfigManager")
     def test_main_skips_stream_when_unconfigured(
         self, MockConfig, MockCapture, MockDiscovery,
-        MockStream, MockHealth, MockSetup
+        MockStream, MockHealth, MockSetup, mock_resolve
     ):
         """Should not start streaming if server not configured."""
         config = MagicMock()

--- a/app/camera/tests/test_main_setup.py
+++ b/app/camera/tests/test_main_setup.py
@@ -9,6 +9,7 @@ import camera_streamer.main as main_module
 class TestMainSetupMode:
     """Test main() behavior during first-boot setup."""
 
+    @patch("camera_streamer.main._resolve_server")
     @patch("camera_streamer.wifi_setup.WifiSetupServer")
     @patch("camera_streamer.health.HealthMonitor")
     @patch("camera_streamer.stream.StreamManager")
@@ -17,7 +18,7 @@ class TestMainSetupMode:
     @patch("camera_streamer.config.ConfigManager")
     def test_main_waits_for_setup(
         self, MockConfig, MockCapture, MockDiscovery,
-        MockStream, MockHealth, MockSetup
+        MockStream, MockHealth, MockSetup, mock_resolve
     ):
         """Main should block while waiting for setup to complete."""
         config = MagicMock()
@@ -89,6 +90,7 @@ class TestMainSetupMode:
 class TestMainCaptureFailure:
     """Test main() when camera device isn't available."""
 
+    @patch("camera_streamer.main._resolve_server")
     @patch("camera_streamer.wifi_setup.WifiSetupServer")
     @patch("camera_streamer.health.HealthMonitor")
     @patch("camera_streamer.stream.StreamManager")
@@ -97,7 +99,7 @@ class TestMainCaptureFailure:
     @patch("camera_streamer.config.ConfigManager")
     def test_continues_without_camera(
         self, MockConfig, MockCapture, MockDiscovery,
-        MockStream, MockHealth, MockSetup
+        MockStream, MockHealth, MockSetup, mock_resolve
     ):
         """Should continue running even if camera check fails."""
         config = MagicMock()

--- a/app/server/config/avahi-homemonitor.service
+++ b/app/server/config/avahi-homemonitor.service
@@ -1,0 +1,33 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<!--
+  Avahi static service file — advertises the Home Monitor server on the LAN.
+  Cameras and browsers can find the server via mDNS:
+    - homemonitor.local (hostname)
+    - _homemonitor._tcp (service type for camera auto-discovery)
+-->
+<service-group>
+  <name replace-wildcards="yes">Home Monitor Server on %h</name>
+
+  <!-- Main web dashboard (HTTPS) -->
+  <service>
+    <type>_https._tcp</type>
+    <port>443</port>
+    <txt-record>path=/</txt-record>
+  </service>
+
+  <!-- HTTP (setup wizard, fallback) -->
+  <service>
+    <type>_http._tcp</type>
+    <port>80</port>
+    <txt-record>path=/</txt-record>
+  </service>
+
+  <!-- Custom service type for camera auto-discovery -->
+  <service>
+    <type>_homemonitor._tcp</type>
+    <port>8554</port>
+    <txt-record>version=1.0</txt-record>
+    <txt-record>role=server</txt-record>
+  </service>
+</service-group>

--- a/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
+++ b/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
@@ -22,6 +22,16 @@ else
     echo "WARNING: /data is NOT mounted — dirs will be on rootfs"
 fi
 
+# Set hostname to 'homemonitor' for mDNS — cameras reach server at homemonitor.local
+DESIRED_HOSTNAME="homemonitor"
+CURRENT_HOSTNAME=$(hostname 2>/dev/null)
+if [ "$CURRENT_HOSTNAME" != "$DESIRED_HOSTNAME" ]; then
+    echo "Setting hostname: ${CURRENT_HOSTNAME} -> ${DESIRED_HOSTNAME}"
+    hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null || \
+        echo "$DESIRED_HOSTNAME" > /etc/hostname
+    echo "Hostname set to ${DESIRED_HOSTNAME} (reachable at ${DESIRED_HOSTNAME}.local)"
+fi
+
 # Create directory structure
 echo "Creating /data directory structure..."
 mkdir -p /data/config

--- a/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
+++ b/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
@@ -19,6 +19,7 @@ SRC_URI = " \
     file://config/nginx-monitor.conf \
     file://config/nftables-server.conf \
     file://config/captive-portal-dnsmasq.conf \
+    file://config/avahi-homemonitor.service \
     file://config/logrotate-monitor.conf \
     file://setup.py \
     file://requirements.txt \
@@ -86,6 +87,10 @@ do_install() {
     # Captive portal DNS redirect (NM shared-mode dnsmasq config)
     install -d ${D}${sysconfdir}/NetworkManager/dnsmasq-shared.d
     install -m 0644 ${WORKDIR}/config/captive-portal-dnsmasq.conf ${D}${sysconfdir}/NetworkManager/dnsmasq-shared.d/captive-portal.conf
+
+    # Avahi mDNS service advertisement (cameras find server at homemonitor.local)
+    install -d ${D}${sysconfdir}/avahi/services
+    install -m 0644 ${WORKDIR}/config/avahi-homemonitor.service ${D}${sysconfdir}/avahi/services/homemonitor.service
 }
 
 FILES:${PN} = " \
@@ -96,4 +101,5 @@ FILES:${PN} = " \
     ${sysconfdir}/nftables.d/monitor.conf \
     ${sysconfdir}/logrotate.d/monitor \
     ${sysconfdir}/NetworkManager/dnsmasq-shared.d/captive-portal.conf \
+    ${sysconfdir}/avahi/services/homemonitor.service \
     "


### PR DESCRIPTION
## Summary
- **mDNS auto-discovery**: Server advertises itself as `homemonitor.local` via Avahi static service file. Cameras find the server without needing a manual IP.
- **Camera setup default**: Server address field pre-filled with `homemonitor.local` instead of empty — zero-config for most users.
- **First-boot hostname**: `hostnamectl set-hostname homemonitor` in first-boot-setup.sh.
- **README updated**: Added "First Boot Setup" section with step-by-step flow, LED status indicator table, and mDNS discovery explanation.
- **CHANGELOG.md**: Added with all recent features (captive portal, LED, hotspot fix, mDNS).

## Test plan
- [ ] Flash server image, verify `avahi-browse -r _homemonitor._tcp` shows the server
- [ ] Verify `ping homemonitor.local` works from another device on the LAN
- [ ] Camera setup page shows `homemonitor.local` as default server address
- [ ] `pytest app/camera/tests/` — 54 tests pass
- [ ] `pytest app/server/tests/` — 366 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)