### PR TITLE
fix: persist WiFi credentials across OTA updates

### DIFF
--- a/meta-home-monitor/recipes-connectivity/nm-persist/files/nm-persist.sh
+++ b/meta-home-monitor/recipes-connectivity/nm-persist/files/nm-persist.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# =============================================================
+# nm-persist.sh — Persist NetworkManager connections across OTA
+#
+# Problem: OTA writes a new rootfs, wiping /etc/NetworkManager/
+#          system-connections/. WiFi credentials are lost.
+#
+# Solution: Store connections on /data (persistent partition),
+#           bind-mount over the rootfs directory every boot.
+#
+# Runs before NetworkManager on every boot:
+#   1. If /data/network/system-connections/ is empty, seed from rootfs
+#   2. Bind-mount /data/network/ over /etc/NetworkManager/system-connections/
+# =============================================================
+set -e
+
+PERSIST_DIR="/data/network/system-connections"
+ROOTFS_DIR="/etc/NetworkManager/system-connections"
+
+# Wait for /data to be mounted
+if ! mountpoint -q /data 2>/dev/null; then
+    echo "nm-persist: /data not mounted, skipping"
+    exit 0
+fi
+
+# Create persistent directory
+mkdir -p "$PERSIST_DIR"
+
+# Seed from rootfs on first run (or if persistent dir is empty)
+if [ -z "$(ls -A "$PERSIST_DIR" 2>/dev/null)" ]; then
+    echo "nm-persist: seeding connections from rootfs"
+    if [ -d "$ROOTFS_DIR" ] && [ -n "$(ls -A "$ROOTFS_DIR" 2>/dev/null)" ]; then
+        cp -a "$ROOTFS_DIR"/* "$PERSIST_DIR"/
+        echo "nm-persist: copied $(ls "$PERSIST_DIR" | wc -l) connection(s)"
+    else
+        echo "nm-persist: no rootfs connections to seed"
+    fi
+fi
+
+# Bind-mount persistent dir over rootfs dir
+if mountpoint -q "$ROOTFS_DIR" 2>/dev/null; then
+    echo "nm-persist: already mounted"
+else
+    mount --bind "$PERSIST_DIR" "$ROOTFS_DIR"
+    echo "nm-persist: bind-mounted $PERSIST_DIR -> $ROOTFS_DIR"
+fi

--- a/meta-home-monitor/recipes-connectivity/nm-persist/nm-persist_1.0.bb
+++ b/meta-home-monitor/recipes-connectivity/nm-persist/nm-persist_1.0.bb
@@ -1,0 +1,55 @@
+# =============================================================
+# nm-persist — Persist NetworkManager connections across OTA
+#
+# WiFi credentials live in /etc/NetworkManager/system-connections/
+# which is on rootfs and gets wiped by A/B OTA updates. This
+# recipe bind-mounts /data/network/system-connections/ over the
+# rootfs directory so credentials survive rootfs replacements.
+#
+# On first boot (or after OTA wipe), seeds from rootfs defaults.
+# =============================================================
+SUMMARY = "Persist NetworkManager connections on /data across OTA updates"
+DESCRIPTION = "Bind-mounts /data/network/system-connections over rootfs NM connections directory"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://nm-persist.sh"
+
+S = "${WORKDIR}"
+
+inherit systemd
+
+do_install() {
+    install -d ${D}/opt/monitor/scripts
+    install -m 0755 ${WORKDIR}/nm-persist.sh ${D}/opt/monitor/scripts/nm-persist.sh
+
+    install -d ${D}${systemd_system_unitdir}
+
+    # Service runs every boot, before NetworkManager
+    cat > ${D}${systemd_system_unitdir}/nm-persist.service << 'UNIT'
+[Unit]
+Description=Persist NetworkManager connections on /data
+DefaultDependencies=no
+After=local-fs.target data.mount
+Before=NetworkManager.service
+Wants=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/monitor/scripts/nm-persist.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+}
+
+SYSTEMD_SERVICE:${PN} = "nm-persist.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+FILES:${PN} = " \
+    /opt/monitor/scripts/nm-persist.sh \
+    ${systemd_system_unitdir}/nm-persist.service \
+    "
+
+RDEPENDS:${PN} = "util-linux-mount"

--- a/meta-home-monitor/recipes-core/packagegroups/packagegroup-monitor-base.bb
+++ b/meta-home-monitor/recipes-core/packagegroups/packagegroup-monitor-base.bb
@@ -14,6 +14,7 @@ RDEPENDS:${PN} = " \
     avahi-daemon \
     tzdata \
     tailscale \
+    nm-persist \
     htop \
     nano \
     curl \


### PR DESCRIPTION
## Summary
- WiFi credentials in `/etc/NetworkManager/system-connections/` are wiped by A/B OTA rootfs updates
- New `nm-persist` recipe bind-mounts `/data/network/system-connections/` over rootfs NM directory
- Seeds from rootfs on first boot, persists all subsequent WiFi config changes
- Already deployed and tested on both server (192.168.1.245) and camera (192.168.1.186)

## Test plan
- [x] Deployed to both boards, verified bind-mount works
- [x] WiFi connection persisted in `/data/network/system-connections/`
- [ ] Verify WiFi survives OTA on next rootfs update
- [ ] `bitbake -p` parse check on build VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)