### PR TITLE
feat: camera LUKS key derivation (HKDF-SHA256)

### DIFF
--- a/app/camera/camera_streamer/encryption.py
+++ b/app/camera/camera_streamer/encryption.py
@@ -1,0 +1,151 @@
+"""
+LUKS key derivation for camera data encryption (ADR-0010).
+
+Derives a LUKS key from the pairing secret (ADR-0009) and CPU serial.
+Uses HKDF-SHA256 — no external dependencies beyond Python stdlib.
+
+The derived key is used to:
+1. Format /data with LUKS2 + Adiantum on first boot
+2. Auto-unlock /data on subsequent boots (keyfile in initramfs)
+
+Key derivation:
+  camera_luks_key = HKDF-SHA256(
+      ikm  = pairing_secret,
+      salt = camera_cpu_serial,
+      info = "home-monitor-camera-luks-v1"
+  )
+"""
+
+import hashlib
+import hmac
+import logging
+import os
+
+log = logging.getLogger("camera-streamer.encryption")
+
+HKDF_INFO = b"home-monitor-camera-luks-v1"
+KEY_LENGTH = 32  # 256-bit key
+
+
+def _hkdf_extract(salt, ikm):
+    """HKDF-Extract: PRK = HMAC-SHA256(salt, IKM)."""
+    return hmac.new(salt, ikm, hashlib.sha256).digest()
+
+
+def _hkdf_expand(prk, info, length):
+    """HKDF-Expand: derive output key material from PRK."""
+    hash_len = 32  # SHA-256 output length
+    n = (length + hash_len - 1) // hash_len
+    okm = b""
+    t = b""
+    for i in range(1, n + 1):
+        t = hmac.new(prk, t + info + bytes([i]), hashlib.sha256).digest()
+        okm += t
+    return okm[:length]
+
+
+def hkdf_sha256(ikm, salt, info, length=KEY_LENGTH):
+    """HKDF-SHA256 key derivation (RFC 5869).
+
+    Args:
+        ikm: Input keying material (bytes).
+        salt: Salt value (bytes).
+        info: Context/application info (bytes).
+        length: Output key length in bytes.
+
+    Returns:
+        Derived key as bytes.
+    """
+    prk = _hkdf_extract(salt, ikm)
+    return _hkdf_expand(prk, info, length)
+
+
+def get_cpu_serial():
+    """Read the RPi CPU serial from /proc/cpuinfo.
+
+    Returns:
+        CPU serial string, or empty string if not found.
+    """
+    try:
+        with open("/proc/cpuinfo") as f:
+            for line in f:
+                if line.startswith("Serial"):
+                    return line.split(":")[-1].strip()
+    except OSError:
+        pass
+    return ""
+
+
+class EncryptionManager:
+    """Manages LUKS key derivation for camera data encryption.
+
+    Args:
+        pairing_manager: PairingManager instance (to read pairing_secret).
+        cpu_serial: CPU serial override (for testing). If None, reads from /proc/cpuinfo.
+    """
+
+    def __init__(self, pairing_manager, cpu_serial=None):
+        self._pairing = pairing_manager
+        self._cpu_serial = cpu_serial
+
+    @property
+    def cpu_serial(self):
+        """Return the CPU serial (cached after first read)."""
+        if self._cpu_serial is None:
+            self._cpu_serial = get_cpu_serial()
+        return self._cpu_serial
+
+    def derive_luks_key(self):
+        """Derive the LUKS key from pairing_secret + CPU serial.
+
+        Returns:
+            (key_bytes, error) tuple. key_bytes is 32 bytes on success,
+            None on failure.
+        """
+        secret_hex = self._pairing.get_pairing_secret()
+        if not secret_hex:
+            return None, "No pairing secret — camera not paired"
+
+        serial = self.cpu_serial
+        if not serial:
+            return None, "Cannot read CPU serial from /proc/cpuinfo"
+
+        try:
+            ikm = bytes.fromhex(secret_hex)
+        except ValueError:
+            return None, "Invalid pairing secret format (not hex)"
+
+        salt = serial.encode("utf-8")
+        key = hkdf_sha256(ikm, salt, HKDF_INFO, KEY_LENGTH)
+
+        log.info(
+            "LUKS key derived (serial=%s...%s, key_len=%d)",
+            serial[:4],
+            serial[-4:],
+            len(key),
+        )
+        return key, ""
+
+    def write_keyfile(self, path):
+        """Derive LUKS key and write to a keyfile.
+
+        Args:
+            path: Path to write the keyfile (e.g., /etc/cryptsetup-keys.d/data.key).
+
+        Returns:
+            (success, error) tuple.
+        """
+        key, err = self.derive_luks_key()
+        if key is None:
+            return False, err
+
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "wb") as f:
+                f.write(key)
+            os.chmod(path, 0o400)
+            log.info("LUKS keyfile written to %s", path)
+            return True, ""
+        except OSError as e:
+            log.error("Failed to write keyfile: %s", e)
+            return False, f"Failed to write keyfile: {e}"

