### PR TITLE
feat: dev build defaults + camera smoke test auth

### DIFF
--- a/docs/adr/0007-dev-build-default-credentials.md
+++ b/docs/adr/0007-dev-build-default-credentials.md
@@ -1,0 +1,65 @@
+# ADR-0007: Dev Build Default Credentials
+
+## Status
+Accepted
+
+## Context
+Development and testing workflows require authenticating with both the server
+and camera after every fresh flash. The server already auto-creates an
+`admin`/`admin` user, but the camera has no default password — the WiFi
+setup wizard must be completed first. This blocks automated smoke testing
+and slows manual development iteration.
+
+We need a pattern that:
+1. Lets dev builds boot straight to a testable state (no setup wizard).
+2. Keeps prod builds secure (no default credentials, setup wizard required).
+3. Never puts dev-only logic in application source code.
+
+## Decision
+Provision default credentials and skip the setup wizard **in dev images
+only**, using a Yocto recipe (not application code).
+
+### Dev defaults (dev images only)
+- **Server**: Already handled — `_ensure_default_admin()` creates
+  `admin`/`admin` on first boot. Dev recipe pre-stamps
+  `/data/.setup-done` so the setup wizard is bypassed.
+- **Camera**: Dev recipe pre-creates `/data/config/camera.conf` with a
+  known admin password hash (`admin`/`admin`) and stamps
+  `/data/.setup-done`.
+- **Smoke test**: Uses `admin` as default password for both server and
+  camera.
+
+### Prod defaults (prod images)
+- **Server**: `_ensure_default_admin()` still creates `admin`/`admin`, but
+  the setup wizard runs and forces the user to set a real password.
+- **Camera**: No password until setup wizard completes.
+
+### Implementation
+The existing `monitor-dev-config` recipe (already dev-image-only) is
+extended with a first-boot systemd oneshot service that:
+1. Creates `/data/.setup-done`
+2. Writes camera config with pre-hashed `admin`/`admin` password
+
+This keeps application code clean — no `if DEV_MODE` branches.
+
+## Alternatives Considered
+
+### 1. Environment variable `DEV_MODE=true`
+Rejected. Adds conditional logic to app code that could accidentally
+ship in prod. Violates the principle of keeping dev-only config in
+Yocto recipes.
+
+### 2. Disable auth entirely in dev builds
+Rejected. Auth bugs would be invisible during development. Smoke tests
+need to exercise auth paths.
+
+### 3. Fixture/seed script run manually
+Rejected. Adds a manual step that everyone forgets. The whole point is
+zero-friction boot-to-testable.
+
+## Consequences
+- Dev images boot directly to a testable state with known credentials.
+- Smoke tests run without manual setup on fresh dev images.
+- Prod images are unaffected — setup wizard still required.
+- The `admin`/`admin` password is well-known and documented; this is
+  acceptable for dev builds that run on local networks only.

--- a/meta-home-monitor/recipes-core/monitor-dev-config/monitor-dev-config_1.0.bb
+++ b/meta-home-monitor/recipes-core/monitor-dev-config/monitor-dev-config_1.0.bb
@@ -1,20 +1,35 @@
 # =============================================================
-# monitor-dev-config — Debug logging for dev builds only
+# monitor-dev-config — Dev-only configuration for Home Monitor
 #
-# Installs systemd drop-in overrides that set LOG_LEVEL=DEBUG
-# for both monitor.service and camera-streamer.service.
+# Installed ONLY in -dev image variants. Prod images don't
+# include this recipe.
 #
-# Only included in -dev image variants. Prod images don't
-# include this, so apps default to LOG_LEVEL=WARNING.
+# What it does:
+#   1. Debug logging — LOG_LEVEL=DEBUG for app services
+#   2. Dev defaults  — skip setup wizard, pre-provision admin/admin
+#                      credentials so dev builds boot straight to a
+#                      testable state (see ADR-0007)
+#
+# Default dev credentials:
+#   Server: admin / admin  (auto-created by app on first boot)
+#   Camera: admin / admin  (pre-provisioned by this recipe)
 # =============================================================
-SUMMARY = "Development logging configuration for Home Monitor"
-DESCRIPTION = "Systemd drop-ins that enable DEBUG logging for dev builds."
+SUMMARY = "Development configuration for Home Monitor"
+DESCRIPTION = "Debug logging and dev defaults for dev builds. See ADR-0007."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+inherit systemd
+
 S = "${WORKDIR}"
 
