### PR TITLE
feat: LUKS first-boot encryption for production images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,6 @@ Full pattern docs: [development-guide.md Section 3.6](docs/development-guide.md)
 
 Only what's NOT done. When you implement a gap, delete it from this list in the same PR.
 
-- **LUKS first-boot** — first-boot LUKS formatting not yet implemented (Phase 2)
 - **Motion detection** — recording mode exists but motion trigger not implemented (Phase 2)
 - **Multi-camera** — framework exists, untested with multiple real cameras (Phase 2)
 - **Cloud relay, mobile app, AI/ML** — Phase 2-3, not started

--- a/meta-home-monitor/recipes-core/first-boot/files/luks-first-boot.sh
+++ b/meta-home-monitor/recipes-core/first-boot/files/luks-first-boot.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+# =============================================================
+# luks-first-boot.sh — LUKS encrypt /data partition (ADR-0010)
+#
+# Production images only. Runs on first boot before the main
+# first-boot-setup.sh (which creates directory structure on /data).
+#
+# Server: prompts user for passphrase via systemd-ask-password
+# Camera: derives key from pairing_secret + CPU serial via HKDF
+#
+# Cipher: xchacha20,aes-adiantum-plain64 (2-3.5x faster than AES
+# on ARM without hardware acceleration)
+# =============================================================
+set -e
+
+STAMP="/data/.luks-done"
+DATA_DEV="/dev/mmcblk0p4"
+DM_NAME="data"
+MOUNT_POINT="/data"
+
+log() {
+    logger -t "luks-first-boot" "$1"
+    echo "luks-first-boot: $1"
+}
+
+# --- Detect device type ---
+is_server() {
+    # Server has monitor-server package installed
+    [ -f /opt/monitor/monitor/__init__.py ] || \
+    systemctl list-unit-files monitor.service >/dev/null 2>&1
+}
+
+is_camera() {
+    [ -f /opt/camera/camera_streamer/__init__.py ] || \
+    systemctl list-unit-files camera-streamer.service >/dev/null 2>&1
+}
+
+# --- Check if already LUKS-formatted ---
+if cryptsetup isLuks "$DATA_DEV" 2>/dev/null; then
+    log "Data partition is already LUKS-encrypted"
+
+    # Open and mount if not already mounted
+    if ! mountpoint -q "$MOUNT_POINT"; then
+        if [ ! -e "/dev/mapper/$DM_NAME" ]; then
+            # Try keyfile first (camera auto-unlock)
+            if [ -f /etc/cryptsetup-keys.d/data.key ]; then
+                log "Unlocking with keyfile..."
+                cryptsetup luksOpen "$DATA_DEV" "$DM_NAME" \
+                    --key-file /etc/cryptsetup-keys.d/data.key
+            else
+                log "Waiting for passphrase to unlock /data..."
+                systemd-ask-password --timeout=0 "Enter passphrase for /data:" | \
+                    cryptsetup luksOpen "$DATA_DEV" "$DM_NAME"
+            fi
+        fi
+        mount /dev/mapper/"$DM_NAME" "$MOUNT_POINT"
+        log "Mounted encrypted /data"
+    fi
+    exit 0
+fi
+
+# --- First-time LUKS formatting ---
+log "=== LUKS first-boot encryption starting ==="
+log "Device: $DATA_DEV"
+
+# Unmount if currently mounted as plain ext4 (from WKS)
+if mountpoint -q "$MOUNT_POINT"; then
+    umount "$MOUNT_POINT" || true
+fi
+
+if is_server; then
+    log "Server mode: requesting passphrase for disk encryption"
+
+    # Server uses passphrase with 1 GB argon2id memory
+    PASSPHRASE=""
+    while [ -z "$PASSPHRASE" ]; do
+        PASSPHRASE=$(systemd-ask-password --timeout=0 \
+            "Create encryption passphrase for /data (min 12 chars):")
+
+        # Check minimum length
+        if [ "${#PASSPHRASE}" -lt 12 ]; then
+            log "Passphrase too short (minimum 12 characters)"
+            PASSPHRASE=""
+            continue
+        fi
+
+        # Confirm
+        CONFIRM=$(systemd-ask-password --timeout=0 \
+            "Confirm encryption passphrase:")
+        if [ "$PASSPHRASE" != "$CONFIRM" ]; then
+            log "Passphrases do not match"
+            PASSPHRASE=""
+        fi
+    done
+
+    log "Formatting $DATA_DEV with LUKS2 + Adiantum (server parameters)..."
+    echo -n "$PASSPHRASE" | cryptsetup luksFormat --type luks2 \
+        --cipher xchacha20,aes-adiantum-plain64 \
+        --hash sha256 \
+        --key-size 256 \
+        --pbkdf argon2id \
+        --pbkdf-memory 1048576 \
+        --pbkdf-force-iterations 4 \
+        --pbkdf-parallel 4 \
+        --batch-mode \
+        --key-file=- \
+        "$DATA_DEV"
+
+    # Open the LUKS container
+    echo -n "$PASSPHRASE" | cryptsetup luksOpen "$DATA_DEV" "$DM_NAME" --key-file=-
+
+    # Clear passphrase from memory
+    PASSPHRASE=""
+
+    log "Server LUKS formatting complete"
+
+elif is_camera; then
+    log "Camera mode: deriving LUKS key from pairing secret"
+
+    # Camera uses HKDF-derived key — needs pairing_secret
+    PAIRING_SECRET_FILE="/data/config/pairing_secret"
+
+    # On first boot after pairing, the pairing_secret is stored by the
+    # PairingManager. But /data isn't formatted yet, so the secret was
+    # written to a temporary location by the pairing exchange.
+    if [ -f /tmp/pairing_secret ]; then
+        PAIRING_SECRET_FILE="/tmp/pairing_secret"
+    elif [ -f /etc/pairing_secret ]; then
+        PAIRING_SECRET_FILE="/etc/pairing_secret"
+    fi
+
+    if [ ! -f "$PAIRING_SECRET_FILE" ]; then
+        log "ERROR: No pairing_secret found — cannot derive LUKS key"
+        log "Camera must be paired with server before LUKS encryption"
+        log "Skipping LUKS formatting — /data will remain unencrypted"
+        # Mount as plain partition so camera can function
+        mount "$DATA_DEV" "$MOUNT_POINT" 2>/dev/null || true
+        exit 0
+    fi
+
+    # Derive key using HKDF-SHA256 (camera_streamer.encryption module)
+    DERIVED_KEY=$(python3 -c "
+import sys
+sys.path.insert(0, '/opt/camera')
+from camera_streamer.encryption import hkdf_sha256, get_cpu_serial, HKDF_INFO, KEY_LENGTH
+secret_hex = open('$PAIRING_SECRET_FILE').read().strip()
+ikm = bytes.fromhex(secret_hex)
+salt = get_cpu_serial().encode('utf-8')
+if not salt:
+    print('ERROR: no CPU serial', file=sys.stderr)
+    sys.exit(1)
+sys.stdout.buffer.write(hkdf_sha256(ikm, salt, HKDF_INFO, KEY_LENGTH))
+" 2>/dev/null) || {
+        log "ERROR: Key derivation failed"
+        mount "$DATA_DEV" "$MOUNT_POINT" 2>/dev/null || true
+        exit 1
+    }
+
+    log "Formatting $DATA_DEV with LUKS2 + Adiantum (camera parameters)..."
+    echo -n "$DERIVED_KEY" | cryptsetup luksFormat --type luks2 \
+        --cipher xchacha20,aes-adiantum-plain64 \
+        --hash sha256 \
+        --key-size 256 \
+        --pbkdf argon2id \
+        --pbkdf-memory 65536 \
+        --pbkdf-force-iterations 4 \
+        --pbkdf-parallel 1 \
+        --batch-mode \
+        --key-file=- \
+        "$DATA_DEV"
+
+    # Open the LUKS container
+    echo -n "$DERIVED_KEY" | cryptsetup luksOpen "$DATA_DEV" "$DM_NAME" --key-file=-
+
+    # Store keyfile for auto-unlock on subsequent boots
+    install -d -m 0700 /etc/cryptsetup-keys.d
+    echo -n "$DERIVED_KEY" > /etc/cryptsetup-keys.d/data.key
+    chmod 0400 /etc/cryptsetup-keys.d/data.key
+
+    # Clear key from memory
+    DERIVED_KEY=""
+
+    log "Camera LUKS formatting complete (keyfile stored for auto-unlock)"
+else
+    log "ERROR: Cannot determine device type (server or camera)"
+    exit 1
+fi
+
+# --- Create filesystem inside LUKS container ---
+log "Creating ext4 filesystem on /dev/mapper/$DM_NAME..."
+mkfs.ext4 -L data /dev/mapper/"$DM_NAME"
+
+# Mount
+mount /dev/mapper/"$DM_NAME" "$MOUNT_POINT"
+log "Mounted encrypted /data at $MOUNT_POINT"
+
+# --- LUKS header backup (server only) ---
+if is_server; then
+    log "Backing up LUKS header to /boot/luks-header.bak..."
+    cryptsetup luksHeaderBackup "$DATA_DEV" \
+        --header-backup-file /boot/luks-header.bak
+    chmod 0400 /boot/luks-header.bak
+fi
+
+log "=== LUKS first-boot encryption complete ==="

