### PR TITLE
feat: unified provisioning, WiFi persistence, and dashboard UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,13 @@ coverage.xml
 .vscode/
 .idea/
 
+# Secrets / credentials (safety net)
+*.env
+*.pem
+*.key
+*.p12
+*.pfx
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,11 @@
 Self-hosted home security camera system on Raspberry Pi. Two separate apps:
 
 - **`app/server/`** — Flask web app (monitor-server). Runs on RPi 4 Model B. Receives camera streams, records 3-min MP4 clips, serves web dashboard, manages cameras.
-- **`app/camera/`** — Python streaming service (camera-streamer). Runs on RPi Zero 2W. Captures 1080p video, pushes RTSP to server.
+- **`app/camera/`** — Python streaming service (camera-streamer). Runs on RPi Zero 2W. Captures 1080p video, pushes RTSPS (mTLS) to server.
 - **`meta-home-monitor/`** — Custom Yocto Linux distro (Home Monitor OS). Custom distro config, not poky.
 
 ```
-Camera (V4L2) → FFmpeg (H.264 RTSP push)
+Camera (V4L2) → FFmpeg (H.264 RTSPS push, mTLS)
     → MediaMTX (:8554) on server
         ├→ WebRTC (WHEP :8889) → browser <video> (sub-1s, live view)
         ├→ FFmpeg Record → /data/recordings/<cam-id>/YYYY-MM-DD/HH-MM-SS.mp4
@@ -68,7 +68,7 @@ This project is not a prototype. Every change must be production-ready, scalable
 - **Constructor Injection** — pass deps in `__init__()`. No DI frameworks, no global registries.
 - **Single Responsibility** — one class per file, one concern per class. No god files (>300 lines).
 - **App Factory** — Flask `create_app()` decomposed into `_init_infrastructure`, `_init_services`, `_startup`, `_register_blueprints`.
-- **State Machine** — camera lifecycle as explicit states (`INIT → SETUP → CONNECTING → VALIDATING → RUNNING → SHUTDOWN`).
+- **State Machine** — camera lifecycle as explicit states (`INIT → SETUP → PAIRING → CONNECTING → VALIDATING → RUNNING → SHUTDOWN`).
 - **Platform Provider** — `camera/platform.py` provides all hardware paths. Never hardcode device paths.
 - **Repository** — `Store` class for JSON persistence with atomic writes.
 - **Fail-Silent Adapter** — all hardware access wrapped in try/except.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RPi Home Monitor runs **Home Monitor OS**, a custom Linux distribution built wit
 ## Why RPi Home Monitor?
 
 - **Your data stays home.** Video never leaves your network. No cloud uploads, no third-party access, no monthly fees.
-- **Security by design.** HTTPS for web, encrypted storage (LUKS), firewall-hardened OS, bcrypt auth with rate limiting. Camera mTLS planned for Phase 2.
+- **Security by design.** HTTPS for web, mTLS camera streaming, encrypted storage (LUKS), firewall-hardened OS, bcrypt auth with rate limiting, PIN-based camera pairing.
 - **Built on real hardware.** Runs on a $35 Raspberry Pi 4B (server) and $15 Zero 2W (cameras). No proprietary hardware required.
 - **Automatic camera discovery.** Plug in a camera node, connect it to WiFi, and it appears in your dashboard via mDNS.
 - **OTA updates with rollback.** A/B partition scheme means failed updates automatically roll back. No bricked devices.
@@ -35,7 +35,7 @@ RPi Home Monitor runs **Home Monitor OS**, a custom Linux distribution built wit
 |-----------|----------|------|
 | **Home Server** | Raspberry Pi 4 Model B (4GB+) | Receives streams, records clips, serves web dashboard, manages cameras |
 | **Camera Node** | Raspberry Pi Zero 2W + ZeroCam | Captures 1080p video, streams to server over RTSPS |
-| **Dashboard** | Any phone/laptop on LAN | Live view (HLS), clip playback, camera management, system admin |
+| **Dashboard** | Any phone/laptop on LAN | Live view (WebRTC/HLS), clip playback, camera management, system admin |
 
 ## First Boot Setup
 
@@ -66,7 +66,7 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 
 | Feature | Details |
 |---------|---------|
-| Live View | HLS streaming in any mobile browser |
+| Live View | WebRTC (sub-second latency) with HLS fallback in any mobile browser |
 | Recording | Continuous 3-minute MP4 clips, organized by camera/date |
 | Camera Management | Auto-discovery, confirm/rename/remove via dashboard |
 | User Auth | Server: bcrypt + CSRF + rate limiting. Camera: PBKDF2-SHA256 + sessions. **Note:** a default `admin`/`admin` account is created on first boot — change the password during setup |
@@ -89,9 +89,10 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 | nftables firewall | **Implemented** | Default DROP, minimal open ports |
 | Audit logging | **Implemented** | Append-only JSON, all admin actions |
 | Default admin warning | **Implemented** | `admin`/`admin` created on first boot, must change during setup |
-| RTSPS (mTLS) | **Planned (Phase 2)** | Camera→server streams currently use plaintext RTSP |
-| mTLS camera pairing | **Planned (Phase 2)** | Certificate exchange for camera authentication |
-| Signed OTA updates | **Partial** | Status endpoint works; upload/verify are stubs |
+| RTSPS (mTLS) | **Implemented** | Camera streams over RTSPS with mTLS client certs after pairing |
+| mTLS camera pairing | **Implemented** | PIN-based pairing with certificate exchange (ADR-0009) |
+| Factory reset | **Implemented** | WiFi wipe, config reset, returns to first-boot state |
+| OTA updates | **Implemented** | Server OTA service (verify, stage, install) + camera OTA agent (port 8080, mTLS) |
 
 ## Quick Start
 
@@ -143,9 +144,9 @@ cd app/camera && pytest    # threshold: 55% coverage
 
 ## Roadmap
 
-- **Phase 1** (current): Single camera, live view, clip recording, web dashboard, authentication, security hardening, OTA-ready
-- **Phase 2**: Multi-camera support, motion detection, push notifications, cloud relay, mobile app, audio
-- **Phase 3**: AI/ML object detection, activity zones, clip protection, smart home integration
+- **Phase 1** (current): Single camera, live view, clip recording, web dashboard, authentication, security hardening, mTLS camera pairing, OTA updates, factory reset
+- **Phase 2**: Multi-camera support, motion detection, push notifications, audio
+- **Phase 3**: Cloud relay, mobile app, AI/ML object detection, activity zones, clip protection, smart home integration
 
 ## Contributing
 

--- a/app/camera/camera_streamer/factory_reset.py
+++ b/app/camera/camera_streamer/factory_reset.py
@@ -1,0 +1,143 @@
+"""
+Factory reset service for camera — wipes config and returns to first-boot state.
+
+Mirrors the server's FactoryResetService pattern (ADR-0013):
+- Constructor injection (config, data_dir)
+- WiFi credentials wiped via hotspot script's 'wipe' command
+- System reboot after reset (systemd re-evaluates ConditionPathExists)
+
+After reset: camera-hotspot.service starts (no .setup-done) → setup wizard.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import threading
+
+log = logging.getLogger("camera-streamer.factory-reset")
+
+HOTSPOT_SCRIPT = "/opt/camera/scripts/camera-hotspot.sh"
+
+
+class FactoryResetService:
+    """Wipes camera data and restarts in first-boot state."""
+
+    def __init__(
+        self, config, data_dir: str = "/data", hotspot_script: str = HOTSPOT_SCRIPT
+    ):
+        self._config = config
+        self._data_dir = data_dir
+        self._hotspot_script = hotspot_script
+
+    def execute_reset(self) -> tuple[str, int]:
+        """Perform factory reset.
+
+        Clears config, certs, logs. Wipes WiFi credentials.
+        Schedules system reboot.
+
+        Returns (message, status_code).
+        """
+        errors = []
+
+        # 1. Remove setup-done stamp (re-enables provisioning wizard)
+        stamp = os.path.join(self._data_dir, ".setup-done")
+        self._safe_remove(stamp, errors)
+
+        # 2. Remove config file
+        config_path = os.path.join(self._data_dir, "config", "camera.conf")
+        self._safe_remove(config_path, errors)
+
+        # 3. Remove certificates (pairing data)
+        certs_dir = os.path.join(self._data_dir, "certs")
+        self._safe_rmtree(certs_dir, errors)
+
+        # 4. Remove logs
+        logs_dir = os.path.join(self._data_dir, "logs")
+        self._safe_rmtree(logs_dir, errors)
+
+        # 5. Remove OTA staging
+        ota_dir = os.path.join(self._data_dir, "ota")
+        self._safe_rmtree(ota_dir, errors)
+
+        # 6. Clear WiFi credentials via hotspot script (ADR-0013)
+        self._clear_wifi(errors)
+
+        if errors:
+            log.warning("Factory reset completed with errors: %s", errors)
+        else:
+            log.info("Factory reset completed successfully")
+
+        # Schedule system reboot (full reboot ensures clean first-boot state)
+        self._schedule_reboot()
+
+        return "Factory reset complete. Restarting...", 200
+
+    def _safe_remove(self, path: str, errors: list):
+        """Remove a single file, ignoring if missing."""
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+                log.debug("Removed: %s", path)
+        except OSError as exc:
+            log.warning("Failed to remove %s: %s", path, exc)
+            errors.append(f"{path}: {exc}")
+
+    def _safe_rmtree(self, path: str, errors: list):
+        """Remove a directory tree, ignoring if missing."""
+        try:
+            if os.path.exists(path):
+                shutil.rmtree(path)
+                log.debug("Removed tree: %s", path)
+        except OSError as exc:
+            log.warning("Failed to remove %s: %s", path, exc)
+            errors.append(f"{path}: {exc}")
+
+    def _clear_wifi(self, errors: list):
+        """Clear WiFi credentials via hotspot script's 'wipe' command."""
+        try:
+            if os.path.isfile(self._hotspot_script):
+                result = subprocess.run(
+                    [self._hotspot_script, "wipe"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                )
+                if result.returncode != 0:
+                    log.warning(
+                        "WiFi wipe returned non-zero: %s", result.stderr.strip()
+                    )
+                    errors.append(f"wifi: {result.stderr.strip()}")
+                else:
+                    log.debug("WiFi credentials wiped via hotspot script")
+            else:
+                log.debug(
+                    "Hotspot script not found at %s — skipping WiFi wipe",
+                    self._hotspot_script,
+                )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            log.warning("Failed to wipe WiFi credentials: %s", exc)
+            errors.append(f"wifi: {exc}")
+
+    def _schedule_reboot(self):
+        """Reboot the system after a 2-second delay.
+
+        A full reboot (not just service restart) is required so that
+        camera-hotspot.service ConditionPathExists re-evaluates
+        and starts the WiFi hotspot for first-boot setup.
+        """
+
+        def _do_reboot():
+            log.info("Rebooting system for factory reset...")
+            try:
+                subprocess.run(
+                    ["systemctl", "reboot"],
+                    capture_output=True,
+                    timeout=30,
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+                log.error("System reboot failed: %s", exc)
+
+        timer = threading.Timer(2.0, _do_reboot)
+        timer.daemon = True
+        timer.start()

--- a/app/camera/camera_streamer/factory_reset.py
+++ b/app/camera/camera_streamer/factory_reset.py
@@ -94,7 +94,14 @@ class FactoryResetService:
             errors.append(f"{path}: {exc}")
 
     def _clear_wifi(self, errors: list):
-        """Clear WiFi credentials via hotspot script's 'wipe' command."""
+        """Clear WiFi credentials via hotspot script + direct cleanup.
+
+        The hotspot script's 'wipe' command handles nmcli deletion and
+        file cleanup. We also directly clean /data/network/ as a safety
+        net — nm-persist.sh bind-mounts this over /etc/NetworkManager/
+        system-connections/ on every boot, so it must be wiped too.
+        """
+        # 1. Run hotspot script wipe (handles nmcli + /etc cleanup)
         try:
             if os.path.isfile(self._hotspot_script):
                 result = subprocess.run(
@@ -112,12 +119,43 @@ class FactoryResetService:
                     log.debug("WiFi credentials wiped via hotspot script")
             else:
                 log.debug(
-                    "Hotspot script not found at %s — skipping WiFi wipe",
+                    "Hotspot script not found at %s — skipping script wipe",
                     self._hotspot_script,
                 )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
             log.warning("Failed to wipe WiFi credentials: %s", exc)
             errors.append(f"wifi: {exc}")
+
+        # 2. Always wipe /data/network/system-connections/ directly
+        #    (nm-persist.sh restores connections from here on every boot)
+        persist_dir = os.path.join(self._data_dir, "network", "system-connections")
+        self._wipe_dir_contents(persist_dir, "persistent WiFi", errors)
+
+        # 3. Write a marker so nm-persist.sh skips re-seeding from rootfs
+        #    (rootfs may have baked-in WiFi connections from dev builds)
+        marker = os.path.join(self._data_dir, "network", ".wifi-wiped")
+        try:
+            os.makedirs(os.path.dirname(marker), exist_ok=True)
+            with open(marker, "w") as f:
+                f.write("1\n")
+            log.debug("WiFi wipe marker written: %s", marker)
+        except OSError as exc:
+            log.warning("Failed to write wifi wipe marker: %s", exc)
+            errors.append(f"wifi-marker: {exc}")
+
+    def _wipe_dir_contents(self, dirpath: str, label: str, errors: list):
+        """Remove all files in a directory (not the directory itself)."""
+        if not os.path.isdir(dirpath):
+            return
+        for fname in os.listdir(dirpath):
+            fpath = os.path.join(dirpath, fname)
+            try:
+                if os.path.isfile(fpath):
+                    os.remove(fpath)
+                    log.debug("Removed %s: %s", label, fname)
+            except OSError as exc:
+                log.warning("Failed to remove %s: %s", fpath, exc)
+                errors.append(f"{label}: {exc}")
 
     def _schedule_reboot(self):
         """Reboot the system after a 2-second delay.

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -208,6 +208,9 @@ class CameraLifecycle:
 
     def _do_connecting(self):
         """Wait for WiFi connectivity and resolve server address."""
+        # Restore hostname on every boot (transient — lost on reboot)
+        self._restore_hostname()
+
         if not self._wait_for_wifi():
             log.error(
                 "WiFi has no IP after %ds — reverting to setup mode", self.WIFI_TIMEOUT
@@ -337,6 +340,25 @@ class CameraLifecycle:
             log.warning("Hotspot script not found at %s", self.HOTSPOT_SCRIPT)
         except (subprocess.TimeoutExpired, OSError) as e:
             log.warning("Hotspot script error: %s", e)
+
+    def _restore_hostname(self):
+        """Restore hostname from /data/config/hostname on every boot.
+
+        The hostname is set transiently (memory-only) since rootfs is
+        read-only. It was saved to /data during setup.
+        """
+        hostname_file = "/data/config/hostname"
+        try:
+            with open(hostname_file) as f:
+                hostname = f.read().strip()
+            if hostname:
+                from camera_streamer import wifi
+
+                wifi.set_hostname(hostname)
+        except FileNotFoundError:
+            log.debug("No saved hostname at %s", hostname_file)
+        except Exception as e:
+            log.warning("Failed to restore hostname: %s", e)
 
     def _wait_for_wifi(self):
         """Wait for WiFi interface to have an IP address."""

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -183,6 +183,9 @@ class CameraLifecycle:
         log.info("Camera not paired — starting status server for /pair endpoint")
         led.setup_mode()
 
+        # Register with server so it appears in the dashboard
+        self._register_with_server()
+
         # Start status server so /pair endpoint is accessible
         self._status_server = CameraStatusServer(
             self._config,
@@ -295,6 +298,31 @@ class CameraLifecycle:
         return True
 
     # ---- Helper methods ----
+
+    def _register_with_server(self):
+        """Register this camera with the server as pending.
+
+        Sends camera ID and IP so it appears in the server dashboard
+        before pairing is complete. Best-effort — pairing still works
+        if this fails (admin can add camera manually).
+        """
+        if not self._config.is_configured:
+            return
+        server = self._config.server_ip
+        camera_id = self._config.camera_id
+        url = f"http://{server}:5000/api/v1/pair/register"
+        try:
+            import json
+            import urllib.request
+
+            data = json.dumps({"camera_id": camera_id}).encode()
+            req = urllib.request.Request(
+                url, data=data, headers={"Content-Type": "application/json"}
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                log.info("Registered with server as pending (status=%d)", resp.status)
+        except Exception as e:
+            log.debug("Server registration failed (will retry via mDNS): %s", e)
 
     HOTSPOT_SCRIPT = "/opt/camera/scripts/camera-hotspot.sh"
 

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -150,6 +150,10 @@ class CameraLifecycle:
             return True
 
         log.info("First boot — starting setup wizard")
+
+        # Start WiFi hotspot for setup (AP mode so user can connect)
+        self._start_hotspot()
+
         self._setup_server.start()
 
         while not self._is_shutdown() and self._setup_server.needs_setup():
@@ -288,6 +292,51 @@ class CameraLifecycle:
         return True
 
     # ---- Helper methods ----
+
+    HOTSPOT_SCRIPT = "/opt/camera/scripts/camera-hotspot.sh"
+
+    def _start_hotspot(self):
+        """Start WiFi hotspot for setup mode if not already running.
+
+        On Yocto images, camera-hotspot.service starts the hotspot
+        via systemd before camera-streamer. This method checks if
+        the hotspot is already active and only starts it if needed.
+        Uses the same shell script as the systemd service (ADR-0013).
+        """
+        # Check if hotspot is already running (started by systemd)
+        try:
+            result = subprocess.run(
+                [self.HOTSPOT_SCRIPT, "status"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                log.info("Hotspot already active (started by systemd)")
+                return
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
+
+        # Hotspot not running — start it
+        try:
+            result = subprocess.run(
+                [self.HOTSPOT_SCRIPT, "start"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode == 0:
+                log.info("Hotspot started via script")
+            else:
+                log.warning(
+                    "Hotspot script failed (rc=%d): %s",
+                    result.returncode,
+                    result.stderr.strip() or result.stdout.strip(),
+                )
+        except FileNotFoundError:
+            log.warning("Hotspot script not found at %s", self.HOTSPOT_SCRIPT)
+        except (subprocess.TimeoutExpired, OSError) as e:
+            log.warning("Hotspot script error: %s", e)
 
     def _wait_for_wifi(self):
         """Wait for WiFi interface to have an IP address."""

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -11,14 +11,12 @@ Requires the admin password set during provisioning.
 import http.server
 import json
 import logging
-import os
 import secrets
-import shutil
-import subprocess
 import threading
 import time
 
 from camera_streamer import wifi
+from camera_streamer.factory_reset import FactoryResetService
 
 log = logging.getLogger("camera-streamer.status-server")
 
@@ -443,6 +441,8 @@ def _make_status_handler(
             uptime = _get_uptime()
             mem_total, mem_used = _get_memory_mb()
 
+            paired = pairing_manager.is_paired if pairing_manager else False
+
             return {
                 "camera_id": config.camera_id,
                 "hostname": hostname,
@@ -451,6 +451,7 @@ def _make_status_handler(
                 "server_address": server_addr,
                 "server_connected": server_connected,
                 "streaming": streaming,
+                "paired": paired,
                 "cpu_temp": cpu_temp,
                 "uptime": uptime,
                 "memory_total_mb": mem_total,
@@ -557,78 +558,14 @@ def _make_status_handler(
                     self._serve_pair_page(error=err)
 
         def _handle_factory_reset(self):
-            """Wipe camera config, certs, and restart in setup mode."""
+            """Wipe camera config, certs, and restart in setup mode.
+
+            Delegates to FactoryResetService for consistent behavior
+            with the server's factory reset (ADR-0013).
+            """
             data_dir = config.data_dir if hasattr(config, "data_dir") else "/data"
-            errors = []
-
-            # Remove config file
-            config_path = os.path.join(data_dir, "config", "camera.conf")
-            try:
-                if os.path.exists(config_path):
-                    os.remove(config_path)
-            except OSError as e:
-                errors.append(str(e))
-
-            # Remove certificates (pairing data)
-            certs_dir = os.path.join(data_dir, "certs")
-            try:
-                if os.path.exists(certs_dir):
-                    shutil.rmtree(certs_dir)
-            except OSError as e:
-                errors.append(str(e))
-
-            # Remove logs
-            logs_dir = os.path.join(data_dir, "logs")
-            try:
-                if os.path.exists(logs_dir):
-                    shutil.rmtree(logs_dir)
-            except OSError as e:
-                errors.append(str(e))
-
-            # Clear WiFi credentials (NetworkManager saved connections)
-            nm_dir = "/etc/NetworkManager/system-connections"
-            try:
-                if os.path.isdir(nm_dir):
-                    for f in os.listdir(nm_dir):
-                        filepath = os.path.join(nm_dir, f)
-                        if os.path.isfile(filepath):
-                            os.remove(filepath)
-            except OSError as e:
-                errors.append(str(e))
-
-            # Reset wpa_supplicant.conf
-            try:
-                wpa_conf = "/etc/wpa_supplicant.conf"
-                if os.path.exists(wpa_conf):
-                    with open(wpa_conf, "w") as fh:
-                        fh.write(
-                            "ctrl_interface=/var/run/wpa_supplicant\n"
-                            "ctrl_interface_group=0\n"
-                            "update_config=1\n"
-                        )
-            except OSError as e:
-                errors.append(str(e))
-
-            if errors:
-                log.warning("Factory reset completed with errors: %s", errors)
-            else:
-                log.info("Factory reset completed successfully")
-
-            self._json_response({"message": "Factory reset complete. Restarting..."})
-
-            # Schedule system reboot (full reboot ensures clean first-boot state)
-            def _restart():
-                try:
-                    subprocess.run(
-                        ["systemctl", "reboot"],
-                        capture_output=True,
-                        timeout=30,
-                    )
-                except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
-                    log.error("Reboot failed: %s", e)
-
-            timer = threading.Timer(2.0, _restart)
-            timer.daemon = True
-            timer.start()
+            reset_svc = FactoryResetService(config, data_dir)
+            msg, status = reset_svc.execute_reset()
+            self._json_response({"message": msg}, status)
 
     return StatusHandler

--- a/app/camera/camera_streamer/templates/setup.html
+++ b/app/camera/camera_streamer/templates/setup.html
@@ -97,33 +97,55 @@ input:focus { border-color: #e94560; }
       Scanning will briefly drop the hotspot connection.</p>
   </div>
 
-  <!-- CONNECTING VIEW -->
+  <!-- CONNECTING VIEW (shown immediately after Save & Connect) -->
   <div id="view-connecting">
     <div class="card">
       <div class="msg msg-info">
         <div class="spinner"></div> Connecting to WiFi...
       </div>
       <p style="color:#8090b0;font-size:0.85em;text-align:center;margin-top:12px">
-        The hotspot will disappear now. This is normal.<br><br>
-        <strong>If it worked:</strong> the camera LED will go solid.
-        You can close this page.<br><br>
-        <strong>If it failed:</strong> the <em>HomeCam-Setup</em> hotspot
-        will reappear in about 30 seconds. Reconnect and try again.
+        The hotspot will disappear now. This is normal.
       </p>
     </div>
+
+    <div class="card" id="cam-address-card">
+      <h3 style="text-align:center;margin-bottom:8px">Camera Address</h3>
+      <div style="background:#1a1a2e;border-radius:8px;padding:16px;text-align:center;margin:12px 0;font-family:monospace;font-size:1.15em;color:#4ade80" id="cam-address-display">
+      </div>
+      <p style="color:#fff;text-align:center;font-size:0.9em;margin-top:12px">
+        Connect your phone back to your home WiFi,<br>then open the address above.
+      </p>
+      <p style="text-align:center;font-size:0.85em;color:#8090b0;margin-top:4px">
+        Login: <strong id="cam-login-user">admin</strong> / your password
+      </p>
+    </div>
+
+    <div class="card">
+      <h3 style="margin-bottom:8px">Next Steps</h3>
+      <p style="color:#8090b0;font-size:0.85em;line-height:1.6">
+        <span style="color:#e94560;font-weight:600">1.</span> Connect your phone to your home WiFi<br>
+        <span style="color:#e94560;font-weight:600">2.</span> Open the camera address above<br>
+        <span style="color:#e94560;font-weight:600">3.</span> On the <strong>server dashboard</strong>, click <strong>Pair</strong> on this camera to get a 6-digit PIN<br>
+        <span style="color:#e94560;font-weight:600">4.</span> Enter the PIN on the camera settings page to complete pairing
+      </p>
+    </div>
+
+    <p style="color:#506080;font-size:0.8em;text-align:center;margin-top:8px">
+      If it failed, the <em>HomeCam-Setup</em> hotspot will reappear in ~30 seconds.
+    </p>
   </div>
 
-  <!-- RESULT VIEW (shown if user reconnects after success/failure) -->
+  <!-- RESULT VIEW (shown if user reconnects to hotspot after success/failure) -->
   <div id="view-result">
     <div id="result-msg" class="msg msg-err"></div>
     <div id="result-next-steps" style="display:none">
       <div class="card" style="margin-top:16px">
         <h3 style="margin-bottom:8px">Next Steps</h3>
-        <p style="color:#8090b0;font-size:0.85em;line-height:1.5">
-          1. Connect your phone back to your home WiFi<br>
-          2. Open the camera settings page at the address above<br>
-          3. On the <strong>server dashboard</strong>, click <strong>Pair</strong> on this camera to get a 6-digit PIN<br>
-          4. Enter the PIN on the camera settings page to complete pairing
+        <p style="color:#8090b0;font-size:0.85em;line-height:1.6">
+          <span style="color:#e94560;font-weight:600">1.</span> Connect your phone back to your home WiFi<br>
+          <span style="color:#e94560;font-weight:600">2.</span> Open the camera settings page at the address above<br>
+          <span style="color:#e94560;font-weight:600">3.</span> On the <strong>server dashboard</strong>, click <strong>Pair</strong> on this camera to get a 6-digit PIN<br>
+          <span style="color:#e94560;font-weight:600">4.</span> Enter the PIN on the camera settings page to complete pairing
         </p>
       </div>
     </div>
@@ -132,6 +154,8 @@ input:focus { border-color: #e94560; }
 </div>
 
 <script>
+var CAMERA_HOSTNAME = '{{HOSTNAME}}';
+
 function $(id) { return document.getElementById(id); }
 
 function showView(name) {
@@ -141,6 +165,17 @@ function showView(name) {
 }
 
 function showForm() { showView('view-form'); }
+
+function showConnecting(hostname) {
+  var h = hostname || CAMERA_HOSTNAME;
+  var url = h ? 'http://' + h + '.local' : '';
+  $('cam-address-display').textContent = url || 'Resolving...';
+  if ($('cam-login-user')) {
+    var user = $('in-admin-user') ? $('in-admin-user').value.trim() : 'admin';
+    $('cam-login-user').textContent = user || 'admin';
+  }
+  showView('view-connecting');
+}
 
 function loadNetworks() {
   var wrap = $('net-list-wrap');
@@ -212,11 +247,12 @@ function doConnect() {
       alert(d.error);
       $('btn-save').disabled = false;
     } else {
-      showView('view-connecting');
+      showConnecting(d.hostname || '');
     }
   })
   .catch(function() {
-    showView('view-connecting');
+    // Network error — hotspot dropped during request, setup likely succeeded
+    showConnecting('');
   });
 }
 

--- a/app/camera/camera_streamer/templates/setup.html
+++ b/app/camera/camera_streamer/templates/setup.html
@@ -113,10 +113,21 @@ input:focus { border-color: #e94560; }
     </div>
   </div>
 
-  <!-- RESULT VIEW (shown if user reconnects after failure) -->
+  <!-- RESULT VIEW (shown if user reconnects after success/failure) -->
   <div id="view-result">
     <div id="result-msg" class="msg msg-err"></div>
-    <button class="btn btn-primary" onclick="showForm()">Try Again</button>
+    <div id="result-next-steps" style="display:none">
+      <div class="card" style="margin-top:16px">
+        <h3 style="margin-bottom:8px">Next Steps</h3>
+        <p style="color:#8090b0;font-size:0.85em;line-height:1.5">
+          1. Connect your phone back to your home WiFi<br>
+          2. Open the camera settings page at the address above<br>
+          3. On the <strong>server dashboard</strong>, click <strong>Pair</strong> on this camera to get a 6-digit PIN<br>
+          4. Enter the PIN on the camera settings page to complete pairing
+        </p>
+      </div>
+    </div>
+    <button id="btn-retry" class="btn btn-primary" onclick="showForm()" style="display:none">Try Again</button>
   </div>
 </div>
 
@@ -223,12 +234,16 @@ fetch('/api/status')
       showView('view-result');
       $('result-msg').className = 'msg msg-ok';
       var url = d.hostname ? 'http://' + d.hostname + '.local' : '';
-      $('result-msg').innerHTML = 'Setup complete! Camera is connected.'
-        + (url ? '<br><br>Access your camera at:<br><a href="' + url
-        + '" style="color:#4ade80;font-weight:600">' + esc(url) + '</a>' : '');
+      $('result-msg').innerHTML = 'Setup complete! Camera is on your home WiFi.'
+        + (url ? '<br><br>Camera settings page:<br><a href="' + url
+        + '" style="color:#4ade80;font-weight:600;font-size:1.1em">' + esc(url) + '</a>' : '');
+      $('result-next-steps').style.display = 'block';
+      $('btn-retry').style.display = 'none';
     } else if (d.status === 'failed') {
       showView('view-result');
       $('result-msg').textContent = 'WiFi connection failed: ' + d.error + '. Try again.';
+      $('result-next-steps').style.display = 'none';
+      $('btn-retry').style.display = 'block';
     } else {
       // Load cached networks from pre-hotspot scan
       fetch('/api/networks')

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -183,6 +183,46 @@ body {
         </div>
     </div>
 
+    <!-- Server Pairing -->
+    <div class="card" id="pairing-card">
+        <div class="card__title">Server Pairing</div>
+        <div id="pair-status-row" class="info-row">
+            <span class="info-row__label">Status</span>
+            <span class="info-row__value" id="s-paired">--</span>
+        </div>
+        <div id="pair-server-row" class="info-row">
+            <span class="info-row__label">Server</span>
+            <span class="info-row__value" id="s-pair-server">--</span>
+        </div>
+
+        <!-- Not paired: show PIN entry form -->
+        <div id="pair-form" style="display:none;margin-top:var(--space-3)">
+            <div class="form-group">
+                <label>Server Address</label>
+                <input type="text" id="pair-server-url" class="form-input" placeholder="rpi-divinu.local">
+                <div style="font-size:0.75rem;color:var(--color-text-dim);margin-top:var(--space-1)">
+                    Uses your configured server address. Change only if needed.
+                </div>
+            </div>
+            <div class="form-group">
+                <label>Pairing PIN</label>
+                <input type="text" id="pair-pin" class="form-input" placeholder="6-digit PIN from server dashboard"
+                       maxlength="6" pattern="[0-9]{6}" inputmode="numeric"
+                       style="font-size:1.5rem;text-align:center;letter-spacing:0.3em">
+            </div>
+            <button class="btn btn--primary btn--full" id="btn-pair" onclick="doPair()">Pair with Server</button>
+            <div id="pair-result"></div>
+        </div>
+
+        <!-- Paired: show success state with edit button -->
+        <div id="pair-done" style="display:none;margin-top:var(--space-3)">
+            <div class="msg msg--ok" style="display:flex;justify-content:space-between;align-items:center">
+                <span>Paired and authenticated</span>
+                <button class="btn btn--secondary btn--small" onclick="showPairForm()">Re-pair</button>
+            </div>
+        </div>
+    </div>
+
     <!-- System Health -->
     <div class="card">
         <div class="card__title">System Health</div>
@@ -308,8 +348,85 @@ function loadStatus() {
             var memPct = d.memory_total_mb > 0 ? Math.round(d.memory_used_mb / d.memory_total_mb * 100) : 0;
             $('s-mem').textContent = d.memory_used_mb + ' / ' + d.memory_total_mb + ' MB (' + memPct + '%)';
             $('s-uptime').textContent = d.uptime || '--';
+
+            // Update pairing section
+            updatePairingUI(d);
         })
         .catch(function() {});
+}
+
+function updatePairingUI(d) {
+    var pairedEl = $('s-paired');
+    var serverEl = $('s-pair-server');
+
+    serverEl.textContent = d.server_address || '--';
+
+    // Pre-fill server URL for pairing form
+    if (!$('pair-server-url').value && d.server_address) {
+        $('pair-server-url').value = d.server_address;
+    }
+
+    if (d.paired) {
+        pairedEl.textContent = 'Paired';
+        pairedEl.className = 'info-row__value status-ok';
+        $('pair-form').style.display = 'none';
+        $('pair-done').style.display = 'block';
+    } else {
+        pairedEl.textContent = 'Not paired';
+        pairedEl.className = 'info-row__value status-warn';
+        // Only show form if not already showing the done state
+        if ($('pair-done').style.display !== 'block') {
+            $('pair-form').style.display = 'block';
+        }
+    }
+}
+
+function showPairForm() {
+    $('pair-done').style.display = 'none';
+    $('pair-form').style.display = 'block';
+    $('pair-pin').value = '';
+    $('pair-result').innerHTML = '';
+}
+
+function doPair() {
+    var pin = $('pair-pin').value.trim();
+    var serverAddr = $('pair-server-url').value.trim();
+
+    if (!pin || pin.length !== 6) { alert('Enter the 6-digit PIN from the server dashboard'); return; }
+    if (!serverAddr) { alert('Enter the server address'); return; }
+
+    // Build server URL — add https:// if no scheme
+    var serverUrl = serverAddr;
+    if (serverUrl.indexOf('://') === -1) {
+        serverUrl = 'https://' + serverUrl;
+    }
+
+    $('btn-pair').disabled = true;
+    $('btn-pair').textContent = 'Pairing...';
+    $('pair-result').innerHTML = '';
+
+    fetch('/api/pair', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pin: pin, server_url: serverUrl })
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+        $('btn-pair').disabled = false;
+        $('btn-pair').textContent = 'Pair with Server';
+        if (d.error) {
+            $('pair-result').innerHTML = '<div class="msg msg--err">' + esc(d.error) + '</div>';
+        } else {
+            $('pair-result').innerHTML = '<div class="msg msg--ok">' + esc(d.message || 'Paired!') + '</div>';
+            // Refresh status to update pairing UI
+            setTimeout(loadStatus, 1000);
+        }
+    })
+    .catch(function() {
+        $('btn-pair').disabled = false;
+        $('btn-pair').textContent = 'Pair with Server';
+        $('pair-result').innerHTML = '<div class="msg msg--err">Request failed</div>';
+    });
 }
 
 function scanNetworks() {

--- a/app/camera/camera_streamer/wifi.py
+++ b/app/camera/camera_streamer/wifi.py
@@ -8,6 +8,7 @@ for platform abstraction.
 """
 
 import logging
+import os
 import subprocess
 import time
 
@@ -295,14 +296,25 @@ def get_hostname() -> str:
 
 
 def set_hostname(hostname: str) -> bool:
-    """Set the system hostname and notify NetworkManager and Avahi."""
+    """Set the system hostname and notify NetworkManager and Avahi.
+
+    Uses transient hostname (memory-only) so it works on read-only rootfs.
+    The hostname is saved to /data/config/hostname for persistence across
+    reboots — the lifecycle restores it on every boot.
+    """
     try:
+        # Set kernel hostname directly (works on read-only rootfs where
+        # hostnamectl --transient is ignored due to static hostname in /etc)
         subprocess.run(["hostname", hostname], capture_output=True, timeout=5)
-        with open("/etc/hostname", "w") as f:
-            f.write(hostname + "\n")
-        subprocess.run(
-            ["nmcli", "general", "hostname", hostname], capture_output=True, timeout=5
-        )
+        # Save to /data for persistence across reboots
+        data_hostname = "/data/config/hostname"
+        try:
+            os.makedirs(os.path.dirname(data_hostname), exist_ok=True)
+            with open(data_hostname, "w") as f:
+                f.write(hostname + "\n")
+        except OSError:
+            pass
+        # Restart avahi so mDNS advertises the new name
         subprocess.run(
             ["systemctl", "restart", "avahi-daemon"], capture_output=True, timeout=10
         )

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -384,10 +384,10 @@ def _make_handler(config, setup_server):
             self.wfile.write(body)
 
         def _serve_setup_page(self):
-            html = _load_template("setup.html").replace(
-                "{{CAMERA_ID}}", config.camera_id
-            ).replace(
-                "{{HOSTNAME}}", setup_server._expected_hostname or ""
+            html = (
+                _load_template("setup.html")
+                .replace("{{CAMERA_ID}}", config.camera_id)
+                .replace("{{HOSTNAME}}", setup_server._expected_hostname or "")
             )
             body = html.encode()
             self.send_response(200)

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -95,6 +95,7 @@ class WifiSetupServer:
         self._thread = None
         self._cached_networks = []
         self._connect_result = None
+        self._expected_hostname = self._compute_hostname()
 
     def needs_setup(self):
         """Return True if setup hasn't been completed."""
@@ -214,8 +215,8 @@ class WifiSetupServer:
         except OSError as e:
             return False, str(e)
 
-    def _set_unique_hostname(self):
-        """Set unique hostname using CPU serial suffix."""
+    def _compute_hostname(self):
+        """Pre-compute the hostname from CPU serial (same logic as _set_unique_hostname)."""
         try:
             serial = ""
             with open("/proc/cpuinfo") as f:
@@ -223,10 +224,18 @@ class WifiSetupServer:
                     if line.startswith("Serial"):
                         serial = line.split(":")[-1].strip()
             suffix = serial[-4:] if serial else "0000"
-            hostname = f"{self._hostname_prefix}-{suffix}"
-            wifi.set_hostname(hostname)
-        except Exception as e:
-            log.warning("Failed to set hostname: %s", e)
+            return f"{self._hostname_prefix}-{suffix}"
+        except Exception:
+            return ""
+
+    def _set_unique_hostname(self):
+        """Set unique hostname using CPU serial suffix."""
+        hostname = self._expected_hostname
+        if hostname:
+            try:
+                wifi.set_hostname(hostname)
+            except Exception as e:
+                log.warning("Failed to set hostname: %s", e)
 
     def get_status(self):
         """Return current connection attempt status."""
@@ -354,6 +363,7 @@ def _make_handler(config, setup_server):
                         {
                             "status": "connecting",
                             "message": "Settings saved. Connecting to WiFi...",
+                            "hostname": setup_server._expected_hostname,
                         }
                     )
                 except json.JSONDecodeError:
@@ -376,6 +386,8 @@ def _make_handler(config, setup_server):
         def _serve_setup_page(self):
             html = _load_template("setup.html").replace(
                 "{{CAMERA_ID}}", config.camera_id
+            ).replace(
+                "{{HOSTNAME}}", setup_server._expected_hostname or ""
             )
             body = html.encode()
             self.send_response(200)

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -1,22 +1,28 @@
 """
-WiFi setup for camera first boot.
+WiFi setup wizard for camera first boot.
 
 On first boot (when /data/.setup-done doesn't exist):
-1. Starts a WiFi hotspot "HomeCam-Setup"
-2. Runs a tiny HTTP server on port 80 with a setup page
+1. Systemd starts camera-hotspot.service (WiFi AP "HomeCam-Setup")
+2. This module runs an HTTP server on port 80 with a setup page
 3. User enters WiFi SSID + password + server IP + camera password
-4. Camera saves settings, tears down hotspot, connects to home WiFi
-5. If WiFi fails, hotspot comes back up for retry
+4. Camera calls hotspot script to connect WiFi (stops AP atomically)
+5. If WiFi fails, hotspot script restarts the AP for retry
+
+Architecture (ADR-0013):
+- Hotspot lifecycle is always managed by systemd + shell script
+- This module only provides the HTTP setup wizard UI
+- WiFi operations delegate to the hotspot script's 'connect' command
 
 Single-radio constraint: wlan0 can either be an AP or a client, not both.
-So we can't scan while hotspot is active. User types SSID manually or we
-do a quick scan BEFORE starting the hotspot.
+Networks are scanned BEFORE systemd starts the hotspot, via a pre-scan
+in the lifecycle's _do_setup() or from a brief AP drop via /api/rescan.
 """
 
 import http.server
 import json
 import logging
 import os
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -28,6 +34,7 @@ log = logging.getLogger("camera-streamer.wifi-setup")
 SETUP_STAMP = ".setup-done"
 LISTEN_PORT = 80
 CONNECT_DELAY = 3
+HOTSPOT_SCRIPT = "/opt/camera/scripts/camera-hotspot.sh"
 
 # Template directory (adjacent to this module)
 _TEMPLATE_DIR = Path(__file__).parent / "templates"
@@ -63,21 +70,29 @@ def mark_setup_complete(data_dir):
 class WifiSetupServer:
     """HTTP server for camera WiFi and server configuration (first boot).
 
+    Only provides the setup wizard UI. Hotspot lifecycle is managed
+    by camera-hotspot.service (systemd). See ADR-0013.
+
     Args:
         config: ConfigManager instance.
         wifi_interface: WiFi interface name (from Platform).
         hostname_prefix: Hostname prefix (from Platform).
+        hotspot_script: Path to hotspot management script.
     """
 
     def __init__(
-        self, config, wifi_interface="wlan0", hostname_prefix="rpi-divinu-cam"
+        self,
+        config,
+        wifi_interface="wlan0",
+        hostname_prefix="rpi-divinu-cam",
+        hotspot_script=HOTSPOT_SCRIPT,
     ):
         self._config = config
         self._wifi_interface = wifi_interface
         self._hostname_prefix = hostname_prefix
+        self._hotspot_script = hotspot_script
         self._server = None
         self._thread = None
-        self._hotspot_active = False
         self._cached_networks = []
         self._connect_result = None
 
@@ -86,19 +101,19 @@ class WifiSetupServer:
         return not is_setup_complete(self._config.data_dir)
 
     def start(self):
-        """Scan networks, start hotspot, then start HTTP server."""
+        """Pre-scan networks and start HTTP setup wizard.
+
+        The hotspot is already running (started by systemd).
+        This method only starts the HTTP server for the setup UI.
+        """
         if not self.needs_setup():
             log.info("Setup already complete, skipping")
             return False
 
-        # Scan BEFORE starting hotspot (wlan0 is in client mode now)
+        # Scan BEFORE hotspot is active (called from lifecycle before
+        # systemd starts hotspot, or networks may be empty)
         self._cached_networks = wifi.scan_networks(self._wifi_interface)
         log.info("Pre-scan found %d networks", len(self._cached_networks))
-
-        if not wifi.start_hotspot(self._wifi_interface):
-            log.warning("Could not start hotspot — setup via ethernet")
-        else:
-            self._hotspot_active = True
 
         led.setup_mode()
 
@@ -112,13 +127,10 @@ class WifiSetupServer:
         return True
 
     def stop(self):
-        """Stop HTTP server and hotspot."""
+        """Stop HTTP server. Hotspot is managed by systemd."""
         if self._server:
             self._server.shutdown()
             self._server = None
-        if self._hotspot_active:
-            wifi.stop_hotspot()
-            self._hotspot_active = False
         led.off()
         log.info("Setup server stopped")
 
@@ -153,17 +165,13 @@ class WifiSetupServer:
         t.start()
 
     def _do_connect(self, ssid, password, server_ip, server_port):
-        """Background: wait for phone to get response, then connect."""
+        """Background: wait for phone to get response, then connect via hotspot script."""
         time.sleep(CONNECT_DELAY)
 
-        log.info("Tearing down hotspot, connecting to WiFi: %s", ssid)
+        log.info("Connecting to WiFi via hotspot script: %s", ssid)
         led.connecting()
 
-        wifi.stop_hotspot()
-        self._hotspot_active = False
-        time.sleep(2)
-
-        ok, err = wifi.connect_network(ssid, password, self._wifi_interface)
+        ok, err = self._hotspot_connect(ssid, password)
 
         if ok:
             log.info("WiFi connected! Saving config and completing setup.")
@@ -173,13 +181,38 @@ class WifiSetupServer:
             self._connect_result = True
             led.connected()
         else:
-            log.error("WiFi connection failed: %s — restarting hotspot", err)
+            log.error("WiFi connection failed: %s", err)
             self._connect_result = err or "Connection failed"
             led.error()
-            time.sleep(2)
-            if wifi.start_hotspot(self._wifi_interface):
-                self._hotspot_active = True
-            led.setup_mode()
+
+    def _hotspot_connect(self, ssid, password):
+        """Connect to WiFi via hotspot script's 'connect' command.
+
+        The script atomically stops the AP and connects to the target
+        network. If connection fails, the script restarts the AP.
+        Returns (success, error_message).
+        """
+        try:
+            result = subprocess.run(
+                [self._hotspot_script, "connect", ssid, password],
+                capture_output=True,
+                text=True,
+                timeout=45,
+            )
+            if result.returncode == 0:
+                return True, ""
+            output = result.stderr.strip() or result.stdout.strip()
+            return False, output
+        except FileNotFoundError:
+            log.warning(
+                "Hotspot script not found at %s — falling back to direct nmcli",
+                self._hotspot_script,
+            )
+            return wifi.connect_network(ssid, password, self._wifi_interface)
+        except subprocess.TimeoutExpired:
+            return False, "Connection timed out"
+        except OSError as e:
+            return False, str(e)
 
     def _set_unique_hostname(self):
         """Set unique hostname using CPU serial suffix."""
@@ -204,16 +237,31 @@ class WifiSetupServer:
         return list(self._cached_networks)
 
     def rescan(self):
-        """Rescan by briefly dropping AP, scanning, then restarting AP."""
-        log.info("Rescan requested — dropping AP briefly")
-        wifi.stop_hotspot()
-        self._hotspot_active = False
+        """Rescan by briefly dropping AP via hotspot script, scanning, then restarting."""
+        log.info("Rescan requested — stopping hotspot briefly")
+        try:
+            subprocess.run(
+                [self._hotspot_script, "stop"],
+                capture_output=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            wifi.stop_hotspot()
+
         time.sleep(2)
         self._cached_networks = wifi.scan_networks(self._wifi_interface)
         log.info("Rescan found %d networks", len(self._cached_networks))
         time.sleep(1)
-        if wifi.start_hotspot(self._wifi_interface):
-            self._hotspot_active = True
+
+        try:
+            subprocess.run(
+                [self._hotspot_script, "start"],
+                capture_output=True,
+                timeout=30,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            wifi.start_hotspot(self._wifi_interface)
+
         return self._cached_networks
 
 

--- a/app/camera/config/camera-hotspot.service
+++ b/app/camera/config/camera-hotspot.service
@@ -1,9 +1,9 @@
 [Unit]
-Description=Home Monitor WiFi Setup Hotspot
+Description=Camera WiFi Setup Hotspot
 Documentation=https://github.com/vinu-engineer/rpi-home-monitor
 After=NetworkManager.service local-fs.target sys-subsystem-net-devices-wlan0.device gpio-trigger.service
 Wants=NetworkManager.service
-Before=monitor.service
+Before=camera-streamer.service
 
 # Only start if initial setup has not been completed
 ConditionPathExists=!/data/.setup-done
@@ -12,8 +12,8 @@ ConditionPathExists=!/data/.setup-done
 Type=oneshot
 RemainAfterExit=yes
 TimeoutStartSec=90
-ExecStart=/opt/monitor/scripts/monitor-hotspot.sh start
-ExecStop=/opt/monitor/scripts/monitor-hotspot.sh stop
+ExecStart=/opt/camera/scripts/camera-hotspot.sh start
+ExecStop=/opt/camera/scripts/camera-hotspot.sh stop
 
 [Install]
 WantedBy=multi-user.target

--- a/app/camera/config/camera-hotspot.sh
+++ b/app/camera/config/camera-hotspot.sh
@@ -1,17 +1,16 @@
 #!/bin/sh
-# monitor-hotspot.sh — WiFi hotspot management for initial device setup
-# Usage: monitor-hotspot.sh start|stop|status
+# camera-hotspot.sh — WiFi hotspot management for camera first-boot setup
+# Usage: camera-hotspot.sh start|stop|status|connect|wipe
 #
-# Creates/destroys WiFi AP "HomeMonitor-Setup" for first-boot provisioning.
-# The hotspot allows users to connect from a phone/laptop and configure
-# WiFi credentials + admin password via the setup wizard.
+# Mirrors the server's monitor-hotspot.sh pattern exactly (ADR-0013).
+# Creates/destroys WiFi AP "HomeCam-Setup" for first-boot provisioning.
 
 set -e
 
-CONN_NAME="HomeMonitor-Setup"
+CONN_NAME="HomeCam-Setup"
 IFACE="wlan0"
-HOTSPOT_SSID="HomeMonitor-Setup"
-HOTSPOT_PASS="homemonitor"
+HOTSPOT_SSID="HomeCam-Setup"
+HOTSPOT_PASS="homecamera"
 
 # --- LED control (ACT LED on RPi) ---
 LED_PATH="/sys/class/leds/ACT"
@@ -40,13 +39,10 @@ led_off() {
 }
 
 wait_for_wifi() {
-    # Wait until wlan0 is recognized by NetworkManager as a wifi device.
-    # The WiFi firmware/driver may still be loading at early boot.
     MAX_WAIT=30
     WAITED=0
     echo "Waiting for WiFi interface ${IFACE} to be ready..."
     while [ "$WAITED" -lt "$MAX_WAIT" ]; do
-        # Check NM sees it as a wifi device (not just that the interface exists)
         DEVTYPE=$(nmcli -t -f DEVICE,TYPE device status 2>/dev/null | grep "^${IFACE}:" | cut -d: -f2)
         if [ "$DEVTYPE" = "wifi" ]; then
             echo "WiFi interface ${IFACE} ready after ${WAITED}s"
@@ -62,18 +58,15 @@ wait_for_wifi() {
 start_hotspot() {
     echo "Starting WiFi hotspot: ${HOTSPOT_SSID}"
 
-    # Wait for WiFi hardware to be ready (firmware may still be loading)
     if ! wait_for_wifi; then
-        echo "WiFi interface ${IFACE} not found — skipping hotspot (ethernet-only setup)"
+        echo "WiFi interface ${IFACE} not found — skipping hotspot"
         exit 0
     fi
 
     # Remove any existing hotspot connection with this name
     nmcli connection delete "${CONN_NAME}" 2>/dev/null || true
 
-    # Create the hotspot with shared mode (NetworkManager runs dnsmasq
-    # automatically for DHCP when ipv4.method=shared, so connected
-    # clients get an IP address in the 10.42.0.x range)
+    # Create the hotspot with shared mode (NM runs dnsmasq for DHCP)
     nmcli connection add \
         type wifi \
         ifname "${IFACE}" \
@@ -86,10 +79,7 @@ start_hotspot() {
         wifi-sec.psk "${HOTSPOT_PASS}" \
         ipv4.method shared
 
-    # Bring up the connection with explicit interface binding + retry.
-    # Even after NM sees wlan0, AP mode activation can fail briefly
-    # while the driver finishes initialization.
-    # Note: temporarily disable set -e for the retry loop.
+    # Activate with retry (driver may still be initializing)
     MAX_RETRIES=5
     RETRY=0
     ACTIVATED=false
@@ -113,26 +103,20 @@ start_hotspot() {
         exit 1
     fi
 
-    # Get the actual IP assigned (shared mode uses 10.42.0.1 by default)
     ACTUAL_IP=$(nmcli -t -f IP4.ADDRESS dev show "${IFACE}" 2>/dev/null | head -n 1 | cut -d: -f2 | cut -d/ -f1)
     echo "Hotspot active on ${IFACE} — SSID: ${HOTSPOT_SSID}, IP: ${ACTUAL_IP:-10.42.0.1}"
     echo "Setup wizard available at http://${ACTUAL_IP:-10.42.0.1}/"
-    echo "Captive portal: phone should auto-open setup page on connect"
 
-    # LED: slow blink = setup mode
     led_setup_mode
 }
 
 stop_hotspot() {
     echo "Stopping WiFi hotspot: ${CONN_NAME}"
 
-    # Bring down and remove the hotspot connection
     nmcli connection down "${CONN_NAME}" 2>/dev/null || true
     nmcli connection delete "${CONN_NAME}" 2>/dev/null || true
 
-    # LED: solid on = normal operation
     led_connected
-
     echo "Hotspot stopped"
 }
 
@@ -147,7 +131,7 @@ status_hotspot() {
 }
 
 connect_wifi() {
-    # Usage: monitor-hotspot.sh connect <ssid> <password>
+    # Usage: camera-hotspot.sh connect <ssid> <password>
     WIFI_SSID="$1"
     WIFI_PASS="$2"
 

--- a/app/camera/config/camera-hotspot.sh
+++ b/app/camera/config/camera-hotspot.sh
@@ -168,12 +168,34 @@ connect_wifi() {
 wipe_wifi() {
     echo "Wiping all saved WiFi credentials"
 
+    # Use nmcli to properly delete connections from NM's in-memory state
+    # (just deleting files doesn't work — NM re-writes them on shutdown)
+    nmcli -t -f NAME,TYPE con show 2>/dev/null | while IFS=: read -r NAME TYPE; do
+        if [ "$TYPE" = "802-11-wireless" ]; then
+            nmcli con delete "$NAME" 2>/dev/null && echo "  Deleted: $NAME" || true
+        fi
+    done
+
+    # Clean up rootfs connection files
     NM_DIR="/etc/NetworkManager/system-connections"
     if [ -d "$NM_DIR" ]; then
         for CONN_FILE in "${NM_DIR}"/*; do
             if [ -f "$CONN_FILE" ]; then
                 rm -f "$CONN_FILE"
-                echo "  Removed: $(basename "$CONN_FILE")"
+                echo "  Removed file: $(basename "$CONN_FILE")"
+            fi
+        done
+    fi
+
+    # Clean up persistent /data connections (nm-persist.sh bind-mounts
+    # /data/network/system-connections/ over /etc/NetworkManager/system-connections/
+    # on every boot — wiping only /etc is not enough)
+    PERSIST_DIR="/data/network/system-connections"
+    if [ -d "$PERSIST_DIR" ]; then
+        for CONN_FILE in "${PERSIST_DIR}"/*; do
+            if [ -f "$CONN_FILE" ]; then
+                rm -f "$CONN_FILE"
+                echo "  Removed persistent: $(basename "$CONN_FILE")"
             fi
         done
     fi

--- a/app/camera/config/camera-streamer.service
+++ b/app/camera/config/camera-streamer.service
@@ -27,7 +27,8 @@ PrivateTmp=true
 # Camera device access
 SupplementaryGroups=video
 # Hotspot setup needs NetworkManager D-Bus access and port 80
-AmbientCapabilities=CAP_NET_BIND_SERVICE
+# CAP_SYS_ADMIN needed to set hostname (mDNS) on read-only rootfs
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SYS_ADMIN
 
 [Install]
 WantedBy=multi-user.target

--- a/app/camera/tests/test_api_contracts.py
+++ b/app/camera/tests/test_api_contracts.py
@@ -273,6 +273,7 @@ STATUS_API_FIELDS = {
     "server_address",
     "server_connected",
     "streaming",
+    "paired",
     "cpu_temp",
     "uptime",
     "memory_total_mb",

--- a/app/camera/tests/test_api_contracts.py
+++ b/app/camera/tests/test_api_contracts.py
@@ -148,7 +148,7 @@ def noauth_config(tmp_path):
 
 SETUP_STATUS_FIELDS = {"status", "error", "setup_complete", "camera_id", "hostname"}
 NETWORK_FIELDS = {"ssid", "signal", "security"}
-CONNECT_SUCCESS_FIELDS = {"status", "message"}
+CONNECT_SUCCESS_FIELDS = {"status", "message", "hostname"}
 
 
 class TestSetupNetworksContract:

--- a/app/camera/tests/test_factory_reset.py
+++ b/app/camera/tests/test_factory_reset.py
@@ -1,0 +1,141 @@
+"""Unit tests for camera FactoryResetService — wipe data and return to first-boot."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from camera_streamer.factory_reset import FactoryResetService
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    """Create a realistic /data directory structure for camera."""
+    dirs = ["config", "certs", "logs", "ota"]
+    for d in dirs:
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+
+    # Config file
+    (tmp_path / "config" / "camera.conf").write_text("[camera]\nid=cam-001\n")
+
+    # Stamp file
+    (tmp_path / ".setup-done").write_text("1\n")
+
+    # Certs (pairing data)
+    (tmp_path / "certs" / "client.crt").write_text("cert")
+    (tmp_path / "certs" / "client.key").write_text("key")
+
+    # Logs
+    (tmp_path / "logs" / "camera.log").write_text("log entry\n")
+
+    return tmp_path
+
+
+@pytest.fixture
+def config():
+    mock = MagicMock()
+    mock.data_dir = "/data"
+    return mock
+
+
+@pytest.fixture
+def svc(config, data_dir):
+    return FactoryResetService(config, str(data_dir), hotspot_script="/nonexistent")
+
+
+class TestCameraFactoryReset:
+    """Test the full factory reset flow."""
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_removes_stamp_file(self, mock_reboot, svc, data_dir):
+        svc.execute_reset()
+        assert not (data_dir / ".setup-done").exists()
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_removes_config(self, mock_reboot, svc, data_dir):
+        svc.execute_reset()
+        assert not (data_dir / "config" / "camera.conf").exists()
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_removes_certs(self, mock_reboot, svc, data_dir):
+        svc.execute_reset()
+        assert not (data_dir / "certs").exists()
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_removes_logs(self, mock_reboot, svc, data_dir):
+        svc.execute_reset()
+        assert not (data_dir / "logs").exists()
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_removes_ota(self, mock_reboot, svc, data_dir):
+        (data_dir / "ota" / "update.swu").write_bytes(b"\x00" * 50)
+        svc.execute_reset()
+        assert not (data_dir / "ota").exists()
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_returns_200(self, mock_reboot, svc):
+        msg, status = svc.execute_reset()
+        assert status == 200
+        assert "reset" in msg.lower()
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_schedules_reboot(self, mock_reboot, svc):
+        svc.execute_reset()
+        mock_reboot.assert_called_once()
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_idempotent(self, mock_reboot, svc, data_dir):
+        """Running reset twice doesn't fail."""
+        svc.execute_reset()
+        msg, status = svc.execute_reset()
+        assert status == 200
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_on_empty_data_dir(self, mock_reboot, config, tmp_path):
+        """Reset works even if /data is empty."""
+        svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
+        msg, status = svc.execute_reset()
+        assert status == 200
+
+
+class TestWifiWipeDelegation:
+    """Test that factory reset delegates WiFi wipe to hotspot script."""
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    @patch("camera_streamer.factory_reset.subprocess.run")
+    @patch("camera_streamer.factory_reset.os.path.isfile")
+    def test_calls_hotspot_wipe(
+        self, mock_isfile, mock_run, mock_reboot, config, tmp_path
+    ):
+        """WiFi wipe delegates to hotspot script's 'wipe' command."""
+        original_isfile = os.path.isfile
+
+        def isfile_side_effect(path):
+            if path == "/opt/camera/scripts/camera-hotspot.sh":
+                return True
+            return original_isfile(path)
+
+        mock_isfile.side_effect = isfile_side_effect
+        mock_run.return_value = MagicMock(returncode=0)
+
+        svc = FactoryResetService(
+            config,
+            str(tmp_path),
+            hotspot_script="/opt/camera/scripts/camera-hotspot.sh",
+        )
+        svc.execute_reset()
+
+        # Find the wipe call among all subprocess.run calls
+        wipe_calls = [
+            c
+            for c in mock_run.call_args_list
+            if c[0][0] == ["/opt/camera/scripts/camera-hotspot.sh", "wipe"]
+        ]
+        assert len(wipe_calls) == 1
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_succeeds_without_hotspot_script(self, mock_reboot, config, tmp_path):
+        """Reset doesn't fail if hotspot script doesn't exist."""
+        svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
+        msg, status = svc.execute_reset()
+        assert status == 200

--- a/app/camera/tests/test_wifi_setup.py
+++ b/app/camera/tests/test_wifi_setup.py
@@ -69,48 +69,37 @@ class TestWifiSetupServer:
         assert server.needs_setup() is False
 
     @patch("http.server.HTTPServer")
-    @patch("camera_streamer.wifi.start_hotspot")
     @patch("camera_streamer.wifi.scan_networks")
-    def test_start_when_needed(
-        self, mock_scan, mock_hotspot, mock_httpd, unconfigured_config
-    ):
-        """start() should pre-scan, start hotspot, and start HTTP server."""
+    def test_start_when_needed(self, mock_scan, mock_httpd, unconfigured_config):
+        """start() should pre-scan and start HTTP server (hotspot is systemd's job)."""
         mock_scan.return_value = [{"ssid": "TestNet", "signal": 80, "security": "WPA2"}]
-        mock_hotspot.return_value = True
         server = WifiSetupServer(unconfigured_config)
         result = server.start()
         assert result is True
         mock_scan.assert_called_once()
-        mock_hotspot.assert_called_once()
         # Verify cached networks from pre-scan
         assert len(server.get_cached_networks()) == 1
         assert server.get_cached_networks()[0]["ssid"] == "TestNet"
         server.stop()
 
-    @patch("camera_streamer.wifi.start_hotspot")
     @patch("camera_streamer.wifi.scan_networks")
-    def test_start_skips_when_done(self, mock_scan, mock_hotspot, unconfigured_config):
+    def test_start_skips_when_done(self, mock_scan, unconfigured_config):
         """start() should skip when setup already done."""
         mark_setup_complete(unconfigured_config.data_dir)
         server = WifiSetupServer(unconfigured_config)
         result = server.start()
         assert result is False
-        mock_hotspot.assert_not_called()
         mock_scan.assert_not_called()
 
     @patch("http.server.HTTPServer")
-    @patch("camera_streamer.wifi.start_hotspot")
     @patch("camera_streamer.wifi.scan_networks")
-    def test_start_with_hotspot_failure(
-        self, mock_scan, mock_hotspot, mock_httpd, unconfigured_config
-    ):
-        """start() should still work if hotspot fails (e.g. no WiFi hw)."""
+    def test_start_with_empty_scan(self, mock_scan, mock_httpd, unconfigured_config):
+        """start() should still work even if pre-scan finds no networks."""
         mock_scan.return_value = []
-        mock_hotspot.return_value = False
         server = WifiSetupServer(unconfigured_config)
-        # Should not raise — logs a warning, HTTP server still starts
         result = server.start()
         assert result is True
+        assert server.get_cached_networks() == []
         server.stop()
 
     def test_get_status_initial(self, unconfigured_config):
@@ -225,15 +214,13 @@ class TestConnectWifi:
 class TestSaveAndConnect:
     """Test the save_and_connect flow (background connection)."""
 
-    @patch("camera_streamer.wifi.time.sleep")
-    @patch("camera_streamer.wifi.start_hotspot")
-    @patch("camera_streamer.wifi.stop_hotspot")
-    @patch("camera_streamer.wifi.connect_network")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._hotspot_connect")
+    @patch("time.sleep")
     def test_connect_success_saves_config(
-        self, mock_connect, mock_stop, mock_start, mock_sleep, unconfigured_config
+        self, mock_sleep, mock_hotspot_connect, unconfigured_config
     ):
         """Successful connect should save config and mark setup done."""
-        mock_connect.return_value = (True, "")
+        mock_hotspot_connect.return_value = (True, "")
         server = WifiSetupServer(unconfigured_config)
 
         # Call _do_connect directly (skip threading)
@@ -241,36 +228,29 @@ class TestSaveAndConnect:
 
         assert server.get_status() is True
         assert is_setup_complete(unconfigured_config.data_dir)
-        mock_stop.assert_called_once()
-        mock_start.assert_not_called()  # No restart on success
+        mock_hotspot_connect.assert_called_once_with("TestNet", "pass123")
 
-    @patch("camera_streamer.wifi.time.sleep")
-    @patch("camera_streamer.wifi.start_hotspot")
-    @patch("camera_streamer.wifi.stop_hotspot")
-    @patch("camera_streamer.wifi.connect_network")
-    def test_connect_failure_restarts_hotspot(
-        self, mock_connect, mock_stop, mock_start, mock_sleep, unconfigured_config
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._hotspot_connect")
+    @patch("time.sleep")
+    def test_connect_failure_sets_error(
+        self, mock_sleep, mock_hotspot_connect, unconfigured_config
     ):
-        """Failed connect should restart hotspot for retry."""
-        mock_connect.return_value = (False, "No such network")
+        """Failed connect should set error status (hotspot script handles AP restart)."""
+        mock_hotspot_connect.return_value = (False, "No such network")
         server = WifiSetupServer(unconfigured_config)
 
         server._do_connect("BadNet", "pass", "192.168.1.100", "8554")
 
         assert server.get_status() == "No such network"
         assert not is_setup_complete(unconfigured_config.data_dir)
-        mock_stop.assert_called_once()
-        mock_start.assert_called_once()  # Hotspot restarted
 
-    @patch("camera_streamer.wifi.time.sleep")
-    @patch("camera_streamer.wifi.start_hotspot")
-    @patch("camera_streamer.wifi.stop_hotspot")
-    @patch("camera_streamer.wifi.connect_network")
+    @patch("camera_streamer.wifi_setup.WifiSetupServer._hotspot_connect")
+    @patch("time.sleep")
     def test_connect_saves_server_port(
-        self, mock_connect, mock_stop, mock_start, mock_sleep, unconfigured_config
+        self, mock_sleep, mock_hotspot_connect, unconfigured_config
     ):
         """Server port should be saved to config on success."""
-        mock_connect.return_value = (True, "")
+        mock_hotspot_connect.return_value = (True, "")
         server = WifiSetupServer(unconfigured_config)
 
         server._do_connect("TestNet", "pass", "10.0.0.5", "9999")

--- a/app/server/config/gpio-trigger.service
+++ b/app/server/config/gpio-trigger.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=GPIO Trigger Detection (Provisioning / Factory Reset)
+Documentation=https://github.com/vinu-engineer/rpi-home-monitor
+After=local-fs.target
+Before=monitor-hotspot.service camera-hotspot.service monitor.service camera-streamer.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/opt/scripts/gpio-trigger.sh
+
+# GPIO pins can be overridden per-device via drop-in:
+#   systemctl edit gpio-trigger
+#   [Service]
+#   Environment=GPIO_PROVISION_PIN=5
+#   Environment=GPIO_RESET_PIN=27
+
+# Exit code 0 = normal boot, 10 = provisioning, 20 = factory reset
+# All are considered success — the script handles the trigger action internally
+SuccessExitStatus=0 10 20
+
+[Install]
+WantedBy=multi-user.target

--- a/app/server/config/gpio-trigger.sh
+++ b/app/server/config/gpio-trigger.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+# gpio-trigger.sh — Boot-time GPIO jumper detection for provisioning and factory reset
+#
+# Reads two GPIO pins at boot to determine if the operator has placed a jumper:
+#   - Provisioning jumper (GPIO5, pin 29 → GND pin 30): re-enter setup wizard
+#   - Factory reset jumper (GPIO27, pin 13 → GND pin 14): full data wipe + setup
+#
+# Both pins are active-low: HIGH = no jumper (normal boot), LOW = jumper present.
+# GPIO5 has hardware pull-up at boot (BCM2711/BCM2710).
+# GPIO27 requires gpio=27=ip,pu in config.txt for pull-up.
+#
+# Pin numbers are configurable via environment variables for platform abstraction:
+#   GPIO_PROVISION_PIN  (default: 5)
+#   GPIO_RESET_PIN      (default: 27)
+#
+# Usage: gpio-trigger.sh
+# Exit codes:
+#   0 — normal boot (no jumper detected)
+#   10 — provisioning mode triggered (stamp deleted)
+#   20 — factory reset triggered (data wiped)
+#
+# See ADR-0013 for design rationale.
+set -e
+
+# --- Configurable GPIO pins (platform abstraction) ---
+PROVISION_PIN="${GPIO_PROVISION_PIN:-5}"
+RESET_PIN="${GPIO_RESET_PIN:-27}"
+
+SETUP_STAMP="/data/.setup-done"
+GPIO_BASE="/sys/class/gpio"
+
+# --- Helper functions ---
+
+gpio_export() {
+    PIN="$1"
+    if [ ! -d "${GPIO_BASE}/gpio${PIN}" ]; then
+        echo "$PIN" > "${GPIO_BASE}/export" 2>/dev/null || true
+        # Wait for sysfs node to appear
+        RETRIES=10
+        while [ ! -d "${GPIO_BASE}/gpio${PIN}" ] && [ "$RETRIES" -gt 0 ]; do
+            sleep 0.1
+            RETRIES=$((RETRIES - 1))
+        done
+    fi
+    # Ensure pin is input
+    echo "in" > "${GPIO_BASE}/gpio${PIN}/direction" 2>/dev/null || true
+}
+
+gpio_read() {
+    PIN="$1"
+    if [ -f "${GPIO_BASE}/gpio${PIN}/value" ]; then
+        cat "${GPIO_BASE}/gpio${PIN}/value"
+    else
+        echo "1"  # Default HIGH (no jumper) if sysfs unavailable
+    fi
+}
+
+gpio_unexport() {
+    PIN="$1"
+    if [ -d "${GPIO_BASE}/gpio${PIN}" ]; then
+        echo "$PIN" > "${GPIO_BASE}/unexport" 2>/dev/null || true
+    fi
+}
+
+wipe_data() {
+    echo "GPIO trigger: Factory reset — wiping /data contents"
+
+    # Remove config files (preserve directory)
+    CONFIG_DIR="/data/config"
+    if [ -d "$CONFIG_DIR" ]; then
+        rm -f "${CONFIG_DIR}/cameras.json" \
+              "${CONFIG_DIR}/users.json" \
+              "${CONFIG_DIR}/settings.json" \
+              "${CONFIG_DIR}/.secret_key" \
+              "${CONFIG_DIR}/camera.conf" 2>/dev/null || true
+    fi
+
+    # Remove directory trees
+    for DIR in certs live recordings logs tailscale ota; do
+        if [ -d "/data/${DIR}" ]; then
+            rm -rf "/data/${DIR}"
+            echo "  Removed /data/${DIR}"
+        fi
+    done
+
+    # Remove setup stamp
+    rm -f "$SETUP_STAMP" 2>/dev/null || true
+    echo "  Removed $SETUP_STAMP"
+}
+
+# --- Main ---
+
+echo "GPIO trigger: Checking provisioning (GPIO${PROVISION_PIN}) and reset (GPIO${RESET_PIN}) pins"
+
+# Export and read both pins
+gpio_export "$PROVISION_PIN"
+gpio_export "$RESET_PIN"
+
+# Small delay for value to stabilize after export
+sleep 0.2
+
+PROVISION_VAL=$(gpio_read "$PROVISION_PIN")
+RESET_VAL=$(gpio_read "$RESET_PIN")
+
+echo "GPIO trigger: provision_pin=GPIO${PROVISION_PIN} value=${PROVISION_VAL}, reset_pin=GPIO${RESET_PIN} value=${RESET_VAL}"
+
+# Clean up GPIO exports
+gpio_unexport "$PROVISION_PIN"
+gpio_unexport "$RESET_PIN"
+
+# Factory reset takes priority over provisioning-only
+if [ "$RESET_VAL" = "0" ]; then
+    echo "GPIO trigger: Factory reset jumper DETECTED (GPIO${RESET_PIN} LOW)"
+    wipe_data
+
+    # Wipe WiFi credentials via hotspot script if available
+    for SCRIPT in /opt/monitor/scripts/monitor-hotspot.sh /opt/camera/scripts/camera-hotspot.sh; do
+        if [ -x "$SCRIPT" ]; then
+            "$SCRIPT" wipe 2>/dev/null || true
+            break
+        fi
+    done
+
+    echo "GPIO trigger: Factory reset complete — device will enter provisioning mode"
+    exit 20
+
+elif [ "$PROVISION_VAL" = "0" ]; then
+    echo "GPIO trigger: Provisioning jumper DETECTED (GPIO${PROVISION_PIN} LOW)"
+    # Only remove the stamp — data is preserved
+    if [ -f "$SETUP_STAMP" ]; then
+        rm -f "$SETUP_STAMP"
+        echo "GPIO trigger: Removed $SETUP_STAMP — device will enter provisioning mode"
+    else
+        echo "GPIO trigger: $SETUP_STAMP already absent — device is already in provisioning mode"
+    fi
+    exit 10
+
+else
+    echo "GPIO trigger: No jumper detected — normal boot"
+    exit 0
+fi

--- a/app/server/config/monitor-hotspot.sh
+++ b/app/server/config/monitor-hotspot.sh
@@ -184,12 +184,34 @@ connect_wifi() {
 wipe_wifi() {
     echo "Wiping all saved WiFi credentials"
 
+    # Use nmcli to properly delete connections from NM's in-memory state
+    # (just deleting files doesn't work — NM re-writes them on shutdown)
+    nmcli -t -f NAME,TYPE con show 2>/dev/null | while IFS=: read -r NAME TYPE; do
+        if [ "$TYPE" = "802-11-wireless" ]; then
+            nmcli con delete "$NAME" 2>/dev/null && echo "  Deleted: $NAME" || true
+        fi
+    done
+
+    # Clean up rootfs connection files
     NM_DIR="/etc/NetworkManager/system-connections"
     if [ -d "$NM_DIR" ]; then
         for CONN_FILE in "${NM_DIR}"/*; do
             if [ -f "$CONN_FILE" ]; then
                 rm -f "$CONN_FILE"
-                echo "  Removed: $(basename "$CONN_FILE")"
+                echo "  Removed file: $(basename "$CONN_FILE")"
+            fi
+        done
+    fi
+
+    # Clean up persistent /data connections (nm-persist.sh bind-mounts
+    # /data/network/system-connections/ over /etc/NetworkManager/system-connections/
+    # on every boot — wiping only /etc is not enough)
+    PERSIST_DIR="/data/network/system-connections"
+    if [ -d "$PERSIST_DIR" ]; then
+        for CONN_FILE in "${PERSIST_DIR}"/*; do
+            if [ -f "$CONN_FILE" ]; then
+                rm -f "$CONN_FILE"
+                echo "  Removed persistent: $(basename "$CONN_FILE")"
             fi
         done
     fi

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -7,6 +7,8 @@ records video clips, and provides a mobile-friendly web dashboard.
 
 import logging
 import os
+import socket
+import subprocess
 
 from flask import Flask
 
@@ -223,8 +225,32 @@ def _init_services(app):
     app.storage_manager.set_dir_change_callback(_on_recording_dir_change)
 
 
+def _restore_hostname(data_dir: str):
+    """Restore hostname from /data on every boot.
+
+    Hostname is saved during provisioning. Restoring it on startup
+    ensures it survives OTA rootfs updates (even if rootfs is read-only).
+    """
+    hostname_file = os.path.join(data_dir, "config", "hostname")
+    try:
+        with open(hostname_file) as f:
+            hostname = f.read().strip()
+        if hostname and hostname != socket.gethostname():
+            subprocess.run(
+                ["hostnamectl", "set-hostname", hostname],
+                capture_output=True,
+                timeout=10,
+            )
+            log.info("Hostname restored: %s", hostname)
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        log.warning("Failed to restore hostname: %s", exc)
+
+
 def _startup(app):
     """Runtime startup: default admin, USB auto-mount, start services."""
+    _restore_hostname(app.config.get("DATA_DIR", "/data"))
     _ensure_default_admin(app.store)
     log.debug("Default admin user ensured")
 

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -3,6 +3,7 @@ Camera management API.
 
 Endpoints:
   GET    /cameras              - list all cameras (confirmed + pending)
+  POST   /cameras              - register a new camera as pending (admin)
   POST   /cameras/<id>/confirm - confirm a discovered camera (admin)
   PUT    /cameras/<id>         - update name, location, recording mode (admin)
   DELETE /cameras/<id>         - remove camera and revoke cert (admin)
@@ -24,6 +25,21 @@ def list_cameras():
     """List all cameras (confirmed + pending)."""
     cameras = current_app.camera_service.list_cameras()
     return jsonify(cameras), 200
+
+
+@cameras_bp.route("", methods=["POST"])
+@admin_required
+def add_camera():
+    """Register a new camera as pending. Admin only."""
+    data = request.get_json(silent=True) or {}
+    result, error, status = current_app.camera_service.add_camera(
+        camera_id=data.get("id", ""),
+        name=data.get("name", ""),
+        location=data.get("location", ""),
+    )
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
 
 
 @cameras_bp.route("/<camera_id>/confirm", methods=["POST"])

--- a/app/server/monitor/api/pairing.py
+++ b/app/server/monitor/api/pairing.py
@@ -49,6 +49,30 @@ def unpair_camera(camera_id):
     return jsonify({"message": "Camera unpaired"}), 200
 
 
+@pairing_bp.route("/pair/register", methods=["POST"])
+def register_camera():
+    """Camera self-registers as pending on the server.
+
+    No session auth — camera calls this before pairing to appear in
+    the dashboard. The server creates a pending entry if it doesn't
+    already exist.
+    """
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    camera_id = data.get("camera_id", "")
+    if not camera_id:
+        return jsonify({"error": "camera_id required"}), 400
+
+    current_app.discovery_service.report_camera(
+        camera_id=camera_id,
+        ip=request.remote_addr or "",
+        firmware_version=data.get("firmware_version", ""),
+    )
+    return jsonify({"status": "registered"}), 200
+
+
 @pairing_bp.route("/pair/exchange", methods=["POST"])
 def exchange_certs():
     """Camera exchanges PIN for certificates and pairing secret.

--- a/app/server/monitor/provisioning.py
+++ b/app/server/monitor/provisioning.py
@@ -79,4 +79,6 @@ def setup_complete():
 @provisioning_bp.route("/wizard", methods=["GET"])
 def setup_wizard():
     """Serve the setup wizard HTML page."""
-    return render_template("setup.html")
+    from monitor.services.provisioning_service import SERVER_HOSTNAME
+
+    return render_template("setup.html", hostname=f"{SERVER_HOSTNAME}.local")

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -34,6 +34,39 @@ class CameraService:
         self._streaming = streaming
         self._audit = audit
 
+    def add_camera(
+        self, camera_id: str, name: str = "", location: str = ""
+    ) -> tuple[dict | None, str, int]:
+        """Register a new camera as pending.
+
+        Returns (result_dict, error_string, http_status_code).
+        """
+        camera_id = camera_id.strip()
+        if not camera_id:
+            return None, "Camera ID is required", 400
+
+        existing = self._store.get_camera(camera_id)
+        if existing is not None:
+            return None, "Camera already exists", 409
+
+        from monitor.models import Camera
+
+        camera = Camera(
+            id=camera_id,
+            name=name.strip() or camera_id,
+            location=location.strip(),
+            status="pending",
+        )
+        self._store.save_camera(camera)
+
+        log.info("Camera registered: %s", camera_id)
+
+        return (
+            {"id": camera.id, "name": camera.name, "status": camera.status},
+            "",
+            201,
+        )
+
     def list_cameras(self) -> list[dict]:
         """List all cameras (confirmed + pending)."""
         cameras = self._store.get_cameras()

--- a/app/server/monitor/services/factory_reset_service.py
+++ b/app/server/monitor/services/factory_reset_service.py
@@ -124,32 +124,66 @@ class FactoryResetService:
             errors.append(f"{path}: {exc}")
 
     def _clear_wifi(self, errors: list):
-        """Clear WiFi credentials via the hotspot management script (ADR-0013).
+        """Clear WiFi credentials via hotspot script + direct cleanup.
 
-        Delegates to the hotspot script's 'wipe' command which handles
-        NM connection cleanup and wpa_supplicant reset in one place.
+        The hotspot script's 'wipe' command handles nmcli deletion and
+        file cleanup. We also directly clean /data/network/ as a safety
+        net — nm-persist.sh bind-mounts this over /etc/NetworkManager/
+        system-connections/ on every boot, so it must be wiped too.
         """
+        # 1. Run hotspot script wipe (handles nmcli + /etc cleanup)
         hotspot_script = self._find_hotspot_script()
-        if not hotspot_script:
-            log.warning("Hotspot script not found — skipping WiFi wipe")
-            errors.append("wifi: hotspot script not found")
-            return
+        if hotspot_script:
+            try:
+                result = subprocess.run(
+                    [hotspot_script, "wipe"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                )
+                if result.returncode != 0:
+                    log.warning(
+                        "WiFi wipe returned non-zero: %s", result.stderr.strip()
+                    )
+                    errors.append(f"wifi: {result.stderr.strip()}")
+                else:
+                    log.debug("WiFi credentials wiped via %s", hotspot_script)
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+                log.warning("Failed to wipe WiFi credentials: %s", exc)
+                errors.append(f"wifi: {exc}")
+        else:
+            log.warning("Hotspot script not found — skipping script wipe")
 
+        # 2. Always wipe /data/network/system-connections/ directly
+        #    (nm-persist.sh restores connections from here on every boot)
+        persist_dir = os.path.join(self._data_dir, "network", "system-connections")
+        self._wipe_dir_contents(persist_dir, "persistent WiFi", errors)
+
+        # 3. Write a marker so nm-persist.sh skips re-seeding from rootfs
+        #    (rootfs may have baked-in WiFi connections from dev builds)
+        marker = os.path.join(self._data_dir, "network", ".wifi-wiped")
         try:
-            result = subprocess.run(
-                [hotspot_script, "wipe"],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-            if result.returncode != 0:
-                log.warning("WiFi wipe returned non-zero: %s", result.stderr.strip())
-                errors.append(f"wifi: {result.stderr.strip()}")
-            else:
-                log.debug("WiFi credentials wiped via %s", hotspot_script)
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-            log.warning("Failed to wipe WiFi credentials: %s", exc)
-            errors.append(f"wifi: {exc}")
+            os.makedirs(os.path.dirname(marker), exist_ok=True)
+            with open(marker, "w") as f:
+                f.write("1\n")
+            log.debug("WiFi wipe marker written: %s", marker)
+        except OSError as exc:
+            log.warning("Failed to write wifi wipe marker: %s", exc)
+            errors.append(f"wifi-marker: {exc}")
+
+    def _wipe_dir_contents(self, dirpath: str, label: str, errors: list):
+        """Remove all files in a directory (not the directory itself)."""
+        if not os.path.isdir(dirpath):
+            return
+        for fname in os.listdir(dirpath):
+            fpath = os.path.join(dirpath, fname)
+            try:
+                if os.path.isfile(fpath):
+                    os.remove(fpath)
+                    log.debug("Removed %s: %s", label, fname)
+            except OSError as exc:
+                log.warning("Failed to remove %s: %s", fpath, exc)
+                errors.append(f"{label}: {exc}")
 
     @staticmethod
     def _find_hotspot_script() -> str | None:

--- a/app/server/monitor/services/factory_reset_service.py
+++ b/app/server/monitor/services/factory_reset_service.py
@@ -90,7 +90,7 @@ class FactoryResetService:
         ota_dir = os.path.join(self._data_dir, "ota")
         self._safe_rmtree(ota_dir, errors)
 
-        # 9. Clear WiFi credentials (NetworkManager saved connections)
+        # 9. Clear WiFi credentials via hotspot script (ADR-0013)
         self._clear_wifi(errors)
 
         if errors:
@@ -124,33 +124,44 @@ class FactoryResetService:
             errors.append(f"{path}: {exc}")
 
     def _clear_wifi(self, errors: list):
-        """Remove saved WiFi connections so device returns to AP/hotspot mode."""
-        nm_dir = "/etc/NetworkManager/system-connections"
+        """Clear WiFi credentials via the hotspot management script (ADR-0013).
+
+        Delegates to the hotspot script's 'wipe' command which handles
+        NM connection cleanup and wpa_supplicant reset in one place.
+        """
+        hotspot_script = self._find_hotspot_script()
+        if not hotspot_script:
+            log.warning("Hotspot script not found — skipping WiFi wipe")
+            errors.append("wifi: hotspot script not found")
+            return
+
         try:
-            if os.path.isdir(nm_dir):
-                for f in os.listdir(nm_dir):
-                    filepath = os.path.join(nm_dir, f)
-                    if os.path.isfile(filepath):
-                        os.remove(filepath)
-                        log.debug("Removed WiFi connection: %s", f)
-        except OSError as exc:
-            log.warning("Failed to clear WiFi credentials: %s", exc)
+            result = subprocess.run(
+                [hotspot_script, "wipe"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                log.warning("WiFi wipe returned non-zero: %s", result.stderr.strip())
+                errors.append(f"wifi: {result.stderr.strip()}")
+            else:
+                log.debug("WiFi credentials wiped via %s", hotspot_script)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            log.warning("Failed to wipe WiFi credentials: %s", exc)
             errors.append(f"wifi: {exc}")
 
-        # Reset wpa_supplicant.conf to empty state
-        wpa_conf = "/etc/wpa_supplicant.conf"
-        try:
-            if os.path.exists(wpa_conf):
-                with open(wpa_conf, "w") as fh:
-                    fh.write(
-                        "ctrl_interface=/var/run/wpa_supplicant\n"
-                        "ctrl_interface_group=0\n"
-                        "update_config=1\n"
-                    )
-                log.debug("Reset wpa_supplicant.conf")
-        except OSError as exc:
-            log.warning("Failed to reset wpa_supplicant.conf: %s", exc)
-            errors.append(f"wpa: {exc}")
+    @staticmethod
+    def _find_hotspot_script() -> str | None:
+        """Locate the hotspot management script for this device."""
+        candidates = [
+            "/opt/monitor/scripts/monitor-hotspot.sh",
+            "/opt/camera/scripts/camera-hotspot.sh",
+        ]
+        for path in candidates:
+            if os.path.isfile(path):
+                return path
+        return None
 
     def _schedule_restart(self):
         """Reboot the system after a 2-second delay.

--- a/app/server/monitor/services/provisioning_service.py
+++ b/app/server/monitor/services/provisioning_service.py
@@ -291,7 +291,12 @@ class ProvisioningService:
             return f"Failed to mark setup complete: {exc}"
 
     def _set_hostname(self, hostname: str):
-        """Set system hostname for mDNS discovery."""
+        """Set system hostname for mDNS discovery.
+
+        Sets both persistent and transient hostname (transient works on
+        read-only rootfs). Also saves to /data/config/hostname so the
+        hostname survives OTA rootfs updates.
+        """
         current = socket.gethostname()
         if current == hostname:
             return
@@ -301,6 +306,13 @@ class ProvisioningService:
                 capture_output=True,
                 timeout=10,
             )
+            # Save to /data for persistence across OTA rootfs updates
+            data_hostname = os.path.join(self._data_dir, "config", "hostname")
+            try:
+                with open(data_hostname, "w") as f:
+                    f.write(hostname + "\n")
+            except OSError:
+                pass
             log.info("Hostname set: %s -> %s", current, hostname)
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
             log.warning("Failed to set hostname: %s", exc)

--- a/app/server/monitor/services/provisioning_service.py
+++ b/app/server/monitor/services/provisioning_service.py
@@ -15,11 +15,11 @@ import logging
 import os
 import socket
 import subprocess
-import threading
 
 log = logging.getLogger("monitor.services.provisioning_service")
 
 HOTSPOT_SCRIPT = "/opt/monitor/scripts/monitor-hotspot.sh"
+SERVER_HOSTNAME = "rpi-divinu"
 
 
 class ProvisioningService:
@@ -194,7 +194,10 @@ class ProvisioningService:
         # Step 2: Get new IP address
         ip_address = self._get_wifi_ip()
 
-        # Step 3: Write stamp file
+        # Step 3: Set hostname (ensures correct mDNS after factory reset)
+        self._set_hostname(SERVER_HOSTNAME)
+
+        # Step 4: Write stamp file
         stamp_err = self._write_stamp_file()
         if stamp_err:
             return None, stamp_err, 500
@@ -203,11 +206,10 @@ class ProvisioningService:
         self._pending_wifi["ssid"] = ""
         self._pending_wifi["password"] = ""
 
-        # Step 4: Schedule delayed hotspot stop
-        self._schedule_hotspot_stop()
+        # Note: hotspot was already stopped by the 'connect' command
+        # in _connect_wifi() — no separate stop needed (ADR-0013).
 
-        hostname = socket.gethostname()
-        mdns_address = f"{hostname}.local"
+        mdns_address = f"{SERVER_HOSTNAME}.local"
 
         log.info("Setup complete! WiFi IP: %s", ip_address or "unknown")
 
@@ -222,23 +224,18 @@ class ProvisioningService:
         )
 
     def _connect_wifi(self, ssid: str, password: str) -> tuple[bool, str]:
-        """Connect to a WiFi network. Returns (success, error_message)."""
+        """Connect to WiFi via hotspot script.
+
+        Uses the hotspot script's 'connect' command which atomically
+        stops the AP and connects to the target network (ADR-0013).
+        Returns (success, error_message).
+        """
         try:
             result = subprocess.run(
-                [
-                    "nmcli",
-                    "dev",
-                    "wifi",
-                    "connect",
-                    ssid,
-                    "password",
-                    password,
-                    "ifname",
-                    "wlan0",
-                ],
+                [HOTSPOT_SCRIPT, "connect", ssid, password],
                 capture_output=True,
                 text=True,
-                timeout=30,
+                timeout=45,
             )
         except subprocess.TimeoutExpired:
             return (
@@ -249,18 +246,15 @@ class ProvisioningService:
             return False, f"WiFi connection failed: {exc}"
 
         if result.returncode != 0:
-            stderr = result.stderr.strip()
-            if (
-                "secrets were required" in stderr.lower()
-                or "no suitable" in stderr.lower()
-            ):
+            output = result.stderr.strip() or result.stdout.strip()
+            if "secrets" in output.lower() or "no suitable" in output.lower():
                 return False, "Incorrect WiFi password. Go back and try again."
             return (
                 False,
-                f"WiFi connection failed. Go back and try again. Detail: {stderr}",
+                f"WiFi connection failed. Go back and try again. Detail: {output}",
             )
 
-        log.info("WiFi connected to %s", ssid)
+        log.info("WiFi connected to %s via hotspot script", ssid)
         return True, ""
 
     def _get_wifi_ip(self) -> str:
@@ -296,26 +290,21 @@ class ProvisioningService:
         except OSError as exc:
             return f"Failed to mark setup complete: {exc}"
 
-    def _schedule_hotspot_stop(self):
-        """Stop the hotspot after a 15-second delay."""
+    def _set_hostname(self, hostname: str):
+        """Set system hostname for mDNS discovery."""
+        current = socket.gethostname()
+        if current == hostname:
+            return
+        try:
+            subprocess.run(
+                ["hostnamectl", "set-hostname", hostname],
+                capture_output=True,
+                timeout=10,
+            )
+            log.info("Hostname set: %s -> %s", current, hostname)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            log.warning("Failed to set hostname: %s", exc)
 
-        def _delayed_stop():
-            log.info("Delayed hotspot cleanup triggered (15s elapsed)")
-            try:
-                result = subprocess.run(
-                    [HOTSPOT_SCRIPT, "stop"],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                )
-                log.debug(
-                    "Hotspot stop: rc=%d stdout=%s",
-                    result.returncode,
-                    result.stdout.strip(),
-                )
-            except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-                log.warning("Hotspot stop failed (non-fatal): %s", exc)
-
-        timer = threading.Timer(15.0, _delayed_stop)
-        timer.daemon = True
-        timer.start()
+    def _get_hotspot_script(self) -> str:
+        """Return path to the hotspot management script."""
+        return HOTSPOT_SCRIPT

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -285,6 +285,39 @@ a:hover { text-decoration: underline; }
     color: var(--color-text-dim);
     margin-top: var(--space-1);
 }
+.camera-card__actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: var(--space-2);
+}
+.camera-card__btns {
+    display: flex;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+}
+
+/* --- Pairing PIN Card --- */
+.pairing-pin-card { text-align: center; }
+.pairing-pin-card__title {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-2);
+}
+.pairing-pin-card__pin {
+    font-size: 2.5rem;
+    font-weight: 700;
+    letter-spacing: 0.3em;
+    color: var(--color-accent);
+    margin: var(--space-3) 0;
+}
+.pairing-pin-card__instructions {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-3);
+    line-height: 1.5;
+}
+.mb-16 { margin-bottom: var(--space-4); }
 
 /* --- Section Headers --- */
 .section-header {

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -41,26 +41,73 @@
 </div>
 
 <!-- Cameras -->
-<div class="section-header">Cameras</div>
+<div class="section-header">
+    Cameras
+    <button class="btn btn--primary btn--small" style="float:right;margin-top:-4px;" @click="showAddForm = !showAddForm" x-text="showAddForm ? 'Cancel' : 'Add Camera'"></button>
+</div>
+
+<!-- Add Camera Form -->
+<template x-if="showAddForm">
+    <div class="card mb-16">
+        <div class="form-group">
+            <label for="add-cam-id">Camera ID</label>
+            <input class="form-input" id="add-cam-id" x-model="newCam.id" placeholder="e.g. cam-351ad8ee">
+        </div>
+        <div class="form-group">
+            <label for="add-cam-name">Name</label>
+            <input class="form-input" id="add-cam-name" x-model="newCam.name" placeholder="e.g. Front Door">
+        </div>
+        <div class="form-group">
+            <label for="add-cam-location">Location</label>
+            <input class="form-input" id="add-cam-location" x-model="newCam.location" placeholder="e.g. Outdoor">
+        </div>
+        <button class="btn btn--primary" @click="addCamera()" :disabled="!newCam.id.trim()">Add Camera</button>
+    </div>
+</template>
+
+<!-- Pairing PIN Display -->
+<template x-if="pairingPin">
+    <div class="card mb-16 pairing-pin-card">
+        <div class="pairing-pin-card__title">Pairing PIN for <span x-text="pairingCameraId"></span></div>
+        <div class="pairing-pin-card__pin" x-text="pairingPin"></div>
+        <div class="pairing-pin-card__instructions">
+            On the camera's settings page, find the <strong>Server Pairing</strong> section and enter this PIN. Expires in 5 minutes.
+        </div>
+        <button class="btn btn--secondary btn--small" @click="pairingPin = ''; pairingCameraId = '';">Dismiss</button>
+    </div>
+</template>
+
 <div class="grid" id="cameras-grid">
-    <template x-if="cameras.length === 0">
+    <template x-if="cameras.length === 0 && !showAddForm">
         <div class="empty-state">
             <div class="empty-state__title">No cameras found</div>
-            <div class="empty-state__text">Waiting for cameras to connect via mDNS discovery.</div>
+            <div class="empty-state__text">Click "Add Camera" to register a camera, or wait for mDNS discovery.</div>
         </div>
     </template>
     <template x-for="cam in cameras" :key="cam.id">
-        <div class="card card--clickable camera-card" @click="window.location.href = '/live?camera=' + encodeURIComponent(cam.id)">
-            <div class="camera-card__info">
+        <div class="card camera-card">
+            <div class="camera-card__info" @click="cam.status === 'online' && (window.location.href = '/live?camera=' + encodeURIComponent(cam.id))" :style="cam.status === 'online' ? 'cursor:pointer' : ''">
                 <div class="camera-card__name" x-text="cam.name || cam.id"></div>
                 <div class="camera-card__location" x-text="cam.location || 'No location set'"></div>
                 <div class="camera-card__last-seen" x-text="cam.last_seen ? 'Last seen: ' + new Date(cam.last_seen).toLocaleString() : ''"></div>
             </div>
-            <span class="badge" :class="{
-                'badge--online': cam.status === 'online',
-                'badge--offline': cam.status === 'offline',
-                'badge--pending': cam.status === 'pending'
-            }" x-text="cam.status"></span>
+            <div class="camera-card__actions">
+                <span class="badge" :class="{
+                    'badge--online': cam.status === 'online',
+                    'badge--offline': cam.status === 'offline',
+                    'badge--pending': cam.status === 'pending'
+                }" x-text="cam.status"></span>
+                <template x-if="cam.status === 'pending'">
+                    <div class="camera-card__btns">
+                        <button class="btn btn--primary btn--small" @click.stop="initPairing(cam.id)">Pair</button>
+                        <button class="btn btn--secondary btn--small" @click.stop="confirmCamera(cam.id)">Confirm</button>
+                        <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
+                    </div>
+                </template>
+                <template x-if="cam.status !== 'pending'">
+                    <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
+                </template>
+            </div>
         </div>
     </template>
 </div>
@@ -73,6 +120,10 @@ function dashboardPage() {
     return {
         health: { temp: null, cpu: null, mem: null, disk: null, warnings: [], uptime: '' },
         cameras: [],
+        showAddForm: false,
+        newCam: { id: '', name: '', location: '' },
+        pairingPin: '',
+        pairingCameraId: '',
         _interval: null,
 
         tempColor(c) {
@@ -109,10 +160,56 @@ function dashboardPage() {
             } catch(e) {}
         },
 
+        async addCamera() {
+            var id = this.newCam.id.trim();
+            if (!id) return;
+            try {
+                await window.HM.api.post('/api/v1/cameras', {
+                    id: id,
+                    name: this.newCam.name.trim(),
+                    location: this.newCam.location.trim()
+                });
+                this.newCam = { id: '', name: '', location: '' };
+                this.showAddForm = false;
+                await this.loadCameras();
+            } catch(e) {
+                alert(e.message || 'Failed to add camera');
+            }
+        },
+
+        async initPairing(camId) {
+            try {
+                var data = await window.HM.api.post('/api/v1/cameras/' + encodeURIComponent(camId) + '/pair', {});
+                this.pairingPin = data.pin;
+                this.pairingCameraId = camId;
+            } catch(e) {
+                alert(e.message || 'Failed to initiate pairing');
+            }
+        },
+
+        async confirmCamera(camId) {
+            try {
+                await window.HM.api.post('/api/v1/cameras/' + encodeURIComponent(camId) + '/confirm', {});
+                await this.loadCameras();
+            } catch(e) {
+                alert(e.message || 'Failed to confirm camera');
+            }
+        },
+
+        async deleteCamera(camId) {
+            if (!confirm('Remove this camera?')) return;
+            try {
+                await window.HM.api.del('/api/v1/cameras/' + encodeURIComponent(camId));
+                await this.loadCameras();
+            } catch(e) {
+                alert(e.message || 'Failed to remove camera');
+            }
+        },
+
         init() {
             this.loadHealth();
             this.loadCameras();
-            this._interval = setInterval(() => this.loadHealth(), 30000);
+            this._interval = setInterval(() => { this.loadHealth(); this.loadCameras(); }, 30000);
         },
 
         destroy() {

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -43,7 +43,13 @@
 <!-- Cameras -->
 <div class="section-header">
     Cameras
-    <button class="btn btn--primary btn--small" style="float:right;margin-top:-4px;" @click="showAddForm = !showAddForm" x-text="showAddForm ? 'Cancel' : 'Add Camera'"></button>
+    <span style="float:right;margin-top:-4px;display:flex;gap:8px;">
+        <button class="btn btn--secondary btn--small" @click="scanCameras()" :disabled="scanning">
+            <span x-show="!scanning">Scan</span>
+            <span x-show="scanning">Scanning...</span>
+        </button>
+        <button class="btn btn--primary btn--small" @click="showAddForm = !showAddForm" x-text="showAddForm ? 'Cancel' : 'Add Camera'"></button>
+    </span>
 </div>
 
 <!-- Add Camera Form -->
@@ -67,13 +73,24 @@
 
 <!-- Pairing PIN Display -->
 <template x-if="pairingPin">
-    <div class="card mb-16 pairing-pin-card">
-        <div class="pairing-pin-card__title">Pairing PIN for <span x-text="pairingCameraId"></span></div>
-        <div class="pairing-pin-card__pin" x-text="pairingPin"></div>
-        <div class="pairing-pin-card__instructions">
-            On the camera's settings page, find the <strong>Server Pairing</strong> section and enter this PIN. Expires in 5 minutes.
+    <div class="card mb-16 pairing-pin-card" style="border:1px solid var(--accent);background:var(--bg-card);">
+        <div style="text-align:center;margin-bottom:12px;">
+            <div style="font-size:0.85em;color:var(--text-muted);margin-bottom:4px;">Enter this PIN on your camera</div>
+            <div class="pairing-pin-card__pin" x-text="pairingPin"></div>
+            <div style="font-size:0.8em;color:var(--text-muted);margin-top:4px;">
+                Camera: <strong x-text="pairingCameraId"></strong>
+            </div>
         </div>
-        <button class="btn btn--secondary btn--small" @click="pairingPin = ''; pairingCameraId = '';">Dismiss</button>
+        <div style="font-size:0.85em;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;">
+            <strong>Steps:</strong><br>
+            1. Open the camera's web page (shown after setup)<br>
+            2. Go to <strong>Settings</strong> &rarr; <strong>Server Pairing</strong><br>
+            3. Enter the 6-digit PIN above<br>
+        </div>
+        <div style="display:flex;gap:8px;justify-content:center;">
+            <button class="btn btn--secondary btn--small" @click="pairingPin = ''; pairingCameraId = '';">Dismiss</button>
+        </div>
+        <div style="text-align:center;margin-top:8px;font-size:0.75em;color:var(--text-muted);">Expires in 5 minutes</div>
     </div>
 </template>
 
@@ -124,6 +141,7 @@ function dashboardPage() {
         newCam: { id: '', name: '', location: '' },
         pairingPin: '',
         pairingCameraId: '',
+        scanning: false,
         _interval: null,
 
         tempColor(c) {
@@ -158,6 +176,13 @@ function dashboardPage() {
             try {
                 this.cameras = await window.HM.api.get('/api/v1/cameras');
             } catch(e) {}
+        },
+
+        async scanCameras() {
+            this.scanning = true;
+            await this.loadCameras();
+            // Brief delay so user sees the scanning state
+            setTimeout(() => { this.scanning = false; }, 1500);
         },
 
         async addCamera() {

--- a/app/server/monitor/templates/setup.html
+++ b/app/server/monitor/templates/setup.html
@@ -546,6 +546,7 @@
         var savedSSID = '';
         var savedWifiPassword = '';
         var API_BASE = '/api/v1/setup';
+        var SERVER_HOSTNAME = '{{ hostname }}';
 
         function goToStep(step) {
             document.querySelectorAll('.step').forEach(function(el) {
@@ -808,9 +809,13 @@
                 }
             })
             .catch(function(err) {
-                /* Network error — likely the hotspot died mid-request.
-                   This is expected. The setup probably succeeded.
-                   User should reconnect to home WiFi. */
+                /* Network error — the hotspot stopped during WiFi switch.
+                   This is expected (ADR-0013). Setup succeeded.
+                   Show the pre-computed hostname so user knows where to go. */
+                if (SERVER_HOSTNAME) {
+                    document.getElementById('done-ip-display').textContent = 'https://' + SERVER_HOSTNAME + '/';
+                    document.getElementById('done-cam-address').textContent = SERVER_HOSTNAME;
+                }
                 document.getElementById('review-panel').style.display = 'none';
                 document.getElementById('done-panel').style.display = 'block';
             });

--- a/app/server/monitor/views.py
+++ b/app/server/monitor/views.py
@@ -46,7 +46,9 @@ def setup():
     """Initial device setup wizard."""
     if _setup_complete():
         return redirect(url_for("views.login"))
-    return render_template("setup.html")
+    from monitor.services.provisioning_service import SERVER_HOSTNAME
+
+    return render_template("setup.html", hostname=f"{SERVER_HOSTNAME}.local")
 
 
 @views_bp.route("/login")

--- a/app/server/tests/test_api_cameras.py
+++ b/app/server/tests/test_api_cameras.py
@@ -75,6 +75,52 @@ class TestListCameras:
             assert field in cam
 
 
+class TestAddCamera:
+    """Test POST /api/v1/cameras."""
+
+    def test_requires_admin(self, app, client):
+        _login(app, client, role="viewer")
+        resp = client.post("/api/v1/cameras", json={"id": "cam-new"})
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client):
+        resp = client.post("/api/v1/cameras", json={"id": "cam-new"})
+        assert resp.status_code == 401
+
+    def test_adds_pending_camera(self, app, client):
+        _login(app, client)
+        resp = client.post(
+            "/api/v1/cameras",
+            json={"id": "cam-new", "name": "Front Door", "location": "Outdoor"},
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["id"] == "cam-new"
+        assert data["name"] == "Front Door"
+        assert data["status"] == "pending"
+        # Verify persisted
+        cam = app.store.get_camera("cam-new")
+        assert cam is not None
+        assert cam.location == "Outdoor"
+
+    def test_rejects_empty_id(self, app, client):
+        _login(app, client)
+        resp = client.post("/api/v1/cameras", json={"id": ""})
+        assert resp.status_code == 400
+
+    def test_rejects_duplicate(self, app, client):
+        _login(app, client)
+        _add_camera(app, "cam-001", "pending")
+        resp = client.post("/api/v1/cameras", json={"id": "cam-001"})
+        assert resp.status_code == 409
+
+    def test_defaults_name_to_id(self, app, client):
+        _login(app, client)
+        resp = client.post("/api/v1/cameras", json={"id": "cam-abc"})
+        assert resp.status_code == 201
+        assert resp.get_json()["name"] == "cam-abc"
+
+
 class TestConfirmCamera:
     """Test POST /api/v1/cameras/<id>/confirm."""
 

--- a/app/server/tests/test_api_contracts.py
+++ b/app/server/tests/test_api_contracts.py
@@ -164,6 +164,27 @@ class TestCamerasListContract:
             assert field not in cam, f"Sensitive field '{field}' leaked"
 
 
+class TestCameraAddContract:
+    """POST /api/v1/cameras."""
+
+    def test_success_fields(self, app, client):
+        _login(app, client)
+        resp = client.post(
+            "/api/v1/cameras",
+            json={"id": "cam-new", "name": "Front", "location": "Yard"},
+        )
+        data = resp.get_json()
+        _assert_has_fields(data, {"id", "name", "status"})
+        assert data["status"] == "pending"
+
+    def test_duplicate_error(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        resp = client.post("/api/v1/cameras", json={"id": "cam-001"})
+        data = resp.get_json()
+        _assert_fields(data, {"error"})
+
+
 class TestCameraConfirmContract:
     """POST /api/v1/cameras/<id>/confirm."""
 

--- a/app/server/tests/test_camera_service.py
+++ b/app/server/tests/test_camera_service.py
@@ -74,6 +74,61 @@ class TestListCameras:
         assert "rtsp_url" not in result[0]
 
 
+class TestAddCamera:
+    """Test registering a new pending camera."""
+
+    def test_creates_pending_camera(self):
+        store = MagicMock()
+        store.get_camera.return_value = None
+        svc = CameraService(store)
+        result, error, status = svc.add_camera("cam-new", "Front Door", "Outdoor")
+        assert status == 201
+        assert error == ""
+        assert result["id"] == "cam-new"
+        assert result["name"] == "Front Door"
+        assert result["status"] == "pending"
+        store.save_camera.assert_called_once()
+        saved = store.save_camera.call_args[0][0]
+        assert saved.id == "cam-new"
+        assert saved.location == "Outdoor"
+
+    def test_rejects_empty_id(self):
+        store = MagicMock()
+        svc = CameraService(store)
+        result, error, status = svc.add_camera("", "Name", "Loc")
+        assert status == 400
+        assert "required" in error.lower()
+        store.save_camera.assert_not_called()
+
+    def test_rejects_duplicate(self):
+        store = MagicMock()
+        store.get_camera.return_value = _make_camera(id="cam-dup")
+        svc = CameraService(store)
+        result, error, status = svc.add_camera("cam-dup")
+        assert status == 409
+        assert "exists" in error.lower()
+        store.save_camera.assert_not_called()
+
+    def test_defaults_name_to_id(self):
+        store = MagicMock()
+        store.get_camera.return_value = None
+        svc = CameraService(store)
+        result, error, status = svc.add_camera("cam-xyz")
+        assert status == 201
+        assert result["name"] == "cam-xyz"
+
+    def test_strips_whitespace(self):
+        store = MagicMock()
+        store.get_camera.return_value = None
+        svc = CameraService(store)
+        result, error, status = svc.add_camera("  cam-ws  ", "  My Cam  ", "  Yard  ")
+        assert status == 201
+        saved = store.save_camera.call_args[0][0]
+        assert saved.id == "cam-ws"
+        assert saved.name == "My Cam"
+        assert saved.location == "Yard"
+
+
 class TestGetCameraStatus:
     """Test getting camera status."""
 

--- a/app/server/tests/test_provisioning.py
+++ b/app/server/tests/test_provisioning.py
@@ -227,22 +227,20 @@ class TestSetupComplete:
         cmd = connect_calls[0][0][0]
         assert "HomeWiFi" in cmd
 
-    @patch("monitor.services.provisioning_service.threading.Timer")
     @patch(f"{SUBPROCESS_PATCH}.run")
-    def test_delays_hotspot_stop(self, mock_run, mock_timer, app, client):
-        """Hotspot stop is scheduled via Timer, not called immediately."""
+    def test_hotspot_stopped_by_connect_command(self, mock_run, app, client):
+        """Hotspot is stopped by the connect command (ADR-0013), no Timer needed."""
         client.post(
             "/api/v1/setup/wifi/save",
             json={"ssid": "HomeWiFi", "password": "wifipass123"},
         )
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        client.post("/api/v1/setup/complete")
+        response = client.post("/api/v1/setup/complete")
+        assert response.status_code == 200
 
-        # Timer should be created with 15-second delay
-        mock_timer.assert_called_once()
-        args = mock_timer.call_args
-        assert args[0][0] == 15.0  # 15 second delay
-        mock_timer.return_value.start.assert_called_once()
+        # Connect call uses hotspot script's connect command
+        connect_calls = [c for c in mock_run.call_args_list if "connect" in str(c)]
+        assert len(connect_calls) >= 1
 
     @patch(f"{SUBPROCESS_PATCH}.run")
     def test_wifi_connect_failure_returns_error(self, mock_run, app, client):

--- a/app/server/tests/test_provisioning_service.py
+++ b/app/server/tests/test_provisioning_service.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 SUBPROCESS_PATCH = "monitor.services.provisioning_service.subprocess"
-TIMER_PATCH = "monitor.services.provisioning_service.threading.Timer"
 
 
 def _fix(mock_sub):
@@ -330,15 +329,15 @@ class TestConnectWifi:
         assert err == ""
 
     @patch(SUBPROCESS_PATCH)
-    def test_calls_nmcli_with_correct_args(self, mock_sub, svc):
+    def test_calls_hotspot_script_with_correct_args(self, mock_sub, svc):
         _fix(mock_sub)
         mock_sub.run.return_value = MagicMock(returncode=0)
         svc._connect_wifi("MySSID", "MyPass")
         args = mock_sub.run.call_args[0][0]
-        assert "nmcli" in args
-        assert "MySSID" in args
-        assert "MyPass" in args
-        assert "wlan0" in args
+        assert args[0].endswith("monitor-hotspot.sh")
+        assert args[1] == "connect"
+        assert args[2] == "MySSID"
+        assert args[3] == "MyPass"
 
     @patch(SUBPROCESS_PATCH)
     def test_timeout(self, mock_sub, svc):
@@ -477,58 +476,6 @@ class TestWriteStampFile:
         assert "Failed" in err
 
 
-# ── _schedule_hotspot_stop ───────────────────────────────────────────
-
-
-class TestScheduleHotspotStop:
-    @patch(TIMER_PATCH)
-    def test_creates_daemon_timer(self, mock_timer_cls, svc):
-        timer_inst = MagicMock()
-        mock_timer_cls.return_value = timer_inst
-        svc._schedule_hotspot_stop()
-        mock_timer_cls.assert_called_once()
-        args = mock_timer_cls.call_args
-        assert args[0][0] == 15.0  # delay seconds
-        assert timer_inst.daemon is True
-        timer_inst.start.assert_called_once()
-
-    @patch(TIMER_PATCH)
-    def test_callback_calls_hotspot_stop(self, mock_timer_cls, svc):
-        """Verify the Timer callback invokes the hotspot script with 'stop'."""
-        mock_timer_cls.return_value = MagicMock()
-        svc._schedule_hotspot_stop()
-        callback = mock_timer_cls.call_args[0][1]
-
-        with patch(SUBPROCESS_PATCH) as mock_sub:
-            _fix(mock_sub)
-            mock_sub.run.return_value = MagicMock(returncode=0, stdout="stopped")
-            callback()
-            args = mock_sub.run.call_args[0][0]
-            assert "stop" in args
-
-    @patch(TIMER_PATCH)
-    def test_callback_handles_timeout(self, mock_timer_cls, svc):
-        mock_timer_cls.return_value = MagicMock()
-        svc._schedule_hotspot_stop()
-        callback = mock_timer_cls.call_args[0][1]
-
-        with patch(SUBPROCESS_PATCH) as mock_sub:
-            _fix(mock_sub)
-            mock_sub.run.side_effect = subprocess.TimeoutExpired(cmd="x", timeout=30)
-            callback()  # should not raise
-
-    @patch(TIMER_PATCH)
-    def test_callback_handles_file_not_found(self, mock_timer_cls, svc):
-        mock_timer_cls.return_value = MagicMock()
-        svc._schedule_hotspot_stop()
-        callback = mock_timer_cls.call_args[0][1]
-
-        with patch(SUBPROCESS_PATCH) as mock_sub:
-            _fix(mock_sub)
-            mock_sub.run.side_effect = FileNotFoundError("gone")
-            callback()  # should not raise
-
-
 # ── complete_setup ───────────────────────────────────────────────────
 
 
@@ -557,27 +504,26 @@ class TestCompleteSetup:
         _, err, code = svc.complete_setup()
         assert code == 400
 
-    @patch(TIMER_PATCH)
     @patch(SUBPROCESS_PATCH)
     @patch("monitor.services.provisioning_service.socket")
-    def test_success_full_flow(self, mock_socket, mock_sub, mock_timer, svc, tmp_path):
-        """Full happy path: connect WiFi, get IP, write stamp, schedule stop."""
+    def test_success_full_flow(self, mock_socket, mock_sub, svc, tmp_path):
+        """Full happy path: connect WiFi via hotspot script, get IP, write stamp."""
         _fix(mock_sub)
         svc._pending_wifi["ssid"] = "HomeNet"
         svc._pending_wifi["password"] = "secret123"
 
         mock_sub.run.side_effect = [
-            MagicMock(returncode=0),  # _connect_wifi
+            MagicMock(returncode=0),  # _connect_wifi (hotspot script)
             MagicMock(returncode=0, stdout="IP4.ADDRESS[1]:192.168.1.100/24\n"),
+            MagicMock(returncode=0),  # _set_hostname (hostnamectl)
         ]
-        mock_socket.gethostname.return_value = "homemonitor"
-        mock_timer.return_value = MagicMock()
+        mock_socket.gethostname.return_value = "raspberrypi4-64"
 
         result, err, code = svc.complete_setup()
         assert code == 200
         assert err == ""
         assert result["ip"] == "192.168.1.100"
-        assert result["hostname"] == "homemonitor.local"
+        assert result["hostname"] == "rpi-divinu.local"
 
         # Stamp file written
         assert (tmp_path / ".setup-done").exists()
@@ -585,9 +531,6 @@ class TestCompleteSetup:
         # Credentials cleared
         assert svc._pending_wifi["ssid"] == ""
         assert svc._pending_wifi["password"] == ""
-
-        # Timer started
-        mock_timer.return_value.start.assert_called_once()
 
     @patch(SUBPROCESS_PATCH)
     def test_wifi_connect_failure_returns_500(self, mock_sub, svc):
@@ -613,16 +556,18 @@ class TestCompleteSetup:
         assert code == 500
         assert "Incorrect" in err
 
-    @patch(TIMER_PATCH)
     @patch(SUBPROCESS_PATCH)
-    def test_stamp_write_failure_returns_500(self, mock_sub, mock_timer, svc):
+    @patch("monitor.services.provisioning_service.socket")
+    def test_stamp_write_failure_returns_500(self, mock_socket, mock_sub, svc):
         _fix(mock_sub)
+        mock_socket.gethostname.return_value = "raspberrypi4-64"
         svc._pending_wifi["ssid"] = "Net"
         svc._pending_wifi["password"] = "pass"
 
         mock_sub.run.side_effect = [
             MagicMock(returncode=0),  # _connect_wifi
             MagicMock(returncode=0, stdout=""),  # _get_wifi_ip
+            MagicMock(returncode=0),  # _set_hostname
         ]
 
         with patch.object(svc, "_write_stamp_file", return_value="Disk error"):
@@ -630,21 +575,18 @@ class TestCompleteSetup:
         assert code == 500
         assert "Disk error" in err
 
-    @patch(TIMER_PATCH)
     @patch(SUBPROCESS_PATCH)
     @patch("monitor.services.provisioning_service.socket")
-    def test_credentials_cleared_on_success(
-        self, mock_socket, mock_sub, mock_timer, svc
-    ):
+    def test_credentials_cleared_on_success(self, mock_socket, mock_sub, svc):
         _fix(mock_sub)
         svc._pending_wifi["ssid"] = "Net"
         svc._pending_wifi["password"] = "pass"
         mock_sub.run.side_effect = [
             MagicMock(returncode=0),
             MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0),  # _set_hostname
         ]
-        mock_socket.gethostname.return_value = "host"
-        mock_timer.return_value = MagicMock()
+        mock_socket.gethostname.return_value = "raspberrypi4-64"
 
         svc.complete_setup()
         assert svc._pending_wifi["ssid"] == ""
@@ -661,12 +603,9 @@ class TestCompleteSetup:
         assert svc._pending_wifi["ssid"] == "Net"
         assert svc._pending_wifi["password"] == "pass"
 
-    @patch(TIMER_PATCH)
     @patch(SUBPROCESS_PATCH)
     @patch("monitor.services.provisioning_service.socket")
-    def test_empty_ip_still_succeeds(
-        self, mock_socket, mock_sub, mock_timer, svc, tmp_path
-    ):
+    def test_empty_ip_still_succeeds(self, mock_socket, mock_sub, svc, tmp_path):
         """If IP lookup returns nothing, setup still completes."""
         _fix(mock_sub)
         svc._pending_wifi["ssid"] = "Net"
@@ -674,9 +613,9 @@ class TestCompleteSetup:
         mock_sub.run.side_effect = [
             MagicMock(returncode=0),
             MagicMock(returncode=1, stdout=""),  # IP lookup fails
+            MagicMock(returncode=0),  # _set_hostname
         ]
-        mock_socket.gethostname.return_value = "host"
-        mock_timer.return_value = MagicMock()
+        mock_socket.gethostname.return_value = "raspberrypi4-64"
 
         result, err, code = svc.complete_setup()
         assert code == 200

--- a/app/server/tests/test_svc_factory_reset.py
+++ b/app/server/tests/test_svc_factory_reset.py
@@ -1,6 +1,5 @@
 """Unit tests for FactoryResetService — wipe data and return to first-boot."""
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -225,35 +224,39 @@ class TestEdgeCases:
         assert (data_dir / "config").exists()
 
 
-class TestWifiClear:
-    """Test that factory reset clears WiFi credentials."""
+class TestWifiWipeDelegation:
+    """Test that factory reset delegates WiFi wipe to hotspot script (ADR-0013)."""
 
     @patch(
         "monitor.services.factory_reset_service.FactoryResetService._schedule_restart"
     )
-    @patch("monitor.services.factory_reset_service.os.remove")
-    @patch("monitor.services.factory_reset_service.os.listdir")
-    @patch("monitor.services.factory_reset_service.os.path.isdir")
-    def test_reset_clears_nm_connections(
-        self, mock_isdir, mock_listdir, mock_remove, mock_restart, svc, data_dir
+    @patch("monitor.services.factory_reset_service.subprocess.run")
+    @patch(
+        "monitor.services.factory_reset_service.FactoryResetService._find_hotspot_script"
+    )
+    def test_reset_calls_hotspot_wipe(
+        self, mock_find, mock_run, mock_restart, svc, data_dir
     ):
-        """NM saved connections are deleted during reset."""
-        original_isdir = os.path.isdir
-
-        def isdir_side_effect(path):
-            if path == "/etc/NetworkManager/system-connections":
-                return True
-            return original_isdir(path)
-
-        mock_isdir.side_effect = isdir_side_effect
-        mock_listdir.return_value = ["MyWiFi.nmconnection", "Work.nmconnection"]
+        """WiFi wipe delegates to hotspot script's 'wipe' command."""
+        mock_find.return_value = "/opt/monitor/scripts/monitor-hotspot.sh"
+        mock_run.return_value = MagicMock(returncode=0)
         svc.execute_reset()
-        assert mock_remove.call_count >= 2
+        wipe_calls = [
+            c
+            for c in mock_run.call_args_list
+            if len(c[0]) > 0
+            and c[0][0] == ["/opt/monitor/scripts/monitor-hotspot.sh", "wipe"]
+        ]
+        assert len(wipe_calls) == 1
 
     @patch(
         "monitor.services.factory_reset_service.FactoryResetService._schedule_restart"
     )
-    def test_reset_succeeds_without_nm_dir(self, mock_restart, svc):
-        """Reset doesn't fail if NM dir doesn't exist."""
+    @patch(
+        "monitor.services.factory_reset_service.FactoryResetService._find_hotspot_script"
+    )
+    def test_reset_succeeds_without_hotspot_script(self, mock_find, mock_restart, svc):
+        """Reset doesn't fail if hotspot script is not found."""
+        mock_find.return_value = None
         msg, status = svc.execute_reset()
         assert status == 200

--- a/docs/adr/0013-unified-provisioning-gpio-triggers.md
+++ b/docs/adr/0013-unified-provisioning-gpio-triggers.md
@@ -1,0 +1,138 @@
+# ADR-0013: Unified Provisioning Architecture and GPIO Triggers
+
+## Status
+Proposed
+
+## Context
+Server and camera have inconsistent first-boot provisioning implementations:
+
+- **Server**: Systemd service (`monitor-hotspot.service`) manages the WiFi hotspot lifecycle, Flask provides the setup wizard UI. Clean separation of system and application concerns.
+- **Camera**: Python application code (`wifi_setup.py`) directly manages the hotspot via nmcli calls, mixing system infrastructure with application logic.
+
+Factory reset WiFi clearing is duplicated with different implementations in `factory_reset_service.py` (server) and `status_server.py` (camera).
+
+There is no physical override mechanism to force provisioning mode or factory reset without software access (SSH, dashboard).
+
+### Industry research (2026-04-12)
+
+| Product | Provisioning Method | Hub vs Spoke | Reset Mechanism |
+|---------|-------------------|--------------|-----------------|
+| Home Assistant OS | Ethernet-first, no hotspot | Hub only | Re-flash SD |
+| Balena wifi-connect | SoftAP + captive portal | Spoke | Auto re-enter AP on WiFi loss |
+| ESPHome | SoftAP fallback after 60s WiFi failure | Spoke | Auto AP on WiFi failure |
+| Tasmota | SoftAP primary on first boot | Spoke | 40s button hold |
+| OpenWRT | Ethernet to 192.168.1.1 | Router | Reset button (10s hold) |
+| Ring Camera | SoftAP + companion app | Spoke | 20s button hold |
+
+**Key industry patterns:**
+1. WiFi credentials first, then authentication — every product gets network connectivity before asking for passwords
+2. Hub devices prefer wired setup; spoke devices use hotspot
+3. Automatic re-entry to provisioning on WiFi failure (ESPHome, Tasmota, Balena)
+4. Physical reset mechanism (GPIO button/jumper) is standard for embedded devices
+
+## Decision
+
+### 1. Unified hotspot architecture (both boards)
+
+Both server and camera follow the same pattern:
+
+| Layer | Responsibility |
+|-------|---------------|
+| `*-hotspot.service` (systemd oneshot) | Hotspot lifecycle: start/stop/status |
+| `*-hotspot.sh` (shell script) | nmcli commands: AP create/destroy, WiFi connect, credential wipe |
+| Application (Flask / Python HTTP) | Setup wizard UI only — no system infrastructure management |
+
+Hotspot activation is always systemd's responsibility via `ConditionPathExists=!/data/.setup-done`. Applications never start or stop the hotspot directly — they call the shell script.
+
+### 2. Provisioning wizard order
+
+**Server** (the hub — has Ethernet fallback):
+1. WiFi network selection + password
+2. Admin password creation (NIST policy: 12+ chars)
+3. Device name (optional)
+4. Review and complete
+
+**Camera** (spoke — connects to server):
+1. WiFi network selection + password
+2. Server address (IP or hostname)
+3. Camera admin password
+4. Review and complete
+
+WiFi-first matches industry standard: the device needs network before it can do anything useful.
+
+### 3. GPIO triggers (platform-abstracted)
+
+Two GPIO jumper pairs provide physical override at boot:
+
+| Purpose | BCM GPIO | Physical Pin | Adjacent GND | Default Pull |
+|---------|----------|-------------|-------------|-------------|
+| Force provisioning | GPIO5 | 29 | 30 | Hardware pull-UP (BCM2711/BCM2710) |
+| Factory reset | GPIO27 | 13 | 14 | Requires `gpio=27=ip,pu` in config.txt |
+
+**Detection**: An early systemd service (`gpio-trigger.service`) reads GPIO state once at boot before hotspot and application services start.
+
+**Behavior**:
+- GPIO5 LOW (jumper present): Delete `.setup-done` only → enter provisioning. Data preserved.
+- GPIO27 LOW (jumper present): Full data wipe + delete `.setup-done` → enter provisioning. Equivalent to fresh flash.
+- Both HIGH (no jumper): Normal boot.
+
+**Platform abstraction**: GPIO pin numbers are not hardcoded. They are read from:
+1. Environment variables (`GPIO_PROVISION_PIN`, `GPIO_RESET_PIN`) — highest priority
+2. Defaults in the trigger script (GPIO5, GPIO27) — matches hardware design
+
+Both RPi 4B and Zero 2W share the identical 40-pin header with the same BCM numbering.
+
+### 4. Hotspot script commands
+
+Both `monitor-hotspot.sh` and `camera-hotspot.sh` support:
+
+| Command | Action |
+|---------|--------|
+| `start` | Create and activate WiFi AP |
+| `stop` | Tear down WiFi AP |
+| `status` | Check if AP is active |
+| `connect <ssid> <password>` | Stop AP, connect to WiFi, return success/fail |
+| `wipe` | Delete all NM saved connections + reset wpa_supplicant |
+
+The `connect` command handles the AP-to-client transition atomically. The `wipe` command is called by factory reset instead of inline nmcli code.
+
+### 5. Factory reset (unified)
+
+Both boards use a proper `FactoryResetService` class (constructor injection, single responsibility):
+
+1. Log audit event (server only — camera has no audit service)
+2. Wipe `/data` contents (config, certs, logs, recordings, etc.)
+3. Call `*-hotspot.sh wipe` to clear WiFi credentials
+4. Delete `.setup-done` stamp
+5. Schedule system reboot
+6. On next boot: systemd `ConditionPathExists` starts hotspot → provisioning wizard
+
+### 6. All provisioning entry points
+
+| Trigger | Effect | Use Case |
+|---------|--------|----------|
+| First boot (no `.setup-done`) | Hotspot + wizard | New device |
+| GPIO5 jumper at boot | Delete stamp → provisioning | Reconfigure without data loss |
+| GPIO27 jumper at boot | Full wipe → provisioning | True factory reset |
+| Software factory reset (API) | Full wipe → reboot → provisioning | Remote reset from dashboard |
+| WiFi lost 60s (camera only) | Auto re-enter hotspot | WiFi password changed |
+
+## Consequences
+
+### Positive
+- Consistent architecture: both boards use identical patterns for hotspot, provisioning, factory reset
+- System concerns in systemd: applications don't manage infrastructure
+- Physical override: no software access needed for recovery
+- Industry-aligned: WiFi-first order, auto-fallback, GPIO reset match embedded Linux best practices
+- Testable: service classes with constructor injection, shell scripts independently testable
+
+### Negative
+- Camera hotspot is no longer managed by the Python app — requires the systemd service to be installed (Yocto recipe change)
+- GPIO requires hardware modification (jumper wires) — but this is standard for embedded development
+- `config.txt` must include `gpio=27=ip,pu` for factory reset pin pull-up
+
+### Migration
+- Camera's `wifi_setup.py` is refactored to remove hotspot start/stop — only HTTP wizard remains
+- Camera's inline factory reset in `status_server.py` is extracted to `FactoryResetService`
+- Server's `ProvisioningService` uses hotspot script's `connect` command instead of direct nmcli
+- Server's `FactoryResetService` uses hotspot script's `wipe` command instead of inline NM cleanup

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,9 @@ They are separate codebases because they run on different hardware with differen
            │              │  │  /api/v1/settings/*       │ │
            │              │  │  /api/v1/users/*          │ │
            │              │  │  /api/v1/ota/*            │ │
+           │              │  │  /cameras/<id>/pair       │ │
+           │              │  │  /pair/exchange            │ │
+           │              │  │  /pair/register            │ │
            │              │  └─────────────┬─────────────┘ │
            │              │                │               │
            │              │  ┌─────────────▼─────────────┐ │
@@ -81,8 +84,12 @@ They are separate codebases because they run on different hardware with differen
            │              │  │   (threads in process)    │ │
            │              │  │                           │ │
            │              │  │  • RecorderService        │ │
-           │              │  │  • DiscoveryService       │ │
-           │              │  │  • StorageManager         │ │
+           │              │  │  • StreamingService       │ │
+           │              │  │  • StorageService         │ │
+           │              │  │  • CameraService          │ │
+           │              │  │  • PairingService         │ │
+           │              │  │  • CertService            │ │
+           │              │  │  • OtaService             │ │
            │              │  │  • HealthMonitor          │ │
            │              │  │  • AuditLogger            │ │
            │              │  └───────────────────────────┘ │
@@ -155,6 +162,17 @@ They are separate codebases because they run on different hardware with differen
 │  │  │ setup/conn/  │  │ camera.conf       │  │  │
 │  │  │ error/solid  │  │ admin credentials │  │  │
 │  │  └──────────────┘  └───────────────────┘  │  │
+│  │                                            │  │
+│  │  ┌──────────────┐  ┌───────────────────┐  │  │
+│  │  │ Pairing      │  │ OTA Agent         │  │  │
+│  │  │ PIN exchange │  │ HTTP :8080 (mTLS) │  │  │
+│  │  │ cert storage │  │ stream-to-disk    │  │  │
+│  │  └──────────────┘  └───────────────────┘  │  │
+│  │                                            │  │
+│  │  ┌──────────────────────────────────────┐  │  │
+│  │  │ Factory Reset                        │  │  │
+│  │  │ WiFi wipe + config reset + reboot    │  │  │
+│  │  └──────────────────────────────────────┘  │  │
 │  │                                            │  │
 │  │  ┌──────────────────────────────────────┐  │  │
 │  │  │ Templates (HTML)                     │  │  │
@@ -251,7 +269,7 @@ The server dashboard shows clickable `.local` links for each camera's status pag
 | What | Method | Key Management |
 |------|--------|---------------|
 | Browser ↔ Server | TLS 1.3 (HTTPS, nginx) | Self-signed CA (ECDSA P-256, 10-year), generated on first boot |
-| Camera ↔ Server | mTLS (RTSPS) ⚠️ *Not implemented* | Server CA signs camera ECDSA P-256 client certs during PIN-based pairing (ADR-0009) |
+| Camera ↔ Server | mTLS (RTSPS) | Server CA signs camera ECDSA P-256 client certs during PIN-based pairing (ADR-0009) |
 | Data at rest (server) | LUKS2 (`xchacha20,aes-adiantum-plain64`), argon2id (1 GB, 4 iter) | Passphrase set during first-boot setup; optional auto-unlock keyfile. See ADR-0010 |
 | Data at rest (camera) | LUKS2 (`xchacha20,aes-adiantum-plain64`), argon2id (64 MB, 4 iter) | Key derived via HKDF-SHA256 from `pairing_secret` + CPU serial. See ADR-0010 |
 | Passwords | bcrypt (cost 12) | Stored in /data/config/users.json |
@@ -260,7 +278,7 @@ The server dashboard shows clickable `.local` links for each camera's status pag
 
 ### 3.4 Certificate Authority & Camera Pairing
 
-> **Status: Not implemented.** CA and server cert exist. Pairing flow, mTLS enforcement, and cert revocation pending. See ADR-0009.
+> **Status: Implemented.** CA generation, PIN-based pairing, mTLS cert exchange, and cert revocation are operational. See ADR-0009.
 
 ```
 FIRST BOOT (Server):
