### PR TITLE
feat: extract RecordingsService, fix auth rate-limit, clean re-exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Full rules in [`docs/development-guide.md`](docs/development-guide.md) Section 3
 | OTA API | `api/ota.py` | PARTIAL | Status endpoint works; upload/push endpoints are stubs |
 | Streaming svc | `services/streaming_service.py` | COMPLETE | Manages FFmpeg pipelines: HLS + recorder + snapshots per camera |
 | Recorder svc | `services/recorder_service.py` | COMPLETE | Clip metadata, listing, deletion (actual recording done by streaming svc) |
+| Recordings svc | `services/recordings_service.py` | COMPLETE | Orchestrates clip queries + deletion with camera validation + audit |
 | Health svc | `services/health.py` | COMPLETE | CPU temp, RAM, disk, uptime. Warns at CPU>70C, disk>85%, RAM>90% |
 | Audit svc | `services/audit.py` | COMPLETE | Append-only JSON audit log at /data/logs/audit.log |
 | Discovery svc | `services/discovery.py` | PARTIAL | Camera online/offline tracking, pending camera reports |
@@ -233,9 +234,9 @@ Full rules in [`docs/development-guide.md`](docs/development-guide.md) Section 3
 
 ## Tests
 
-- **Server:** 760 tests, 89% coverage (`python -m pytest app/server/tests/ -v`)
-- **Camera:** 269 tests, 82% coverage (`python -m pytest app/camera/tests/ -v`)
-- **Total:** 1029 tests
+- **Server:** 777 tests, 90% coverage (`python -m pytest app/server/tests/ -v`)
+- **Camera:** 268 tests, 82% coverage (`python -m pytest app/camera/tests/ -v`)
+- **Total:** 1045 tests
 
 ## PR History
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 | Live View | HLS streaming in any mobile browser |
 | Recording | Continuous 3-minute MP4 clips, organized by camera/date |
 | Camera Management | Auto-discovery, confirm/rename/remove via dashboard |
-| User Auth | Server: bcrypt + CSRF + rate limiting. Camera: PBKDF2-SHA256 + sessions |
+| User Auth | Server: bcrypt + CSRF + rate limiting. Camera: PBKDF2-SHA256 + sessions. **Note:** a default `admin`/`admin` account is created on first boot — change the password during setup |
 | Role-Based Access | Admin (full control) and Viewer (read-only) roles |
 | System Health | CPU temp, memory, disk usage, uptime monitoring |
 | Storage Management | Automatic cleanup of oldest clips when disk is full |
@@ -77,6 +77,21 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 | Audit Logging | All admin actions logged (append-only) |
 | Encrypted Storage | LUKS-encrypted /data partition for recordings and config |
 | Firewall | nftables — cameras can only talk to server, minimal open ports |
+
+### Security Feature Status
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| HTTPS (TLS) | **Implemented** | Self-signed certs, NGINX terminates TLS |
+| bcrypt auth + CSRF | **Implemented** | Cost 12, rate limiting (warn at 5, block at 10) |
+| Session management | **Implemented** | 30min idle / 24hr absolute timeout |
+| LUKS encryption | **Implemented** | /data partition encrypted at rest |
+| nftables firewall | **Implemented** | Default DROP, minimal open ports |
+| Audit logging | **Implemented** | Append-only JSON, all admin actions |
+| Default admin warning | **Implemented** | `admin`/`admin` created on first boot, must change during setup |
+| RTSPS (mTLS) | **Planned (Phase 2)** | Camera→server streams currently use plaintext RTSP |
+| mTLS camera pairing | **Planned (Phase 2)** | Certificate exchange for camera authentication |
+| Signed OTA updates | **Partial** | Status endpoint works; upload/verify are stubs |
 
 ## Quick Start
 
@@ -111,11 +126,11 @@ First build takes 2-4 hours. Subsequent builds use cached artifacts and are much
 ## Run Tests
 
 ```bash
-cd app/server && pytest    # 371 tests, 88% coverage (threshold: 80%)
-cd app/camera && pytest    # 164 tests, 63% coverage (threshold: 55%)
+cd app/server && pytest    # 777 tests, 90% coverage (threshold: 80%)
+cd app/camera && pytest    # 268 tests, 82% coverage (threshold: 55%)
 ```
 
