### PR TITLE
feat: camera OTA agent with mTLS + stream-to-disk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,6 @@ Full pattern docs: [development-guide.md Section 3.6](docs/development-guide.md)
 
 Only what's NOT done. When you implement a gap, delete it from this list in the same PR.
 
-- **ota_agent.py** — camera OTA update listener (stub, Phase 2)
 - **LUKS first-boot** — first-boot LUKS formatting not yet implemented (Phase 2)
 - **Motion detection** — recording mode exists but motion trigger not implemented (Phase 2)
 - **Multi-camera** — framework exists, untested with multiple real cameras (Phase 2)

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -27,6 +27,7 @@ from camera_streamer.capture import CaptureManager
 from camera_streamer.discovery import DiscoveryService
 from camera_streamer.health import HealthMonitor
 from camera_streamer.led import LedController
+from camera_streamer.ota_agent import OTAAgent
 from camera_streamer.pairing import PairingManager
 from camera_streamer.status_server import CameraStatusServer
 from camera_streamer.stream import StreamManager
@@ -72,6 +73,7 @@ class CameraLifecycle:
         self._status_server = None
         self._health = None
         self._setup_server = None
+        self._ota_agent = None
         self._pairing = PairingManager(config)
 
     @property
@@ -109,6 +111,8 @@ class CameraLifecycle:
 
         if self._health:
             self._health.stop()
+        if self._ota_agent:
+            self._ota_agent.stop()
         if self._stream:
             self._stream.stop()
         if self._status_server:
@@ -246,6 +250,10 @@ class CameraLifecycle:
             pairing_manager=self._pairing,
         )
         self._status_server.start()