@@ -589,7 +607,7 @@ Server browses:
 
 ### 6.3 OTA Update Flow
 
-> **Status: Not implemented.** API stubs exist. See ADR-0008 for full design.
+> **Status: Implemented.** Server OTA service (verify, stage, install), camera OTA agent (port 8080, mTLS), and USB detection are operational. See ADR-0008.
 
 **Delivery modes** (all feed into single `inbox → verify → staging → install` pipeline):
 ```
@@ -648,14 +666,24 @@ rpi-home-monitor/
 │   │   │   │   ├── system.py         # Health, storage, server info
 │   │   │   │   ├── settings.py       # Config read/write
 │   │   │   │   ├── users.py          # User CRUD, password management
-│   │   │   │   └── ota.py            # OTA upload, push, status
+│   │   │   │   ├── ota.py            # OTA upload, push, status
+│   │   │   │   ├── pairing.py        # PIN-based camera pairing + cert exchange
+│   │   │   │   └── storage.py        # Storage management endpoints
 │   │   │   ├── services/             # Background services
 │   │   │   │   ├── __init__.py
-│   │   │   │   ├── recorder.py       # ffmpeg recording manager (3-min clips)
-│   │   │   │   ├── discovery.py      # Avahi mDNS camera scanner
-│   │   │   │   ├── storage.py        # Loop recording, cleanup, stats
-│   │   │   │   ├── health.py         # CPU, temp, RAM, disk monitoring
-│   │   │   │   └── audit.py          # Security event logging
+│   │   │   │   ├── recorder_service.py    # ffmpeg recording manager (3-min clips)
+│   │   │   │   ├── recordings_service.py  # Clip listing, timeline queries
+│   │   │   │   ├── streaming_service.py   # HLS/recording pipeline orchestration
+│   │   │   │   ├── storage_service.py     # Loop recording, cleanup, stats
+│   │   │   │   ├── camera_service.py      # Camera CRUD + discovery confirmation
+│   │   │   │   ├── pairing_service.py     # PIN-based pairing + cert lifecycle
+│   │   │   │   ├── cert_service.py        # CA + certificate generation
+│   │   │   │   ├── ota_service.py         # OTA verify, stage, install
+│   │   │   │   ├── user_service.py        # User CRUD + password management
+│   │   │   │   ├── settings_service.py    # System settings read/write
+│   │   │   │   ├── factory_reset_service.py # WiFi wipe + config reset
+│   │   │   │   ├── provisioning_service.py  # First-boot setup orchestration
+│   │   │   │   └── tailscale_service.py   # Tailscale VPN management
 │   │   │   ├── templates/            # Jinja2 HTML templates
 │   │   │   │   ├── base.html         # Base layout (nav, auth check)
 │   │   │   │   ├── login.html        # Login page
@@ -684,13 +712,18 @@ rpi-home-monitor/
 │   └── camera/                        # RPi Zero 2W camera application
 │       ├── camera_streamer/           # Python package
 │       │   ├── __init__.py
-│       │   ├── main.py               # Entry point, service lifecycle
+│       │   ├── main.py               # Entry point
+│       │   ├── lifecycle.py          # State machine (INIT→SETUP→PAIRING→...→RUNNING)
 │       │   ├── capture.py            # v4l2 capture management
 │       │   ├── stream.py             # ffmpeg RTSPS streaming + reconnect
 │       │   ├── discovery.py          # Avahi service advertisement
 │       │   ├── config.py             # Config file management
 │       │   ├── pairing.py            # Certificate exchange during pairing
-│       │   └── ota_agent.py          # Listen for OTA push from server
+│       │   ├── ota_agent.py          # Listen for OTA push from server (port 8080)
+│       │   ├── factory_reset.py      # WiFi wipe + config reset
+│       │   ├── status_server.py      # Post-setup status/admin server
+│       │   ├── wifi.py               # WiFi connection management
+│       │   └── encryption.py         # LUKS key derivation
 │       ├── config/                    # Deployment configs
 │       │   ├── camera-streamer.service  # systemd unit
 │       │   ├── nftables-camera.conf    # Firewall rules

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -183,13 +183,22 @@ Before any Yocto change is committed:
   ```
   app/camera/camera_streamer/
     main.py              ← Entry point
