### PR TITLE
feat: camera pairing — service, API, and camera-side implementation

### DIFF
--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -4,6 +4,7 @@ Camera lifecycle state machine — orchestrates startup, streaming, and shutdown
 States:
   INIT        → Load config, detect platform, configure LED
   SETUP       → First-boot WiFi hotspot + setup wizard (skipped if already done)
+  PAIRING     → Wait for PIN-based pairing with server (skipped if already paired)
   CONNECTING  → Wait for WiFi IP, resolve server address via mDNS
   VALIDATING  → Check camera hardware (V4L2 device + H.264 support)
   RUNNING     → mDNS advertisement + RTSP streaming + health monitor + status server
@@ -26,6 +27,7 @@ from camera_streamer.capture import CaptureManager
 from camera_streamer.discovery import DiscoveryService
 from camera_streamer.health import HealthMonitor
 from camera_streamer.led import LedController
+from camera_streamer.pairing import PairingManager
 from camera_streamer.status_server import CameraStatusServer
 from camera_streamer.stream import StreamManager
 from camera_streamer.wifi_setup import WifiSetupServer
@@ -38,6 +40,7 @@ class State:
 
     INIT = "init"
     SETUP = "setup"
+    PAIRING = "pairing"
     CONNECTING = "connecting"
     VALIDATING = "validating"
     RUNNING = "running"
@@ -69,6 +72,7 @@ class CameraLifecycle:
         self._status_server = None
         self._health = None
         self._setup_server = None
+        self._pairing = PairingManager(config)
 
     @property
     def state(self):
@@ -79,6 +83,7 @@ class CameraLifecycle:
         transitions = [
             (State.INIT, self._do_init),
             (State.SETUP, self._do_setup),
+            (State.PAIRING, self._do_pairing),
             (State.CONNECTING, self._do_connecting),
             (State.VALIDATING, self._do_validating),
             (State.RUNNING, self._do_running),
@@ -156,6 +161,29 @@ class CameraLifecycle:
         log.info("Setup complete, config reloaded")
         return True
 
+    def _do_pairing(self):
+        """Wait for pairing if camera has no client certificate.
+
+        If already paired (client.crt exists), skip immediately.
+        Otherwise, the status server's /pair page allows the admin
+        to enter the PIN shown on the server dashboard.
+        """
+        if self._pairing.is_paired:
+            log.info("Camera already paired — skipping pairing state")
+            return True
+
+        log.info("Camera not paired — waiting for pairing via status page /pair")
+        led.setup_mode()
+
+        # Poll until paired or shutdown
+        while not self._is_shutdown():
+            if self._pairing.is_paired:
+                log.info("Pairing complete — certificates stored")
+                return True
+            time.sleep(2)
+
+        return False
+
     def _do_connecting(self):
         """Wait for WiFi connectivity and resolve server address."""
         if not self._wait_for_wifi():
@@ -215,6 +243,7 @@ class CameraLifecycle:
             self._stream,
             wifi_interface=self._platform.wifi_interface,
             thermal_path=self._platform.thermal_path,
+            pairing_manager=self._pairing,
         )
         self._status_server.start()
 

--- a/app/camera/camera_streamer/pairing.py
+++ b/app/camera/camera_streamer/pairing.py
@@ -1,15 +1,147 @@
 """
-Camera pairing protocol.
+Camera pairing manager — handles certificate exchange with server.
 
-Handles the certificate exchange when a camera is confirmed
-by the admin in the server dashboard.
+Implements the camera side of PIN-based pairing (ADR-0009):
+1. Camera is unpaired (no /data/certs/client.crt)
+2. Admin enters 6-digit PIN on camera status page
+3. Camera POSTs PIN to server's /api/v1/pair/exchange
+4. Server returns client cert, key, CA cert, pairing_secret
+5. Camera stores certs at /data/certs/, pairing_secret in config
 
-Flow:
-1. Camera boots unpaired → starts temporary AP for setup
-2. Server generates client cert + pairing token
-3. Token entered on camera setup page (via AP) or auto-exchanged
-4. Camera stores client cert at /data/certs/client.crt + key
-5. Camera restarts streaming with mTLS
+Design patterns:
+- Constructor Injection (config, certs_dir)
+- Single Responsibility (pairing lifecycle only)
 """
 