+
+        # OTA update agent (port 8080)
+        self._ota_agent = OTAAgent(self._config)
+        self._ota_agent.start()
 
         # Health monitoring
         self._health = HealthMonitor(

--- a/app/camera/camera_streamer/ota_agent.py
+++ b/app/camera/camera_streamer/ota_agent.py
@@ -1,16 +1,297 @@
 """
-OTA update agent.
+OTA update agent (ADR-0008).
 
-Listens for update pushes from the home server.
+Listens for update pushes from the home server over mTLS.
 When an update is received:
-1. Download .swu image from server
-2. Verify Ed25519 signature
-3. Run swupdate to install to inactive rootfs partition
-4. Reboot into new partition
-5. If boot fails 3 times → automatic rollback
+1. Stream .swu bundle to disk (never buffer in RAM — 512MB camera)
+2. Verify Ed25519 signature via swupdate -c
+3. Install via swupdate -i (A/B partition swap)
+4. Report status back to server
+5. If boot fails 3 times → automatic rollback (U-Boot bootlimit)
 
-The agent runs a small HTTP endpoint (port 8080) that only
-accepts connections from the server IP (enforced by nftables).
+The agent runs a small HTTP server on port 8080.
+When paired (certs available), it uses mTLS. Otherwise plain HTTP.
+
+Design patterns:
+- Constructor Injection (config)
+- Stream-to-Disk (never buffer full bundle in RAM)
+- Fail-Silent (agent errors don't crash camera main loop)
 """
 
-# TODO: Implement OTAAgent class
+import logging
+import os
+import ssl
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+log = logging.getLogger("camera-streamer.ota-agent")
+
+OTA_PORT = 8080
+MAX_BUNDLE_SIZE = 500 * 1024 * 1024  # 500MB
+CHUNK_SIZE = 64 * 1024  # 64KB chunks for streaming to disk
+
+
+class OTAAgent:
+    """Camera-side OTA update agent.
+
+    Runs an HTTP server that accepts .swu bundle uploads from the
+    home server, verifies them, and installs via swupdate.
+
+    Args:
+        config: ConfigManager instance for paths and settings.
+    """
+
+    def __init__(self, config):
+        self._config = config
+        self._server = None
+        self._thread = None
+        self._running = False
+        self._status = {"state": "idle", "progress": 0, "error": ""}
+        self._status_lock = threading.Lock()
+
+    @property
+    def status(self):
+        """Return current OTA status."""
+        with self._status_lock:
+            return dict(self._status)
+
+    @property
+    def staging_dir(self):
+        return os.path.join(self._config.data_dir, "ota", "staging")
+
+    def _set_status(self, state, **kwargs):
+        """Update OTA status (thread-safe)."""
+        with self._status_lock:
+            self._status["state"] = state
+            self._status.update(kwargs)
+
+    def start(self):
+        """Start the OTA HTTP server in a background thread."""
+        if self._running:
+            return
+
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._run_server, daemon=True, name="ota-agent"
+        )
+        self._thread.start()
+        log.info("OTA agent started on port %d", OTA_PORT)
+
+    def stop(self):
+        """Stop the OTA HTTP server."""
+        self._running = False
+        if self._server:
+            self._server.shutdown()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+
+    def _run_server(self):
+        """Run the HTTP server (blocking)."""
+        agent = self
+
+        class OTAHandler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                if self.path == "/ota/upload":
+                    agent._handle_upload(self)
+                else:
+                    self.send_error(404)
+
+            def do_GET(self):
+                if self.path == "/ota/status":
+                    agent._handle_status(self)
+                else:
+                    self.send_error(404)
+
+            def log_message(self, format, *args):
+                log.debug("OTA HTTP: %s", format % args)
+
+        try:
+            self._server = HTTPServer(("0.0.0.0", OTA_PORT), OTAHandler)
+            self._server = self._wrap_tls(self._server)
+            while self._running:
+                self._server.handle_request()
+        except Exception:
+            log.exception("OTA agent server error")
+
+    def _wrap_tls(self, server):
+        """Wrap server socket with mTLS if certs are available."""
+        certs_dir = self._config.certs_dir
+        cert_path = os.path.join(certs_dir, "client.crt")
+        key_path = os.path.join(certs_dir, "client.key")
+        ca_path = os.path.join(certs_dir, "ca.crt")
+
+        if not all(os.path.isfile(p) for p in [cert_path, key_path, ca_path]):
+            log.warning("mTLS certs not found — OTA agent running without TLS")
+            return server
+
+        try:
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(cert_path, key_path)
+            ctx.load_verify_locations(ca_path)
+            ctx.verify_mode = ssl.CERT_REQUIRED
+            server.socket = ctx.wrap_socket(server.socket, server_side=True)
+            log.info("OTA agent using mTLS")
+        except (ssl.SSLError, OSError) as e:
+            log.warning("Failed to enable mTLS for OTA agent: %s", e)
+
+        return server
+
+    def _handle_status(self, handler):
+        """Handle GET /ota/status — return current update status."""
+        import json
+
+        body = json.dumps(self.status).encode()
+        handler.send_response(200)
+        handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(body)))
+        handler.end_headers()
+        handler.wfile.write(body)
+
+    def _handle_upload(self, handler):
+        """Handle POST /ota/upload — receive and install .swu bundle.
+
+        Streams the upload directly to disk to avoid OOM on the
+        512MB camera. Never buffers the full bundle in memory.
+        """
+        content_length = int(handler.headers.get("Content-Length", 0))
+        if content_length <= 0:
+            self._send_json(handler, 400, {"error": "No content"})
+            return
+
+        if content_length > MAX_BUNDLE_SIZE:
+            self._send_json(handler, 400, {"error": "Bundle too large"})
+            return
+
+        self._set_status("downloading", progress=0, error="")
+
+        # Stream to disk
+        os.makedirs(self.staging_dir, exist_ok=True)
+        bundle_path = os.path.join(self.staging_dir, "update.swu")
+
+        try:
+            received = 0
+            with open(bundle_path, "wb") as f:
+                while received < content_length:
+                    chunk_size = min(CHUNK_SIZE, content_length - received)
+                    chunk = handler.rfile.read(chunk_size)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+                    received += len(chunk)
+                    progress = int((received / content_length) * 50)
+                    self._set_status("downloading", progress=progress)
+
+            if received != content_length:
+                self._set_status("error", error="Incomplete upload")
+                self._send_json(handler, 400, {"error": "Incomplete upload"})
+                return
+
+        except OSError as e:
+            self._set_status("error", error=str(e))
+            self._send_json(handler, 500, {"error": f"Write failed: {e}"})
+            return
+
+        log.info("OTA bundle received: %d bytes", received)
+
+        # Verify
+        self._set_status("verifying", progress=50)
+        valid, verify_err = self._verify_bundle(bundle_path)
+        if not valid:
+            self._set_status("error", error=verify_err)
+            self._cleanup(bundle_path)
+            self._send_json(handler, 400, {"error": verify_err})
+            return
+
+        # Install
+        self._set_status("installing", progress=60)
+        ok, install_err = self._install_bundle(bundle_path)
+        if not ok:
+            self._set_status("error", error=install_err)
+            self._cleanup(bundle_path)
+            self._send_json(handler, 500, {"error": install_err})
+            return
+
+        self._set_status("installed", progress=100, error="")
+        self._cleanup(bundle_path)
+        log.info("OTA installation complete — reboot required")
+        self._send_json(handler, 200, {"message": "Installed — reboot required"})
+
+    def _verify_bundle(self, bundle_path):
+        """Verify Ed25519 signature of a .swu bundle.
+
+        Returns:
+            (valid, error) tuple.
+        """
+        public_key = os.path.join(self._config.certs_dir, "swupdate-public.pem")
+        if not os.path.isfile(public_key):
+            log.warning("No public key found — skipping verification (dev mode)")
+            return True, ""
+
+        try:
+            result = subprocess.run(
+                ["swupdate", "-c", "-i", bundle_path, "-k", public_key],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode == 0:
+                log.info("Bundle signature verified")
+                return True, ""
+            error = result.stderr.strip() or "Signature verification failed"
+            log.error("Bundle verification failed: %s", error)
+            return False, error
+
+        except FileNotFoundError:
+            log.warning("swupdate not found — skipping verification (dev mode)")
+            return True, ""
+        except subprocess.TimeoutExpired:
+            return False, "Verification timed out"
+        except OSError as e:
+            return False, str(e)
+
+    def _install_bundle(self, bundle_path):
+        """Install a .swu bundle via swupdate.
+
+        Returns:
+            (success, error) tuple.
+        """
+        try:
+            result = subprocess.run(
+                ["swupdate", "-i", bundle_path],
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+            if result.returncode == 0:
+                log.info("swupdate installation complete")
+                return True, ""
+            error = result.stderr.strip() or "Installation failed"
+            log.error("swupdate installation failed: %s", error)
+            return False, error
+
+        except FileNotFoundError:
+            return False, "swupdate not installed"
+        except subprocess.TimeoutExpired:
+            return False, "Installation timed out (10 min)"
+        except OSError as e:
+            return False, str(e)
+
+    def _cleanup(self, bundle_path):
+        """Remove bundle file after install or failure."""
+        try:
+            if os.path.isfile(bundle_path):
+                os.remove(bundle_path)
+        except OSError:
+            pass
+
+    def _send_json(self, handler, status_code, data):
+        """Send a JSON response."""
+        import json
+
+        body = json.dumps(data).encode()
+        handler.send_response(status_code)
+        handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(body)))
+        handler.end_headers()
+        handler.wfile.write(body)