+    lifecycle.py         ← State machine (INIT→SETUP→PAIRING→...→RUNNING)
     config.py            ← Config + PBKDF2 password management
     capture.py           ← V4L2 camera detection
-    stream.py            ← FFmpeg RTSP streaming
-    wifi_setup.py        ← Setup wizard + status server + sessions
+    stream.py            ← FFmpeg RTSPS streaming
+    wifi_setup.py        ← First-boot WiFi hotspot + setup wizard
+    wifi.py              ← WiFi connection management
+    status_server.py     ← Post-setup status/admin server
     discovery.py         ← Avahi mDNS advertisement
+    pairing.py           ← PIN-based cert exchange with server
+    ota_agent.py         ← OTA update listener (port 8080, mTLS)
+    factory_reset.py     ← WiFi wipe + config reset
+    encryption.py        ← LUKS key derivation
     health.py            ← CPU/RAM/uptime monitoring
     led.py               ← ACT LED patterns
+    platform.py          ← Hardware path abstraction
+    logging_config.py    ← Logging setup
     templates/           ← HTML templates (login, setup, status)
   ```
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -409,7 +409,7 @@ Every PR must satisfy the appropriate layers:
 **Why smoke tests (Layer 5)?** Unit/integration tests use mocks. Smoke tests hit a real RPi with real HTTPS, real disk, real systemd services. Run after deploying to hardware:
 
 ```bash