-**535 total tests.** Results and coverage reports are available in the [CI workflow](https://github.com/vinu-engineer/rpi-home-monitor/actions).
+**1045 total tests.** Results and coverage reports are available in the [CI workflow](https://github.com/vinu-engineer/rpi-home-monitor/actions).
 
 ## Documentation
 

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -26,8 +26,9 @@ from camera_streamer.capture import CaptureManager
 from camera_streamer.discovery import DiscoveryService
 from camera_streamer.health import HealthMonitor
 from camera_streamer.led import LedController
+from camera_streamer.status_server import CameraStatusServer
 from camera_streamer.stream import StreamManager
-from camera_streamer.wifi_setup import CameraStatusServer, WifiSetupServer
+from camera_streamer.wifi_setup import WifiSetupServer
 
 log = logging.getLogger("camera-streamer.lifecycle")
 

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -217,7 +217,6 @@ class WifiSetupServer:
         return self._cached_networks
 
 
-
 # ============================================================
 # Setup page HTTP handler (first boot — no auth required)
 # ============================================================

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -217,29 +217,6 @@ class WifiSetupServer:
         return self._cached_networks
 
 
-# ---- Backward compatibility re-exports ----
-# Existing code and tests import these from wifi_setup
-from camera_streamer.wifi import HOTSPOT_CONN_NAME as CONN_NAME  # noqa: F401, E402
-from camera_streamer.wifi import HOTSPOT_PASS  # noqa: F401, E402
-from camera_streamer.wifi import HOTSPOT_SSID  # noqa: F401, E402
-from camera_streamer.status_server import (  # noqa: F401, E402
-    SESSION_TIMEOUT,
-    CameraStatusServer,
-    _check_session,
-    _create_session,
-    _destroy_session,
-    _get_cpu_temp,
-    _get_memory_mb,
-    _get_session_cookie,
-    _get_uptime,
-    _html_escape,
-    _session_lock,
-    _sessions,
-)
-
-# Legacy constant — tests reference this
-IFACE = "wlan0"
-
 
 # ============================================================
 # Setup page HTTP handler (first boot — no auth required)

--- a/app/camera/tests/test_wifi_setup.py
+++ b/app/camera/tests/test_wifi_setup.py
@@ -4,22 +4,27 @@ import os
 from unittest.mock import MagicMock, patch
 
 from camera_streamer import wifi
-from camera_streamer.wifi_setup import (
-    CONN_NAME,
-    CONNECT_DELAY,
-    HOTSPOT_PASS,
-    HOTSPOT_SSID,
-    IFACE,
+from camera_streamer.status_server import (
     SESSION_TIMEOUT,
     CameraStatusServer,
-    WifiSetupServer,
     _check_session,
     _create_session,
     _destroy_session,
     _get_session_cookie,
-    _make_handler,
     _session_lock,
     _sessions,
+)
+from camera_streamer.wifi import (
+    HOTSPOT_CONN_NAME as CONN_NAME,
+)
+from camera_streamer.wifi import (
+    HOTSPOT_PASS,
+    HOTSPOT_SSID,
+)
+from camera_streamer.wifi_setup import (
+    CONNECT_DELAY,
+    WifiSetupServer,
+    _make_handler,
     is_setup_complete,
     mark_setup_complete,
 )
@@ -540,7 +545,7 @@ class TestSystemInfoHelpers:
 
     def test_get_cpu_temp(self):
         """Should return float temperature."""
-        from camera_streamer.wifi_setup import _get_cpu_temp
+        from camera_streamer.status_server import _get_cpu_temp
 
         with patch(
             "builtins.open",
@@ -564,14 +569,14 @@ class TestSystemInfoHelpers:
 
     def test_get_uptime(self):
         """Should return human-readable uptime string."""
-        from camera_streamer.wifi_setup import _get_uptime
+        from camera_streamer.status_server import _get_uptime
 
         with patch("builtins.open", side_effect=OSError("no file")):
             assert _get_uptime() == "0m"
 
     def test_get_memory_mb(self):
         """Should return (total, used) tuple."""
-        from camera_streamer.wifi_setup import _get_memory_mb
+        from camera_streamer.status_server import _get_memory_mb
 
         with patch("builtins.open", side_effect=OSError("no file")):
             total, used = _get_memory_mb()
@@ -603,10 +608,6 @@ class TestSetupHTTPHandler:
     def test_connection_name(self):
         """Connection name should match SSID."""
         assert CONN_NAME == "HomeCam-Setup"
-
-    def test_interface(self):
-        """Interface should be wlan0."""
-        assert IFACE == "wlan0"
 
     def test_connect_delay(self):
         """Connect delay should be positive (give phone time to receive response)."""

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -14,6 +14,7 @@ from monitor.logging_config import configure_logging
 from monitor.services.audit import AuditLogger
 from monitor.services.camera_service import CameraService
 from monitor.services.provisioning_service import ProvisioningService
+from monitor.services.recordings_service import RecordingsService
 from monitor.services.settings_service import SettingsService
 from monitor.services.storage_manager import StorageManager
 from monitor.services.storage_service import StorageService
@@ -158,6 +159,15 @@ def _init_services(app):
 
     # User service — user CRUD + password management
     app.user_service = UserService(store=app.store, audit=app.audit)
+
+    # Recordings service — clip queries, deletion, audit
+    app.recordings_service = RecordingsService(
+        storage_manager=app.storage_manager,
+        store=app.store,
+        audit=app.audit,
+        live_dir=app.config["LIVE_DIR"],
+        default_recordings_dir=recordings_dir,
+    )
 
     # Settings service — system config + WiFi management
     app.settings_service = SettingsService(store=app.store, audit=app.audit)

--- a/app/server/monitor/api/recordings.py
+++ b/app/server/monitor/api/recordings.py
@@ -1,97 +1,66 @@
 """
-Recordings API.
+Recordings API — thin HTTP adapter.
+
+Delegates all business logic to RecordingsService.
 
 Endpoints:
   GET    /recordings/<cam-id>?date=YYYY-MM-DD  - list clips for a camera/date
   GET    /recordings/<cam-id>/dates             - list dates with clips
   GET    /recordings/<cam-id>/latest            - most recent clip
+  GET    /recordings/<cam-id>/<date>/<filename> - serve a clip file
   DELETE /recordings/<cam-id>/<date>/<filename> - delete a clip (admin)
 """
-
-import os
-from dataclasses import asdict
 
 from flask import Blueprint, current_app, jsonify, request, send_file, session
 
 from monitor.auth import admin_required, login_required
-from monitor.services.recorder_service import RecorderService
 
 recordings_bp = Blueprint("recordings", __name__)
 
 
-def _get_recorder() -> RecorderService:
-    """Get recorder service using the current recordings directory.
-
-    Uses StorageManager's live path (which may be USB) rather than
-    the static RECORDINGS_DIR from config.
-    """
-    storage = getattr(current_app, "storage_manager", None)
-    recordings_dir = (
-        storage.recordings_dir if storage else current_app.config["RECORDINGS_DIR"]
-    )
-    return RecorderService(
-        recordings_dir,
-        current_app.config["LIVE_DIR"],
-    )
+def _svc():
+    """Get the recordings service from the app."""
+    return current_app.recordings_service
 
 
 @recordings_bp.route("/<camera_id>", methods=["GET"])
 @login_required
 def list_clips(camera_id):
     """List clips for a camera, optionally filtered by date."""
-    # Verify camera exists
-    camera = current_app.store.get_camera(camera_id)
-    if camera is None:
-        return jsonify({"error": "Camera not found"}), 404
-
     clip_date = request.args.get("date", "")
-    recorder = _get_recorder()
-    clips = recorder.list_clips(camera_id, clip_date)
-
-    return jsonify([asdict(c) for c in clips]), 200
+    result, error, status = _svc().list_clips(camera_id, clip_date)
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
 
 
 @recordings_bp.route("/<camera_id>/dates", methods=["GET"])
 @login_required
 def list_dates(camera_id):
     """List dates that have recordings for a camera."""
-    camera = current_app.store.get_camera(camera_id)
-    if camera is None:
-        return jsonify({"error": "Camera not found"}), 404
-
-    recorder = _get_recorder()
-    dates = recorder.get_dates_with_clips(camera_id)
-    return jsonify({"camera_id": camera_id, "dates": dates}), 200
+    result, error, status = _svc().list_dates(camera_id)
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
 
 
 @recordings_bp.route("/<camera_id>/latest", methods=["GET"])
 @login_required
 def latest_clip(camera_id):
     """Get the most recent clip for a camera."""
-    camera = current_app.store.get_camera(camera_id)
-    if camera is None:
-        return jsonify({"error": "Camera not found"}), 404
-
-    recorder = _get_recorder()
-    clip = recorder.get_latest_clip(camera_id)
-    if clip is None:
-        return jsonify({"error": "No recordings found"}), 404
-
-    return jsonify(asdict(clip)), 200
+    result, error, status = _svc().latest_clip(camera_id)
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
 
 
 @recordings_bp.route("/<camera_id>/<clip_date>/<filename>", methods=["GET"])
 @login_required
 def get_clip(camera_id, clip_date, filename):
-    """Serve a clip file. Works for both internal and USB storage."""
-    if not filename.endswith(".mp4"):
-        return jsonify({"error": "Invalid filename"}), 400
-
-    recorder = _get_recorder()
-    clip_path = os.path.join(recorder._recordings_dir, camera_id, clip_date, filename)
-    if not os.path.isfile(clip_path):
-        return jsonify({"error": "Clip not found"}), 404
-
+    """Serve a clip file."""
+    clip_path, error, status = _svc().resolve_clip_path(camera_id, clip_date, filename)
+    if error:
+        return jsonify({"error": error}), status
     return send_file(clip_path, mimetype="video/mp4")
 
 
@@ -99,22 +68,13 @@ def get_clip(camera_id, clip_date, filename):
 @admin_required
 def delete_clip(camera_id, clip_date, filename):
     """Delete a specific clip. Admin only."""
-    # Basic input validation
-    if not filename.endswith(".mp4"):
-        return jsonify({"error": "Invalid filename"}), 400
-
-    recorder = _get_recorder()
-    deleted = recorder.delete_clip(camera_id, clip_date, filename)
-    if not deleted:
-        return jsonify({"error": "Clip not found"}), 404
-
-    audit = getattr(current_app, "audit", None)
-    if audit:
-        audit.log_event(
-            "CLIP_DELETED",
-            user=session.get("username", ""),
-            ip=request.remote_addr or "",
-            detail=f"deleted {camera_id}/{clip_date}/{filename}",
-        )
-
-    return jsonify({"message": "Clip deleted"}), 200
+    result, error, status = _svc().delete_clip(
+        camera_id,
+        clip_date,
+        filename,
+        requesting_user=session.get("username", ""),
+        requesting_ip=request.remote_addr or "",
+    )
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status

--- a/app/server/monitor/auth.py
+++ b/app/server/monitor/auth.py
@@ -60,10 +60,15 @@ def generate_csrf_token() -> str:
     return token
 
 
-def _check_rate_limit(ip: str) -> bool:
+def _check_rate_limit(ip: str) -> tuple[bool, bool]:
     """Check if an IP has exceeded the login rate limit.
 
-    Returns True if the request should be allowed, False if blocked.
+    Two-tier system:
+    - RATE_LIMIT_MAX (5): soft limit — request allowed but a warning is logged.
+    - RATE_LIMIT_BLOCK (10): hard limit — request is rejected (HTTP 429).
+
+    Returns:
+        (allowed, warn) — allowed=False means block; warn=True means soft limit hit.
     """
     now = time.time()
     attempts = _login_attempts.get(ip, [])
@@ -71,7 +76,12 @@ def _check_rate_limit(ip: str) -> bool:
     attempts = [t for t in attempts if now - t < RATE_LIMIT_WINDOW]
     _login_attempts[ip] = attempts
 
-    return len(attempts) < RATE_LIMIT_BLOCK
+    count = len(attempts)
+    if count >= RATE_LIMIT_BLOCK:
+        return False, False  # hard block
+    if count >= RATE_LIMIT_MAX:
+        return True, True  # allowed but warned
+    return True, False  # normal
 
 
 def _record_attempt(ip: str):
@@ -160,11 +170,14 @@ def login():
     ip = request.remote_addr or ""
     audit = _get_audit_logger()
 
-    # Rate limiting
-    if not _check_rate_limit(ip):
+    # Rate limiting (two-tier: warn at 5, block at 10)
+    allowed, warn = _check_rate_limit(ip)
+    if not allowed:
         if audit:
-            audit.log_event("LOGIN_FAILED", ip=ip, detail="rate limited")
+            audit.log_event("LOGIN_BLOCKED", ip=ip, detail="rate limited (hard block)")
         return jsonify({"error": "Too many login attempts. Try again later."}), 429
+    if warn and audit:
+        audit.log_event("LOGIN_RATE_WARN", ip=ip, detail="approaching rate limit")
 
     data = request.get_json(silent=True)
     if not data or not data.get("username") or not data.get("password"):

--- a/app/server/monitor/services/__init__.py
+++ b/app/server/monitor/services/__init__.py
@@ -15,6 +15,7 @@ Services:
   storage_manager.py      - StorageManager: FIFO loop recording cleanup, disk monitoring
   streaming_service.py    - StreamingService: ffmpeg pipeline management (HLS, recording, snapshots)
   recorder_service.py     - RecorderService: clip metadata, listing, deletion
+  recordings_service.py   - RecordingsService: orchestrates clip queries + deletion + audit
   discovery.py            - DiscoveryService: camera discovery via Avahi/mDNS
   audit.py                - AuditLogger: append-only security event log
   health.py               - HealthService: CPU temp, RAM, disk, uptime

--- a/app/server/monitor/services/recordings_service.py
+++ b/app/server/monitor/services/recordings_service.py
@@ -1,0 +1,162 @@
+"""
+Recordings service — orchestrates clip queries and deletion.
+
+Thin service layer over RecorderService that adds:
+- Camera existence validation (via store)
+- Audit logging for destructive actions
+- Storage-aware recordings directory resolution
+
+Routes in api/recordings.py delegate here; they never touch
+the store or audit logger directly.
+"""
+
+import logging
+from dataclasses import asdict
+from pathlib import Path
+
+from monitor.services.recorder_service import RecorderService
+
+log = logging.getLogger("monitor.recordings-service")
+
+
+class RecordingsService:
+    """Business logic for recording queries and management.
+
+    Args:
+        storage_manager: StorageManager (provides recordings_dir).
+        store: Store for camera existence checks.
+        audit: AuditLogger (optional, for delete events).
+        live_dir: Path to HLS live segments directory.
+        default_recordings_dir: Fallback if storage_manager is None.
+    """
+
+    def __init__(
+        self,
+        storage_manager,
+        store,
+        audit=None,
+        live_dir="",
+        default_recordings_dir="",
+    ):
+        self._storage_manager = storage_manager
+        self._store = store
+        self._audit = audit
+        self._live_dir = live_dir
+        self._default_recordings_dir = default_recordings_dir
+
+    def _get_recorder(self) -> RecorderService:
+        """Build a RecorderService using the current recordings directory."""
+        if self._storage_manager:
+            recordings_dir = self._storage_manager.recordings_dir
+        else:
+            recordings_dir = self._default_recordings_dir
+        return RecorderService(recordings_dir, self._live_dir)
+
+    def _log_audit(self, event, **kwargs):
+        """Log an audit event (fail-silent)."""
+        if not self._audit:
+            return
+        try:
+            self._audit.log_event(event, **kwargs)
+        except Exception:
+            log.debug("Audit log failed for %s", event)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def list_clips(self, camera_id: str, date: str = ""):
+        """List clips for a camera on a date.
+
+        Returns:
+            (list[dict], None, 200) on success.
+            (None, error_message, status_code) on failure.
+        """
+        camera = self._store.get_camera(camera_id)
+        if camera is None:
+            return None, "Camera not found", 404
+
+        recorder = self._get_recorder()
+        clips = recorder.list_clips(camera_id, date)
+        return [asdict(c) for c in clips], None, 200
+
+    def list_dates(self, camera_id: str):
+        """List dates that have recordings for a camera.
+
+        Returns:
+            (dict, None, 200) on success.
+            (None, error_message, 404) if camera not found.
+        """
+        camera = self._store.get_camera(camera_id)
+        if camera is None:
+            return None, "Camera not found", 404
+
+        recorder = self._get_recorder()
+        dates = recorder.get_dates_with_clips(camera_id)
+        return {"camera_id": camera_id, "dates": dates}, None, 200
+
+    def latest_clip(self, camera_id: str):
+        """Get the most recent clip for a camera.
+
+        Returns:
+            (dict, None, 200) on success.
+            (None, error_message, status_code) on failure.
+        """
+        camera = self._store.get_camera(camera_id)
+        if camera is None:
+            return None, "Camera not found", 404
+
+        recorder = self._get_recorder()
+        clip = recorder.get_latest_clip(camera_id)
+        if clip is None:
+            return None, "No recordings found", 404
+
+        return asdict(clip), None, 200
+
+    def resolve_clip_path(self, camera_id: str, date: str, filename: str):
+        """Resolve the full path to a clip file.
+
+        Returns:
+            (Path, None, 200) if file exists.
+            (None, error_message, status_code) on failure.
+        """
+        if not filename.endswith(".mp4"):
+            return None, "Invalid filename", 400
+
+        recorder = self._get_recorder()
+        clip_path = Path(recorder._recordings_dir) / camera_id / date / filename
+        if not clip_path.is_file():
+            return None, "Clip not found", 404
+
+        return clip_path, None, 200
+
+    def delete_clip(
+        self,
+        camera_id: str,
+        date: str,
+        filename: str,
+        requesting_user: str = "",
+        requesting_ip: str = "",
+    ):
+        """Delete a clip and log the action.
+
+        Returns:
+            (dict, None, 200) on success.
+            (None, error_message, status_code) on failure.
+        """
+        if not filename.endswith(".mp4"):
+            return None, "Invalid filename", 400
+
+        recorder = self._get_recorder()
+        deleted = recorder.delete_clip(camera_id, date, filename)
+        if not deleted:
+            return None, "Clip not found", 404
+
+        self._log_audit(
+            "CLIP_DELETED",
+            user=requesting_user,
+            ip=requesting_ip,
+            detail=f"deleted {camera_id}/{date}/{filename}",
+        )
+
+        return {"message": "Clip deleted"}, None, 200

--- a/app/server/tests/test_auth.py
+++ b/app/server/tests/test_auth.py
@@ -4,7 +4,13 @@ import time
 
 import pytest
 
-from monitor.auth import _login_attempts, check_password, hash_password
+from monitor.auth import (
+    _check_rate_limit,
+    _login_attempts,
+    _record_attempt,
+    check_password,
+    hash_password,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -243,6 +249,34 @@ class TestRateLimiting:
             },
         )
         assert response.status_code == 429
+
+    def test_check_rate_limit_two_tier(self):
+        """_check_rate_limit returns (allowed, warn) tuple."""
+        ip = "10.0.0.99"
+        # Under soft limit — allowed, no warn
+        for _ in range(4):
+            _record_attempt(ip)
+        allowed, warn = _check_rate_limit(ip)
+        assert allowed is True
+        assert warn is False
+
+        # At soft limit (5) — allowed, warn=True
+        _record_attempt(ip)
+        allowed, warn = _check_rate_limit(ip)
+        assert allowed is True
+        assert warn is True
+
+        # Between soft and hard limit
+        for _ in range(4):
+            _record_attempt(ip)
+        allowed, warn = _check_rate_limit(ip)
+        assert allowed is True
+        assert warn is True
+
+        # At hard limit (10) — blocked
+        _record_attempt(ip)
+        allowed, warn = _check_rate_limit(ip)
+        assert allowed is False
 
 
 class TestCSRF:

--- a/app/server/tests/test_svc_recordings.py
+++ b/app/server/tests/test_svc_recordings.py
@@ -138,7 +138,9 @@ class TestResolveClipPath:
     """Test resolve_clip_path."""
 
     def test_invalid_filename(self, svc):
-        result, error, status = svc.resolve_clip_path("cam-001", "2026-04-09", "bad.txt")
+        result, error, status = svc.resolve_clip_path(
+            "cam-001", "2026-04-09", "bad.txt"
+        )
         assert error == "Invalid filename"
         assert status == 400
 
@@ -167,9 +169,7 @@ class TestDeleteClip:
         assert status == 400
 
     def test_not_found(self, svc):
-        result, error, status = svc.delete_clip(
-            "cam-001", "2026-04-09", "99-99-99.mp4"
-        )
+        result, error, status = svc.delete_clip("cam-001", "2026-04-09", "99-99-99.mp4")
         assert error == "Clip not found"
         assert status == 404
 
@@ -198,9 +198,7 @@ class TestDeleteClip:
             live_dir=str(tmp_path / "live"),
         )
         _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-30-00")
-        result, error, status = svc.delete_clip(
-            "cam-001", "2026-04-09", "14-30-00.mp4"
-        )
+        result, error, status = svc.delete_clip("cam-001", "2026-04-09", "14-30-00.mp4")
         assert error is None
         assert status == 200
 

--- a/app/server/tests/test_svc_recordings.py
+++ b/app/server/tests/test_svc_recordings.py
@@ -1,0 +1,223 @@
+"""Tests for the recordings service (orchestration layer)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from monitor.models import Camera, Clip
+from monitor.services.recordings_service import RecordingsService
+
+
+def _make_clip(cam_id="cam-001", date="2026-04-09", time="14-30-00", size=1024):
+    """Helper: create a fake clip file on disk and return path."""
+    return Clip(
+        camera_id=cam_id,
+        filename=f"{time}.mp4",
+        date=date,
+        start_time=time.replace("-", ":"),
+        size_bytes=size,
+        thumbnail="",
+    )
+
+
+def _make_camera(cam_id="cam-001"):
+    return Camera(
+        id=cam_id,
+        name="Test Cam",
+        status="online",
+    )
+
+
+@pytest.fixture
+def store():
+    s = MagicMock()
+    s.get_camera.return_value = _make_camera()
+    return s
+
+
+@pytest.fixture
+def storage_manager(tmp_path):
+    sm = MagicMock()
+    rec_dir = tmp_path / "recordings"
+    rec_dir.mkdir()
+    sm.recordings_dir = str(rec_dir)
+    return sm
+
+
+@pytest.fixture
+def audit():
+    return MagicMock()
+
+
+@pytest.fixture
+def svc(storage_manager, store, audit, tmp_path):
+    live_dir = tmp_path / "live"
+    live_dir.mkdir()
+    return RecordingsService(
+        storage_manager=storage_manager,
+        store=store,
+        audit=audit,
+        live_dir=str(live_dir),
+        default_recordings_dir=str(tmp_path / "recordings"),
+    )
+
+
+def _create_clip_file(storage_manager, cam_id, date, time_str, size=1024):
+    """Create a real clip file for integration-style tests."""
+    from pathlib import Path
+
+    clip_dir = Path(storage_manager.recordings_dir) / cam_id / date
+    clip_dir.mkdir(parents=True, exist_ok=True)
+    mp4 = clip_dir / f"{time_str}.mp4"
+    mp4.write_bytes(b"x" * size)
+    return mp4
+
+
+class TestListClips:
+    """Test list_clips delegation and validation."""
+
+    def test_camera_not_found(self, svc, store):
+        store.get_camera.return_value = None
+        result, error, status = svc.list_clips("no-cam", "2026-04-09")
+        assert result is None
+        assert error == "Camera not found"
+        assert status == 404
+
+    def test_returns_clips(self, svc, storage_manager):
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-30-00")
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "15-00-00")
+        result, error, status = svc.list_clips("cam-001", "2026-04-09")
+        assert error is None
+        assert status == 200
+        assert len(result) == 2
+
+    def test_empty_date(self, svc):
+        result, error, status = svc.list_clips("cam-001", "2099-01-01")
+        assert error is None
+        assert result == []
+
+
+class TestListDates:
+    """Test list_dates delegation."""
+
+    def test_camera_not_found(self, svc, store):
+        store.get_camera.return_value = None
+        result, error, status = svc.list_dates("no-cam")
+        assert status == 404
+
+    def test_returns_dates(self, svc, storage_manager):
+        _create_clip_file(storage_manager, "cam-001", "2026-04-07", "10-00-00")
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-00-00")
+        result, error, status = svc.list_dates("cam-001")
+        assert error is None
+        assert result["dates"] == ["2026-04-07", "2026-04-09"]
+
+
+class TestLatestClip:
+    """Test latest_clip delegation."""
+
+    def test_camera_not_found(self, svc, store):
+        store.get_camera.return_value = None
+        result, error, status = svc.latest_clip("no-cam")
+        assert status == 404
+
+    def test_no_recordings(self, svc):
+        result, error, status = svc.latest_clip("cam-001")
+        assert error == "No recordings found"
+        assert status == 404
+
+    def test_returns_latest(self, svc, storage_manager):
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-00-00")
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "15-30-00")
+        result, error, status = svc.latest_clip("cam-001")
+        assert error is None
+        assert result["start_time"] == "15:30:00"
+
+
+class TestResolveClipPath:
+    """Test resolve_clip_path."""
+
+    def test_invalid_filename(self, svc):
+        result, error, status = svc.resolve_clip_path("cam-001", "2026-04-09", "bad.txt")
+        assert error == "Invalid filename"
+        assert status == 400
+
+    def test_not_found(self, svc):
+        result, error, status = svc.resolve_clip_path(
+            "cam-001", "2026-04-09", "99-99-99.mp4"
+        )
+        assert error == "Clip not found"
+        assert status == 404
+
+    def test_found(self, svc, storage_manager):
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-30-00")
+        result, error, status = svc.resolve_clip_path(
+            "cam-001", "2026-04-09", "14-30-00.mp4"
+        )
+        assert error is None
+        assert result.name == "14-30-00.mp4"
+
+
+class TestDeleteClip:
+    """Test delete_clip with audit logging."""
+
+    def test_invalid_filename(self, svc):
+        result, error, status = svc.delete_clip("cam-001", "2026-04-09", "bad.avi")
+        assert error == "Invalid filename"
+        assert status == 400
+
+    def test_not_found(self, svc):
+        result, error, status = svc.delete_clip(
+            "cam-001", "2026-04-09", "99-99-99.mp4"
+        )
+        assert error == "Clip not found"
+        assert status == 404
+
+    def test_deletes_and_audits(self, svc, storage_manager, audit):
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-30-00")
+        result, error, status = svc.delete_clip(
+            "cam-001",
+            "2026-04-09",
+            "14-30-00.mp4",
+            requesting_user="admin",
+            requesting_ip="127.0.0.1",
+        )
+        assert error is None
+        assert status == 200
+        assert result["message"] == "Clip deleted"
+        audit.log_event.assert_called_once()
+        call_args = audit.log_event.call_args
+        assert call_args[0][0] == "CLIP_DELETED"
+
+    def test_no_audit_logger(self, storage_manager, store, tmp_path):
+        """Service works without audit logger."""
+        svc = RecordingsService(
+            storage_manager=storage_manager,
+            store=store,
+            audit=None,
+            live_dir=str(tmp_path / "live"),
+        )
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-30-00")
+        result, error, status = svc.delete_clip(
+            "cam-001", "2026-04-09", "14-30-00.mp4"
+        )
+        assert error is None
+        assert status == 200
+
+
+class TestFallbackRecordingsDir:
+    """Test fallback when storage_manager is None."""
+
+    def test_uses_default_dir(self, store, tmp_path):
+        rec_dir = tmp_path / "fallback"
+        rec_dir.mkdir()
+        svc = RecordingsService(
+            storage_manager=None,
+            store=store,
+            default_recordings_dir=str(rec_dir),
+            live_dir=str(tmp_path / "live"),
+        )
+        # Should not crash — uses default_recordings_dir
+        result, error, status = svc.list_clips("cam-001", "2026-04-09")
+        assert error is None
+        assert result == []


### PR DESCRIPTION
## Summary

- **Extract RecordingsService** — new `services/recordings_service.py` with camera validation, audit logging, and `(result, error, status)` return tuples. `api/recordings.py` rewritten as thin HTTP adapter. 16 new unit tests.
- **Fix auth rate-limit two-tier logic** — `_check_rate_limit()` now returns `(allowed, warn)` tuple. Warn at 5 attempts (audit log), hard block at 10 (HTTP 429). Previously only block-at-10 was implemented despite the docstring claiming two tiers.
- **Remove wifi_setup.py backward compatibility re-exports** — 22-line re-export block removed. `lifecycle.py` and test imports updated to use canonical modules (`status_server`, `wifi`) directly.
- **Docs honesty** — Added security feature status table (Implemented/Partial/Planned) to README. Noted default `admin`/`admin` account in security section.

Server: 777 tests, 90% coverage. Camera: 268 tests, 82% coverage. Total: 1045 tests.

## Test plan

- [x] All 777 server tests pass (90% coverage)
- [x] All 268 camera tests pass (82% coverage)
- [x] Ruff lint clean
- [ ] CI passes
- [ ] Deploy to RPi 4B server, verify smoke test
- [ ] Deploy to RPi Zero 2W camera, verify status server

🤖 Generated with [Claude Code](https://claude.com/claude-code)