--- a/app/camera/tests/test_ota_agent.py
+++ b/app/camera/tests/test_ota_agent.py
@@ -1,0 +1,357 @@
+"""Tests for OTAAgent — camera-side OTA update handler."""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from camera_streamer.ota_agent import CHUNK_SIZE, MAX_BUNDLE_SIZE, OTA_PORT, OTAAgent
+
+
+@pytest.fixture
+def config(tmp_path):
+    """Create a mock config with temp directories."""
+    cfg = MagicMock()
+    cfg.data_dir = str(tmp_path)
+    cfg.certs_dir = str(tmp_path / "certs")
+    os.makedirs(cfg.certs_dir, exist_ok=True)
+    return cfg
+
+
+@pytest.fixture
+def agent(config):
+    """Create an OTAAgent with mock config."""
+    return OTAAgent(config)
+
+
+class TestInit:
+    """Test agent initialization."""
+
+    def test_default_status_idle(self, agent):
+        assert agent.status["state"] == "idle"
+        assert agent.status["progress"] == 0
+        assert agent.status["error"] == ""
+
+    def test_staging_dir(self, agent, config):
+        expected = os.path.join(config.data_dir, "ota", "staging")
+        assert agent.staging_dir == expected
+
+    def test_status_returns_copy(self, agent):
+        s1 = agent.status
+        s1["state"] = "modified"
+        assert agent.status["state"] == "idle"
+
+
+class TestSetStatus:
+    """Test status updates."""
+
+    def test_set_status(self, agent):
+        agent._set_status("downloading", progress=25)
+        assert agent.status["state"] == "downloading"
+        assert agent.status["progress"] == 25
+
+    def test_set_status_with_error(self, agent):
+        agent._set_status("error", error="disk full")
+        assert agent.status["state"] == "error"
+        assert agent.status["error"] == "disk full"
+
+    def test_set_status_preserves_fields(self, agent):
+        agent._set_status("downloading", progress=50)
+        agent._set_status("verifying")
+        assert agent.status["progress"] == 50  # preserved
+
+
+class TestVerifyBundle:
+    """Test bundle signature verification."""
+
+    def test_no_public_key_skips(self, agent, tmp_path):
+        """Should skip verification when no public key exists (dev mode)."""
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+        valid, err = agent._verify_bundle(bundle)
+        assert valid is True
+        assert err == ""
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_verify_success(self, mock_run, agent, config, tmp_path):
+        """Should return True when swupdate verification passes."""
+        # Create public key so verification runs
+        key_path = os.path.join(config.certs_dir, "swupdate-public.pem")
+        with open(key_path, "w") as f:
+            f.write("PUBLIC KEY")
+
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        valid, err = agent._verify_bundle(bundle)
+        assert valid is True
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_verify_failure(self, mock_run, agent, config, tmp_path):
+        """Should return False when signature is invalid."""
+        key_path = os.path.join(config.certs_dir, "swupdate-public.pem")
+        with open(key_path, "w") as f:
+            f.write("PUBLIC KEY")
+
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="bad signature"
+        )
+        valid, err = agent._verify_bundle(bundle)
+        assert valid is False
+        assert "bad signature" in err
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_swupdate_not_found(self, mock_run, agent, config, tmp_path):
+        """Should skip verification when swupdate not installed."""
+        key_path = os.path.join(config.certs_dir, "swupdate-public.pem")
+        with open(key_path, "w") as f:
+            f.write("PUBLIC KEY")
+
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.side_effect = FileNotFoundError
+        valid, err = agent._verify_bundle(bundle)
+        assert valid is True  # dev mode fallback
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_verify_timeout(self, mock_run, agent, config, tmp_path):
+        key_path = os.path.join(config.certs_dir, "swupdate-public.pem")
+        with open(key_path, "w") as f:
+            f.write("PUBLIC KEY")
+
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.side_effect = subprocess.TimeoutExpired("swupdate", 60)
+        valid, err = agent._verify_bundle(bundle)
+        assert valid is False
+        assert "timed out" in err.lower()
+
+
+class TestInstallBundle:
+    """Test bundle installation via swupdate."""
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_install_success(self, mock_run, agent, tmp_path):
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ok, err = agent._install_bundle(bundle)
+        assert ok is True
+        assert err == ""
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_install_failure(self, mock_run, agent, tmp_path):
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="write failed"
+        )
+        ok, err = agent._install_bundle(bundle)
+        assert ok is False
+        assert "write failed" in err
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_install_not_found(self, mock_run, agent, tmp_path):
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.side_effect = FileNotFoundError
+        ok, err = agent._install_bundle(bundle)
+        assert ok is False
+        assert "not installed" in err
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_install_timeout(self, mock_run, agent, tmp_path):
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.side_effect = subprocess.TimeoutExpired("swupdate", 600)
+        ok, err = agent._install_bundle(bundle)
+        assert ok is False
+        assert "timed out" in err.lower()
+
+
+class TestCleanup:
+    """Test bundle cleanup."""
+
+    def test_removes_file(self, agent, tmp_path):
+        path = str(tmp_path / "test.swu")
+        with open(path, "w") as f:
+            f.write("test")
+        agent._cleanup(path)
+        assert not os.path.exists(path)
+
+    def test_handles_missing_file(self, agent):
+        agent._cleanup("/nonexistent/file.swu")  # Should not raise
+
+
+class TestStartStop:
+    """Test agent lifecycle."""
+
+    def test_start_creates_thread(self, agent):
+        with patch.object(agent, "_run_server"):
+            agent.start()
+            assert agent._thread is not None
+            assert agent._running is True
+            agent.stop()
+
+    def test_stop_sets_flag(self, agent):
+        with patch.object(agent, "_run_server"):
+            agent.start()
+            agent.stop()
+            assert agent._running is False
+
+    def test_start_idempotent(self, agent):
+        with patch.object(agent, "_run_server"):
+            agent.start()
+            thread1 = agent._thread
+            agent.start()  # Should not create a second thread
+            assert agent._thread is thread1
+            agent.stop()
+
+
+class TestWrapTLS:
+    """Test mTLS wrapper."""
+
+    def test_no_certs_returns_plain_server(self, agent):
+        """Should return server unchanged when no certs exist."""
+        mock_server = MagicMock()
+        result = agent._wrap_tls(mock_server)
+        assert result is mock_server
+
+    def test_with_certs_wraps_socket(self, agent, config):
+        """Should attempt to wrap socket when all certs exist."""
+        for name in ["client.crt", "client.key", "ca.crt"]:
+            with open(os.path.join(config.certs_dir, name), "w") as f:
+                f.write("FAKE")
+
+        mock_server = MagicMock()
+        with patch("camera_streamer.ota_agent.ssl.SSLContext") as mock_ctx:
+            mock_ctx.return_value = MagicMock()
+            agent._wrap_tls(mock_server)
+            mock_ctx.assert_called_once()
+
+
+class TestHandleUpload:
+    """Test the upload handler logic."""
+
+    def _make_handler(self, body, content_length=None):
+        """Create a mock HTTP handler with given body."""
+        import io
+
+        handler = MagicMock()
+        handler.headers = {"Content-Length": str(content_length or len(body))}
+        handler.rfile = io.BytesIO(body)
+        handler.wfile = io.BytesIO()
+        return handler
+
+    def test_rejects_no_content(self, agent):
+        handler = self._make_handler(b"", content_length=0)
+        agent._handle_upload(handler)
+        handler.send_response.assert_called_with(400)
+
+    def test_rejects_oversized(self, agent):
+        handler = self._make_handler(b"x", content_length=MAX_BUNDLE_SIZE + 1)
+        agent._handle_upload(handler)
+        handler.send_response.assert_called_with(400)
+
+    @patch.object(OTAAgent, "_install_bundle", return_value=(True, ""))
+    @patch.object(OTAAgent, "_verify_bundle", return_value=(True, ""))
+    def test_successful_upload(self, mock_verify, mock_install, agent, config):
+        """Should download, verify, install, and return 200."""
+        body = b"fake-swu-content" * 100
+        handler = self._make_handler(body)
+        agent._handle_upload(handler)
+        handler.send_response.assert_called_with(200)
+        mock_verify.assert_called_once()
+        mock_install.assert_called_once()
+        assert agent.status["state"] == "installed"
+
+    @patch.object(OTAAgent, "_verify_bundle", return_value=(False, "bad sig"))
+    def test_verification_failure(self, mock_verify, agent, config):
+        """Should return 400 on verification failure."""
+        body = b"fake-swu-content"
+        handler = self._make_handler(body)
+        agent._handle_upload(handler)
+        handler.send_response.assert_called_with(400)
+        assert agent.status["state"] == "error"
+
+    @patch.object(OTAAgent, "_install_bundle", return_value=(False, "disk full"))
+    @patch.object(OTAAgent, "_verify_bundle", return_value=(True, ""))
+    def test_install_failure(self, mock_verify, mock_install, agent, config):
+        """Should return 500 on install failure."""
+        body = b"fake-swu-content"
+        handler = self._make_handler(body)
+        agent._handle_upload(handler)
+        handler.send_response.assert_called_with(500)
+        assert agent.status["state"] == "error"
+
+    @patch.object(OTAAgent, "_install_bundle", return_value=(True, ""))
+    @patch.object(OTAAgent, "_verify_bundle", return_value=(True, ""))
+    def test_streams_to_disk(self, mock_verify, mock_install, agent, config):
+        """Should write bundle to staging dir, not hold in memory."""
+        body = b"x" * (CHUNK_SIZE * 3)  # Multiple chunks
+        handler = self._make_handler(body)
+        agent._handle_upload(handler)
+        # Verify the bundle was passed to verify and install
+        bundle_path = mock_verify.call_args[0][0]
+        assert "staging" in bundle_path
+        assert bundle_path.endswith("update.swu")
+
+    def test_incomplete_upload(self, agent, config):
+        """Should reject incomplete uploads."""
+        body = b"short"
+        handler = self._make_handler(body, content_length=1000)
+        agent._handle_upload(handler)
+        handler.send_response.assert_called_with(400)
+        assert agent.status["state"] == "error"
+
+
+class TestHandleStatus:
+    """Test the status handler."""
+
+    def test_returns_status_json(self, agent):
+        import io
+        import json
+
+        handler = MagicMock()
+        handler.wfile = io.BytesIO()
+        agent._set_status("installing", progress=75)
+        agent._handle_status(handler)
+        handler.send_response.assert_called_with(200)
+        # Parse the response body
+        body = handler.wfile.getvalue()
+        data = json.loads(body)
+        assert data["state"] == "installing"
+        assert data["progress"] == 75
+
+
+class TestConstants:
+    """Test module constants."""
+
+    def test_port(self):
+        assert OTA_PORT == 8080
+
+    def test_max_bundle_size(self):
+        assert MAX_BUNDLE_SIZE == 500 * 1024 * 1024
+
+    def test_chunk_size(self):
+        assert CHUNK_SIZE == 64 * 1024


### PR DESCRIPTION
## Summary
- Replace `ota_agent.py` stub with full `OTAAgent` class (ADR-0008)
- HTTP server on port 8080, mTLS when paired (certs available)
- Stream uploads to disk in 64KB chunks — never buffer full bundle in RAM (512MB camera)
- Ed25519 signature verification via `swupdate -c`, installation via `swupdate -i`
- Wire into camera lifecycle: starts in RUNNING state, stops in SHUTDOWN
- Dev-mode fallbacks: skip verification when swupdate/public key not available

## Test plan
- [x] 33 new tests in `test_ota_agent.py`
- [x] All 352 camera tests pass
- [x] Coverage: 82.19%
- [x] Lint clean (ruff check + format)
- [x] Remove `ota_agent.py` from CLAUDE.md known gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)