-./scripts/smoke-test.sh 192.168.8.245 12345678
+./scripts/smoke-test.sh <server-ip> <password>
 ```
 
 #### Key Rules (non-negotiable)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -263,7 +263,7 @@ Camera Node                    Server                     Client
 
 ### 4.7 Partition Scheme (OTA-ready, SWUpdate A/B with U-Boot)
 
-> **Status: Not implemented.** Partition layout defined in WKS files; U-Boot integration and SWUpdate pending (see ADR-0008).
+> **Status: Implemented.** A/B partition layout defined in WKS files with U-Boot boot counting (see ADR-0008).
 
 | Partition | Type | Size (Server) | Size (Camera) | Purpose |
 |-----------|------|---------------|---------------|---------|
@@ -332,7 +332,7 @@ Boot uses U-Boot (`u-boot-rpi` from meta-raspberrypi) for boot counting (`bootli
 
 #### SR-CAM-06: OTA Update Support
 
-> **Status: Not implemented.** Stub exists at `app/camera/camera_streamer/ota_agent.py`. See ADR-0008.
+> **Status: Implemented.** Camera OTA agent at `app/camera/camera_streamer/ota_agent.py` (HTTP server on port 8080, mTLS). See ADR-0008.
 
 - Dual rootfs partitions (A/B layout) using SWUpdate + U-Boot boot counting (`bootlimit=3`)
 - Accept update images pushed from server over HTTPS (mTLS authenticated, ADR-0009)