-# TODO: Implement PairingManager class
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.request
+
+log = logging.getLogger("camera-streamer.pairing")
+
+
+class PairingManager:
+    """Manages camera-side pairing with the server.
+
+    Args:
+        config: ConfigManager instance.
+        certs_dir: Path to certificate directory (default: /data/certs).
+    """
+
+    def __init__(self, config, certs_dir=None):
+        self._config = config
+        self._certs_dir = certs_dir or os.path.join(
+            os.environ.get("CAMERA_DATA_DIR", "/data"), "certs"
+        )
+
+    @property
+    def is_paired(self):
+        """Check if camera has been paired (client cert exists)."""
+        return os.path.isfile(os.path.join(self._certs_dir, "client.crt"))
+
+    @property
+    def client_cert_path(self):
+        return os.path.join(self._certs_dir, "client.crt")
+
+    @property
+    def client_key_path(self):
+        return os.path.join(self._certs_dir, "client.key")
+
+    @property
+    def ca_cert_path(self):
+        return os.path.join(self._certs_dir, "ca.crt")
+
+    def exchange(self, pin, server_url):
+        """Exchange PIN for certificates and pairing secret.
+
+        Args:
+            pin: 6-digit PIN string from admin dashboard.
+            server_url: Server base URL (e.g., https://192.168.1.100).
+
+        Returns:
+            (success, error_message) tuple.
+        """
+        camera_id = self._config.camera_id
+        if not camera_id:
+            return False, "Camera ID not configured"
+
+        url = f"{server_url}/api/v1/pair/exchange"
+        payload = json.dumps({"pin": pin, "camera_id": camera_id}).encode("utf-8")
+
+        try:
+            # Skip TLS verification for first pairing (no CA cert yet)
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+
+            req = urllib.request.Request(
+                url,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+
+        except urllib.error.HTTPError as e:
+            try:
+                body = json.loads(e.read().decode("utf-8"))
+                error = body.get("error", f"HTTP {e.code}")
+            except Exception:
+                error = f"HTTP {e.code}"
+            log.error("Pairing exchange failed: %s", error)
+            return False, error
+
+        except (urllib.error.URLError, OSError) as e:
+            log.error("Cannot reach server at %s: %s", url, e)
+            return False, f"Cannot reach server: {e}"
+
+        # Store certificates
+        try:
+            self._store_certs(data)
+        except (KeyError, OSError) as e:
+            log.error("Failed to store certificates: %s", e)
+            return False, f"Failed to store certificates: {e}"
+
+        # Store pairing secret
+        try:
+            pairing_secret = data.get("pairing_secret", "")
+            if pairing_secret:
+                secret_path = os.path.join(self._certs_dir, "pairing_secret")
+                with open(secret_path, "w") as f:
+                    f.write(pairing_secret)
+                os.chmod(secret_path, 0o600)
+        except OSError as e:
+            log.warning("Failed to store pairing secret: %s", e)
+
+        log.info("Pairing successful — certificates stored at %s", self._certs_dir)
+        return True, ""
+
+    def _store_certs(self, data):
+        """Write certificate files to disk."""
+        os.makedirs(self._certs_dir, exist_ok=True)
+
+        files = {
+            "client.crt": data["client_cert"],
+            "client.key": data["client_key"],
+            "ca.crt": data["ca_cert"],
+        }
+        for filename, content in files.items():
+            path = os.path.join(self._certs_dir, filename)
+            with open(path, "w") as f:
+                f.write(content)
+            # Private key should be readable only by owner
+            if filename.endswith(".key"):
+                os.chmod(path, 0o600)
+
+    def get_pairing_secret(self):
+        """Read the stored pairing secret. Returns empty string if not found."""
+        path = os.path.join(self._certs_dir, "pairing_secret")
+        try:
+            with open(path) as f:
+                return f.read().strip()
+        except OSError:
+            return ""

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -150,12 +150,18 @@ class CameraStatusServer:
     """
 
     def __init__(
-        self, config, stream_manager=None, wifi_interface="wlan0", thermal_path=None
+        self,
+        config,
+        stream_manager=None,
+        wifi_interface="wlan0",
+        thermal_path=None,
+        pairing_manager=None,
     ):
         self._config = config
         self._stream = stream_manager
         self._wifi_interface = wifi_interface
         self._thermal_path = thermal_path
+        self._pairing = pairing_manager
         self._server = None
         self._thread = None
 
@@ -167,6 +173,7 @@ class CameraStatusServer:
             self,
             self._wifi_interface,
             self._thermal_path,
+            self._pairing,
         )
         try:
             self._server = http.server.HTTPServer(("0.0.0.0", LISTEN_PORT), handler)
@@ -194,8 +201,42 @@ class CameraStatusServer:
         return wifi.connect_network(ssid, password, self._wifi_interface)
 
 
+_PAIR_PAGE_HTML = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>Pair Camera — {{CAMERA_ID}}</title>
+<style>
+body{font-family:sans-serif;max-width:480px;margin:40px auto;padding:0 16px}
+h1{font-size:1.4em}
+.error{color:#c0392b;background:#fde8e8;padding:8px 12px;border-radius:4px;display:{{ERROR_DISPLAY}}}
+.success{color:#27ae60;background:#e8fde8;padding:8px 12px;border-radius:4px;display:{{SUCCESS_DISPLAY}}}
+label{display:block;margin-top:12px;font-weight:bold}
+input{width:100%;padding:8px;margin-top:4px;box-sizing:border-box;font-size:1em}
+button{margin-top:16px;padding:10px 24px;font-size:1em;cursor:pointer}
+.status{margin-bottom:16px;padding:8px;background:#f0f0f0;border-radius:4px}
+</style>
+</head>
+<body>
+<h1>Pair Camera</h1>
+<div class="status">Camera ID: {{CAMERA_ID}} | Status: {{PAIRED_STATUS}}</div>
+<div class="error">{{ERROR}}</div>
+<div class="success">{{SUCCESS}}</div>
+<div style="display:{{FORM_DISPLAY}}">
+<form method="POST" action="/pair">
+<label>Server URL<input type="text" name="server_url" placeholder="https://192.168.1.100" required></label>
+<label>PIN<input type="text" name="pin" pattern="[0-9]{6}" maxlength="6" placeholder="6-digit PIN from server" required></label>
+<button type="submit">Pair</button>
+</form>
+</div>
+<p><a href="/">Back to status</a></p>
+</body>
+</html>
+"""
+
+
 def _make_status_handler(
-    config, stream_manager, status_server, wifi_interface, thermal_path
+    config, stream_manager, status_server, wifi_interface, thermal_path, pairing_manager
 ):
     """Create HTTP handler for the camera status page."""
 
@@ -232,6 +273,10 @@ def _make_status_handler(
                 )
                 self.send_header("Location", "/login")
                 self.end_headers()
+            elif self.path == "/pair":
+                if not self._require_auth():
+                    return
+                self._serve_pair_page()
             elif self.path == "/" or self.path == "/status":
                 if not self._require_auth():
                     return
@@ -256,6 +301,10 @@ def _make_status_handler(
 
             if self.path == "/login":
                 self._handle_login(body)
+            elif self.path == "/pair" or self.path == "/api/pair":
+                if not self._require_auth():
+                    return
+                self._handle_pair(body)
             elif self.path == "/api/wifi":
                 if not self._require_auth():
                     return
@@ -435,5 +484,71 @@ def _make_status_handler(
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+
+        def _serve_pair_page(self, error="", success=""):
+            is_paired = pairing_manager.is_paired if pairing_manager else False
+            html = (
+                _PAIR_PAGE_HTML.replace("{{CAMERA_ID}}", _html_escape(config.camera_id))
+                .replace(
+                    "{{PAIRED_STATUS}}",
+                    "Paired" if is_paired else "Not paired",
+                )
+                .replace("{{ERROR}}", _html_escape(error))
+                .replace("{{ERROR_DISPLAY}}", "block" if error else "none")
+                .replace("{{SUCCESS}}", _html_escape(success))
+                .replace("{{SUCCESS_DISPLAY}}", "block" if success else "none")
+                .replace("{{FORM_DISPLAY}}", "none" if is_paired else "block")
+            )
+            body = html.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _handle_pair(self, body):
+            if not pairing_manager:
+                self._json_response({"error": "Pairing not available"}, 500)
+                return
+
+            content_type = self.headers.get("Content-Type", "")
+            pin = ""
+            server_url = ""
+
+            if "application/json" in content_type:
+                try:
+                    data = json.loads(body)
+                    pin = data.get("pin", "").strip()
+                    server_url = data.get("server_url", "").strip()
+                except json.JSONDecodeError:
+                    self._json_response({"error": "Invalid JSON"}, 400)
+                    return
+            else:
+                from urllib.parse import parse_qs
+
+                params = parse_qs(body.decode("utf-8", errors="replace"))
+                pin = params.get("pin", [""])[0].strip()
+                server_url = params.get("server_url", [""])[0].strip()
+
+            if not pin or not server_url:
+                if "application/json" in content_type:
+                    self._json_response({"error": "PIN and server_url required"}, 400)
+                else:
+                    self._serve_pair_page(error="PIN and server URL are required")
+                return
+
+            ok, err = pairing_manager.exchange(pin, server_url)
+            if "application/json" in content_type:
+                if ok:
+                    self._json_response({"message": "Pairing successful"})
+                else:
+                    self._json_response({"error": err}, 400)
+            else:
+                if ok:
+                    self._serve_pair_page(
+                        success="Pairing successful! Camera is now paired."
+                    )
+                else:
+                    self._serve_pair_page(error=err)
 
     return StatusHandler

--- a/app/camera/tests/test_pairing.py
+++ b/app/camera/tests/test_pairing.py
@@ -1,0 +1,303 @@
+"""Tests for camera PairingManager and PAIRING lifecycle state."""
+
+import json
+import os
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from camera_streamer.pairing import PairingManager
+
+
+@pytest.fixture
+def pairing_config(data_dir):
+    """Config mock with camera_id set."""
+    config = MagicMock()
+    config.camera_id = "cam-test001"
+    config.certs_dir = str(data_dir / "certs")
+    return config
+
+
+@pytest.fixture
+def pairing_mgr(pairing_config, data_dir):
+    """PairingManager with temp certs dir."""
+    return PairingManager(pairing_config, certs_dir=str(data_dir / "certs"))
+
+
+class TestIsPaired:
+    """Test the is_paired property."""
+
+    def test_not_paired_when_no_cert(self, pairing_mgr):
+        assert pairing_mgr.is_paired is False
+
+    def test_paired_when_cert_exists(self, pairing_mgr, data_dir):
+        cert_path = data_dir / "certs" / "client.crt"
+        cert_path.write_text("CERT DATA")
+        assert pairing_mgr.is_paired is True
+
+
+class TestCertPaths:
+    """Test certificate path properties."""
+
+    def test_client_cert_path(self, pairing_mgr, data_dir):
+        expected = os.path.join(str(data_dir / "certs"), "client.crt")
+        assert pairing_mgr.client_cert_path == expected
+
+    def test_client_key_path(self, pairing_mgr, data_dir):
+        expected = os.path.join(str(data_dir / "certs"), "client.key")
+        assert pairing_mgr.client_key_path == expected
+
+    def test_ca_cert_path(self, pairing_mgr, data_dir):
+        expected = os.path.join(str(data_dir / "certs"), "ca.crt")
+        assert pairing_mgr.ca_cert_path == expected
+
+
+class TestExchange:
+    """Test the exchange method (PIN → certs)."""
+
+    def test_fails_without_camera_id(self, data_dir):
+        config = MagicMock()
+        config.camera_id = ""
+        mgr = PairingManager(config, certs_dir=str(data_dir / "certs"))
+        ok, err = mgr.exchange("123456", "https://192.168.1.100")
+        assert ok is False
+        assert "Camera ID" in err
+
+    @patch("camera_streamer.pairing.urllib.request.urlopen")
+    def test_successful_exchange(self, mock_urlopen, pairing_mgr, data_dir):
+        """Exchange stores certs on success."""
+        response_data = {
+            "client_cert": "CLIENT CERT DATA",
+            "client_key": "CLIENT KEY DATA",
+            "ca_cert": "CA CERT DATA",
+            "pairing_secret": "abc123hex",
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response_data).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        ok, err = pairing_mgr.exchange("123456", "https://192.168.1.100")
+        assert ok is True
+        assert err == ""
+
+        # Verify certs were written
+        certs_dir = data_dir / "certs"
+        assert (certs_dir / "client.crt").read_text() == "CLIENT CERT DATA"
+        assert (certs_dir / "client.key").read_text() == "CLIENT KEY DATA"
+        assert (certs_dir / "ca.crt").read_text() == "CA CERT DATA"
+        assert (certs_dir / "pairing_secret").read_text() == "abc123hex"
+
+    @patch("camera_streamer.pairing.urllib.request.urlopen")
+    def test_exchange_sends_correct_payload(self, mock_urlopen, pairing_mgr):
+        """Exchange sends PIN and camera_id to server."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(
+            {
+                "client_cert": "C",
+                "client_key": "K",
+                "ca_cert": "CA",
+                "pairing_secret": "s",
+            }
+        ).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        pairing_mgr.exchange("654321", "https://10.0.0.1")
+
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        assert req.full_url == "https://10.0.0.1/api/v1/pair/exchange"
+        body = json.loads(req.data)
+        assert body["pin"] == "654321"
+        assert body["camera_id"] == "cam-test001"
+
+    @patch("camera_streamer.pairing.urllib.request.urlopen")
+    def test_exchange_http_error(self, mock_urlopen, pairing_mgr):
+        """HTTP error returns failure tuple."""
+        import urllib.error
+
+        error_resp = MagicMock()
+        error_resp.read.return_value = json.dumps({"error": "Invalid PIN"}).encode()
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "url", 403, "Forbidden", {}, error_resp
+        )
+
+        ok, err = pairing_mgr.exchange("000000", "https://192.168.1.100")
+        assert ok is False
+        assert "Invalid PIN" in err
+
+    @patch("camera_streamer.pairing.urllib.request.urlopen")
+    def test_exchange_network_error(self, mock_urlopen, pairing_mgr):
+        """Network error returns failure tuple."""
+        import urllib.error
+
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+
+        ok, err = pairing_mgr.exchange("123456", "https://192.168.1.100")
+        assert ok is False
+        assert "Cannot reach server" in err
+
+    @patch("camera_streamer.pairing.urllib.request.urlopen")
+    def test_exchange_missing_cert_data(self, mock_urlopen, pairing_mgr):
+        """Missing cert fields in response returns failure."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"client_cert": "C"}).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        ok, err = pairing_mgr.exchange("123456", "https://192.168.1.100")
+        assert ok is False
+        assert "Failed to store certificates" in err
+
+    @patch("camera_streamer.pairing.urllib.request.urlopen")
+    def test_exchange_no_pairing_secret(self, mock_urlopen, pairing_mgr, data_dir):
+        """Exchange succeeds even without pairing_secret in response."""
+        response_data = {
+            "client_cert": "C",
+            "client_key": "K",
+            "ca_cert": "CA",
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response_data).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        ok, err = pairing_mgr.exchange("123456", "https://192.168.1.100")
+        assert ok is True
+
+
+class TestStoreCerts:
+    """Test _store_certs internal method."""
+
+    def test_creates_certs_dir(self, pairing_config, tmp_path):
+        """Creates certs directory if it doesn't exist."""
+        new_certs = tmp_path / "new_certs"
+        mgr = PairingManager(pairing_config, certs_dir=str(new_certs))
+        mgr._store_certs({"client_cert": "C", "client_key": "K", "ca_cert": "CA"})
+        assert (new_certs / "client.crt").exists()
+        assert (new_certs / "client.key").exists()
+        assert (new_certs / "ca.crt").exists()
+
+
+class TestGetPairingSecret:
+    """Test get_pairing_secret method."""
+
+    def test_returns_empty_when_no_file(self, pairing_mgr):
+        assert pairing_mgr.get_pairing_secret() == ""
+
+    def test_reads_stored_secret(self, pairing_mgr, data_dir):
+        secret_path = data_dir / "certs" / "pairing_secret"
+        secret_path.write_text("hex_secret_value\n")
+        assert pairing_mgr.get_pairing_secret() == "hex_secret_value"
+
+
+class TestDefaultCertsDir:
+    """Test default certs_dir from environment."""
+
+    def test_uses_env_var(self, tmp_path):
+        config = MagicMock()
+        config.camera_id = "cam-test"
+        with patch.dict(os.environ, {"CAMERA_DATA_DIR": str(tmp_path)}):
+            mgr = PairingManager(config)
+        expected = os.path.join(str(tmp_path), "certs")
+        assert mgr.client_cert_path == os.path.join(expected, "client.crt")
+
+
+class TestPairingLifecycleState:
+    """Test PAIRING state in CameraLifecycle."""
+
+    def test_pairing_state_defined(self):
+        from camera_streamer.lifecycle import State
+
+        assert State.PAIRING == "pairing"
+
+    @patch("camera_streamer.lifecycle.led")
+    @patch("camera_streamer.lifecycle.LedController")
+    @patch("camera_streamer.lifecycle.PairingManager")
+    def test_skips_pairing_when_already_paired(self, MockPM, MockLed, mock_led):
+        from camera_streamer.lifecycle import CameraLifecycle
+
+        mock_pm = MagicMock()
+        mock_pm.is_paired = True
+        MockPM.return_value = mock_pm
+
+        config = MagicMock(
+            server_ip="192.168.1.100",
+            camera_id="cam-test",
+            is_configured=True,
+        )
+        platform = MagicMock(
+            camera_device="/dev/video0",
+            wifi_interface="wlan0",
+            led_path=None,
+            thermal_path=None,
+            hostname_prefix="homecam",
+        )
+
+        lc = CameraLifecycle(config, platform, lambda: False)
+        result = lc._do_pairing()
+        assert result is True
+
+    @patch("camera_streamer.lifecycle.led")
+    @patch("camera_streamer.lifecycle.LedController")
+    @patch("camera_streamer.lifecycle.PairingManager")
+    def test_waits_for_pairing_then_succeeds(self, MockPM, MockLed, mock_led):
+        from camera_streamer.lifecycle import CameraLifecycle
+
+        mock_pm = MagicMock()
+        # is_paired returns False first (initial check), then False (loop),
+        # then True (loop check triggers exit)
+        type(mock_pm).is_paired = PropertyMock(side_effect=[False, False, True])
+        MockPM.return_value = mock_pm
+
+        config = MagicMock(
+            server_ip="192.168.1.100",
+            camera_id="cam-test",
+            is_configured=True,
+        )
+        platform = MagicMock(
+            camera_device="/dev/video0",
+            wifi_interface="wlan0",
+            led_path=None,
+            thermal_path=None,
+            hostname_prefix="homecam",
+        )
+
+        lc = CameraLifecycle(config, platform, lambda: False)
+
+        with patch("camera_streamer.lifecycle.time.sleep"):
+            result = lc._do_pairing()
+        assert result is True
+
+    @patch("camera_streamer.lifecycle.led")
+    @patch("camera_streamer.lifecycle.LedController")
+    @patch("camera_streamer.lifecycle.PairingManager")
+    def test_pairing_returns_false_on_shutdown(self, MockPM, MockLed, mock_led):
+        from camera_streamer.lifecycle import CameraLifecycle
+
+        mock_pm = MagicMock()
+        mock_pm.is_paired = False
+        MockPM.return_value = mock_pm
+
+        config = MagicMock(
+            server_ip="192.168.1.100",
+            camera_id="cam-test",
+            is_configured=True,
+        )
+        platform = MagicMock(
+            camera_device="/dev/video0",
+            wifi_interface="wlan0",
+            led_path=None,
+            thermal_path=None,
+            hostname_prefix="homecam",
+        )
+
+        # Shutdown immediately
+        lc = CameraLifecycle(config, platform, lambda: True)
+        result = lc._do_pairing()
+        assert result is False

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -13,6 +13,7 @@ from flask import Flask
 from monitor.logging_config import configure_logging
 from monitor.services.audit import AuditLogger
 from monitor.services.camera_service import CameraService
+from monitor.services.pairing_service import PairingService
 from monitor.services.provisioning_service import ProvisioningService
 from monitor.services.recordings_service import RecordingsService
 from monitor.services.settings_service import SettingsService
@@ -167,6 +168,13 @@ def _init_services(app):
         audit=app.audit,
         live_dir=app.config["LIVE_DIR"],
         default_recordings_dir=recordings_dir,
+    )
+
+    # Pairing service — camera cert exchange and revocation
+    app.pairing_service = PairingService(
+        store=app.store,
+        audit=app.audit,
+        certs_dir=app.config["CERTS_DIR"],
     )
 
     # Settings service — system config + WiFi management

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -269,6 +269,7 @@ def _register_blueprints(app):
     from monitor.api.cameras import cameras_bp
     from monitor.api.live import live_bp
     from monitor.api.ota import ota_bp
+    from monitor.api.pairing import pairing_bp
     from monitor.api.recordings import recordings_bp
     from monitor.api.settings import settings_bp
     from monitor.api.storage import storage_bp
@@ -288,4 +289,5 @@ def _register_blueprints(app):
     app.register_blueprint(settings_bp, url_prefix="/api/v1/settings")
     app.register_blueprint(users_bp, url_prefix="/api/v1/users")
     app.register_blueprint(ota_bp, url_prefix="/api/v1/ota")
+    app.register_blueprint(pairing_bp, url_prefix="/api/v1")
     app.register_blueprint(storage_bp, url_prefix="/api/v1/storage")

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -65,7 +65,15 @@ def update_camera(camera_id):
 @cameras_bp.route("/<camera_id>", methods=["DELETE"])
 @admin_required
 def delete_camera(camera_id):
-    """Remove a camera. Admin only."""
+    """Remove a camera and revoke its cert. Admin only."""
+    # Revoke cert first (if paired)
+    if hasattr(current_app, "pairing_service"):
+        current_app.pairing_service.unpair(
+            camera_id,
+            user=session.get("username", ""),
+            ip=request.remote_addr or "",
+        )
+
     error, status = current_app.camera_service.delete(
         camera_id,
         user=session.get("username", ""),

--- a/app/server/monitor/api/pairing.py
+++ b/app/server/monitor/api/pairing.py
@@ -1,0 +1,72 @@
+"""
+Camera pairing API.
+
+Endpoints:
+  POST /cameras/<id>/pair   - initiate pairing, generate PIN (admin)
+  POST /cameras/<id>/unpair - revoke cert, reset pairing (admin)
+  POST /pair/exchange        - camera trades PIN for certs (no auth — PIN is auth)
+
+The exchange endpoint intentionally has no session auth — the 6-digit PIN
+(rate-limited, 5-min expiry) is the authentication mechanism for the camera.
+Routes are thin — all orchestration is in PairingService.
+"""
+
+from flask import Blueprint, current_app, jsonify, request, session
+
+from monitor.auth import admin_required
+
+pairing_bp = Blueprint("pairing", __name__)
+
+
+@pairing_bp.route("/cameras/<camera_id>/pair", methods=["POST"])
+@admin_required
+def initiate_pairing(camera_id):
+    """Initiate pairing for a camera. Admin only.
+
+    Returns a 6-digit PIN to display on the dashboard.
+    """
+    pin, error, status = current_app.pairing_service.initiate_pairing(
+        camera_id,
+        user=session.get("username", ""),
+        ip=request.remote_addr or "",
+    )
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify({"pin": pin, "expires_in": 300}), 200
+
+
+@pairing_bp.route("/cameras/<camera_id>/unpair", methods=["POST"])
+@admin_required
+def unpair_camera(camera_id):
+    """Unpair a camera and revoke its certificate. Admin only."""
+    error, status = current_app.pairing_service.unpair(
+        camera_id,
+        user=session.get("username", ""),
+        ip=request.remote_addr or "",
+    )
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify({"message": "Camera unpaired"}), 200
+
+
+@pairing_bp.route("/pair/exchange", methods=["POST"])
+def exchange_certs():
+    """Camera exchanges PIN for certificates and pairing secret.
+
+    No session auth required — the PIN is the authentication.
+    Rate-limited to 3 attempts per camera per 5-minute window.
+    """
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    pin = data.get("pin", "")
+    camera_id = data.get("camera_id", "")
+
+    if not pin or not camera_id:
+        return jsonify({"error": "pin and camera_id are required"}), 400
+
+    result, error, status = current_app.pairing_service.exchange_certs(pin, camera_id)
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), 200

--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -31,6 +31,7 @@ class Camera:
     last_seen: str | None = None
     firmware_version: str = ""
     cert_serial: str = ""
+    pairing_secret: str = ""  # hex-encoded, for camera LUKS key derivation (ADR-0010)
 
 
 @dataclass

--- a/app/server/monitor/services/pairing_service.py
+++ b/app/server/monitor/services/pairing_service.py
@@ -1,0 +1,369 @@
+"""
+Camera pairing service — manages PIN-based pairing and certificate lifecycle.
+
+Handles the server side of camera pairing (ADR-0009):
+1. Admin initiates pairing → generates client cert + 6-digit PIN
+2. Camera exchanges PIN for certs + pairing_secret
+3. Admin unpairs → cert revoked, camera removed from trust
+
+Design patterns:
+- Constructor Injection (store, audit, certs_dir)
+- Single Responsibility (pairing lifecycle only)
+- Fail-Silent (audit failures don't break operations)
+"""
+
+import logging
+import os
+import secrets
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+log = logging.getLogger("monitor.pairing_service")
+
+PIN_EXPIRY_SECONDS = 300  # 5 minutes
+PIN_MAX_ATTEMPTS = 3
+PIN_DIGITS = 6
+
+
+class PairingService:
+    """Manages camera pairing: cert generation, PIN exchange, and revocation.
+
+    Args:
+        store: Data persistence layer (Store instance).
+        audit: Security audit logger (AuditLogger instance or None).
+        certs_dir: Path to /data/certs/ directory.
+    """
+
+    def __init__(self, store, audit=None, certs_dir="/data/certs"):
+        self._store = store
+        self._audit = audit
+        self._certs_dir = Path(certs_dir)
+        self._pending_pairings = {}  # camera_id -> {pin, expires_at, attempts, cert_data}
+        self._revoked_serials = set()
+        self._load_revoked_serials()
+
+    def _load_revoked_serials(self):
+        """Rebuild revocation set from cameras/revoked/ on startup."""
+        revoked_dir = self._certs_dir / "cameras" / "revoked"
+        if not revoked_dir.is_dir():
+            return
+        for cert_file in revoked_dir.glob("*.crt"):
+            try:
+                result = subprocess.run(
+                    ["openssl", "x509", "-in", str(cert_file), "-serial", "-noout"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.returncode == 0:
+                    serial = result.stdout.strip().split("=")[-1]
+                    self._revoked_serials.add(serial)
+            except (subprocess.TimeoutExpired, OSError):
+                log.warning("Failed to read serial from revoked cert: %s", cert_file)
+
+    def initiate_pairing(self, camera_id, user="", ip=""):
+        """Generate client cert and PIN for a camera.
+
+        Returns (pin, error, status_code).
+        """
+        camera = self._store.get_camera(camera_id)
+        if camera is None:
+            return None, "Camera not found", 404
+
+        if camera.status not in ("pending", "offline"):
+            return None, "Camera must be in pending or offline state to pair", 400
+
+        # Generate client cert
+        cert_data, error = self._generate_client_cert(camera_id)
+        if error:
+            return None, f"Certificate generation failed: {error}", 500
+
+        # Generate PIN
+        pin = str(secrets.randbelow(10**PIN_DIGITS)).zfill(PIN_DIGITS)
+
+        self._pending_pairings[camera_id] = {
+            "pin": pin,
+            "expires_at": time.time() + PIN_EXPIRY_SECONDS,
+            "attempts": 0,
+            "cert_data": cert_data,
+        }
+
+        self._log_audit(
+            "PAIRING_INITIATED",
+            user,
+            ip,
+            f"pairing initiated for camera {camera_id}",
+        )
+
+        return pin, "", 200
+
+    def exchange_certs(self, pin, camera_id):
+        """Validate PIN and return certs + pairing_secret.
+
+        Returns (result_dict, error, status_code).
+        """
+        pending = self._pending_pairings.get(camera_id)
+        if pending is None:
+            return None, "No pairing in progress for this camera", 404
+
+        # Check expiry
+        if time.time() > pending["expires_at"]:
+            del self._pending_pairings[camera_id]
+            return None, "Pairing PIN has expired", 410
+
+        # Rate limiting
+        pending["attempts"] += 1
+        if pending["attempts"] > PIN_MAX_ATTEMPTS:
+            del self._pending_pairings[camera_id]
+            self._log_audit(
+                "PAIRING_FAILED",
+                "",
+                "",
+                f"too many PIN attempts for camera {camera_id}",
+            )
+            return None, "Too many attempts, pairing cancelled", 429
+
+        # Validate PIN
+        if not secrets.compare_digest(pin, pending["pin"]):
+            remaining = PIN_MAX_ATTEMPTS - pending["attempts"]
+            self._log_audit(
+                "PAIRING_FAILED",
+                "",
+                "",
+                f"invalid PIN for camera {camera_id}, {remaining} attempts remaining",
+            )
+            return None, f"Invalid PIN, {remaining} attempts remaining", 403
+
+        # PIN valid — generate pairing_secret and finalize
+        cert_data = pending["cert_data"]
+        pairing_secret = os.urandom(32).hex()
+
+        # Read CA cert for the response
+        ca_cert = self._read_file(self._certs_dir / "ca.crt")
+        if ca_cert is None:
+            return None, "CA certificate not found", 500
+
+        # Update camera in store
+        camera = self._store.get_camera(camera_id)
+        if camera is None:
+            return None, "Camera not found", 404
+
+        camera.status = "online"
+        camera.cert_serial = cert_data["serial"]
+        camera.pairing_secret = pairing_secret
+        self._store.save_camera(camera)
+
+        # Clean up pending state
+        del self._pending_pairings[camera_id]
+
+        self._log_audit(
+            "CAMERA_PAIRED",
+            "",
+            "",
+            f"camera {camera_id} paired successfully, cert serial {cert_data['serial']}",
+        )
+
+        return (
+            {
+                "client_cert": cert_data["cert"],
+                "client_key": cert_data["key"],
+                "ca_cert": ca_cert,
+                "pairing_secret": pairing_secret,
+                "rtsps_url": f"rtsps://home-monitor.local:8554/{camera_id}",
+            },
+            "",
+            200,
+        )
+
+    def unpair(self, camera_id, user="", ip=""):
+        """Revoke camera cert and reset pairing state.
+
+        Returns (error, status_code).
+        """
+        camera = self._store.get_camera(camera_id)
+        if camera is None:
+            return "Camera not found", 404
+
+        # Move cert to revoked
+        cert_path = self._certs_dir / "cameras" / f"{camera_id}.crt"
+        revoked_dir = self._certs_dir / "cameras" / "revoked"
+        revoked_dir.mkdir(parents=True, exist_ok=True)
+
+        if cert_path.exists():
+            revoked_path = revoked_dir / f"{camera_id}.crt"
+            shutil.move(str(cert_path), str(revoked_path))
+            if camera.cert_serial:
+                self._revoked_serials.add(camera.cert_serial)
+
+        # Remove key file
+        key_path = self._certs_dir / "cameras" / f"{camera_id}.key"
+        if key_path.exists():
+            key_path.unlink()
+
+        # Update camera state
+        camera.status = "pending"
+        camera.cert_serial = ""
+        camera.pairing_secret = ""
+        self._store.save_camera(camera)
+
+        # Cancel any pending pairing
+        self._pending_pairings.pop(camera_id, None)
+
+        self._log_audit(
+            "CERT_REVOKED",
+            user,
+            ip,
+            f"cert revoked for camera {camera_id}",
+        )
+
+        return "", 200
+
+    def is_cert_revoked(self, serial):
+        """Check if a certificate serial is in the revocation set."""
+        return serial in self._revoked_serials
+
+    def get_pending_pairing(self, camera_id):
+        """Get pending pairing info (for dashboard display). Returns None if none."""
+        pending = self._pending_pairings.get(camera_id)
+        if pending is None:
+            return None
+        if time.time() > pending["expires_at"]:
+            del self._pending_pairings[camera_id]
+            return None
+        return {
+            "pin": pending["pin"],
+            "expires_in": int(pending["expires_at"] - time.time()),
+            "attempts": pending["attempts"],
+        }
+
+    def _generate_client_cert(self, camera_id):
+        """Generate ECDSA P-256 client cert signed by the CA.
+
+        Returns (cert_data_dict, error_string).
+        cert_data_dict has keys: cert, key, serial, cert_path, key_path.
+        """
+        cameras_dir = self._certs_dir / "cameras"
+        cameras_dir.mkdir(parents=True, exist_ok=True)
+
+        ca_key = self._certs_dir / "ca.key"
+        ca_cert = self._certs_dir / "ca.crt"
+        client_key = cameras_dir / f"{camera_id}.key"
+        client_cert = cameras_dir / f"{camera_id}.crt"
+        client_csr = cameras_dir / f"{camera_id}.csr"
+
+        if not ca_key.exists() or not ca_cert.exists():
+            return None, "CA key or certificate not found"
+
+        try:
+            # Generate client private key
+            self._run_openssl(
+                [
+                    "openssl",
+                    "ecparam",
+                    "-genkey",
+                    "-name",
+                    "prime256v1",
+                    "-out",
+                    str(client_key),
+                ]
+            )
+            os.chmod(str(client_key), 0o600)
+
+            # Generate CSR
+            self._run_openssl(
+                [
+                    "openssl",
+                    "req",
+                    "-new",
+                    "-key",
+                    str(client_key),
+                    "-out",
+                    str(client_csr),
+                    "-subj",
+                    f"/CN={camera_id}/O=HomeMonitor",
+                ]
+            )
+
+            # Sign with CA (5 years = 1825 days)
+            self._run_openssl(
+                [
+                    "openssl",
+                    "x509",
+                    "-req",
+                    "-in",
+                    str(client_csr),
+                    "-CA",
+                    str(ca_cert),
+                    "-CAkey",
+                    str(ca_key),
+                    "-CAcreateserial",
+                    "-out",
+                    str(client_cert),
+                    "-days",
+                    "1825",
+                ]
+            )
+
+            # Read serial
+            result = subprocess.run(
+                ["openssl", "x509", "-in", str(client_cert), "-serial", "-noout"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            serial = (
+                result.stdout.strip().split("=")[-1] if result.returncode == 0 else ""
+            )
+
+            # Read cert and key content
+            cert_content = self._read_file(client_cert)
+            key_content = self._read_file(client_key)
+
+            if cert_content is None or key_content is None:
+                return None, "Failed to read generated certificate files"
+
+            return {
+                "cert": cert_content,
+                "key": key_content,
+                "serial": serial,
+                "cert_path": str(client_cert),
+                "key_path": str(client_key),
+            }, ""
+
+        except subprocess.CalledProcessError as e:
+            log.error("OpenSSL command failed: %s", e.stderr)
+            return None, f"OpenSSL error: {e.stderr}"
+        except OSError as e:
+            log.error("File operation failed: %s", e)
+            return None, str(e)
+        finally:
+            # Clean up CSR
+            if client_csr.exists():
+                client_csr.unlink()
+
+    def _run_openssl(self, cmd):
+        """Run an openssl command, raising on failure."""
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode, cmd, result.stdout, result.stderr
+            )
+        return result
+
+    def _read_file(self, path):
+        """Read a file's text content. Returns None on failure."""
+        try:
+            return Path(path).read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+    def _log_audit(self, event, user, ip, detail):
+        """Log audit event, swallowing errors."""
+        if not self._audit:
+            return
+        try:
+            self._audit.log_event(event, user=user, ip=ip, detail=detail)
+        except Exception as e:
+            log.warning("Audit log failed: %s", e)

--- a/app/server/tests/test_api_pairing.py
+++ b/app/server/tests/test_api_pairing.py
@@ -1,0 +1,200 @@
+"""Tests for the pairing API endpoints."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from monitor.auth import hash_password
+from monitor.models import Camera, User
+
+
+@pytest.fixture(autouse=True)
+def _setup_ca_files(app):
+    """Create fake CA files so PairingService can read them."""
+    certs_dir = app.config["CERTS_DIR"]
+    os.makedirs(os.path.join(certs_dir, "cameras", "revoked"), exist_ok=True)
+    ca_crt = os.path.join(certs_dir, "ca.crt")
+    ca_key = os.path.join(certs_dir, "ca.key")
+    if not os.path.exists(ca_crt):
+        with open(ca_crt, "w") as f:
+            f.write("FAKE CA CERT FOR TESTING")
+    if not os.path.exists(ca_key):
+        with open(ca_key, "w") as f:
+            f.write("FAKE CA KEY FOR TESTING")
+
+
+def _login(app, client, role="admin"):
+    """Helper: create admin user and login."""
+    app.store.save_user(
+        User(
+            id="user-admin",
+            username="admin",
+            password_hash=hash_password("pass"),
+            role=role,
+        )
+    )
+    client.post("/api/v1/auth/login", json={"username": "admin", "password": "pass"})
+
+
+def _add_camera(app, camera_id="cam-001", status="pending"):
+    """Helper: add a camera to the store."""
+    camera = Camera(id=camera_id, status=status, ip="192.168.1.50")
+    app.store.save_camera(camera)
+    return camera
+
+
+class TestInitiatePairing:
+    """Test POST /api/v1/cameras/<id>/pair."""
+
+    def test_requires_admin(self, client):
+        resp = client.post("/api/v1/cameras/cam-001/pair")
+        assert resp.status_code == 401
+
+    def test_viewer_cannot_pair(self, app, client):
+        _login(app, client, role="viewer")
+        resp = client.post("/api/v1/cameras/cam-001/pair")
+        assert resp.status_code == 403
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_returns_pin_on_success(self, mock_gen, app, client):
+        _login(app, client)
+        _add_camera(app)
+        mock_gen.return_value = (
+            {"cert": "CERT", "key": "KEY", "serial": "ABC123"},
+            "",
+        )
+        resp = client.post("/api/v1/cameras/cam-001/pair")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "pin" in data
+        assert len(data["pin"]) == 6
+        assert data["expires_in"] == 300
+
+    def test_returns_404_for_unknown_camera(self, app, client):
+        _login(app, client)
+        resp = client.post("/api/v1/cameras/nonexistent/pair")
+        assert resp.status_code == 404
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_rejects_online_camera(self, mock_gen, app, client):
+        _login(app, client)
+        _add_camera(app, status="online")
+        resp = client.post("/api/v1/cameras/cam-001/pair")
+        assert resp.status_code == 400
+
+
+class TestUnpairCamera:
+    """Test POST /api/v1/cameras/<id>/unpair."""
+
+    def test_requires_admin(self, client):
+        resp = client.post("/api/v1/cameras/cam-001/unpair")
+        assert resp.status_code == 401
+
+    def test_viewer_cannot_unpair(self, app, client):
+        _login(app, client, role="viewer")
+        resp = client.post("/api/v1/cameras/cam-001/unpair")
+        assert resp.status_code == 403
+
+    def test_unpairs_camera(self, app, client):
+        _login(app, client)
+        _add_camera(app, status="online")
+        resp = client.post("/api/v1/cameras/cam-001/unpair")
+        assert resp.status_code == 200
+        assert resp.get_json()["message"] == "Camera unpaired"
+
+    def test_returns_404_for_unknown_camera(self, app, client):
+        _login(app, client)
+        resp = client.post("/api/v1/cameras/nonexistent/unpair")
+        assert resp.status_code == 404
+
+
+class TestExchangeCerts:
+    """Test POST /api/v1/pair/exchange."""
+
+    def test_does_not_require_session_auth(self, app, client):
+        """Exchange endpoint uses PIN auth, not session auth."""
+        resp = client.post(
+            "/api/v1/pair/exchange",
+            json={"pin": "123456", "camera_id": "cam-001"},
+        )
+        # Should not return 401 — instead returns 404 (no pending pairing)
+        assert resp.status_code != 401
+
+    def test_requires_json_body(self, client):
+        resp = client.post("/api/v1/pair/exchange")
+        assert resp.status_code == 400
+        assert "JSON body" in resp.get_json()["error"]
+
+    def test_requires_pin_and_camera_id(self, client):
+        resp = client.post("/api/v1/pair/exchange", json={"pin": "123456"})
+        assert resp.status_code == 400
+        assert "required" in resp.get_json()["error"]
+
+    def test_requires_camera_id(self, client):
+        resp = client.post("/api/v1/pair/exchange", json={"camera_id": "cam-001"})
+        assert resp.status_code == 400
+
+    def test_returns_404_when_no_pending(self, app, client):
+        resp = client.post(
+            "/api/v1/pair/exchange",
+            json={"pin": "123456", "camera_id": "cam-001"},
+        )
+        assert resp.status_code == 404
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_full_pairing_flow(self, mock_gen, app, client):
+        """End-to-end: initiate as admin, exchange as camera."""
+        _login(app, client)
+        _add_camera(app)
+        mock_gen.return_value = (
+            {"cert": "CLIENT CERT", "key": "CLIENT KEY", "serial": "ABC123"},
+            "",
+        )
+
+        # Admin initiates
+        resp = client.post("/api/v1/cameras/cam-001/pair")
+        assert resp.status_code == 200
+        pin = resp.get_json()["pin"]
+
+        # Camera exchanges (new client without session)
+        with app.test_client() as camera_client:
+            resp = camera_client.post(
+                "/api/v1/pair/exchange",
+                json={"pin": pin, "camera_id": "cam-001"},
+            )
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["client_cert"] == "CLIENT CERT"
+            assert data["client_key"] == "CLIENT KEY"
+            assert "ca_cert" in data
+            assert "pairing_secret" in data
+            assert "rtsps_url" in data
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_wrong_pin_rejected(self, mock_gen, app, client):
+        """Wrong PIN returns 403."""
+        _login(app, client)
+        _add_camera(app)
+        mock_gen.return_value = (
+            {"cert": "CERT", "key": "KEY", "serial": "S"},
+            "",
+        )
+        client.post("/api/v1/cameras/cam-001/pair")
+
+        with app.test_client() as camera_client:
+            resp = camera_client.post(
+                "/api/v1/pair/exchange",
+                json={"pin": "000000", "camera_id": "cam-001"},
+            )
+            assert resp.status_code == 403
+
+
+class TestDeleteCameraUnpairs:
+    """Test that DELETE /cameras/<id> also revokes certs."""
+
+    def test_delete_calls_unpair(self, app, client):
+        _login(app, client)
+        _add_camera(app, status="online")
+        resp = client.delete("/api/v1/cameras/cam-001")
+        assert resp.status_code == 200

--- a/app/server/tests/test_app.py
+++ b/app/server/tests/test_app.py
@@ -76,5 +76,5 @@ class TestBlueprintRegistration:
         assert "provisioning" in app.blueprints
 
     def test_all_blueprints_count(self, app):
-        """We expect exactly 11 blueprints (9 API + views + setup)."""
-        assert len(app.blueprints) == 11
+        """We expect exactly 12 blueprints (10 API + views + setup)."""
+        assert len(app.blueprints) == 12

--- a/app/server/tests/test_svc_pairing.py
+++ b/app/server/tests/test_svc_pairing.py
@@ -1,0 +1,426 @@
+"""Tests for the pairing service."""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monitor.services.pairing_service import (
+    PIN_DIGITS,
+    PIN_EXPIRY_SECONDS,
+    PIN_MAX_ATTEMPTS,
+    PairingService,
+)
+
+
+def _make_camera(**overrides):
+    """Create a fake camera object with sensible defaults."""
+    defaults = {
+        "id": "cam-001",
+        "name": "Front Door",
+        "location": "Porch",
+        "status": "pending",
+        "ip": "192.168.1.50",
+        "recording_mode": "continuous",
+        "resolution": "1080p",
+        "fps": 25,
+        "paired_at": None,
+        "last_seen": None,
+        "firmware_version": "1.0.0",
+        "rtsp_url": "",
+        "cert_serial": "",
+        "pairing_secret": "",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def certs_dir(tmp_path):
+    """Create a temporary certs directory with CA files."""
+    certs = tmp_path / "certs"
+    certs.mkdir()
+    cameras = certs / "cameras"
+    cameras.mkdir()
+    (cameras / "revoked").mkdir()
+    # Create fake CA files
+    (certs / "ca.key").write_text("FAKE CA KEY")
+    (certs / "ca.crt").write_text("FAKE CA CERT")
+    return certs
+
+
+@pytest.fixture
+def store():
+    return MagicMock()
+
+
+@pytest.fixture
+def audit():
+    return MagicMock()
+
+
+@pytest.fixture
+def svc(store, audit, certs_dir):
+    return PairingService(store=store, audit=audit, certs_dir=str(certs_dir))
+
+
+class TestInitiatePairing:
+    """Test pairing initiation (PIN + cert generation)."""
+
+    def test_returns_404_when_camera_not_found(self, svc, store):
+        store.get_camera.return_value = None
+        pin, error, status = svc.initiate_pairing("nonexistent")
+        assert status == 404
+        assert pin is None
+        assert "not found" in error
+
+    def test_rejects_camera_not_in_pending_or_offline(self, svc, store):
+        store.get_camera.return_value = _make_camera(status="online")
+        pin, error, status = svc.initiate_pairing("cam-001")
+        assert status == 400
+        assert pin is None
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_returns_6_digit_pin_on_success(self, mock_gen, svc, store):
+        store.get_camera.return_value = _make_camera(status="pending")
+        mock_gen.return_value = (
+            {"cert": "CERT", "key": "KEY", "serial": "ABC123"},
+            "",
+        )
+        pin, error, status = svc.initiate_pairing("cam-001")
+        assert status == 200
+        assert error == ""
+        assert len(pin) == PIN_DIGITS
+        assert pin.isdigit()
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_stores_pending_pairing(self, mock_gen, svc, store):
+        store.get_camera.return_value = _make_camera(status="pending")
+        mock_gen.return_value = (
+            {"cert": "CERT", "key": "KEY", "serial": "ABC123"},
+            "",
+        )
+        svc.initiate_pairing("cam-001")
+        assert "cam-001" in svc._pending_pairings
+        pending = svc._pending_pairings["cam-001"]
+        assert pending["attempts"] == 0
+        assert pending["expires_at"] > time.time()
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_logs_audit_event(self, mock_gen, svc, store, audit):
+        store.get_camera.return_value = _make_camera(status="pending")
+        mock_gen.return_value = (
+            {"cert": "CERT", "key": "KEY", "serial": "ABC123"},
+            "",
+        )
+        svc.initiate_pairing("cam-001", user="admin", ip="10.0.0.1")
+        audit.log_event.assert_called_once()
+        assert audit.log_event.call_args[0][0] == "PAIRING_INITIATED"
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_returns_500_when_cert_generation_fails(self, mock_gen, svc, store):
+        store.get_camera.return_value = _make_camera(status="pending")
+        mock_gen.return_value = (None, "openssl not found")
+        pin, error, status = svc.initiate_pairing("cam-001")
+        assert status == 500
+        assert pin is None
+        assert "Certificate generation failed" in error
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_allows_pairing_offline_camera(self, mock_gen, svc, store):
+        store.get_camera.return_value = _make_camera(status="offline")
+        mock_gen.return_value = (
+            {"cert": "CERT", "key": "KEY", "serial": "ABC123"},
+            "",
+        )
+        pin, error, status = svc.initiate_pairing("cam-001")
+        assert status == 200
+
+
+class TestExchangeCerts:
+    """Test PIN-for-certs exchange."""
+
+    def _setup_pending(self, svc, store, pin="123456"):
+        """Set up a pending pairing with known PIN."""
+        store.get_camera.return_value = _make_camera(status="pending")
+        svc._pending_pairings["cam-001"] = {
+            "pin": pin,
+            "expires_at": time.time() + PIN_EXPIRY_SECONDS,
+            "attempts": 0,
+            "cert_data": {
+                "cert": "CLIENT CERT",
+                "key": "CLIENT KEY",
+                "serial": "ABC123",
+            },
+        }
+
+    def test_returns_404_when_no_pending_pairing(self, svc):
+        result, error, status = svc.exchange_certs("123456", "cam-001")
+        assert status == 404
+        assert result is None
+
+    def test_returns_410_when_pin_expired(self, svc, store):
+        self._setup_pending(svc, store)
+        svc._pending_pairings["cam-001"]["expires_at"] = time.time() - 1
+        result, error, status = svc.exchange_certs("123456", "cam-001")
+        assert status == 410
+        assert "expired" in error
+        assert "cam-001" not in svc._pending_pairings
+
+    def test_returns_403_on_wrong_pin(self, svc, store):
+        self._setup_pending(svc, store, pin="123456")
+        result, error, status = svc.exchange_certs("000000", "cam-001")
+        assert status == 403
+        assert "Invalid PIN" in error
+        assert result is None
+
+    def test_returns_429_after_max_attempts(self, svc, store, audit):
+        self._setup_pending(svc, store, pin="123456")
+        svc._pending_pairings["cam-001"]["attempts"] = PIN_MAX_ATTEMPTS
+        result, error, status = svc.exchange_certs("000000", "cam-001")
+        assert status == 429
+        assert "Too many attempts" in error
+        assert "cam-001" not in svc._pending_pairings
+
+    def test_successful_exchange_returns_certs(self, svc, store, certs_dir):
+        self._setup_pending(svc, store, pin="123456")
+        result, error, status = svc.exchange_certs("123456", "cam-001")
+        assert status == 200
+        assert error == ""
+        assert result["client_cert"] == "CLIENT CERT"
+        assert result["client_key"] == "CLIENT KEY"
+        assert result["ca_cert"] == "FAKE CA CERT"
+        assert "pairing_secret" in result
+        assert len(result["pairing_secret"]) == 64  # 32 bytes hex
+        assert "rtsps_url" in result
+
+    def test_successful_exchange_updates_camera(self, svc, store, certs_dir):
+        cam = _make_camera(status="pending")
+        store.get_camera.return_value = cam
+        svc._pending_pairings["cam-001"] = {
+            "pin": "123456",
+            "expires_at": time.time() + PIN_EXPIRY_SECONDS,
+            "attempts": 0,
+            "cert_data": {
+                "cert": "CERT",
+                "key": "KEY",
+                "serial": "ABC123",
+            },
+        }
+        svc.exchange_certs("123456", "cam-001")
+        assert cam.status == "online"
+        assert cam.cert_serial == "ABC123"
+        assert cam.pairing_secret != ""
+        store.save_camera.assert_called_once_with(cam)
+
+    def test_successful_exchange_removes_pending(self, svc, store, certs_dir):
+        self._setup_pending(svc, store, pin="123456")
+        svc.exchange_certs("123456", "cam-001")
+        assert "cam-001" not in svc._pending_pairings
+
+    def test_successful_exchange_logs_audit(self, svc, store, audit, certs_dir):
+        self._setup_pending(svc, store, pin="123456")
+        svc.exchange_certs("123456", "cam-001")
+        assert any(
+            call[0][0] == "CAMERA_PAIRED" for call in audit.log_event.call_args_list
+        )
+
+    def test_wrong_pin_decrements_remaining(self, svc, store):
+        self._setup_pending(svc, store, pin="123456")
+        result, error, status = svc.exchange_certs("000000", "cam-001")
+        assert f"{PIN_MAX_ATTEMPTS - 1} attempts remaining" in error
+
+    def test_pin_comparison_is_constant_time(self, svc, store):
+        """Verify we use secrets.compare_digest (tested indirectly via behavior)."""
+        self._setup_pending(svc, store, pin="123456")
+        # Wrong PIN should fail regardless of partial match
+        result, error, status = svc.exchange_certs("123000", "cam-001")
+        assert status == 403
+
+
+class TestUnpair:
+    """Test camera unpairing / cert revocation."""
+
+    def test_returns_404_when_camera_not_found(self, svc, store):
+        store.get_camera.return_value = None
+        error, status = svc.unpair("nonexistent")
+        assert status == 404
+
+    def test_moves_cert_to_revoked(self, svc, store, certs_dir):
+        cam = _make_camera(status="online", cert_serial="ABC123")
+        store.get_camera.return_value = cam
+        # Create fake cert file
+        cert_path = certs_dir / "cameras" / "cam-001.crt"
+        cert_path.write_text("CERT CONTENT")
+        key_path = certs_dir / "cameras" / "cam-001.key"
+        key_path.write_text("KEY CONTENT")
+
+        error, status = svc.unpair("cam-001")
+        assert status == 200
+        assert not cert_path.exists()
+        assert not key_path.exists()
+        assert (certs_dir / "cameras" / "revoked" / "cam-001.crt").exists()
+
+    def test_adds_serial_to_revocation_set(self, svc, store, certs_dir):
+        cam = _make_camera(status="online", cert_serial="ABC123")
+        store.get_camera.return_value = cam
+        (certs_dir / "cameras" / "cam-001.crt").write_text("CERT")
+
+        svc.unpair("cam-001")
+        assert svc.is_cert_revoked("ABC123")
+
+    def test_resets_camera_state(self, svc, store, certs_dir):
+        cam = _make_camera(status="online", cert_serial="ABC123", pairing_secret="aabb")
+        store.get_camera.return_value = cam
+
+        svc.unpair("cam-001")
+        assert cam.status == "pending"
+        assert cam.cert_serial == ""
+        assert cam.pairing_secret == ""
+        store.save_camera.assert_called_once_with(cam)
+
+    def test_cancels_pending_pairing(self, svc, store, certs_dir):
+        cam = _make_camera(status="pending")
+        store.get_camera.return_value = cam
+        svc._pending_pairings["cam-001"] = {"pin": "123456"}
+
+        svc.unpair("cam-001")
+        assert "cam-001" not in svc._pending_pairings
+
+    def test_logs_audit_event(self, svc, store, audit, certs_dir):
+        cam = _make_camera(status="online")
+        store.get_camera.return_value = cam
+
+        svc.unpair("cam-001", user="admin", ip="10.0.0.1")
+        audit.log_event.assert_called_once()
+        assert audit.log_event.call_args[0][0] == "CERT_REVOKED"
+
+    def test_works_when_cert_file_missing(self, svc, store, certs_dir):
+        cam = _make_camera(status="online", cert_serial="ABC123")
+        store.get_camera.return_value = cam
+        # No cert file on disk
+        error, status = svc.unpair("cam-001")
+        assert status == 200
+
+
+class TestIsCertRevoked:
+    """Test certificate revocation checks."""
+
+    def test_returns_false_for_unknown_serial(self, svc):
+        assert not svc.is_cert_revoked("UNKNOWN")
+
+    def test_returns_true_after_unpair(self, svc, store, certs_dir):
+        cam = _make_camera(status="online", cert_serial="REVOKED123")
+        store.get_camera.return_value = cam
+        (certs_dir / "cameras" / "cam-001.crt").write_text("CERT")
+
+        svc.unpair("cam-001")
+        assert svc.is_cert_revoked("REVOKED123")
+
+
+class TestGetPendingPairing:
+    """Test pending pairing info retrieval."""
+
+    def test_returns_none_when_no_pending(self, svc):
+        assert svc.get_pending_pairing("cam-001") is None
+
+    def test_returns_info_when_pending(self, svc):
+        svc._pending_pairings["cam-001"] = {
+            "pin": "123456",
+            "expires_at": time.time() + 120,
+            "attempts": 1,
+            "cert_data": {},
+        }
+        info = svc.get_pending_pairing("cam-001")
+        assert info["pin"] == "123456"
+        assert info["expires_in"] > 0
+        assert info["attempts"] == 1
+
+    def test_returns_none_when_expired(self, svc):
+        svc._pending_pairings["cam-001"] = {
+            "pin": "123456",
+            "expires_at": time.time() - 1,
+            "attempts": 0,
+            "cert_data": {},
+        }
+        assert svc.get_pending_pairing("cam-001") is None
+        assert "cam-001" not in svc._pending_pairings
+
+
+class TestGenerateClientCert:
+    """Test certificate generation (subprocess calls mocked)."""
+
+    @patch("monitor.services.pairing_service.subprocess.run")
+    def test_generates_cert_with_correct_openssl_commands(
+        self, mock_run, svc, certs_dir
+    ):
+        # Mock all subprocess calls to succeed
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "serial=ABC123\n"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        # Create cert/key files that _read_file expects
+        cameras_dir = certs_dir / "cameras"
+        (cameras_dir / "cam-001.crt").write_text("GENERATED CERT")
+        (cameras_dir / "cam-001.key").write_text("GENERATED KEY")
+
+        cert_data, error = svc._generate_client_cert("cam-001")
+        assert error == ""
+        assert cert_data["cert"] == "GENERATED CERT"
+        assert cert_data["key"] == "GENERATED KEY"
+        assert cert_data["serial"] == "ABC123"
+
+        # Verify openssl was called (at least genkey, req, x509, serial read)
+        assert mock_run.call_count >= 4
+
+    @patch("monitor.services.pairing_service.subprocess.run")
+    def test_returns_error_on_openssl_failure(self, mock_run, svc, certs_dir):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "openssl error"
+        mock_run.return_value = mock_result
+
+        cert_data, error = svc._generate_client_cert("cam-001")
+        assert cert_data is None
+        assert "OpenSSL error" in error
+
+    def test_returns_error_when_ca_missing(self, store, audit, tmp_path):
+        empty_certs = tmp_path / "empty_certs"
+        empty_certs.mkdir()
+        (empty_certs / "cameras").mkdir()
+        svc = PairingService(store=store, audit=audit, certs_dir=str(empty_certs))
+        cert_data, error = svc._generate_client_cert("cam-001")
+        assert cert_data is None
+        assert "CA key or certificate not found" in error
+
+
+class TestAuditFailureResilience:
+    """Test that audit failures don't break pairing operations."""
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_initiate_works_when_audit_fails(self, mock_gen, store, certs_dir):
+        audit = MagicMock()
+        audit.log_event.side_effect = RuntimeError("disk full")
+        svc = PairingService(store=store, audit=audit, certs_dir=str(certs_dir))
+        store.get_camera.return_value = _make_camera(status="pending")
+        mock_gen.return_value = ({"cert": "C", "key": "K", "serial": "S"}, "")
+        pin, error, status = svc.initiate_pairing("cam-001")
+        assert status == 200
+
+    def test_unpair_works_when_audit_fails(self, store, certs_dir):
+        audit = MagicMock()
+        audit.log_event.side_effect = RuntimeError("disk full")
+        svc = PairingService(store=store, audit=audit, certs_dir=str(certs_dir))
+        store.get_camera.return_value = _make_camera(status="online")
+        error, status = svc.unpair("cam-001")
+        assert status == 200
+
+    def test_works_without_audit_service(self, store, certs_dir):
+        svc = PairingService(store=store, audit=None, certs_dir=str(certs_dir))
+        store.get_camera.return_value = _make_camera(status="online")
+        error, status = svc.unpair("cam-001")
+        assert status == 200


### PR DESCRIPTION
## Summary

- **PR 2A-1**: `PairingService` — server-side PIN generation, cert exchange, revocation, rate limiting (35 tests)
- **PR 2A-2**: Pairing API blueprint — `POST /cameras/<id>/pair`, `POST /cameras/<id>/unpair`, `POST /pair/exchange` (17 tests)
- **PR 2A-3**: Camera `PairingManager` — exchanges PIN for certs via server API, `PAIRING` lifecycle state, `/pair` page on status server (20 tests)

Implements the full PIN-based camera pairing flow from ADR-0009:
1. Admin clicks "Pair" on server dashboard → gets 6-digit PIN (5-min expiry)
2. Admin enters PIN + server URL on camera's `/pair` page
3. Camera POSTs to server's `/api/v1/pair/exchange`
4. Server returns ECDSA P-256 client cert, key, CA cert, pairing_secret
5. Camera stores certs → transitions from PAIRING to CONNECTING

## Test plan

- [x] Server pairing service tests pass (35 tests)
- [x] Server API pairing tests pass (17 tests)
- [x] Camera pairing tests pass (20 tests)
- [x] Full server test suite: 854 passed (90% coverage)
- [x] Full camera test suite: 288 passed (81% coverage)
- [x] Ruff lint + format clean
- [ ] Hardware: SCP deploy to RPi 4B + Zero 2W, test end-to-end pairing

🤖 Generated with [Claude Code](https://claude.com/claude-code)