--- a/meta-home-monitor/recipes-core/first-boot/first-boot_1.0.bb
+++ b/meta-home-monitor/recipes-core/first-boot/first-boot_1.0.bb
@@ -1,14 +1,24 @@
 # =============================================================
 # first-boot — Create /data directory structure on first boot
+#
+# In production images (LUKS_ENABLED = "1"), also installs the
+# LUKS encryption service that formats /data with Adiantum
+# cipher before the directory setup runs.
 # =============================================================
 SUMMARY = "First boot setup for Home Monitor OS"
 DESCRIPTION = "Creates the /data directory structure on first boot."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = "file://first-boot-setup.sh"
+SRC_URI = " \
+    file://first-boot-setup.sh \
+    file://luks-first-boot.sh \
+    "
 
 S = "${WORKDIR}"
+
+# Set to "1" in production image recipes to enable LUKS encryption
+LUKS_ENABLED ?= "0"
 
 inherit systemd
 
@@ -17,6 +27,8 @@ do_install() {
     install -m 0755 ${WORKDIR}/first-boot-setup.sh ${D}/opt/monitor/scripts/first-boot-setup.sh
 
     install -d ${D}${systemd_system_unitdir}
+
+    # --- Main first-boot service (always installed) ---
     cat > ${D}${systemd_system_unitdir}/first-boot-setup.service << 'UNIT'
 [Unit]
 Description=First boot data directory setup
@@ -33,12 +45,53 @@ RemainAfterExit=yes
 [Install]
 WantedBy=multi-user.target
 UNIT
+
+    # --- LUKS first-boot service (production only) ---
+    if [ "${LUKS_ENABLED}" = "1" ]; then
+        install -m 0755 ${WORKDIR}/luks-first-boot.sh ${D}/opt/monitor/scripts/luks-first-boot.sh
+
+        cat > ${D}${systemd_system_unitdir}/luks-first-boot.service << 'UNIT'
+[Unit]
+Description=LUKS encrypt /data partition (ADR-0010)
+DefaultDependencies=no
+After=local-fs-pre.target systemd-udevd.service
+Before=local-fs.target first-boot-setup.service
+ConditionPathExists=!/data/.luks-done
+
+[Service]
+Type=oneshot
+ExecStart=/opt/monitor/scripts/luks-first-boot.sh
+RemainAfterExit=yes
+TimeoutStartSec=300
+
+[Install]
+WantedBy=local-fs.target
+UNIT
+
+        # Make first-boot-setup wait for LUKS to finish
+        install -d ${D}${systemd_system_unitdir}/first-boot-setup.service.d
+        cat > ${D}${systemd_system_unitdir}/first-boot-setup.service.d/luks.conf << 'DROP'
+[Unit]
+After=luks-first-boot.service
+Requires=luks-first-boot.service
+DROP
+    fi
 }
 
 SYSTEMD_SERVICE:${PN} = "first-boot-setup.service"
