### PR TITLE
fix: set product hostname in image rootfs

### DIFF
--- a/meta-home-monitor/recipes-core/images/home-camera-image.inc
+++ b/meta-home-monitor/recipes-core/images/home-camera-image.inc
@@ -42,5 +42,13 @@ WKS_FILE_DEPENDS = "e2fsprogs-native dosfstools-native mtools-native"
 # --- Default hostname (suffixed with CPU serial by wifi_setup on first boot) ---
 hostname = "rpi-divinu-cam"
 
+# Write hostname into /etc/hostname at image creation time.
+# (base-files defaults to MACHINE; this override ensures the image
+# ships with our product hostname out of the box.)
+set_product_hostname() {
+    echo "${hostname}" > ${IMAGE_ROOTFS}${sysconfdir}/hostname
+}
+ROOTFS_POSTPROCESS_COMMAND += "set_product_hostname;"
+
 # --- Keep image small ---
 IMAGE_ROOTFS_EXTRA_SPACE = "262144"

--- a/meta-home-monitor/recipes-core/images/home-monitor-image.inc
+++ b/meta-home-monitor/recipes-core/images/home-monitor-image.inc
@@ -55,5 +55,13 @@ WKS_FILE_DEPENDS = "e2fsprogs-native dosfstools-native mtools-native"
 # --- Default hostname (overridden by first-boot and provisioning) ---
 hostname = "rpi-divinu"
 
+# Write hostname into /etc/hostname at image creation time.
+# (base-files defaults to MACHINE; this override ensures the image
+# ships with our product hostname out of the box.)
+set_product_hostname() {
+    echo "${hostname}" > ${IMAGE_ROOTFS}${sysconfdir}/hostname
+}
+ROOTFS_POSTPROCESS_COMMAND += "set_product_hostname;"
+
 # --- Extra space for video recordings (1GB) ---
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"


### PR DESCRIPTION
## Summary
- Add `ROOTFS_POSTPROCESS_COMMAND` to both image `.inc` files to write product hostnames (`rpi-divinu` / `rpi-divinu-cam`) into `/etc/hostname` at image build time
- `base-files` defaults `/etc/hostname` to `MACHINE` (e.g. `raspberrypi4-64`); this fix ensures the image ships with the correct hostname out of the box

## Test plan
- [x] Verified server rootfs `/etc/hostname` = `rpi-divinu` after rebuild
- [x] Verified camera rootfs `/etc/hostname` = `rpi-divinu-cam` after rebuild
- [x] Both images build successfully (5432/5432 camera, 6953/6953 server)
- [x] `.swu` generation works for both targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)