### PR TITLE
Fix hostname conflicts, 502 startup, dashboard zeros, camera debug

### DIFF
--- a/app/camera/camera_streamer/capture.py
+++ b/app/camera/camera_streamer/capture.py
@@ -44,25 +44,52 @@ class CaptureManager:
 
         Returns True if the device is ready to use.
         """
+        log.info("Checking camera device %s ...", self._device)
+
+        # List all video devices for debugging
+        video_devs = [
+            f"/dev/{d}" for d in os.listdir("/dev")
+            if d.startswith("video")
+        ] if os.path.isdir("/dev") else []
+        log.info("Video devices found: %s", video_devs or "NONE")
+
         # Check device node exists
         if not os.path.exists(self._device):
-            log.error("Camera device %s not found", self._device)
+            log.error(
+                "Camera device %s not found. Available: %s. "
+                "Check ribbon cable is connected and camera overlay is enabled "
+                "(dtoverlay=ov5647 for PiHut ZeroCam in config.txt)",
+                self._device,
+                video_devs or "none",
+            )
             self._available = False
             return False
 
         # Check it's a character device (video device)
-        if not os.stat(self._device).st_mode & 0o020000:
+        mode = os.stat(self._device).st_mode
+        if not mode & 0o020000:
             # Not a char device — might be in test env
-            log.warning("%s exists but is not a character device", self._device)
+            log.warning("%s exists but is not a character device (mode=%o)", self._device, mode)
 
         # Try to query formats via v4l2-ctl
         self._formats = self._query_formats()
-        self._available = True
+        if self._formats:
+            log.info("Camera formats:\n  %s", "\n  ".join(self._formats[:20]))
+        else:
+            log.warning(
+                "No formats detected for %s — v4l2-ctl may not be installed "
+                "or camera driver not loaded. Check: lsmod | grep ov5647",
+                self._device,
+            )
+
+        h264_ok = self.supports_h264()
         log.info(
-            "Camera device %s ready (%d format(s) detected)",
+            "Camera device %s ready — %d format(s), H.264=%s",
             self._device,
             len(self._formats),
+            "YES" if h264_ok else "NO (will try anyway)",
         )
+        self._available = True
         return True
 
     def supports_h264(self):

--- a/app/camera/camera_streamer/main.py
+++ b/app/camera/camera_streamer/main.py
@@ -97,10 +97,23 @@ def main():
         _resolve_server(config)
 
     # 3. Validate camera device
+    log.info("--- Camera Hardware Check ---")
     from camera_streamer.capture import CaptureManager
     capture = CaptureManager()
     if not capture.check():
-        log.error("Camera device not available — will retry via health monitor")
+        log.error(
+            "Camera device not available. Troubleshooting:\n"
+            "  1. Check ribbon cable is seated firmly (blue side to board)\n"
+            "  2. Check config.txt has: start_x=1 and gpu_mem=128\n"
+            "  3. For PiHut ZeroCam (OV5647): dtoverlay=ov5647\n"
+            "  4. Run: vcgencmd get_camera\n"
+            "  5. Run: ls -la /dev/video*\n"
+            "  6. Run: dmesg | grep -i camera\n"
+            "Will retry via health monitor..."
+        )
+    else:
+        log.info("Camera hardware OK: device=%s h264=%s",
+                 capture.device, capture.supports_h264())
 
     # 4. Start mDNS advertisement
     from camera_streamer.discovery import DiscoveryService

--- a/app/camera/camera_streamer/stream.py
+++ b/app/camera/camera_streamer/stream.py
@@ -121,6 +121,25 @@ class StreamManager:
         """Launch the ffmpeg process."""
         cmd = self._build_ffmpeg_cmd()
         log.info("Starting ffmpeg: %s", " ".join(cmd))
+        log.info(
+            "Stream config: device=/dev/video0 resolution=%dx%d fps=%d "
+            "server=%s:%s camera_id=%s",
+            self._config.width, self._config.height, self._config.fps,
+            self._config.server_ip, self._config.server_port,
+            self._config.camera_id,
+        )
+        log.info("RTSP target URL: %s", self._config.rtsp_url)
+
+        # Check if ffmpeg is installed
+        import shutil
+        if not shutil.which("ffmpeg"):
+            log.error("ffmpeg binary not found in PATH — cannot stream")
+            return
+
+        # Check if video device exists before starting
+        if not os.path.exists("/dev/video0"):
+            log.error("/dev/video0 not found — camera not detected")
+            return
 
         with self._lock:
             self._process = subprocess.Popen(

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -497,8 +497,8 @@ input:focus { border-color: #e94560; }
     <div class="card">
       <h3>Server Connection</h3>
       <label>Server Address</label>
-      <input type="text" id="in-server" value="homemonitor.local" placeholder="homemonitor.local or 192.168.1.x">
-      <div class="hint">Default: homemonitor.local (auto-discovery). Or enter server IP manually.</div>
+      <input type="text" id="in-server" value="" placeholder="homemonitor-XXXX.local or 192.168.1.x">
+      <div class="hint">Enter your server's address. Find it on the server setup complete screen (e.g. homemonitor-a1b2.local) or use the server's IP address.</div>
       <label>RTSP Port</label>
       <input type="text" id="in-port" value="8554">
     </div>

--- a/app/server/config/nginx-monitor.conf
+++ b/app/server/config/nginx-monitor.conf
@@ -20,6 +20,14 @@ server {
     # Samsung
     location = /gen_204 { return 302 http://$host/api/v1/setup/wizard; }
 
+    # 502 handler — Flask not ready yet, auto-refresh until it is
+    error_page 502 /502.html;
+    location = /502.html {
+        internal;
+        default_type text/html;
+        return 200 '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="3"><title>Starting...</title><style>body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}.card{background:#16213e;border-radius:12px;padding:32px;text-align:center;max-width:320px}h2{color:#fff;margin-bottom:12px}.spinner{width:32px;height:32px;border:3px solid rgba(255,255,255,.2);border-top-color:#e94560;border-radius:50%;animation:s .7s linear infinite;margin:0 auto 16px}@keyframes s{to{transform:rotate(360deg)}}</style></head><body><div class="card"><div class="spinner"></div><h2>Starting Up</h2><p>Home Monitor is loading...<br>This page will refresh automatically.</p></div></body></html>';
+    }
+
     # Proxy to Flask app
     location / {
         proxy_pass http://127.0.0.1:5000;
@@ -79,6 +87,14 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
+
+    # 502 handler — Flask not ready yet, auto-refresh until it is
+    error_page 502 /502.html;
+    location = /502.html {
+        internal;
+        default_type text/html;
+        return 200 '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="3"><title>Starting...</title><style>body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}.card{background:#16213e;border-radius:12px;padding:32px;text-align:center;max-width:320px}h2{color:#fff;margin-bottom:12px}.spinner{width:32px;height:32px;border:3px solid rgba(255,255,255,.2);border-top-color:#e94560;border-radius:50%;animation:s .7s linear infinite;margin:0 auto 16px}@keyframes s{to{transform:rotate(360deg)}}</style></head><body><div class="card"><div class="spinner"></div><h2>Starting Up</h2><p>Home Monitor is loading...<br>This page will refresh automatically.</p></div></body></html>';
+    }
 
     # Proxy to Flask app
     location / {

--- a/app/server/monitor/provisioning.py
+++ b/app/server/monitor/provisioning.py
@@ -332,10 +332,15 @@ def setup_complete():
         ip_address or "unknown",
     )
 
+    # Get the actual hostname for mDNS address
+    import socket
+    hostname = socket.gethostname()
+    mdns_address = f"{hostname}.local"
+
     return jsonify({
         "message": "Setup complete",
         "ip": ip_address,
-        "hostname": "homemonitor.local",
+        "hostname": mdns_address,
     }), 200
 
 

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -70,22 +70,20 @@
                 var memEl = document.getElementById('health-mem');
                 var diskEl = document.getElementById('health-disk');
 
-                var temp = data.cpu_temp || 0;
-                tempEl.textContent = window.HM.formatTemp(temp);
+                // API returns: cpu_temp_c, cpu_usage_percent, memory.percent, disk.percent
+                var temp = data.cpu_temp_c || 0;
+                tempEl.textContent = temp.toFixed(1) + '\u00B0C';
                 tempEl.className = 'health-card__value ' + tempColor(temp);
 
-                var cpu = data.cpu_percent || 0;
+                var cpu = data.cpu_usage_percent || 0;
                 cpuEl.textContent = cpu.toFixed(0) + '%';
                 cpuEl.className = 'health-card__value ' + usageColor(cpu);
 
-                var mem = data.memory_percent || 0;
+                var mem = (data.memory && data.memory.percent) || 0;
                 memEl.textContent = mem.toFixed(0) + '%';
                 memEl.className = 'health-card__value ' + usageColor(mem);
 
-                var disk = 0;
-                if (data.disk && data.disk.percent !== undefined) {
-                    disk = data.disk.percent;
-                }
+                var disk = (data.disk && data.disk.percent) || 0;
                 diskEl.textContent = disk.toFixed(0) + '%';
                 diskEl.className = 'health-card__value ' + usageColor(disk);
 
@@ -106,7 +104,12 @@
         window.HM.api.get('/api/v1/system/info')
             .then(function(data) {
                 var uptimeEl = document.getElementById('health-uptime');
-                uptimeEl.textContent = data.uptime || '--';
+                // uptime is {seconds, display} from API
+                if (data.uptime && data.uptime.display) {
+                    uptimeEl.textContent = data.uptime.display;
+                } else {
+                    uptimeEl.textContent = data.uptime || '--';
+                }
             })
             .catch(function() {});
     }

--- a/app/server/monitor/templates/setup.html
+++ b/app/server/monitor/templates/setup.html
@@ -511,7 +511,7 @@
                     <p style="text-align:center;">Your server is now on your home WiFi.</p>
 
                     <div class="ip-display" id="done-ip-display" style="font-size:1.15rem;">
-                        https://homemonitor.local/
+                        Connecting...
                     </div>
                     <div id="done-ip-fallback" style="text-align:center;font-size:0.8rem;color:#607090;margin-top:-8px;margin-bottom:12px;display:none;">
                         Or try: <span id="done-ip-raw" style="color:#4ade80;"></span>
@@ -771,6 +771,15 @@
                     /* Success — show the done panel.
                        User may or may not see this (hotspot is dying). */
                     var ip = res.data.ip || '';
+                    var hostname = res.data.hostname || '';
+
+                    /* Show the mDNS hostname as primary address */
+                    if (hostname) {
+                        document.getElementById('done-ip-display').textContent = 'https://' + hostname + '/';
+                    } else if (ip) {
+                        document.getElementById('done-ip-display').textContent = 'https://' + ip + '/';
+                    }
+                    /* Show IP as fallback */
                     if (ip) {
                         document.getElementById('done-ip-raw').textContent = 'https://' + ip + '/';
                         document.getElementById('done-ip-fallback').style.display = 'block';

--- a/app/server/tests/test_provisioning.py
+++ b/app/server/tests/test_provisioning.py
@@ -199,10 +199,11 @@ class TestSetupComplete:
         stamp = os.path.join(app.config["DATA_DIR"], ".setup-done")
         assert os.path.isfile(stamp)
 
-        # Verify response has IP + hostname
+        # Verify response has IP + hostname (dynamic, not hardcoded)
         data = response.get_json()
         assert data["ip"] == "192.168.1.42"
-        assert data["hostname"] == "homemonitor.local"
+        assert data["hostname"].endswith(".local")
+        assert len(data["hostname"]) > len(".local")
 
     @patch("monitor.provisioning.threading.Timer")
     @patch("monitor.provisioning.subprocess.run")

--- a/config/zero2w/local.conf
+++ b/config/zero2w/local.conf
@@ -22,7 +22,12 @@ SSTATE_DIR = "${TOPDIR}/../sstate-cache"
 
 # --- RPi Zero 2W hardware settings ---
 ENABLE_UART = "1"
-GPU_MEM = "64"
+GPU_MEM = "128"
 RASPBERRYPI_CAMERA_V2 = "1"
 MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-rpidistro-bcm43436s"
 KERNEL_IMAGETYPE = "Image"
+
+# --- Camera support ---
+# PiHut ZeroCam uses OV5647 sensor (RPi Camera V1 compatible).
+# Enable both V1 and V2 overlays so either camera module works.
+KERNEL_DEVICETREE_OVERLAYS:append = " overlays/ov5647.dtbo"

--- a/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
+++ b/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
@@ -22,13 +22,27 @@ else
     echo "WARNING: /data is NOT mounted — dirs will be on rootfs"
 fi
 
-# Set hostname to 'homemonitor' for mDNS — cameras reach server at homemonitor.local
-DESIRED_HOSTNAME="homemonitor"
+# Set unique hostname using RPi serial suffix — avoids mDNS conflicts.
+# Format: homemonitor-XXXX where XXXX = last 4 hex digits of CPU serial.
+# The camera setup wizard shows this hostname so the user knows exactly
+# what to enter, or they can use the IP address instead.
+SERIAL=$(grep -oP 'Serial\s*:\s*\K[0-9a-f]+' /proc/cpuinfo 2>/dev/null || echo "")
+if [ -n "$SERIAL" ]; then
+    SUFFIX=$(echo "$SERIAL" | tail -c 5)
+    DESIRED_HOSTNAME="homemonitor-${SUFFIX}"
+else
+    DESIRED_HOSTNAME="homemonitor"
+fi
+
 CURRENT_HOSTNAME=$(hostname 2>/dev/null)
 if [ "$CURRENT_HOSTNAME" != "$DESIRED_HOSTNAME" ]; then
     echo "Setting hostname: ${CURRENT_HOSTNAME} -> ${DESIRED_HOSTNAME}"
     hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null || \
         echo "$DESIRED_HOSTNAME" > /etc/hostname
+    # Restart avahi so it picks up the new hostname immediately
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl restart avahi-daemon 2>/dev/null || true
+    fi
     echo "Hostname set to ${DESIRED_HOSTNAME} (reachable at ${DESIRED_HOSTNAME}.local)"
 fi
 


### PR DESCRIPTION
## Summary
- **Unique hostname:** `homemonitor-XXXX` (CPU serial suffix) — no more mDNS conflicts with other devices
- **502 fix:** NGINX shows "Starting Up" page with auto-refresh while Flask loads, instead of ugly Bad Gateway
- **Dashboard fix:** Health values were all zeros — field name mismatch between API (`cpu_temp_c`) and JS (`cpu_temp`)
- **Camera debug:** Detailed logging for V4L2 detection, ffmpeg startup, troubleshooting hints. Added OV5647 overlay for PiHut ZeroCam. GPU_MEM 64→128.
- **Camera setup:** Server address field now blank (user enters their specific `homemonitor-XXXX.local` or IP)

## Test plan
- [x] 371 server tests pass (91% coverage)
- [x] 139 camera tests pass (82% coverage)
- [ ] Flash server — verify unique hostname, 502 page, dashboard health values
- [ ] Flash camera — verify ZeroCam detection, debug logs visible


🤖 Generated with [Claude Code](https://claude.com/claude-code)