+# Pre-computed PBKDF2-SHA256 hash of "admin" with fixed dev salt.
+# Only used in dev builds — prod builds require the setup wizard.
+DEV_ADMIN_HASH = "devdefault00000000000000000000000:864af9109b394c877ae9076d96104693c91c04f020fec42481a8ff9680c1c3b4"
+
 do_install() {
+    # ── 1. Debug logging drop-ins ──────────────────────────────
+
     # Monitor server debug logging
     install -d ${D}${sysconfdir}/systemd/system/monitor.service.d
     cat > ${D}${sysconfdir}/systemd/system/monitor.service.d/10-dev-logging.conf << 'CONF'
@@ -28,9 +43,71 @@ CONF
 [Service]
 Environment=LOG_LEVEL=DEBUG
 CONF
+
+    # ── 2. Dev defaults oneshot service ────────────────────────
+
+    install -d ${D}${sysconfdir}/systemd/system
+    cat > ${D}${sysconfdir}/systemd/system/monitor-dev-defaults.service << 'UNIT'
+[Unit]
+Description=Provision dev defaults (skip setup wizard, admin/admin)
+# Run once before app services start, only if not already done
+ConditionPathExists=!/data/.setup-done
+After=local-fs.target
+Before=monitor.service camera-streamer.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/monitor-dev-defaults.sh
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+    install -d ${D}${bindir}
+    cat > ${D}${bindir}/monitor-dev-defaults.sh << SCRIPT
+#!/bin/sh
+# Provision dev defaults — only runs on first boot of dev images.
+# See ADR-0007: Dev Build Default Credentials.
+set -e
+
+echo "[dev-defaults] Provisioning dev defaults..."
+
+# Create data directories
+mkdir -p /data/config
+
+# Stamp setup as complete (skips the first-boot wizard)
+touch /data/.setup-done
+
+# Camera config with admin/admin password pre-set
+if [ ! -f /data/config/camera.conf ]; then
+    cat > /data/config/camera.conf << 'CAMCONF'
+# Dev defaults — auto-generated, see ADR-0007
+SERVER_IP=
+SERVER_PORT=8554
+STREAM_NAME=stream
+WIDTH=1920
+HEIGHT=1080
+FPS=25
+CAMERA_ID=
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=${DEV_ADMIN_HASH}
+CAMCONF
+    echo "[dev-defaults] Camera config created with admin/admin"
+else
+    echo "[dev-defaults] Camera config already exists, skipping"
+fi
+
+echo "[dev-defaults] Dev defaults provisioned successfully"
+SCRIPT
+    chmod 755 ${D}${bindir}/monitor-dev-defaults.sh
 }
+
+SYSTEMD_SERVICE:${PN} = "monitor-dev-defaults.service"
 
 FILES:${PN} = " \
     ${sysconfdir}/systemd/system/monitor.service.d/10-dev-logging.conf \
     ${sysconfdir}/systemd/system/camera-streamer.service.d/10-dev-logging.conf \
+    ${sysconfdir}/systemd/system/monitor-dev-defaults.service \
+    ${bindir}/monitor-dev-defaults.sh \
     "

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6,12 +6,16 @@
 # Checks: HTTPS, API health, auth, camera endpoints, HLS readiness.
 #
 # Usage:
-#   ./scripts/smoke-test.sh <server-ip> [admin-password] [camera-ip]
+#   ./scripts/smoke-test.sh <server-ip> [admin-password] [camera-ip] [camera-password]
 #
 # Examples:
 #   ./scripts/smoke-test.sh 192.168.8.245 12345678
 #   ./scripts/smoke-test.sh 192.168.8.245 12345678 192.168.8.187
+#   ./scripts/smoke-test.sh 192.168.8.245 12345678 192.168.8.187 cam-pass
 #   ./scripts/smoke-test.sh homemonitor.local
+#
+# Camera password defaults to admin-password if not specified (dev builds
+# use admin/admin for both — see ADR-0007).
 #
 # Exit codes:
 #   0 = all checks passed
@@ -37,8 +41,8 @@ FAILED=0
 SKIPPED=0
 
 if [ -z "$SERVER" ]; then
-    echo "Usage: $0 <server-ip> [admin-password]"
-    echo "Example: $0 192.168.8.245 12345678"
+    echo "Usage: $0 <server-ip> [admin-password] [camera-ip] [camera-password]"
+    echo "Example: $0 192.168.8.245 12345678 192.168.8.187"
     exit 1
 fi
 
@@ -216,35 +220,86 @@ check_status "GET /ota/status" "${API_BASE}/ota/status" 200
 # ---------------------------------------------------------------------------
 
 CAMERA_IP="${3:-}"
+CAMERA_PASSWORD="${4:-${PASSWORD}}"
+CAM_COOKIE_JAR="/tmp/smoke-test-cam-cookies.txt"
+
+cleanup_cam() {
+    rm -f "$CAM_COOKIE_JAR"
+}
+trap 'cleanup; cleanup_cam' EXIT
+
 if [ -n "$CAMERA_IP" ]; then
     echo ""
     echo "[8/8] Camera node: ${CAMERA_IP}"
     CAM_URL="http://${CAMERA_IP}"
     CAM_CURL="curl -s --connect-timeout 5 --max-time 10"
 