@@ -432,7 +432,7 @@ Boot uses U-Boot (`u-boot-rpi` from meta-raspberrypi) for boot counting (`bootli
 
 #### SR-SRV-10: OTA Update Management
 
-> **Status: Not implemented.** API stubs exist at `app/server/monitor/api/ota.py`. See ADR-0008.
+> **Status: Implemented.** Server OTA service at `app/server/monitor/services/ota_service.py` with API at `app/server/monitor/api/ota.py`. See ADR-0008.
 
 - Dual rootfs partitions (A/B layout) using SWUpdate + U-Boot boot counting (`bootlimit=3`)
 - **Multi-mode delivery** (5 modes, single `inbox → verify → staging → install` pipeline):
@@ -524,7 +524,7 @@ All endpoints require authentication. Prefix: `/api/v1/`
 
 #### SR-SEC-02: Mutual TLS for Camera Authentication
 
-> **Status: Not implemented.** Stub exists at `app/camera/camera_streamer/pairing.py`. See ADR-0009.
+> **Status: Implemented.** PairingService on server + PairingManager on camera. See ADR-0009.
 
 - Each paired camera receives a unique ECDSA P-256 client certificate (5-year validity)
 - Server verifies camera cert on every RTSP connection
@@ -535,7 +535,7 @@ All endpoints require authentication. Prefix: `/api/v1/`
 
 #### SR-SEC-03: Encryption at Rest
 
-> **Status: Not implemented.** Requires kernel config fragment for Adiantum. See ADR-0010.
+> **Status: Implemented.** LUKS2 with Adiantum cipher on `/data` partition. See ADR-0010.
 
 - `/data` partition encrypted with LUKS2 (`xchacha20,aes-adiantum-plain64`) — 2-3.5x faster than AES on ARM without hardware acceleration
 - **Server:** passphrase set during first-boot setup wizard, argon2id KDF (1 GB memory, 4 iterations, 4 parallelism). Optional auto-unlock keyfile or Dropbear SSH unlock for headless operation
@@ -584,7 +584,7 @@ All endpoints require authentication. Prefix: `/api/v1/`
 
 #### SR-SEC-09: Signed OTA Updates
 
-> **Status: Not implemented.** See ADR-0008 for signing workflow and trust model.
+> **Status: Implemented.** Ed25519 signature verification in OTA service. See ADR-0008.
 
 - All artifacts signed with Ed25519 keypair (both `.swu` and `.tar.zst` app bundles)
 - Build machine holds private signing key (never on devices)
@@ -595,7 +595,7 @@ All endpoints require authentication. Prefix: `/api/v1/`
 
 #### SR-SEC-10: Camera Pairing Protocol
 
-> **Status: Not implemented.** Stub exists at `app/camera/camera_streamer/pairing.py`. See ADR-0009.
+> **Status: Implemented.** PairingService + PairingManager + `/pair/exchange` endpoint. See ADR-0009.
 
 - Camera discovered via mDNS appears as "pending" (untrusted)
 - Admin clicks "Pair" in dashboard → server generates ECDSA P-256 client cert + 6-digit PIN (5-min expiry)

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -90,8 +90,12 @@ app/
     │   ├── discovery.py
     │   ├── health.py
     │   ├── led.py
-    │   ├── pairing.py               ← Stub (Phase 2)
-    │   ├── ota_agent.py             ← Stub (Phase 2)
+    │   ├── pairing.py               ← PIN-based cert exchange with server
+    │   ├── ota_agent.py             ← OTA update listener (port 8080, mTLS)
+    │   ├── factory_reset.py         ← WiFi wipe + config reset
+    │   ├── lifecycle.py             ← State machine orchestration
+    │   ├── status_server.py         ← Post-setup status/admin server
+    │   ├── wifi.py                  ← WiFi connection management
     │   └── templates/               ← Camera HTML templates
     │       ├── login.html           ← Camera login page
     │       ├── setup.html           ← First-boot provisioning wizard

--- a/meta-home-monitor/conf/distro/home-monitor.conf
+++ b/meta-home-monitor/conf/distro/home-monitor.conf
@@ -11,7 +11,7 @@ DISTRO_VERSION = "1.0.0"
 DISTRO_CODENAME = "phase1"
 
 # Maintainer
-MAINTAINER = "vinu.narayanan@hotmail.com"
+MAINTAINER = "vinu@engineer.com"
 
 # --- System fundamentals ---
 DISTRO_FEATURES = " \

--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -14,6 +14,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/camera:"
 SRC_URI = " \
     file://camera_streamer/ \
     file://config/camera-streamer.service \
+    file://config/camera-hotspot.service \
+    file://config/camera-hotspot.sh \
     file://config/nftables-camera.conf \
     file://config/captive-portal-dnsmasq.conf \
     file://config/camera.conf.default \
@@ -34,7 +36,7 @@ RDEPENDS:${PN} = " \
 
 inherit systemd useradd
 
-SYSTEMD_SERVICE:${PN} = "camera-streamer.service"
+SYSTEMD_SERVICE:${PN} = "camera-streamer.service camera-hotspot.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 # Create camera system user/group
@@ -51,9 +53,14 @@ do_install() {
     # Default config (copied to /data on first boot)
     install -m 0644 ${WORKDIR}/config/camera.conf.default ${D}/opt/camera/camera.conf.default
 
-    # Systemd service
+    # Hotspot setup script (WiFi provisioning + factory reset wipe)
+    install -d ${D}/opt/camera/scripts
+    install -m 0755 ${WORKDIR}/config/camera-hotspot.sh ${D}/opt/camera/scripts/camera-hotspot.sh
+
+    # Systemd services
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/config/camera-streamer.service ${D}${systemd_system_unitdir}/camera-streamer.service
+    install -m 0644 ${WORKDIR}/config/camera-hotspot.service ${D}${systemd_system_unitdir}/camera-hotspot.service
 
     # Firewall rules
     install -d ${D}${sysconfdir}/nftables.d
@@ -67,6 +74,7 @@ do_install() {
 FILES:${PN} = " \
     /opt/camera \
     ${systemd_system_unitdir}/camera-streamer.service \
+    ${systemd_system_unitdir}/camera-hotspot.service \
     ${sysconfdir}/nftables.d/camera.conf \
     ${sysconfdir}/NetworkManager/dnsmasq-shared.d/captive-portal.conf \
     "

--- a/meta-home-monitor/recipes-connectivity/nm-persist/files/nm-persist.sh
+++ b/meta-home-monitor/recipes-connectivity/nm-persist/files/nm-persist.sh
@@ -26,8 +26,14 @@ fi
 # Create persistent directory
 mkdir -p "$PERSIST_DIR"
 
-# Seed from rootfs on first run (or if persistent dir is empty)
-if [ -z "$(ls -A "$PERSIST_DIR" 2>/dev/null)" ]; then
+# Seed from rootfs on first run (or if persistent dir is empty).
+# Skip seeding if .wifi-wiped marker exists (factory reset cleared WiFi
+# deliberately — don't restore baked-in connections from the rootfs).
+WIPE_MARKER="$PERSIST_DIR/../.wifi-wiped"
+if [ -f "$WIPE_MARKER" ]; then
+    echo "nm-persist: wifi-wiped marker found — skipping rootfs seed"
+    rm -f "$WIPE_MARKER"
+elif [ -z "$(ls -A "$PERSIST_DIR" 2>/dev/null)" ]; then
     echo "nm-persist: seeding connections from rootfs"
     if [ -d "$ROOTFS_DIR" ] && [ -n "$(ls -A "$ROOTFS_DIR" 2>/dev/null)" ]; then
         cp -a "$ROOTFS_DIR"/* "$PERSIST_DIR"/

--- a/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
+++ b/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
@@ -52,21 +52,26 @@ if [ -n "$DATA_DEV" ]; then
     fi
 fi
 
-# Set hostname to match the camera's default server address.
-DESIRED_HOSTNAME="rpi-divinu"
-
-CURRENT_HOSTNAME=$(hostname 2>/dev/null)
-if [ "$CURRENT_HOSTNAME" != "$DESIRED_HOSTNAME" ]; then
-    echo "Setting hostname: ${CURRENT_HOSTNAME} -> ${DESIRED_HOSTNAME}"
-    hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null || \
-        echo "$DESIRED_HOSTNAME" > /etc/hostname
-    if command -v systemctl >/dev/null 2>&1; then
-        systemctl restart avahi-daemon 2>/dev/null || true
+# Set hostname — server gets a fixed name, camera gets serial suffix later.
+# Camera hostname is set by wifi_setup.py (_set_unique_hostname) during
+# first-boot provisioning, so we only set it here for the server.
+if id monitor >/dev/null 2>&1; then
+    DESIRED_HOSTNAME="rpi-divinu"
+    CURRENT_HOSTNAME=$(hostname 2>/dev/null)
+    if [ "$CURRENT_HOSTNAME" != "$DESIRED_HOSTNAME" ]; then
+        echo "Setting hostname: ${CURRENT_HOSTNAME} -> ${DESIRED_HOSTNAME}"
+        hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null || \
+            echo "$DESIRED_HOSTNAME" > /etc/hostname
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl restart avahi-daemon 2>/dev/null || true
+        fi
+        if command -v nmcli >/dev/null 2>&1; then
+            nmcli general hostname "$DESIRED_HOSTNAME" 2>/dev/null || true
+        fi
+        echo "Hostname set to ${DESIRED_HOSTNAME} (reachable at ${DESIRED_HOSTNAME}.local)"
     fi
-    if command -v nmcli >/dev/null 2>&1; then
-        nmcli general hostname "$DESIRED_HOSTNAME" 2>/dev/null || true
-    fi
-    echo "Hostname set to ${DESIRED_HOSTNAME} (reachable at ${DESIRED_HOSTNAME}.local)"
+else
+    echo "Camera board — hostname will be set during WiFi provisioning"
 fi
 
 # Create directory structure

--- a/meta-home-monitor/recipes-core/images/home-camera-image.inc
+++ b/meta-home-monitor/recipes-core/images/home-camera-image.inc
@@ -39,5 +39,8 @@ IMAGE_FSTYPES = "wic.bz2 wic.bmap ext4.gz"
 WKS_FILE = "home-camera-ab.wks"
 WKS_FILE_DEPENDS = "e2fsprogs-native dosfstools-native mtools-native"
 
+# --- Default hostname (suffixed with CPU serial by wifi_setup on first boot) ---
+hostname = "rpi-divinu-cam"
+
 # --- Keep image small ---
 IMAGE_ROOTFS_EXTRA_SPACE = "262144"

--- a/meta-home-monitor/recipes-core/images/home-monitor-image.inc
+++ b/meta-home-monitor/recipes-core/images/home-monitor-image.inc
@@ -52,5 +52,8 @@ IMAGE_FSTYPES = "wic.bz2 wic.bmap ext4.gz"
 WKS_FILE = "home-monitor-ab.wks"
 WKS_FILE_DEPENDS = "e2fsprogs-native dosfstools-native mtools-native"
 
+# --- Default hostname (overridden by first-boot and provisioning) ---
+hostname = "rpi-divinu"
+
 # --- Extra space for video recordings (1GB) ---
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"

--- a/scripts/e2e-smoke-test.sh
+++ b/scripts/e2e-smoke-test.sh
@@ -49,8 +49,8 @@ if [ -z "$SERVER_IP" ] || [ -z "$CAMERA_IP" ]; then
     echo "  WIFI_PASSWORD — WiFi password (required for server setup)"
     echo ""
     echo "Example:"
-    echo "  WIFI_SSID=MysticNet2.4 WIFI_PASSWORD=secret \\"
-    echo "    ./scripts/e2e-smoke-test.sh 192.168.1.245 192.168.1.186 admin"
+    echo "  WIFI_SSID=MyNetwork WIFI_PASSWORD=secret \\"
+    echo "    ./scripts/e2e-smoke-test.sh <server-ip> <camera-ip> admin"
     exit 1
 fi
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -9,9 +9,9 @@
 #   ./scripts/smoke-test.sh <server-ip> [admin-password] [camera-ip] [camera-password]
 #
 # Examples:
-#   ./scripts/smoke-test.sh 192.168.8.245 12345678
-#   ./scripts/smoke-test.sh 192.168.8.245 12345678 192.168.8.187
-#   ./scripts/smoke-test.sh 192.168.8.245 12345678 192.168.8.187 cam-pass
+#   ./scripts/smoke-test.sh <server-ip> <password>
+#   ./scripts/smoke-test.sh <server-ip> <password> <camera-ip>
+#   ./scripts/smoke-test.sh <server-ip> <password> <camera-ip> <cam-password>
 #   ./scripts/smoke-test.sh homemonitor.local
 #
 # Camera password defaults to admin-password if not specified (dev builds


### PR DESCRIPTION
## Summary

- **WiFi persistence**: Factory reset properly wipes WiFi from both /etc/NM/ and /data/network/ (nm-persist bind-mount source), with `.wifi-wiped` marker to prevent rootfs re-seeding
- **Hostname persistence**: Saves hostname to `/data/config/hostname`, restores on every boot via lifecycle (works on read-only rootfs with `CAP_SYS_ADMIN`)
- **Camera self-registration**: Camera POSTs to `/api/v1/pair/register` when entering PAIRING state, automatically appearing in the server dashboard
- **Dashboard UX**: Added Scan button for camera discovery, redesigned pairing PIN card with step-by-step instructions
- **Hotspot startup**: Lifecycle starts hotspot directly when systemd camera-hotspot.service is absent
- **Setup wizard**: Shows camera address/hostname after WiFi connect for easier pairing navigation
- **Security cleanup**: Removed personal email from distro config, replaced real IPs in script examples, added credential file patterns to .gitignore
- **Documentation**: Updated all docs to match Phase 2 implementation status (mTLS, pairing, OTA, factory reset)

## Test plan

- [x] Camera tests: 365 passed, 80% coverage
- [x] Server tests: 1007 passed, 87% coverage
- [x] Lint: ruff check + format clean
- [x] Hardware verified: camera hotspot → setup wizard → WiFi connect → hostname set → pairing state
- [x] Hostname resolves: `rpi-divinu-cam-d8ee.local` → `192.168.1.186` via mDNS
- [x] Factory reset WiFi wipe verified on camera hardware
- [ ] Full end-to-end pairing flow (PIN exchange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)