+SYSTEMD_SERVICE:${PN} += "${@'luks-first-boot.service' if d.getVar('LUKS_ENABLED') == '1' else ''}"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 FILES:${PN} = " \
     /opt/monitor/scripts/first-boot-setup.sh \
     ${systemd_system_unitdir}/first-boot-setup.service \
     "
+
+# Conditionally include LUKS files
+FILES:${PN} += "${@'/opt/monitor/scripts/luks-first-boot.sh \
+    ${systemd_system_unitdir}/luks-first-boot.service \
+    ${systemd_system_unitdir}/first-boot-setup.service.d/luks.conf' \
+    if d.getVar('LUKS_ENABLED') == '1' else ''}"
+
+# LUKS requires cryptsetup on the target
+RDEPENDS:${PN} += "${@'cryptsetup' if d.getVar('LUKS_ENABLED') == '1' else ''}"

--- a/meta-home-monitor/recipes-core/images/home-camera-image-prod.bb
+++ b/meta-home-monitor/recipes-core/images/home-camera-image-prod.bb
@@ -1,6 +1,8 @@
 # =============================================================
 # home-camera-image-prod.bb — Production image for RPi Zero 2W camera
 #
+# LUKS encryption on /data partition with 64MB argon2id (ADR-0010).
+#
 # Build: bitbake home-camera-image-prod
 # =============================================================
 
