### PR TITLE
feat: USB update detection for OTA service

### DIFF
--- a/app/server/monitor/api/ota.py
+++ b/app/server/monitor/api/ota.py
@@ -2,10 +2,12 @@
 Over-the-Air update API.
 
 Endpoints:
-  POST /ota/server/upload     - upload .swu image for server (admin)
+  POST /ota/server/upload      - upload .swu image for server (admin)
   POST /ota/server/install     - install staged bundle (admin)
-  POST /ota/camera/<id>/push  - push update to camera (admin)
-  GET  /ota/status            - update status for all devices
+  POST /ota/camera/<id>/push   - push update to camera (admin)
+  GET  /ota/status             - update status for all devices
+  GET  /ota/usb/scan           - scan USB devices for .swu bundles (admin)
+  POST /ota/usb/import         - import .swu bundle from USB (admin)
 
 OTA uses swupdate with A/B partition scheme.
 Images must be Ed25519 signed — unsigned images are rejected.
@@ -157,3 +159,47 @@ def push_camera_update(camera_id):
         )
 
     return jsonify({"message": f"Update queued for camera {camera_id}"}), 200
+
+
+@ota_bp.route("/usb/scan", methods=["GET"])
+@admin_required
+def scan_usb():
+    """Scan USB devices for .swu update bundles. Admin only."""
+    ota = current_app.ota_service
+    bundles = ota.scan_usb()
+    return jsonify({"bundles": bundles}), 200
+
+
+@ota_bp.route("/usb/import", methods=["POST"])
+@admin_required
+def import_from_usb():
+    """Import a .swu bundle from a USB device. Admin only.
+
+    Request body: {"path": "/mnt/recordings/updates/update-1.2.swu"}
+    """
+    ota = current_app.ota_service
+    data = request.get_json(silent=True) or {}
+    usb_path = data.get("path", "")
+
+    if not usb_path:
+        return jsonify({"error": "No file path provided"}), 400
+
+    user = session.get("username", "")
+    ip = request.remote_addr or ""
+
+    staged_path, err = ota.import_from_usb(usb_path, user=user, ip=ip)
+    if err:
+        return jsonify({"error": err}), 400
+
+    # Verify bundle signature
+    valid, verify_err = ota.verify_bundle(staged_path)
+    if not valid:
+        ota.clean_staging()
+        return jsonify({"error": f"Verification failed: {verify_err}"}), 400
+
+    return jsonify(
+        {
+            "message": "USB bundle imported, staged, and verified",
+            "staged_path": staged_path,
+        }
+    ), 200

--- a/app/server/monitor/services/ota_service.py
+++ b/app/server/monitor/services/ota_service.py
@@ -29,6 +29,15 @@ MAX_BUNDLE_SIZE = 500 * 1024 * 1024
 MIN_FREE_SPACE = 100 * 1024 * 1024
 
 
