### PR TITLE
fix: close code block in README Run Tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ First build takes 2-4 hours. Subsequent builds use cached artifacts and are much
 ```bash
 cd app/server && pytest    # threshold: 80% coverage
 cd app/camera && pytest    # threshold: 55% coverage
-``` Results and coverage reports are available in the [CI workflow](https://github.com/vinu-engineer/rpi-home-monitor/actions).
+```
+
+Results and coverage reports are available in the [CI workflow](https://github.com/vinu-engineer/rpi-home-monitor/actions).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Fix broken markdown code block in Run Tests section — closing ``` was on the same line as text

## Test plan
- [x] Visual inspection of README rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)