@@ -12,3 +14,8 @@ SUMMARY .= " (Production)"
 EXTRA_IMAGE_FEATURES += "ssh-server-openssh"
 
 # No debug-tweaks: root locked, managed by server
+
+# --- LUKS encryption (ADR-0010) ---
+LUKS_ENABLED = "1"
+WKS_FILE = "home-camera-ab-luks.wks"
+IMAGE_INSTALL += "cryptsetup"

--- a/meta-home-monitor/recipes-core/images/home-monitor-image-prod.bb
+++ b/meta-home-monitor/recipes-core/images/home-monitor-image-prod.bb
@@ -2,6 +2,7 @@
 # home-monitor-image-prod.bb — Production image for RPi 4B server
 #
 # Hardened: no root password, no debug-tweaks, key-only SSH.
+# LUKS encryption on /data partition (ADR-0010).
 # This is what gets flashed to production devices.
 #
 # Build: bitbake home-monitor-image-prod
@@ -15,3 +16,8 @@ SUMMARY .= " (Production)"
 EXTRA_IMAGE_FEATURES += "ssh-server-openssh"
 
 # No debug-tweaks: root account is locked, must use first-boot wizard
+
+# --- LUKS encryption (ADR-0010) ---
+LUKS_ENABLED = "1"
+WKS_FILE = "home-monitor-ab-luks.wks"
+IMAGE_INSTALL += "cryptsetup"