+def _human_size(nbytes):
+    """Convert bytes to human-readable size string."""
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if nbytes < 1024:
+            return f"{nbytes:.1f} {unit}"
+        nbytes /= 1024
+    return f"{nbytes:.1f} PB"
+
+
 class OTAService:
     """Manages OTA update verification, staging, and installation.
 
@@ -252,6 +261,121 @@ class OTAService:
         except OSError as e:
             self.set_status("server", "error", error=str(e))
             return False, str(e)
+
+    def scan_usb(self):
+        """Scan USB devices for .swu update bundles.
+
+        Looks at all mounted USB devices for .swu files in root and
+        common update directories (updates/, ota/).
+
+        Returns:
+            list of dicts: [{filename, path, size, size_human, device}]
+        """
+        from monitor.services import usb
+
+        bundles = []
+        try:
+            devices = usb.detect_devices()
+        except Exception as e:
+            log.warning("USB detection failed during OTA scan: %s", e)
+            return bundles
+
+        for dev in devices:
+            mp = dev.get("mountpoint", "")
+            if not mp:
+                continue
+
+            # Search root and common update directories
+            search_dirs = [mp]
+            for subdir in ("updates", "ota", "OTA"):
+                candidate = os.path.join(mp, subdir)
+                if os.path.isdir(candidate):
+                    search_dirs.append(candidate)
+
+            for search_dir in search_dirs:
+                try:
+                    for entry in os.scandir(search_dir):
+                        if entry.is_file() and entry.name.lower().endswith(".swu"):
+                            stat = entry.stat()
+                            bundles.append(
+                                {
+                                    "filename": entry.name,
+                                    "path": entry.path,
+                                    "size": stat.st_size,
+                                    "size_human": _human_size(stat.st_size),
+                                    "device": dev.get("path", ""),
+                                }
+                            )
+                except OSError as e:
+                    log.debug("Cannot read %s: %s", search_dir, e)
+
+        log.info("USB scan found %d bundle(s)", len(bundles))
+        return bundles
+
+    def import_from_usb(self, usb_path, user="", ip=""):
+        """Import a .swu bundle from a USB device.
+
+        Copies (not moves) the file from USB to inbox, then stages it.
+        The original file on USB is preserved.
+
+        Args:
+            usb_path: Full path to the .swu file on USB.
+            user: Username for audit log.
+            ip: IP address for audit log.
+
+        Returns:
+            (staged_path, error) tuple.
+        """
+        filename = os.path.basename(usb_path)
+
+        if not filename.lower().endswith(".swu"):
+            return None, "Only .swu files are accepted"
+
+        if not os.path.isfile(usb_path):
+            return None, f"File not found: {usb_path}"
+
+        try:
+            size = os.path.getsize(usb_path)
+        except OSError as e:
+            return None, f"Cannot read file: {e}"
+
+        if size > MAX_BUNDLE_SIZE:
+            return None, f"File too large ({size} bytes, max {MAX_BUNDLE_SIZE})"
+
+        if size == 0:
+            return None, "File is empty"
+
+        # Check disk space
+        has_space, free, err = self.check_space(size)
+        if not has_space:
+            return (
+                None,
+                f"Insufficient disk space (free: {free}, need: {size + MIN_FREE_SPACE})",
+            )
+
+        # Copy to inbox (preserve original on USB)
+        os.makedirs(self.inbox_dir, exist_ok=True)
+        inbox_path = os.path.join(self.inbox_dir, filename)
+
+        try:
+            shutil.copy2(usb_path, inbox_path)
+        except OSError as e:
+            return None, f"Failed to copy from USB: {e}"
+
+        # Stage the bundle
+        staged_path, stage_err = self.stage_bundle(
+            inbox_path, filename, user=user, ip=ip
+        )
+        if stage_err:
+            try:
+                os.unlink(inbox_path)
+            except OSError:
+                pass
+            return None, stage_err
+
+        self._log_audit("OTA_USB_IMPORT", user, ip, f"Imported from USB: {usb_path}")
+        log.info("OTA bundle imported from USB: %s", usb_path)
+        return staged_path, ""
 
     def clean_staging(self):
         """Remove staged bundles from the staging directory."""

--- a/app/server/tests/test_api_contracts.py
+++ b/app/server/tests/test_api_contracts.py
@@ -662,6 +662,42 @@ class TestOtaStatusContract:
 # ===========================================================================
 
 
+class TestOtaUsbScanContract:
+    """GET /api/v1/ota/usb/scan."""
+
+    def test_fields(self, app, client):
+        _login(app, client)
+        resp = client.get("/api/v1/ota/usb/scan")
+        data = resp.get_json()
+        _assert_has_fields(data, {"bundles"})
+        assert isinstance(data["bundles"], list)
+
+    def test_requires_admin(self, app, client):
+        _login(app, client, role="viewer")
+        resp = client.get("/api/v1/ota/usb/scan")
+        assert resp.status_code == 403
+
+
+class TestOtaUsbImportContract:
+    """POST /api/v1/ota/usb/import."""
+
+    def test_requires_path(self, app, client):
+        csrf = _login(app, client)
+        resp = client.post(
+            "/api/v1/ota/usb/import",
+            json={},
+            headers={"X-CSRF-Token": csrf},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        _assert_has_fields(data, {"error"})
+
+    def test_requires_admin(self, app, client):
+        _login(app, client, role="viewer")
+        resp = client.post("/api/v1/ota/usb/import", json={"path": "/mnt/usb/x.swu"})
+        assert resp.status_code == 403
+
+
 class TestTailscaleStatusContract:
     """GET /api/v1/system/tailscale."""
 

--- a/app/server/tests/test_svc_ota.py
+++ b/app/server/tests/test_svc_ota.py
@@ -282,6 +282,161 @@ class TestCleanStaging:
         svc.clean_staging()  # Should not raise
 
 
+class TestScanUsb:
+    """Test USB .swu bundle scanning."""
+
+    @patch("monitor.services.usb.detect_devices")
+    def test_scan_finds_bundles(self, mock_detect, svc, data_dir):
+        """Should find .swu files on mounted USB devices."""
+        usb_mount = os.path.join(data_dir, "usb_mount")
+        os.makedirs(usb_mount)
+        swu_path = os.path.join(usb_mount, "update-1.2.swu")
+        with open(swu_path, "wb") as f:
+            f.write(b"x" * 256)
+
+        mock_detect.return_value = [{"path": "/dev/sda1", "mountpoint": usb_mount}]
+
+        bundles = svc.scan_usb()
+        assert len(bundles) == 1
+        assert bundles[0]["filename"] == "update-1.2.swu"
+        assert bundles[0]["size"] == 256
+        assert bundles[0]["device"] == "/dev/sda1"
+
+    @patch("monitor.services.usb.detect_devices")
+    def test_scan_searches_subdirs(self, mock_detect, svc, data_dir):
+        """Should search updates/ and ota/ subdirectories."""
+        usb_mount = os.path.join(data_dir, "usb_mount2")
+        updates_dir = os.path.join(usb_mount, "updates")
+        os.makedirs(updates_dir)
+        swu_path = os.path.join(updates_dir, "camera-2.0.swu")
+        with open(swu_path, "wb") as f:
+            f.write(b"x" * 128)
+
+        mock_detect.return_value = [{"path": "/dev/sda1", "mountpoint": usb_mount}]
+
+        bundles = svc.scan_usb()
+        assert len(bundles) == 1
+        assert bundles[0]["filename"] == "camera-2.0.swu"
+
+    @patch("monitor.services.usb.detect_devices")
+    def test_scan_ignores_non_swu(self, mock_detect, svc, data_dir):
+        """Should skip non-.swu files."""
+        usb_mount = os.path.join(data_dir, "usb_mount3")
+        os.makedirs(usb_mount)
+        with open(os.path.join(usb_mount, "readme.txt"), "w") as f:
+            f.write("not an update")
+        with open(os.path.join(usb_mount, "image.img"), "wb") as f:
+            f.write(b"x" * 64)
+
+        mock_detect.return_value = [{"path": "/dev/sda1", "mountpoint": usb_mount}]
+
+        bundles = svc.scan_usb()
+        assert len(bundles) == 0
+
+    @patch("monitor.services.usb.detect_devices")
+    def test_scan_skips_unmounted(self, mock_detect, svc):
+        """Should skip USB devices that aren't mounted."""
+        mock_detect.return_value = [{"path": "/dev/sda1", "mountpoint": ""}]
+        bundles = svc.scan_usb()
+        assert len(bundles) == 0
+
+    @patch("monitor.services.usb.detect_devices")
+    def test_scan_no_usb(self, mock_detect, svc):
+        """Should return empty list when no USB devices found."""
+        mock_detect.return_value = []
+        bundles = svc.scan_usb()
+        assert len(bundles) == 0
+
+    @patch("monitor.services.usb.detect_devices")
+    def test_scan_handles_detection_error(self, mock_detect, svc):
+        """Should return empty list on detection failure."""
+        mock_detect.side_effect = RuntimeError("lsblk broken")
+        bundles = svc.scan_usb()
+        assert len(bundles) == 0
+
+
+class TestImportFromUsb:
+    """Test USB .swu bundle import."""
+
+    def test_import_success(self, svc, data_dir):
+        """Should copy .swu from USB and stage it."""
+        usb_file = os.path.join(data_dir, "usb", "update.swu")
+        os.makedirs(os.path.dirname(usb_file))
+        with open(usb_file, "wb") as f:
+            f.write(b"x" * 512)
+
+        staged, err = svc.import_from_usb(usb_file, user="admin", ip="1.2.3.4")
+        assert err == ""
+        assert staged is not None
+        assert os.path.isfile(staged)
+        # Original on USB should still exist (copy, not move)
+        assert os.path.isfile(usb_file)
+
+    def test_import_preserves_original(self, svc, data_dir):
+        """Should preserve the original file on USB."""
+        usb_file = os.path.join(data_dir, "usb2", "firmware.swu")
+        os.makedirs(os.path.dirname(usb_file))
+        content = b"firmware content"
+        with open(usb_file, "wb") as f:
+            f.write(content)
+
+        svc.import_from_usb(usb_file)
+        with open(usb_file, "rb") as f:
+            assert f.read() == content
+
+    def test_import_rejects_non_swu(self, svc, data_dir):
+        """Should reject non-.swu files."""
+        usb_file = os.path.join(data_dir, "usb3", "image.img")
+        os.makedirs(os.path.dirname(usb_file))
+        with open(usb_file, "wb") as f:
+            f.write(b"x" * 64)
+        _, err = svc.import_from_usb(usb_file)
+        assert "swu" in err.lower()
+
+    def test_import_missing_file(self, svc):
+        """Should return error for missing file."""
+        _, err = svc.import_from_usb("/nonexistent/update.swu")
+        assert "not found" in err.lower()
+
+    def test_import_empty_file(self, svc, data_dir):
+        """Should reject empty files."""
+        usb_file = os.path.join(data_dir, "usb4", "empty.swu")
+        os.makedirs(os.path.dirname(usb_file))
+        open(usb_file, "w").close()
+        _, err = svc.import_from_usb(usb_file)
+        assert "empty" in err.lower()
+
+    def test_import_oversized(self, svc, data_dir):
+        """Should reject files over MAX_BUNDLE_SIZE."""
+        usb_file = os.path.join(data_dir, "usb5", "big.swu")
+        os.makedirs(os.path.dirname(usb_file))
+        with open(usb_file, "wb") as f:
+            f.write(b"x" * 100)
+
+        with patch("os.path.getsize", return_value=MAX_BUNDLE_SIZE + 1):
+            _, err = svc.import_from_usb(usb_file)
+        assert "too large" in err.lower()
+
+    def test_import_sets_staged_status(self, svc, data_dir):
+        """Should set status to staged after import."""
+        usb_file = os.path.join(data_dir, "usb6", "update.swu")
+        os.makedirs(os.path.dirname(usb_file))
+        with open(usb_file, "wb") as f:
+            f.write(b"x" * 128)
+        svc.import_from_usb(usb_file)
+        assert svc.get_status("server")["state"] == "staged"
+
+    def test_import_logs_audit(self, svc, data_dir):
+        """Should log USB import audit event."""
+        usb_file = os.path.join(data_dir, "usb7", "update.swu")
+        os.makedirs(os.path.dirname(usb_file))
+        with open(usb_file, "wb") as f:
+            f.write(b"x" * 128)
+        svc.import_from_usb(usb_file, user="admin", ip="1.2.3.4")
+        calls = [str(c) for c in svc._audit.log_event.call_args_list]
+        assert any("OTA_USB_IMPORT" in c for c in calls)
+
+
 class TestAuditResilience:
     """Test that audit failures don't crash the service."""
 


### PR DESCRIPTION
## Summary
- Add `scan_usb()` to OTAService — scans mounted USB devices for `.swu` bundles in root, `updates/`, and `ota/` directories
- Add `import_from_usb()` to OTAService — copies (preserves original) `.swu` from USB to inbox, then stages and validates
- Add `GET /api/v1/ota/usb/scan` endpoint (admin) — returns list of found bundles with filename, size, device info
- Add `POST /api/v1/ota/usb/import` endpoint (admin) — imports, stages, and verifies a USB bundle by path

## Test plan
- [x] 14 new unit tests (6 scan + 8 import) — all pass
- [x] 4 new API contract tests (scan + import) — all pass
- [x] Full test suite passes (51 contract tests, 42 OTA tests)
- [x] Lint clean (`ruff check` + `ruff format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)