### PR TITLE
feat: Tailscale VPN service + settings API

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -22,6 +22,7 @@ from monitor.services.settings_service import SettingsService
 from monitor.services.storage_manager import StorageManager
 from monitor.services.storage_service import StorageService
 from monitor.services.streaming_service import StreamingService
+from monitor.services.tailscale_service import TailscaleService
 from monitor.services.user_service import UserService
 from monitor.store import Store
 
@@ -200,6 +201,9 @@ def _init_services(app):
         certs_dir=app.config["CERTS_DIR"],
         audit=app.audit,
     )
+
+    # Tailscale service — VPN status and management
+    app.tailscale_service = TailscaleService(audit=app.audit)
 
     # Connect storage manager → streaming service for dir change notifications
     def _on_recording_dir_change(new_dir):

--- a/app/server/monitor/api/system.py
+++ b/app/server/monitor/api/system.py
@@ -2,13 +2,16 @@
 System health and info API.
 
 Endpoints:
-  GET /system/health  - CPU temp, CPU%, RAM%, disk usage, warnings
-  GET /system/info    - firmware version, uptime, hostname
+  GET  /system/health              - CPU temp, CPU%, RAM%, disk usage, warnings
+  GET  /system/info                - firmware version, uptime, hostname
+  GET  /system/tailscale           - Tailscale VPN status
+  POST /system/tailscale/connect   - Start Tailscale, return auth URL if needed
+  POST /system/tailscale/disconnect - Stop Tailscale
 """
 
 from flask import Blueprint, current_app, jsonify
 
-from monitor.auth import login_required
+from monitor.auth import admin_required, login_required
 from monitor.services.health import get_health_summary, get_uptime
 
 system_bp = Blueprint("system", __name__)
@@ -36,3 +39,45 @@ def info():
             "uptime": uptime,
         }
     ), 200
+
+
+# ---------------------------------------------------------------------------
+# Tailscale VPN management
+# ---------------------------------------------------------------------------
+
+
+@system_bp.route("/tailscale", methods=["GET"])
+@login_required
+def tailscale_status():
+    """Get Tailscale VPN status."""
+    ts = current_app.tailscale_service
+    return jsonify(ts.get_status()), 200
+
+
+@system_bp.route("/tailscale/connect", methods=["POST"])
+@admin_required
+def tailscale_connect():
+    """Start Tailscale. Returns auth URL if login is needed. Admin only."""
+    ts = current_app.tailscale_service
+    auth_url, err = ts.connect()
+    if err:
+        return jsonify({"error": err}), 500
+
+    if auth_url:
+        return jsonify(
+            {"auth_url": auth_url, "message": "Visit URL to authenticate"}
+        ), 200
+
+    return jsonify({"message": "Tailscale connected"}), 200
+
+
+@system_bp.route("/tailscale/disconnect", methods=["POST"])
+@admin_required
+def tailscale_disconnect():
+    """Stop Tailscale (keeps authentication). Admin only."""
+    ts = current_app.tailscale_service
+    ok, err = ts.disconnect()
+    if not ok:
+        return jsonify({"error": err}), 500
+
+    return jsonify({"message": "Tailscale disconnected"}), 200

--- a/app/server/monitor/services/tailscale_service.py
+++ b/app/server/monitor/services/tailscale_service.py
@@ -1,0 +1,230 @@
+"""
+Tailscale VPN management service.
+
+Wraps the tailscale CLI to provide status, connect/disconnect, and
+auth URL retrieval for the web dashboard settings page.
+
+Design patterns:
+- Constructor Injection (audit)
+- Single Responsibility (Tailscale lifecycle only)
+- Fail-Silent (CLI failures return error tuples, never crash)
+"""
+
+import json
+import logging
+import subprocess
+
+log = logging.getLogger("monitor.tailscale")
+
+# Timeout for tailscale CLI commands (seconds)
+CLI_TIMEOUT = 15
+
+# Longer timeout for 'tailscale up' which may need network negotiation
+CONNECT_TIMEOUT = 30
+
+
+class TailscaleService:
+    """Manages Tailscale VPN status and connection.
+
+    Args:
+        audit: AuditLogger instance (optional).
+    """
+
+    def __init__(self, audit=None):
+        self._audit = audit
+
+    def get_status(self):
+        """Get current Tailscale status.
+
+        Returns:
+            dict with keys:
+                installed (bool): Whether tailscale binary exists.
+                running (bool): Whether tailscaled daemon is running.
+                state (str): "connected", "needs-login", "stopped", or "unavailable".
+                hostname (str): Tailscale hostname (if connected).
+                tailscale_ip (str): Tailscale IP address (if connected).
+                exit_node (bool): Whether acting as exit node.
+                peers (list[dict]): Connected peers [{name, ip, online}].
+        """
+        result = {
+            "installed": False,
+            "running": False,
+            "state": "unavailable",
+            "hostname": "",
+            "tailscale_ip": "",
+            "exit_node": False,
+            "peers": [],
+        }
+
+        # Check if binary exists
+        if not self._binary_exists():
+            return result
+        result["installed"] = True
+
+        # Get JSON status from tailscale
+        status_data, err = self._run_json(["tailscale", "status", "--json"])
+        if err:
+            err_lower = err.lower()
+            if (
+                "not running" in err_lower
+                or "not connect" in err_lower
+                or "doesn't appear to be running" in err_lower
+            ):
+                result["state"] = "stopped"
+            return result
+
+        result["running"] = True
+
+        # Parse backend state
+        backend_state = status_data.get("BackendState", "")
+        if backend_state == "Running":
+            result["state"] = "connected"
+        elif backend_state == "NeedsLogin":
+            result["state"] = "needs-login"
+        elif backend_state == "Stopped":
+            result["state"] = "stopped"
+        else:
+            result["state"] = backend_state.lower() if backend_state else "unknown"
+
+        # Parse self node info
+        self_node = status_data.get("Self", {})
+        if self_node:
+            result["hostname"] = self_node.get("HostName", "")
+            ips = self_node.get("TailscaleIPs", [])
+            if ips:
+                # First IP is always the IPv4 Tailscale address
+                result["tailscale_ip"] = ips[0]
+            result["exit_node"] = self_node.get("ExitNode", False)
+
+        # Parse peers
+        peer_map = status_data.get("Peer", {})
+        for _key, peer in peer_map.items():
+            result["peers"].append(
+                {
+                    "name": peer.get("HostName", ""),
+                    "ip": (peer.get("TailscaleIPs") or [""])[0],
+                    "online": peer.get("Online", False),
+                }
+            )
+
+        return result
+
+    def connect(self):
+        """Start Tailscale and return auth URL if login is needed.
+
+        Returns:
+            (auth_url_or_none, error) tuple.
+            auth_url is a string URL if login is needed, None if already connected.
+        """
+        if not self._binary_exists():
+            return None, "Tailscale is not installed"
+
+        try:
+            proc = subprocess.run(
+                ["tailscale", "up"],
+                capture_output=True,
+                text=True,
+                timeout=CONNECT_TIMEOUT,
+            )
+        except FileNotFoundError:
+            return None, "Tailscale binary not found"
+        except subprocess.TimeoutExpired:
+            return None, "Connection timed out"
+        except OSError as e:
+            return None, str(e)
+
+        combined = proc.stdout + proc.stderr
+
+        # Look for auth URL in output
+        auth_url = self._extract_auth_url(combined)
+        if auth_url:
+            self._log_audit("TAILSCALE_AUTH_NEEDED", "Auth URL generated")
+            return auth_url, ""
+
+        if proc.returncode == 0:
+            self._log_audit("TAILSCALE_CONNECTED", "Tailscale connected")
+            return None, ""
+
+        return None, combined.strip() or "Unknown error"
+
+    def disconnect(self):
+        """Stop Tailscale (keeps authentication).
+
+        Returns:
+            (success, error) tuple.
+        """
+        if not self._binary_exists():
+            return False, "Tailscale is not installed"
+
+        try:
+            result = subprocess.run(
+                ["tailscale", "down"],
+                capture_output=True,
+                text=True,
+                timeout=CLI_TIMEOUT,
+            )
+            if result.returncode == 0:
+                self._log_audit("TAILSCALE_DISCONNECTED", "Tailscale disconnected")
+                return True, ""
+            return False, result.stderr.strip() or "Disconnect failed"
+        except FileNotFoundError:
+            return False, "Tailscale binary not found"
+        except subprocess.TimeoutExpired:
+            return False, "Disconnect timed out"
+        except OSError as e:
+            return False, str(e)
+
+    def _binary_exists(self):
+        """Check if tailscale binary is available."""
+        try:
+            subprocess.run(
+                ["tailscale", "version"],
+                capture_output=True,
+                timeout=5,
+            )
+            return True
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return False
+
+    def _run_json(self, cmd):
+        """Run a tailscale command and parse JSON output.
+
+        Returns:
+            (parsed_dict, error_string) tuple.
+        """
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=CLI_TIMEOUT,
+            )
+            if result.returncode != 0:
+                return {}, result.stderr.strip() or "Command failed"
+            try:
+                return json.loads(result.stdout), ""
+            except (json.JSONDecodeError, ValueError):
+                return {}, "Invalid JSON response"
+        except FileNotFoundError:
+            return {}, "Tailscale binary not found"
+        except subprocess.TimeoutExpired:
+            return {}, "Command timed out"
+        except OSError as e:
+            return {}, str(e)
+
+    @staticmethod
+    def _extract_auth_url(text):
+        """Extract Tailscale auth URL from CLI output."""
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("https://login.tailscale.com/"):
+                return line
+        return None
+
+    def _log_audit(self, event, detail):
+        """Log audit event (fail-silent)."""
+        if self._audit:
+            try:
+                self._audit.log_event(event, detail=detail)
+            except Exception:
+                pass

--- a/app/server/tests/test_api_contracts.py
+++ b/app/server/tests/test_api_contracts.py
@@ -647,6 +647,55 @@ class TestOtaStatusContract:
 
 
 # ===========================================================================
+# Tailscale contracts (/api/v1/system/tailscale*)
+# ===========================================================================
+
+
+class TestTailscaleStatusContract:
+    """GET /api/v1/system/tailscale."""
+
+    def test_fields(self, app, client):
+        _login(app, client)
+        resp = client.get("/api/v1/system/tailscale")
+        data = resp.get_json()
+        _assert_has_fields(
+            data,
+            {"installed", "running", "state", "hostname", "tailscale_ip", "peers"},
+        )
+        assert isinstance(data["peers"], list)
+
+    def test_requires_auth(self, client):
+        resp = client.get("/api/v1/system/tailscale")
+        assert resp.status_code == 401
+
+
+class TestTailscaleConnectContract:
+    """POST /api/v1/system/tailscale/connect."""
+
+    def test_requires_admin(self, app, client):
+        _login(app, client, role="viewer")
+        resp = client.post("/api/v1/system/tailscale/connect")
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client):
+        resp = client.post("/api/v1/system/tailscale/connect")
+        assert resp.status_code == 401
+
+
+class TestTailscaleDisconnectContract:
+    """POST /api/v1/system/tailscale/disconnect."""
+
+    def test_requires_admin(self, app, client):
+        _login(app, client, role="viewer")
+        resp = client.post("/api/v1/system/tailscale/disconnect")
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client):
+        resp = client.post("/api/v1/system/tailscale/disconnect")
+        assert resp.status_code == 401
+
+
+# ===========================================================================
 # Error response contracts (consistency check)
 # ===========================================================================
 

--- a/app/server/tests/test_svc_tailscale.py
+++ b/app/server/tests/test_svc_tailscale.py
@@ -1,0 +1,327 @@
+"""Tests for TailscaleService — Tailscale VPN management."""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monitor.services.tailscale_service import TailscaleService
+
+
+@pytest.fixture
+def svc():
+    """Create TailscaleService with mock audit."""
+    return TailscaleService(audit=MagicMock())
+
+
+# Sample tailscale status --json output (connected state)
+SAMPLE_STATUS_CONNECTED = {
+    "BackendState": "Running",
+    "Self": {
+        "HostName": "rpi-divinu",
+        "TailscaleIPs": ["100.64.0.1", "fd7a:115c:a1e0::1"],
+        "ExitNode": False,
+    },
+    "Peer": {
+        "node1": {
+            "HostName": "my-laptop",
+            "TailscaleIPs": ["100.64.0.2"],
+            "Online": True,
+        },
+        "node2": {
+            "HostName": "my-phone",
+            "TailscaleIPs": ["100.64.0.3"],
+            "Online": False,
+        },
+    },
+}
+
+SAMPLE_STATUS_NEEDS_LOGIN = {
+    "BackendState": "NeedsLogin",
+    "Self": {"HostName": "rpi-divinu", "TailscaleIPs": [], "ExitNode": False},
+    "Peer": {},
+}
+
+SAMPLE_STATUS_STOPPED = {
+    "BackendState": "Stopped",
+    "Self": {"HostName": "rpi-divinu", "TailscaleIPs": [], "ExitNode": False},
+    "Peer": {},
+}
+
+
+class TestGetStatus:
+    """Test Tailscale status retrieval."""
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_connected_status(self, mock_run, svc):
+        """Should return full status when connected."""
+        # First call: version check (binary_exists)
+        # Second call: status --json
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # version check
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps(SAMPLE_STATUS_CONNECTED),
+                stderr="",
+            ),
+        ]
+        status = svc.get_status()
+        assert status["installed"] is True
+        assert status["running"] is True
+        assert status["state"] == "connected"
+        assert status["hostname"] == "rpi-divinu"
+        assert status["tailscale_ip"] == "100.64.0.1"
+        assert len(status["peers"]) == 2
+        assert status["peers"][0]["name"] == "my-laptop"
+        assert status["peers"][0]["online"] is True
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_needs_login_status(self, mock_run, svc):
+        """Should report needs-login state."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps(SAMPLE_STATUS_NEEDS_LOGIN),
+                stderr="",
+            ),
+        ]
+        status = svc.get_status()
+        assert status["state"] == "needs-login"
+        assert status["tailscale_ip"] == ""
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_stopped_status(self, mock_run, svc):
+        """Should report stopped state."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps(SAMPLE_STATUS_STOPPED),
+                stderr="",
+            ),
+        ]
+        status = svc.get_status()
+        assert status["state"] == "stopped"
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_not_installed(self, mock_run, svc):
+        """Should return unavailable when binary not found."""
+        mock_run.side_effect = FileNotFoundError
+        status = svc.get_status()
+        assert status["installed"] is False
+        assert status["state"] == "unavailable"
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_daemon_not_running(self, mock_run, svc):
+        """Should return stopped when daemon isn't running."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # binary exists (version check)
+            MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="failed to connect to local tailscaled; it doesn't appear to be running",
+            ),  # status --json fails
+        ]
+        status = svc.get_status()
+        assert status["installed"] is True
+        assert status["running"] is False
+        assert status["state"] == "stopped"
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_no_peers(self, mock_run, svc):
+        """Should return empty peers list when none connected."""
+        status_data = {**SAMPLE_STATUS_CONNECTED, "Peer": {}}
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout=json.dumps(status_data), stderr=""),
+        ]
+        status = svc.get_status()
+        assert status["peers"] == []
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_timeout_on_version_check(self, mock_run, svc):
+        """Should handle timeout gracefully."""
+        mock_run.side_effect = subprocess.TimeoutExpired("tailscale", 5)
+        status = svc.get_status()
+        assert status["installed"] is False
+        assert status["state"] == "unavailable"
+
+
+class TestConnect:
+    """Test Tailscale connect."""
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_connect_already_authenticated(self, mock_run, svc):
+        """Should return no auth URL when already connected."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # binary exists
+            MagicMock(returncode=0, stdout="", stderr=""),  # tailscale up
+        ]
+        auth_url, err = svc.connect()
+        assert auth_url is None
+        assert err == ""
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_connect_returns_auth_url(self, mock_run, svc):
+        """Should extract auth URL from tailscale up output."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # binary exists
+            MagicMock(
+                returncode=0,
+                stdout="To authenticate, visit:\n\n\thttps://login.tailscale.com/a/abc123def\n",
+                stderr="",
+            ),
+        ]
+        auth_url, err = svc.connect()
+        assert auth_url == "https://login.tailscale.com/a/abc123def"
+        assert err == ""
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_connect_auth_url_in_stderr(self, mock_run, svc):
+        """Should also check stderr for auth URL."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(
+                returncode=0,
+                stdout="",
+                stderr="To authenticate, visit:\n\n\thttps://login.tailscale.com/a/xyz789\n",
+            ),
+        ]
+        auth_url, err = svc.connect()
+        assert auth_url == "https://login.tailscale.com/a/xyz789"
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_connect_not_installed(self, mock_run, svc):
+        """Should return error when binary not found."""
+        mock_run.side_effect = FileNotFoundError
+        auth_url, err = svc.connect()
+        assert auth_url is None
+        assert "not installed" in err
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_connect_timeout(self, mock_run, svc):
+        """Should handle timeout."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            subprocess.TimeoutExpired("tailscale", 30),
+        ]
+        auth_url, err = svc.connect()
+        assert auth_url is None
+        assert "timed out" in err.lower()
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_connect_logs_audit_on_auth_needed(self, mock_run, svc):
+        """Should log audit event when auth URL is generated."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(
+                returncode=0,
+                stdout="https://login.tailscale.com/a/test123\n",
+                stderr="",
+            ),
+        ]
+        svc.connect()
+        calls = [str(c) for c in svc._audit.log_event.call_args_list]
+        assert any("TAILSCALE_AUTH_NEEDED" in c for c in calls)
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_connect_logs_audit_on_success(self, mock_run, svc):
+        """Should log audit when connected without auth."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        svc.connect()
+        calls = [str(c) for c in svc._audit.log_event.call_args_list]
+        assert any("TAILSCALE_CONNECTED" in c for c in calls)
+
+
+class TestDisconnect:
+    """Test Tailscale disconnect."""
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_disconnect_success(self, mock_run, svc):
+        """Should disconnect successfully."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # binary exists
+            MagicMock(returncode=0, stdout="", stderr=""),  # tailscale down
+        ]
+        ok, err = svc.disconnect()
+        assert ok is True
+        assert err == ""
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_disconnect_failure(self, mock_run, svc):
+        """Should return error on failure."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=1, stdout="", stderr="not connected"),
+        ]
+        ok, err = svc.disconnect()
+        assert ok is False
+        assert "not connected" in err
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_disconnect_not_installed(self, mock_run, svc):
+        """Should return error when binary not found."""
+        mock_run.side_effect = FileNotFoundError
+        ok, err = svc.disconnect()
+        assert ok is False
+        assert "not installed" in err
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_disconnect_logs_audit(self, mock_run, svc):
+        """Should log audit on disconnect."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        svc.disconnect()
+        calls = [str(c) for c in svc._audit.log_event.call_args_list]
+        assert any("TAILSCALE_DISCONNECTED" in c for c in calls)
+
+
+class TestExtractAuthUrl:
+    """Test auth URL extraction from CLI output."""
+
+    def test_standard_format(self):
+        text = "To authenticate, visit:\n\n\thttps://login.tailscale.com/a/abc123\n"
+        assert (
+            TailscaleService._extract_auth_url(text)
+            == "https://login.tailscale.com/a/abc123"
+        )
+
+    def test_no_url(self):
+        assert TailscaleService._extract_auth_url("some other output") is None
+
+    def test_empty(self):
+        assert TailscaleService._extract_auth_url("") is None
+
+    def test_url_with_long_code(self):
+        text = "https://login.tailscale.com/a/16cc78fe01ed46abcdef"
+        assert TailscaleService._extract_auth_url(text) == text
+
+
+class TestAuditResilience:
+    """Test that audit failures don't crash the service."""
+
+    @patch("monitor.services.tailscale_service.subprocess.run")
+    def test_audit_error_ignored(self, mock_run):
+        audit = MagicMock()
+        audit.log_event.side_effect = RuntimeError("audit broken")
+        svc = TailscaleService(audit=audit)
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        # Should not raise despite audit failure
+        ok, err = svc.disconnect()
+        assert ok is True
+
+    def test_no_audit_logger(self):
+        """Should work fine without audit logger."""
+        svc = TailscaleService(audit=None)
+        svc._log_audit("TEST", "test")  # Should not raise


### PR DESCRIPTION
## Summary
- New `TailscaleService` wrapping the tailscale CLI for status, connect, and disconnect
- API endpoints: `GET /system/tailscale`, `POST /system/tailscale/connect`, `POST /system/tailscale/disconnect`
- Connect returns auth URL when login is needed — enables settings page integration
- Admin-only for mutations, login-required for status reads
- Constructor injection, fail-silent audit logging

## Test plan
- [x] 24 service tests covering connected/stopped/needs-login/unavailable states
- [x] 6 API contract tests (auth + admin enforcement)
- [x] Audit resilience tests
- [x] 129 total tests pass, 88.69% coverage
- [x] Verified on hardware: tailscale up returns auth URL via serial

🤖 Generated with [Claude Code](https://claude.com/claude-code)