--- a/meta-home-monitor/wic/home-camera-ab-luks.wks
+++ b/meta-home-monitor/wic/home-camera-ab-luks.wks
@@ -1,0 +1,17 @@
+# Partition layout for RPi Zero 2W Camera Node — Production (LUKS)
+#
+# Target SD card: 64 GB (minimum 32 GB)
+#
+# Part 1: boot    (512MB, vfat)  - U-Boot, kernel, DTBs, config.txt, U-Boot env
+# Part 2: rootfsA (8GB, ext4)    - active root filesystem
+# Part 3: rootfsB (8GB, ext4)    - standby root (OTA target)
+# Part 4: data    (raw, no fs)   - LUKS-encrypted on first boot (ADR-0010)
+#
+# The data partition is left unformatted. The luks-first-boot.service
+# runs cryptsetup luksFormat with Adiantum cipher (64MB argon2id memory
+# to fit within Zero 2W's 512MB RAM), creates ext4, and mounts at /data.
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 512M
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfsA --align 4096 --size 8192M
+part --ondisk mmcblk0 --fstype=ext4 --label rootfsB --align 4096 --size 8192M
+part --ondisk mmcblk0 --align 4096 --size 4096M

--- a/meta-home-monitor/wic/home-monitor-ab-luks.wks
+++ b/meta-home-monitor/wic/home-monitor-ab-luks.wks
@@ -1,0 +1,17 @@
+# Partition layout for RPi 4B Home Monitor Server — Production (LUKS)
+#
+# Target SD card: 64 GB (minimum 32 GB)
+#
+# Part 1: boot    (512MB, vfat)  - U-Boot, kernel, DTBs, config.txt, U-Boot env
+# Part 2: rootfsA (8GB, ext4)    - active root filesystem
+# Part 3: rootfsB (8GB, ext4)    - standby root (OTA target)
+# Part 4: data    (raw, no fs)   - LUKS-encrypted on first boot (ADR-0010)
+#
+# The data partition is left unformatted. The luks-first-boot.service
+# runs cryptsetup luksFormat with Adiantum cipher, creates ext4 inside
+# the LUKS container, and mounts at /data.
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 512M
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfsA --align 4096 --size 8192M
+part --ondisk mmcblk0 --fstype=ext4 --label rootfsB --align 4096 --size 8192M
+part --ondisk mmcblk0 --align 4096 --size 4096M


### PR DESCRIPTION
## Summary
- Add `luks-first-boot.sh` that encrypts `/data` with LUKS2 + Adiantum cipher on first boot
  - **Server**: prompts for passphrase via `systemd-ask-password` (1 GB argon2id)
  - **Camera**: derives key from `pairing_secret` + CPU serial via HKDF-SHA256 (64 MB argon2id)
- Create production WKS files (`*-ab-luks.wks`) with raw data partition (no fstype) — LUKS formats during first boot
- Update `first-boot_1.0.bb` with conditional LUKS support (`LUKS_ENABLED` variable)
- Production image recipes set `LUKS_ENABLED = "1"`, use LUKS WKS, include `cryptsetup`
- Dev images unchanged — no encryption for fast iteration

### Architecture (ADR-0010)
- Cipher: `xchacha20,aes-adiantum-plain64` (2-3.5x faster than AES on ARM without hw accel)
- Server argon2id: 1 GB memory, 4 iterations, 4 threads
- Camera argon2id: 64 MB memory, 4 iterations, 1 thread (fits in 512 MB RAM)
- Server LUKS header backup saved to `/boot/luks-header.bak`
- Camera keyfile stored at `/etc/cryptsetup-keys.d/data.key` for auto-unlock

## Test plan
- [ ] `bitbake -p` parse check passes
- [ ] Build `home-monitor-image-prod`: verify LUKS WKS used, cryptsetup in manifest
- [ ] Build `home-camera-image-prod`: verify 64MB argon2id params
- [ ] Flash server prod image: verify passphrase prompt on first boot
- [ ] Flash camera prod image: pair with server, verify HKDF key derivation + LUKS format
- [ ] Reboot both: verify `/data` mounts from LUKS container
- [ ] Dev images: verify no LUKS, plain ext4 data partition

🤖 Generated with [Claude Code](https://claude.com/claude-code)