--- a/app/camera/tests/test_encryption.py
+++ b/app/camera/tests/test_encryption.py
@@ -1,0 +1,209 @@
+"""Tests for camera LUKS key derivation (ADR-0010)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from camera_streamer.encryption import (
+    HKDF_INFO,
+    KEY_LENGTH,
+    EncryptionManager,
+    get_cpu_serial,
+    hkdf_sha256,
+)
+
+
+class TestHKDFSHA256:
+    """Test HKDF-SHA256 implementation against known vectors."""
+
+    def test_output_length(self):
+        """Should produce exactly KEY_LENGTH bytes."""
+        key = hkdf_sha256(b"secret", b"salt", b"info", KEY_LENGTH)
+        assert len(key) == KEY_LENGTH
+
+    def test_deterministic(self):
+        """Same inputs should produce same output."""
+        key1 = hkdf_sha256(b"secret", b"salt", b"info")
+        key2 = hkdf_sha256(b"secret", b"salt", b"info")
+        assert key1 == key2
+
+    def test_different_ikm_different_key(self):
+        """Different IKM should produce different key."""
+        key1 = hkdf_sha256(b"secret1", b"salt", b"info")
+        key2 = hkdf_sha256(b"secret2", b"salt", b"info")
+        assert key1 != key2
+
+    def test_different_salt_different_key(self):
+        """Different salt should produce different key."""
+        key1 = hkdf_sha256(b"secret", b"salt1", b"info")
+        key2 = hkdf_sha256(b"secret", b"salt2", b"info")
+        assert key1 != key2
+
+    def test_different_info_different_key(self):
+        """Different info should produce different key."""
+        key1 = hkdf_sha256(b"secret", b"salt", b"info1")
+        key2 = hkdf_sha256(b"secret", b"salt", b"info2")
+        assert key1 != key2
+
+    def test_custom_length(self):
+        """Should support custom output lengths."""
+        key16 = hkdf_sha256(b"secret", b"salt", b"info", 16)
+        key64 = hkdf_sha256(b"secret", b"salt", b"info", 64)
+        assert len(key16) == 16
+        assert len(key64) == 64
+
+    def test_rfc5869_test_vector(self):
+        """Verify against RFC 5869 test vector 1 (SHA-256).
+
+        IKM  = 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b (22 bytes)
+        salt = 0x000102030405060708090a0b0c (13 bytes)
+        info = 0xf0f1f2f3f4f5f6f7f8f9 (10 bytes)
+        L    = 42
+        """
+        ikm = bytes.fromhex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+        salt = bytes.fromhex("000102030405060708090a0b0c")
+        info = bytes.fromhex("f0f1f2f3f4f5f6f7f8f9")
+        expected_okm = bytes.fromhex(
+            "3cb25f25faacd57a90434f64d0362f2a"
+            "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+            "34007208d5b887185865"
+        )
+        okm = hkdf_sha256(ikm, salt, info, 42)
+        assert okm == expected_okm
+
+
+class TestGetCpuSerial:
+    """Test CPU serial reading."""
+
+    def test_reads_serial(self):
+        """Should extract serial from /proc/cpuinfo format."""
+        cpuinfo = "processor\t: 0\nmodel name\t: ARMv7\nSerial\t\t: 100000006789abcd\n"
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__ = lambda s: iter(cpuinfo.splitlines(True))
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            serial = get_cpu_serial()
+        assert serial == "100000006789abcd"
+
+    def test_returns_empty_on_error(self):
+        """Should return empty string if /proc/cpuinfo not readable."""
+        with patch("builtins.open", side_effect=OSError):
+            serial = get_cpu_serial()
+        assert serial == ""
+
+
+class TestEncryptionManager:
+    """Test EncryptionManager key derivation."""
+
+    @pytest.fixture
+    def pairing_mgr(self):
+        mgr = MagicMock()
+        # 32 bytes = 64 hex chars
+        mgr.get_pairing_secret.return_value = "ab" * 32
+        return mgr
+
+    def test_derive_luks_key_success(self, pairing_mgr):
+        """Should derive a 32-byte key from pairing_secret + serial."""
+        em = EncryptionManager(pairing_mgr, cpu_serial="100000006789abcd")
+        key, err = em.derive_luks_key()
+        assert key is not None
+        assert len(key) == 32
+        assert err == ""
+
+    def test_derive_key_deterministic(self, pairing_mgr):
+        """Same inputs should always produce same key."""
+        em1 = EncryptionManager(pairing_mgr, cpu_serial="100000006789abcd")
+        em2 = EncryptionManager(pairing_mgr, cpu_serial="100000006789abcd")
+        key1, _ = em1.derive_luks_key()
+        key2, _ = em2.derive_luks_key()
+        assert key1 == key2
+
+    def test_different_serial_different_key(self, pairing_mgr):
+        """Different CPU serials should produce different keys."""
+        em1 = EncryptionManager(pairing_mgr, cpu_serial="1111111111111111")
+        em2 = EncryptionManager(pairing_mgr, cpu_serial="2222222222222222")
+        key1, _ = em1.derive_luks_key()
+        key2, _ = em2.derive_luks_key()
+        assert key1 != key2
+
+    def test_different_secret_different_key(self):
+        """Different pairing secrets should produce different keys."""
+        mgr1 = MagicMock()
+        mgr1.get_pairing_secret.return_value = "aa" * 32
+        mgr2 = MagicMock()
+        mgr2.get_pairing_secret.return_value = "bb" * 32
+
+        em1 = EncryptionManager(mgr1, cpu_serial="100000006789abcd")
+        em2 = EncryptionManager(mgr2, cpu_serial="100000006789abcd")
+        key1, _ = em1.derive_luks_key()
+        key2, _ = em2.derive_luks_key()
+        assert key1 != key2
+
+    def test_fails_without_pairing_secret(self):
+        """Should fail if no pairing secret."""
+        mgr = MagicMock()
+        mgr.get_pairing_secret.return_value = ""
+        em = EncryptionManager(mgr, cpu_serial="100000006789abcd")
+        key, err = em.derive_luks_key()
+        assert key is None
+        assert "not paired" in err
+
+    def test_fails_without_cpu_serial(self, pairing_mgr):
+        """Should fail if CPU serial not available."""
+        em = EncryptionManager(pairing_mgr, cpu_serial="")
+        key, err = em.derive_luks_key()
+        assert key is None
+        assert "CPU serial" in err
+
+    def test_fails_with_invalid_hex_secret(self):
+        """Should fail if pairing secret is not valid hex."""
+        mgr = MagicMock()
+        mgr.get_pairing_secret.return_value = "not-valid-hex!"
+        em = EncryptionManager(mgr, cpu_serial="100000006789abcd")
+        key, err = em.derive_luks_key()
+        assert key is None
+        assert "not hex" in err
+
+    def test_uses_correct_hkdf_info(self, pairing_mgr):
+        """Should use the standard info string for key derivation."""
+        assert HKDF_INFO == b"home-monitor-camera-luks-v1"
+
+    def test_key_length_constant(self):
+        """Key length should be 32 bytes (256-bit)."""
+        assert KEY_LENGTH == 32
+
+
+class TestWriteKeyfile:
+    """Test writing LUKS keyfile to disk."""
+
+    @pytest.fixture
+    def pairing_mgr(self):
+        mgr = MagicMock()
+        mgr.get_pairing_secret.return_value = "ab" * 32
+        return mgr
+
+    def test_writes_keyfile(self, pairing_mgr, tmp_path):
+        """Should write derived key to file."""
+        em = EncryptionManager(pairing_mgr, cpu_serial="100000006789abcd")
+        keyfile = tmp_path / "keydir" / "data.key"
+        ok, err = em.write_keyfile(str(keyfile))
+        assert ok is True
+        assert err == ""
+        assert keyfile.exists()
+        assert len(keyfile.read_bytes()) == 32
+
+    def test_keyfile_contents_match_derived_key(self, pairing_mgr, tmp_path):
+        """Keyfile contents should match derive_luks_key output."""
+        em = EncryptionManager(pairing_mgr, cpu_serial="100000006789abcd")
+        key, _ = em.derive_luks_key()
+        keyfile = tmp_path / "data.key"
+        em.write_keyfile(str(keyfile))
+        assert keyfile.read_bytes() == key
+
+    def test_fails_without_secret(self, tmp_path):
+        """Should fail if no pairing secret."""
+        mgr = MagicMock()
+        mgr.get_pairing_secret.return_value = ""
+        em = EncryptionManager(mgr, cpu_serial="100000006789abcd")
+        ok, err = em.write_keyfile(str(tmp_path / "data.key"))
+        assert ok is False
+        assert "not paired" in err


### PR DESCRIPTION
## Summary

- **PR 2E-1**: `EncryptionManager` for camera LUKS key derivation (ADR-0010)
- HKDF-SHA256 derives 256-bit key from `pairing_secret` (ADR-0009) + CPU serial
- Pure stdlib implementation (hmac + hashlib) — no external dependencies
- Verified against RFC 5869 test vector 1
- `write_keyfile()` for initramfs keyfile generation

## Test plan

- [x] 21 encryption tests pass including RFC 5869 test vector
- [x] Full camera suite: 309 passed (81% coverage)
- [x] Ruff lint + format clean
- [ ] Hardware: verify CPU serial reads correctly on Zero 2W

🤖 Generated with [Claude Code](https://claude.com/claude-code)