+    # --- Reachability ---
     if $CAM_CURL -o /dev/null "$CAM_URL/" 2>/dev/null; then
         pass "Camera HTTP reachable"
     else
         fail "Camera HTTP unreachable at ${CAMERA_IP}"
+        echo ""
+        echo -e "${RED}Camera unreachable. Skipping camera tests.${NC}"
+        # Jump to summary
+        CAMERA_IP=""
     fi
+fi
 
-    # Check /api/status (no auth if no password, or auth required)
+if [ -n "$CAMERA_IP" ]; then
+    # --- Try unauthenticated status first ---
     CAM_STATUS=$($CAM_CURL "${CAM_URL}/api/status" 2>/dev/null) || true
+    CAM_AUTHED=false
+
     if echo "$CAM_STATUS" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'camera_id' in d" 2>/dev/null; then
-        pass "Camera /api/status has camera_id"
-        check_json_field "Camera status has hostname" "${CAM_URL}/api/status" "hostname"
-        check_json_field "Camera status has wifi_ssid" "${CAM_URL}/api/status" "wifi_ssid"
-        check_json_field "Camera status has streaming" "${CAM_URL}/api/status" "streaming"
-        check_json_field "Camera status has cpu_temp" "${CAM_URL}/api/status" "cpu_temp"
+        # No auth required — status is open
+        pass "Camera /api/status accessible (no auth)"
+        CAM_AUTHED=true
     elif echo "$CAM_STATUS" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'error' in d" 2>/dev/null; then
+        # Auth required — login
         pass "Camera /api/status requires auth (expected)"
+
+        CAM_LOGIN=$($CAM_CURL -c "$CAM_COOKIE_JAR" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"admin\",\"password\":\"${CAMERA_PASSWORD}\"}" \
+            "${CAM_URL}/login" 2>/dev/null) || true
+
+        if echo "$CAM_LOGIN" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'message' in d" 2>/dev/null; then
+            pass "Camera login successful"
+            CAM_AUTHED=true
+            # Re-fetch status with session cookie
+            CAM_STATUS=$($CAM_CURL -b "$CAM_COOKIE_JAR" "${CAM_URL}/api/status" 2>/dev/null) || true
+        else
+            fail "Camera login failed (check password, tried: admin/${CAMERA_PASSWORD})"
+        fi
     else
         fail "Camera /api/status unexpected response"
     fi
+
+    # --- Verify all status fields if authenticated ---
+    if [ "$CAM_AUTHED" = true ]; then
+        for field in camera_id hostname ip_address wifi_ssid server_address \
+                     server_connected streaming cpu_temp uptime \
+                     memory_total_mb memory_used_mb; do
+            if echo "$CAM_STATUS" | python3 -c "import sys,json; d=json.load(sys.stdin); assert '$field' in d" 2>/dev/null; then
+                pass "Camera status has '$field'"
+            else
+                fail "Camera status missing '$field'"
+            fi
+        done
+
+        # Show key values for human review
+        CAM_ID=$(echo "$CAM_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('camera_id','?'))" 2>/dev/null) || CAM_ID="?"
+        CAM_STREAM=$(echo "$CAM_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('streaming','?'))" 2>/dev/null) || CAM_STREAM="?"
+        CAM_TEMP=$(echo "$CAM_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cpu_temp','?'))" 2>/dev/null) || CAM_TEMP="?"
+        echo -e "  ${YELLOW}INFO${NC} Camera: id=${CAM_ID}, streaming=${CAM_STREAM}, cpu_temp=${CAM_TEMP}"
+    fi
 else
-    echo ""
-    echo "[8/8] Camera node"
-    skip "No camera IP provided (pass as 3rd argument)"
+    if [ -z "${3:-}" ]; then
+        echo ""
+        echo "[8/8] Camera node"
+        skip "No camera IP provided (pass as 3rd argument)"
+    fi
 fi
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- **ADR-0007**: Documents decision to provision default credentials (`admin`/`admin`) in dev images only, using Yocto recipe (not app code). Prod images unaffected.
- **monitor-dev-config recipe**: Extended with a systemd oneshot service (`monitor-dev-defaults.service`) that runs on first boot of dev images to pre-stamp `.setup-done` and create camera config with admin password hash. Skips setup wizard so dev builds boot straight to testable state.
- **Smoke test enhancement**: Camera section now authenticates (POST `/login`), then verifies all 11 `/api/status` fields. Previously only checked HTTP reachability and "auth required" (2 checks → 14 checks). Accepts optional `$4` camera password, defaults to server password.

## Test plan
- [x] `bash -n scripts/smoke-test.sh` — syntax OK
- [x] `ruff check app/ && ruff format --check app/` — lint clean
- [x] `pytest app/server/tests/` — 802 passed
- [x] `pytest app/camera/tests/` — 268 passed
- [x] Smoke test on hardware: 39/39 passed (camera: login + 11 status fields verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)