### PR TITLE
fix: harden server and restore camera boot streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Both the server and camera use a **captive portal** for zero-config WiFi provisi
 2. **Connect phone** to hotspot (`HomeMonitor-Setup` / `HomeCam-Setup`)
 3. **Setup wizard auto-opens** — configure WiFi + admin password (server) or WiFi + server address + camera login (camera)
 4. **Done** — LED goes solid = running. Camera finds server automatically via `rpi-divinu.local`
-5. **Access camera** at `http://rpi-divinu-cam-XXXX.local` (shown after setup completes)
+5. **Access camera** at `https://rpi-divinu-cam-XXXX.local` (shown after setup completes)
 
 ### LED Status Indicators
 
@@ -60,7 +60,7 @@ Both the server and camera use a **captive portal** for zero-config WiFi provisi
 
 ### Server Discovery (mDNS)
 
-The server advertises itself as `rpi-divinu.local` on the local network via Avahi/mDNS. Cameras find the server automatically — no need to know the server's IP address. Each camera also gets its own `.local` address (e.g., `http://rpi-divinu-cam-d8ee.local`) for direct access to its status page. If mDNS doesn't work on your network, enter IPs manually.
+The server advertises itself as `rpi-divinu.local` on the local network via Avahi/mDNS. Cameras find the server automatically — no need to know the server's IP address. Each camera also gets its own `.local` address (e.g., `https://rpi-divinu-cam-d8ee.local`) for direct access to its status page. If mDNS doesn't work on your network, enter IPs manually.
 
 ## Key Features
 

--- a/app/camera/camera_streamer/discovery.py
+++ b/app/camera/camera_streamer/discovery.py
@@ -17,6 +17,8 @@ Uses avahi-publish-service which is part of avahi-daemon package.
 import logging
 import subprocess
 
+from camera_streamer import wifi
+
 log = logging.getLogger("camera-streamer.discovery")
 
 SERVICE_TYPE = "_rtsp._tcp"
@@ -30,6 +32,7 @@ class DiscoveryService:
     def __init__(self, config):
         self._config = config
         self._process = None
+        self._host_process = None
         self._running = False
 
     @property
@@ -72,6 +75,7 @@ class DiscoveryService:
                 SERVICE_TYPE,
                 SERVICE_PORT,
             )
+            self._start_host_advertisement()
         except FileNotFoundError:
             log.error("avahi-publish-service not found — mDNS disabled")
             self._running = False
@@ -79,19 +83,58 @@ class DiscoveryService:
             log.error("Failed to start mDNS: %s", e)
             self._running = False
 
+    def _start_host_advertisement(self):
+        """Publish the unique camera hostname as an mDNS A record."""
+        hostname = wifi.get_hostname()
+        ip_address = wifi.get_ip_address()
+        if not hostname or not ip_address:
+            log.warning(
+                "Skipping hostname mDNS advertisement (hostname=%s ip=%s)",
+                hostname or "(missing)",
+                ip_address or "(missing)",
+            )
+            return
+
+        host_label = hostname if hostname.endswith(".local") else f"{hostname}.local"
+        cmd = [
+            "avahi-publish-address",
+            "-R",
+            "-f",
+            host_label,
+            ip_address,
+        ]
+
+        try:
+            self._host_process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+            log.info(
+                "mDNS hostname advertisement started: %s -> %s", host_label, ip_address
+            )
+        except FileNotFoundError:
+            log.warning("avahi-publish-address not found — hostname mDNS disabled")
+        except OSError as e:
+            log.warning("Failed to start hostname mDNS advertisement: %s", e)
+
     def stop(self):
         """Stop mDNS advertisement."""
         self._running = False
-        if self._process is not None:
+        for attr_name in ["_process", "_host_process"]:
+            process = getattr(self, attr_name)
+            if process is None:
+                continue
             try:
-                self._process.terminate()
-                self._process.wait(timeout=5)
+                process.terminate()
+                process.wait(timeout=5)
             except (OSError, subprocess.TimeoutExpired):
                 try:
-                    self._process.kill()
+                    process.kill()
                 except OSError:
                     pass
-            self._process = None
+            setattr(self, attr_name, None)
+        if self._process is None and self._host_process is None:
             log.info("mDNS advertisement stopped")
 
     def update_paired_status(self, paired):

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -265,7 +265,7 @@ class CameraLifecycle:
         else:
             log.warning("Server not configured — streaming disabled")
 
-        # Status HTTP server (port 80)
+        # Status HTTPS server (port 443)
         self._status_server = CameraStatusServer(
             self._config,
             self._stream,

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -1,7 +1,7 @@
 """
 Camera status page server (post-setup).
 
-Runs on port 80 after first-boot setup is complete. Provides a
+Runs on port 443 after first-boot setup is complete. Provides a
 login-protected status page where the user can view camera info,
 system health, and change WiFi settings.
 
@@ -11,7 +11,11 @@ Requires the admin password set during provisioning.
 import http.server
 import json
 import logging
+import os
 import secrets
+import socket
+import ssl
+import subprocess
 import threading
 import time
 
@@ -20,8 +24,10 @@ from camera_streamer.factory_reset import FactoryResetService
 
 log = logging.getLogger("camera-streamer.status-server")
 
-LISTEN_PORT = 80
+LISTEN_PORT = 443
 SESSION_TIMEOUT = 7200  # 2 hours
+TLS_CERT_NAME = "status.crt"
+TLS_KEY_NAME = "status.key"
 
 # ---- Session store (in-memory) ----
 _sessions = {}
@@ -66,6 +72,111 @@ def _get_session_cookie(headers):
         if part.startswith("cam_session="):
             return part.split("=", 1)[1]
     return ""
+
+
+def _build_session_cookie(token):
+    """Build a secure session cookie value."""
+    return (
+        f"cam_session={token}; Path=/; Max-Age={SESSION_TIMEOUT}; "
+        "HttpOnly; Secure; SameSite=Strict"
+    )
+
+
+def _clear_session_cookie():
+    """Build a secure expired session cookie value."""
+    return "cam_session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Strict"
+
+
+def _status_tls_paths(config):
+    """Return cert/key paths for the camera status HTTPS endpoint."""
+    certs_dir = config.certs_dir
+    return (
+        os.path.join(certs_dir, TLS_CERT_NAME),
+        os.path.join(certs_dir, TLS_KEY_NAME),
+    )
+
+
+def _status_server_names():
+    """Return hostname variants that should be present in the cert SAN."""
+    names = []
+    hostname = wifi.get_hostname() or socket.gethostname()
+    if hostname:
+        names.append(hostname)
+        if "." not in hostname:
+            names.append(f"{hostname}.local")
+    names.extend(["localhost"])
+    return list(dict.fromkeys(n for n in names if n))
+
+
+def _ensure_tls_material(config):
+    """Create a self-signed cert for the camera HTTPS status page if needed."""
+    cert_path, key_path = _status_tls_paths(config)
+    if os.path.isfile(cert_path) and os.path.isfile(key_path):
+        return cert_path, key_path
+
+    os.makedirs(config.certs_dir, exist_ok=True)
+    names = _status_server_names()
+    common_name = names[0]
+    san = ",".join(f"DNS:{name}" for name in names)
+    san = f"{san},IP:127.0.0.1"
+
+    try:
+        subprocess.run(
+            [
+                "openssl",
+                "ecparam",
+                "-genkey",
+                "-name",
+                "prime256v1",
+                "-out",
+                key_path,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-new",
+                "-x509",
+                "-key",
+                key_path,
+                "-out",
+                cert_path,
+                "-days",
+                "1825",
+                "-subj",
+                f"/CN={common_name}",
+                "-addext",
+                f"subjectAltName={san}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        os.chmod(key_path, 0o600)
+    except FileNotFoundError as e:
+        raise RuntimeError("openssl is required for camera HTTPS status page") from e
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        raise RuntimeError(f"failed to generate camera HTTPS cert: {stderr}") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError("timed out generating camera HTTPS cert") from e
+
+    return cert_path, key_path
+
+
+def _wrap_https_server(server, config):
+    """Wrap the status server socket with TLS."""
+    cert_path, key_path = _ensure_tls_material(config)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(cert_path, key_path)
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    return server
 
 
 def _get_cpu_temp(thermal_path=None):
@@ -137,9 +248,9 @@ def _load_template(name):
 
 
 class CameraStatusServer:
-    """HTTP server showing camera status after setup.
+    """HTTPS server showing camera status after setup.
 
-    Runs on port 80. Requires login with the password set during
+    Runs on port 443. Requires login with the password set during
     provisioning. Shows camera ID, WiFi, server connection, stream
     status, system health, and a form to change WiFi.
 
@@ -167,7 +278,7 @@ class CameraStatusServer:
         self._thread = None
 
     def start(self):
-        """Start the status HTTP server on port 80."""
+        """Start the status HTTPS server on port 443."""
         handler = _make_status_handler(
             self._config,
             self._stream,
@@ -178,20 +289,21 @@ class CameraStatusServer:
         )
         try:
             self._server = http.server.HTTPServer(("0.0.0.0", LISTEN_PORT), handler)
+            self._server = _wrap_https_server(self._server, self._config)
             self._thread = threading.Thread(
                 target=self._server.serve_forever,
                 daemon=True,
-                name="status-http",
+                name="status-https",
             )
             self._thread.start()
-            log.info("Status server listening on port %d", LISTEN_PORT)
+            log.info("Status server listening on HTTPS port %d", LISTEN_PORT)
             return True
         except Exception as e:
             log.error("Failed to start status server: %s", e)
             return False
 
     def stop(self):
-        """Stop the status HTTP server."""
+        """Stop the status HTTPS server."""
         if self._server:
             self._server.shutdown()
             self._server = None
@@ -243,7 +355,7 @@ def _make_status_handler(
 
     class StatusHandler(http.server.BaseHTTPRequestHandler):
         def log_message(self, format, *args):
-            log.debug("Status HTTP: " + format % args)
+            log.debug("Status HTTPS: " + format % args)
 
         def _is_authenticated(self):
             if not config.has_password:
@@ -269,9 +381,7 @@ def _make_status_handler(
                 token = _get_session_cookie(self.headers)
                 _destroy_session(token)
                 self.send_response(302)
-                self.send_header(
-                    "Set-Cookie", "cam_session=; Path=/; Max-Age=0; HttpOnly"
-                )
+                self.send_header("Set-Cookie", _clear_session_cookie())
                 self.send_header("Location", "/login")
                 self.end_headers()
             elif self.path == "/pair":
@@ -392,20 +502,14 @@ def _make_status_handler(
                 if "application/json" in content_type:
                     self.send_response(200)
                     self.send_header("Content-Type", "application/json")
-                    self.send_header(
-                        "Set-Cookie",
-                        f"cam_session={token}; Path=/; HttpOnly; SameSite=Strict",
-                    )
+                    self.send_header("Set-Cookie", _build_session_cookie(token))
                     resp = json.dumps({"message": "Login successful"}).encode()
                     self.send_header("Content-Length", str(len(resp)))
                     self.end_headers()
                     self.wfile.write(resp)
                 else:
                     self.send_response(302)
-                    self.send_header(
-                        "Set-Cookie",
-                        f"cam_session={token}; Path=/; HttpOnly; SameSite=Strict",
-                    )
+                    self.send_header("Set-Cookie", _build_session_cookie(token))
                     self.send_header("Location", "/")
                     self.end_headers()
             else:

--- a/app/camera/camera_streamer/templates/setup.html
+++ b/app/camera/camera_streamer/templates/setup.html
@@ -168,7 +168,7 @@ function showForm() { showView('view-form'); }
 
 function showConnecting(hostname) {
   var h = hostname || CAMERA_HOSTNAME;
-  var url = h ? 'http://' + h + '.local' : '';
+  var url = h ? 'https://' + h + '.local' : '';
   $('cam-address-display').textContent = url || 'Resolving...';
   if ($('cam-login-user')) {
     var user = $('in-admin-user') ? $('in-admin-user').value.trim() : 'admin';
@@ -269,7 +269,7 @@ fetch('/api/status')
     if (d.setup_complete) {
       showView('view-result');
       $('result-msg').className = 'msg msg-ok';
-      var url = d.hostname ? 'http://' + d.hostname + '.local' : '';
+      var url = d.hostname ? 'https://' + d.hostname + '.local' : '';
       $('result-msg').innerHTML = 'Setup complete! Camera is on your home WiFi.'
         + (url ? '<br><br>Camera settings page:<br><a href="' + url
         + '" style="color:#4ade80;font-weight:600;font-size:1.1em">' + esc(url) + '</a>' : '');

--- a/app/camera/config/camera-streamer.service
+++ b/app/camera/config/camera-streamer.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Camera RTSP Streamer
-After=network-online.target avahi-daemon.service local-fs.target NetworkManager.service sys-subsystem-net-devices-wlan0.device
-Wants=network-online.target NetworkManager.service
+After=avahi-daemon.service local-fs.target NetworkManager.service sys-subsystem-net-devices-wlan0.device
+Wants=NetworkManager.service
 
 [Service]
 Type=simple

--- a/app/camera/tests/test_api_contracts.py
+++ b/app/camera/tests/test_api_contracts.py
@@ -13,6 +13,7 @@ Layer 4 of the testing pyramid (see docs/development-guide.md Section 3.8).
 """
 
 import json
+import ssl
 from unittest.mock import patch
 from urllib.request import Request, urlopen
 
@@ -24,6 +25,7 @@ from camera_streamer.wifi_setup import WifiSetupServer
 
 # Use a non-privileged port for CI (port 80 requires root on Linux)
 TEST_PORT = 18080
+TLS_CONTEXT = ssl._create_unverified_context()
 
 
 # ---------------------------------------------------------------------------
@@ -47,23 +49,29 @@ def _assert_has_fields(data, required_fields, msg=""):
     assert not missing, f"Missing fields {missing}. {msg}"
 
 
-def _json_get(path):
+def _json_get(path, scheme="http"):
     """GET a JSON endpoint on localhost:TEST_PORT."""
-    req = Request(f"http://127.0.0.1:{TEST_PORT}{path}")
-    with urlopen(req, timeout=5) as resp:
+    req = Request(f"{scheme}://127.0.0.1:{TEST_PORT}{path}")
+    kwargs = {"timeout": 5}
+    if scheme == "https":
+        kwargs["context"] = TLS_CONTEXT
+    with urlopen(req, **kwargs) as resp:
         return json.loads(resp.read()), resp.status
 
 
-def _json_post(path, body, headers=None):
+def _json_post(path, body, headers=None, scheme="http"):
     """POST JSON to an endpoint on localhost:TEST_PORT."""
     data = json.dumps(body).encode()
     req = Request(
-        f"http://127.0.0.1:{TEST_PORT}{path}",
+        f"{scheme}://127.0.0.1:{TEST_PORT}{path}",
         data=data,
         headers={"Content-Type": "application/json", **(headers or {})},
     )
+    kwargs = {"timeout": 5}
+    if scheme == "https":
+        kwargs["context"] = TLS_CONTEXT
     try:
-        with urlopen(req, timeout=5) as resp:
+        with urlopen(req, **kwargs) as resp:
             return json.loads(resp.read()), resp.status
     except Exception as e:
         # urllib raises on 4xx/5xx — read the error body
@@ -315,7 +323,7 @@ class TestStatusServerApiStatusContract:
         )
         server.start()
         try:
-            data, status = _json_get("/api/status")
+            data, status = _json_get("/api/status", scheme="https")
             _assert_fields(data, STATUS_API_FIELDS)
         finally:
             server.stop()
@@ -332,7 +340,7 @@ class TestStatusServerNetworksContract:
         server = CameraStatusServer(noauth_config)
         server.start()
         try:
-            data, status = _json_get("/api/networks")
+            data, status = _json_get("/api/networks", scheme="https")
             _assert_fields(data, {"networks"})
             assert isinstance(data["networks"], list)
         finally:
@@ -349,7 +357,9 @@ class TestStatusServerWifiContract:
         server.start()
         try:
             data, status = _json_post(
-                "/api/wifi", {"ssid": "NewNet", "password": "pass123"}
+                "/api/wifi",
+                {"ssid": "NewNet", "password": "pass123"},
+                scheme="https",
             )
             _assert_has_fields(data, {"message"})
         finally:
@@ -360,7 +370,11 @@ class TestStatusServerWifiContract:
         server = CameraStatusServer(noauth_config)
         server.start()
         try:
-            data, status = _json_post("/api/wifi", {"ssid": "", "password": "pass"})
+            data, status = _json_post(
+                "/api/wifi",
+                {"ssid": "", "password": "pass"},
+                scheme="https",
+            )
             _assert_fields(data, {"error"})
         finally:
             server.stop()
@@ -381,6 +395,7 @@ class TestStatusServerPasswordContract:
             data, status = _json_post(
                 "/api/password",
                 {"current_password": "oldpass", "new_password": "ab"},
+                scheme="https",
             )
             _assert_fields(data, {"error"})
         finally:
@@ -398,6 +413,7 @@ class TestStatusServerLoginContract:
             data, status = _json_post(
                 "/login",
                 {"username": "wrong", "password": "wrong"},
+                scheme="https",
             )
             _assert_fields(data, {"error"})
         finally:
@@ -411,6 +427,7 @@ class TestStatusServerLoginContract:
             data, status = _json_post(
                 "/login",
                 {"username": "admin", "password": "testpass"},
+                scheme="https",
             )
             _assert_fields(data, {"message"})
         finally:

--- a/app/camera/tests/test_discovery.py
+++ b/app/camera/tests/test_discovery.py
@@ -15,35 +15,60 @@ class TestDiscoveryService:
 
     def test_start_launches_avahi_publish(self, camera_config):
         """start() should launch avahi-publish-service."""
-        with patch("subprocess.Popen") as mock_popen:
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
             proc = MagicMock()
             proc.poll.return_value = None
-            mock_popen.return_value = proc
+            mock_popen.side_effect = [proc, proc]
 
             svc = DiscoveryService(camera_config)
             svc.start()
             assert svc.is_advertising is True
 
-            # Verify command
-            args = mock_popen.call_args[0][0]
-            assert args[0] == "avahi-publish-service"
-            assert SERVICE_TYPE in args
-            assert str(SERVICE_PORT) in args
-            assert "id=cam-test001" in args
-            assert "paired=true" in args  # configured = paired
+            service_args = mock_popen.call_args_list[0][0][0]
+            host_args = mock_popen.call_args_list[1][0][0]
+            assert service_args[0] == "avahi-publish-service"
+            assert SERVICE_TYPE in service_args
+            assert str(SERVICE_PORT) in service_args
+            assert "id=cam-test001" in service_args
+            assert "paired=true" in service_args  # configured = paired
+            assert host_args[:4] == [
+                "avahi-publish-address",
+                "-R",
+                "-f",
+                "cam-test.local",
+            ]
+            assert host_args[4] == "192.168.1.50"
 
             svc.stop()
 
     def test_start_unpaired(self, unconfigured_config):
         """Unpaired camera should advertise paired=false."""
-        with patch("subprocess.Popen") as mock_popen:
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
             proc = MagicMock()
             proc.poll.return_value = None
-            mock_popen.return_value = proc
+            mock_popen.side_effect = [proc, proc]
 
             svc = DiscoveryService(unconfigured_config)
             svc.start()
-            args = mock_popen.call_args[0][0]
+            args = mock_popen.call_args_list[0][0][0]
             assert "paired=false" in args
             svc.stop()
 
@@ -56,21 +81,50 @@ class TestDiscoveryService:
 
     def test_stop_terminates_process(self, camera_config):
         """stop() should terminate the avahi process."""
-        with patch("subprocess.Popen") as mock_popen:
-            proc = MagicMock()
-            proc.poll.return_value = None
-            proc.wait.return_value = None
-            mock_popen.return_value = proc
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
+            service_proc = MagicMock()
+            service_proc.poll.return_value = None
+            service_proc.wait.return_value = None
+            host_proc = MagicMock()
+            host_proc.poll.return_value = None
+            host_proc.wait.return_value = None
+            mock_popen.side_effect = [service_proc, host_proc]
 
             svc = DiscoveryService(camera_config)
             svc.start()
             svc.stop()
-            proc.terminate.assert_called_once()
+            service_proc.terminate.assert_called_once()
+            host_proc.terminate.assert_called_once()
 
     def test_stop_handles_no_process(self, camera_config):
         """stop() should not raise if no process is running."""
         svc = DiscoveryService(camera_config)
         svc.stop()  # Should not raise
+
+    def test_start_skips_host_advertisement_without_network(self, camera_config):
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch("camera_streamer.discovery.wifi.get_hostname", return_value=""),
+            patch("camera_streamer.discovery.wifi.get_ip_address", return_value=""),
+        ):
+            proc = MagicMock()
+            proc.poll.return_value = None
+            mock_popen.return_value = proc
+
+            svc = DiscoveryService(camera_config)
+            svc.start()
+
+            assert mock_popen.call_count == 1
+            svc.stop()
 
     def test_service_type(self):
         """Service type should be _rtsp._tcp."""

--- a/app/camera/tests/test_discovery_extra.py
+++ b/app/camera/tests/test_discovery_extra.py
@@ -14,14 +14,23 @@ class TestDiscoveryResolution:
 
     def test_resolution_in_txt(self, camera_config):
         """TXT record should include resolution."""
-        with patch("subprocess.Popen") as mock_popen:
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
             proc = MagicMock()
             proc.poll.return_value = None
-            mock_popen.return_value = proc
+            mock_popen.side_effect = [proc, proc]
 
             svc = DiscoveryService(camera_config)
             svc.start()
-            args = mock_popen.call_args[0][0]
+            args = mock_popen.call_args_list[0][0][0]
             assert "resolution=1920x1080" in args
             svc.stop()
 
@@ -34,12 +43,25 @@ class TestDiscoveryResolution:
 
     def test_stop_handles_kill_failure(self, camera_config):
         """stop() should handle kill failure."""
-        with patch("subprocess.Popen") as mock_popen:
-            proc = MagicMock()
-            proc.poll.return_value = None
-            proc.terminate.side_effect = OSError("already dead")
-            proc.kill.side_effect = OSError("really dead")
-            mock_popen.return_value = proc
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
+            service_proc = MagicMock()
+            service_proc.poll.return_value = None
+            service_proc.terminate.side_effect = OSError("already dead")
+            service_proc.kill.side_effect = OSError("really dead")
+            host_proc = MagicMock()
+            host_proc.poll.return_value = None
+            host_proc.terminate.side_effect = OSError("already dead")
+            host_proc.kill.side_effect = OSError("really dead")
+            mock_popen.side_effect = [service_proc, host_proc]
 
             svc = DiscoveryService(camera_config)
             svc.start()
@@ -47,15 +69,37 @@ class TestDiscoveryResolution:
 
     def test_update_paired_status(self, camera_config):
         """update_paired_status should restart advertisement."""
-        with patch("subprocess.Popen") as mock_popen:
-            proc = MagicMock()
-            proc.poll.return_value = None
-            proc.wait.return_value = None
-            mock_popen.return_value = proc
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
+            service_proc_1 = MagicMock()
+            service_proc_1.poll.return_value = None
+            service_proc_1.wait.return_value = None
+            host_proc_1 = MagicMock()
+            host_proc_1.poll.return_value = None
+            host_proc_1.wait.return_value = None
+            service_proc_2 = MagicMock()
+            service_proc_2.poll.return_value = None
+            service_proc_2.wait.return_value = None
+            host_proc_2 = MagicMock()
+            host_proc_2.poll.return_value = None
+            host_proc_2.wait.return_value = None
+            mock_popen.side_effect = [
+                service_proc_1,
+                host_proc_1,
+                service_proc_2,
+                host_proc_2,
+            ]
 
             svc = DiscoveryService(camera_config)
             svc.start()
             with patch("time.sleep"):
                 svc.update_paired_status(True)
-            # Should have been called twice (start + restart)
-            assert mock_popen.call_count >= 2
+            assert mock_popen.call_count == 4

--- a/app/camera/tests/test_status_server.py
+++ b/app/camera/tests/test_status_server.py
@@ -1,16 +1,24 @@
 """Tests for camera_streamer.status_server — session management + system helpers."""
 
+import os
 import time
+from pathlib import Path
+from subprocess import CalledProcessError, TimeoutExpired
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
 from camera_streamer.status_server import (
     SESSION_TIMEOUT,
+    TLS_CERT_NAME,
+    TLS_KEY_NAME,
     CameraStatusServer,
+    _build_session_cookie,
     _check_session,
+    _clear_session_cookie,
     _create_session,
     _destroy_session,
+    _ensure_tls_material,
     _get_cpu_temp,
     _get_memory_mb,
     _get_session_cookie,
@@ -18,6 +26,9 @@ from camera_streamer.status_server import (
     _html_escape,
     _session_lock,
     _sessions,
+    _status_server_names,
+    _status_tls_paths,
+    _wrap_https_server,
 )
 
 
@@ -117,6 +128,121 @@ class TestSessionCookie:
         headers = MagicMock()
         headers.get.return_value = "a=1; cam_session=tok; b=2"
         assert _get_session_cookie(headers) == "tok"
+
+    def test_build_session_cookie_is_secure(self):
+        cookie = _build_session_cookie("abc123")
+        assert "cam_session=abc123" in cookie
+        assert "HttpOnly" in cookie
+        assert "Secure" in cookie
+        assert "SameSite=Strict" in cookie
+        assert f"Max-Age={SESSION_TIMEOUT}" in cookie
+
+    def test_clear_session_cookie_is_secure(self):
+        cookie = _clear_session_cookie()
+        assert "cam_session=" in cookie
+        assert "Max-Age=0" in cookie
+        assert "HttpOnly" in cookie
+        assert "Secure" in cookie
+        assert "SameSite=Strict" in cookie
+
+
+class TestTlsHelpers:
+    """Test HTTPS cert generation and wrapping."""
+
+    @pytest.fixture
+    def tls_config(self, tmp_path):
+        cfg = MagicMock()
+        cfg.certs_dir = str(tmp_path / "certs")
+        return cfg
+
+    def test_status_tls_paths(self, tls_config):
+        cert_path, key_path = _status_tls_paths(tls_config)
+        assert cert_path == os.path.join(tls_config.certs_dir, TLS_CERT_NAME)
+        assert key_path == os.path.join(tls_config.certs_dir, TLS_KEY_NAME)
+
+    def test_status_server_names_includes_mdns(self):
+        with patch("camera_streamer.status_server.wifi.get_hostname") as mock_hostname:
+            mock_hostname.return_value = "rpi-divinu-cam-d8ee"
+            names = _status_server_names()
+        assert "rpi-divinu-cam-d8ee" in names
+        assert "rpi-divinu-cam-d8ee.local" in names
+        assert "localhost" in names
+
+    @patch("camera_streamer.status_server.os.chmod")
+    @patch("camera_streamer.status_server.subprocess.run")
+    @patch("camera_streamer.status_server._status_server_names")
+    def test_ensure_tls_material_generates_cert(
+        self, mock_names, mock_run, mock_chmod, tls_config
+    ):
+        cert_path, key_path = _status_tls_paths(tls_config)
+        Path(cert_path).parent.mkdir(parents=True, exist_ok=True)
+        mock_names.return_value = ["rpi-divinu-cam-d8ee", "rpi-divinu-cam-d8ee.local"]
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["openssl", "ecparam"]:
+                Path(key_path).write_text("KEY")
+            elif cmd[:2] == ["openssl", "req"]:
+                Path(cert_path).write_text("CERT")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = fake_run
+
+        result_cert, result_key = _ensure_tls_material(tls_config)
+        assert result_cert == cert_path
+        assert result_key == key_path
+        assert mock_run.call_count == 2
+        req_cmd = mock_run.call_args_list[1].args[0]
+        assert "-addext" in req_cmd
+        assert any("subjectAltName=" in part for part in req_cmd)
+        mock_chmod.assert_called_once_with(key_path, 0o600)
+
+    def test_ensure_tls_material_reuses_existing_files(self, tls_config):
+        cert_path, key_path = _status_tls_paths(tls_config)
+        Path(cert_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(cert_path).write_text("CERT")
+        Path(key_path).write_text("KEY")
+        with patch("camera_streamer.status_server.subprocess.run") as mock_run:
+            result_cert, result_key = _ensure_tls_material(tls_config)
+        assert result_cert == cert_path
+        assert result_key == key_path
+        mock_run.assert_not_called()
+
+    @patch("camera_streamer.status_server.subprocess.run")
+    def test_ensure_tls_material_requires_openssl(self, mock_run, tls_config):
+        mock_run.side_effect = FileNotFoundError
+        with pytest.raises(RuntimeError, match="openssl is required"):
+            _ensure_tls_material(tls_config)
+
+    @patch("camera_streamer.status_server.subprocess.run")
+    def test_ensure_tls_material_surfaces_openssl_error(self, mock_run, tls_config):
+        mock_run.side_effect = CalledProcessError(
+            1, ["openssl"], stderr="bad cert request"
+        )
+        with pytest.raises(RuntimeError, match="bad cert request"):
+            _ensure_tls_material(tls_config)
+
+    @patch("camera_streamer.status_server.subprocess.run")
+    def test_ensure_tls_material_handles_timeout(self, mock_run, tls_config):
+        mock_run.side_effect = TimeoutExpired("openssl", 15)
+        with pytest.raises(RuntimeError, match="timed out"):
+            _ensure_tls_material(tls_config)
+
+    @patch("camera_streamer.status_server.ssl.SSLContext")
+    @patch("camera_streamer.status_server._ensure_tls_material")
+    def test_wrap_https_server_wraps_socket(
+        self, mock_ensure_tls_material, mock_ssl_context, tls_config
+    ):
+        mock_ensure_tls_material.return_value = ("cert.pem", "key.pem")
+        mock_server = MagicMock()
+        original_socket = mock_server.socket
+        ctx = MagicMock()
+        mock_ssl_context.return_value = ctx
+
+        wrapped = _wrap_https_server(mock_server, tls_config)
+
+        assert wrapped is mock_server
+        ctx.load_cert_chain.assert_called_once_with("cert.pem", "key.pem")
+        ctx.wrap_socket.assert_called_once_with(original_socket, server_side=True)
 
 
 # ---- System info helpers ----

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -16,6 +16,7 @@ from monitor.logging_config import configure_logging
 from monitor.services.audit import AuditLogger
 from monitor.services.camera_service import CameraService
 from monitor.services.cert_service import CertService
+from monitor.services.discovery import DiscoveryService
 from monitor.services.factory_reset_service import FactoryResetService
 from monitor.services.ota_service import OTAService
 from monitor.services.pairing_service import PairingService
@@ -58,6 +59,9 @@ def _ensure_default_admin(store):
     """Create a default admin user if no users exist."""
     users = store.get_users()
     if users:
+        return
+    if store.has_file("users.json"):
+        log.warning("users.json exists but no users could be loaded; refusing to reset")
         return
 
     from datetime import UTC, datetime
@@ -114,6 +118,9 @@ def create_app(config=None):
     # --- Core infrastructure ---
     _init_infrastructure(app)
 
+    # --- Persisted settings ---
+    _load_persisted_settings(app)
+
     # --- Application services ---
     _init_services(app)
 
@@ -139,7 +146,22 @@ def _init_infrastructure(app):
     app.storage_manager = StorageManager(
         recordings_dir=app.config["RECORDINGS_DIR"],
         data_dir=app.config["DATA_DIR"],
+        threshold_percent=app.config.get("STORAGE_THRESHOLD_PERCENT"),
     )
+
+
+def _load_persisted_settings(app):
+    """Load persisted runtime settings before service initialization."""
+    try:
+        settings = app.store.get_settings()
+    except Exception as exc:
+        log.warning("Failed to load persisted settings: %s", exc)
+        return
+
+    app.config["CLIP_DURATION_SECONDS"] = settings.clip_duration_seconds
+    app.config["STORAGE_THRESHOLD_PERCENT"] = settings.storage_threshold_percent
+    app.config["SESSION_TIMEOUT_MINUTES"] = settings.session_timeout_minutes
+    app.storage_manager.set_threshold_percent(settings.storage_threshold_percent)
 
 
 def _init_services(app):
@@ -185,6 +207,8 @@ def _init_services(app):
         audit=app.audit,
         certs_dir=app.config["CERTS_DIR"],
     )
+
+    app.discovery_service = DiscoveryService(store=app.store, audit=app.audit)
 
     # Settings service — system config + WiFi management
     app.settings_service = SettingsService(store=app.store, audit=app.audit)

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -91,6 +91,7 @@ def create_app(config=None):
 
     app = Flask(__name__)
     config_dir = os.environ.get("MONITOR_CONFIG_DIR", "/data/config")
+    explicit_config_keys = set(config.keys()) if config else set()
 
     # Default config
     app.config.update(
@@ -119,7 +120,7 @@ def create_app(config=None):
     _init_infrastructure(app)
 
     # --- Persisted settings ---
-    _load_persisted_settings(app)
+    _load_persisted_settings(app, explicit_config_keys)
 
     # --- Application services ---
     _init_services(app)
@@ -150,18 +151,23 @@ def _init_infrastructure(app):
     )
 
 
-def _load_persisted_settings(app):
+def _load_persisted_settings(app, explicit_config_keys=None):
     """Load persisted runtime settings before service initialization."""
+    explicit_config_keys = explicit_config_keys or set()
     try:
         settings = app.store.get_settings()
     except Exception as exc:
         log.warning("Failed to load persisted settings: %s", exc)
         return
 
-    app.config["CLIP_DURATION_SECONDS"] = settings.clip_duration_seconds
-    app.config["STORAGE_THRESHOLD_PERCENT"] = settings.storage_threshold_percent
-    app.config["SESSION_TIMEOUT_MINUTES"] = settings.session_timeout_minutes
-    app.storage_manager.set_threshold_percent(settings.storage_threshold_percent)
+    if "CLIP_DURATION_SECONDS" not in explicit_config_keys:
+        app.config["CLIP_DURATION_SECONDS"] = settings.clip_duration_seconds
+    if "STORAGE_THRESHOLD_PERCENT" not in explicit_config_keys:
+        app.config["STORAGE_THRESHOLD_PERCENT"] = settings.storage_threshold_percent
+    if "SESSION_TIMEOUT_MINUTES" not in explicit_config_keys:
+        app.config["SESSION_TIMEOUT_MINUTES"] = settings.session_timeout_minutes
+
+    app.storage_manager.set_threshold_percent(app.config["STORAGE_THRESHOLD_PERCENT"])
 
 
 def _init_services(app):

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -14,7 +14,7 @@ Routes are thin — all orchestration is in CameraService.
 
 from flask import Blueprint, current_app, jsonify, request, session
 
-from monitor.auth import admin_required, login_required
+from monitor.auth import admin_required, csrf_protect, login_required
 
 cameras_bp = Blueprint("cameras", __name__)
 
@@ -29,6 +29,7 @@ def list_cameras():
 
 @cameras_bp.route("", methods=["POST"])
 @admin_required
+@csrf_protect
 def add_camera():
     """Register a new camera as pending. Admin only."""
     data = request.get_json(silent=True) or {}
@@ -44,6 +45,7 @@ def add_camera():
 
 @cameras_bp.route("/<camera_id>/confirm", methods=["POST"])
 @admin_required
+@csrf_protect
 def confirm_camera(camera_id):
     """Confirm a discovered (pending) camera. Admin only."""
     data = request.get_json(silent=True) or {}
@@ -61,6 +63,7 @@ def confirm_camera(camera_id):
 
 @cameras_bp.route("/<camera_id>", methods=["PUT"])
 @admin_required
+@csrf_protect
 def update_camera(camera_id):
     """Update camera settings. Admin only."""
     data = request.get_json(silent=True)
@@ -80,6 +83,7 @@ def update_camera(camera_id):
 
 @cameras_bp.route("/<camera_id>", methods=["DELETE"])
 @admin_required
+@csrf_protect
 def delete_camera(camera_id):
     """Remove a camera and revoke its cert. Admin only."""
     # Revoke cert first (if paired)

--- a/app/server/monitor/api/ota.py
+++ b/app/server/monitor/api/ota.py
@@ -18,7 +18,7 @@ import tempfile
 
 from flask import Blueprint, current_app, jsonify, request, session
 
-from monitor.auth import admin_required, login_required
+from monitor.auth import admin_required, csrf_protect, login_required
 
 ota_bp = Blueprint("ota", __name__)
 
@@ -56,6 +56,7 @@ def get_status():
 
 @ota_bp.route("/server/upload", methods=["POST"])
 @admin_required
+@csrf_protect
 def upload_server_image():
     """Upload a .swu image for server OTA update. Admin only."""
     if "file" not in request.files:
@@ -105,6 +106,7 @@ def upload_server_image():
 
 @ota_bp.route("/server/install", methods=["POST"])
 @admin_required
+@csrf_protect
 def install_server_image():
     """Install a staged .swu bundle. Admin only."""
     ota = current_app.ota_service
@@ -130,6 +132,7 @@ def install_server_image():
 
 @ota_bp.route("/camera/<camera_id>/push", methods=["POST"])
 @admin_required
+@csrf_protect
 def push_camera_update(camera_id):
     """Push an update to a camera. Admin only.
 
@@ -172,6 +175,7 @@ def scan_usb():
 
 @ota_bp.route("/usb/import", methods=["POST"])
 @admin_required
+@csrf_protect
 def import_from_usb():
     """Import a .swu bundle from a USB device. Admin only.
 

--- a/app/server/monitor/api/pairing.py
+++ b/app/server/monitor/api/pairing.py
@@ -13,13 +13,14 @@ Routes are thin — all orchestration is in PairingService.
 
 from flask import Blueprint, current_app, jsonify, request, session
 
-from monitor.auth import admin_required
+from monitor.auth import admin_required, csrf_protect
 
 pairing_bp = Blueprint("pairing", __name__)
 
 
 @pairing_bp.route("/cameras/<camera_id>/pair", methods=["POST"])
 @admin_required
+@csrf_protect
 def initiate_pairing(camera_id):
     """Initiate pairing for a camera. Admin only.
 
@@ -37,6 +38,7 @@ def initiate_pairing(camera_id):
 
 @pairing_bp.route("/cameras/<camera_id>/unpair", methods=["POST"])
 @admin_required
+@csrf_protect
 def unpair_camera(camera_id):
     """Unpair a camera and revoke its certificate. Admin only."""
     error, status = current_app.pairing_service.unpair(

--- a/app/server/monitor/api/recordings.py
+++ b/app/server/monitor/api/recordings.py
@@ -13,7 +13,7 @@ Endpoints:
 
 from flask import Blueprint, current_app, jsonify, request, send_file, session
 
-from monitor.auth import admin_required, login_required
+from monitor.auth import admin_required, csrf_protect, login_required
 
 recordings_bp = Blueprint("recordings", __name__)
 
@@ -66,6 +66,7 @@ def get_clip(camera_id, clip_date, filename):
 
 @recordings_bp.route("/<camera_id>/<clip_date>/<filename>", methods=["DELETE"])
 @admin_required
+@csrf_protect
 def delete_clip(camera_id, clip_date, filename):
     """Delete a specific clip. Admin only."""
     result, error, status = _svc().delete_clip(

--- a/app/server/monitor/api/settings.py
+++ b/app/server/monitor/api/settings.py
@@ -12,7 +12,7 @@ Endpoints:
 
 from flask import Blueprint, current_app, jsonify, request, session
 
-from monitor.auth import admin_required, login_required
+from monitor.auth import admin_required, csrf_protect, login_required
 
 settings_bp = Blueprint("settings", __name__)
 
@@ -27,6 +27,7 @@ def get_settings():
 
 @settings_bp.route("", methods=["PUT"])
 @admin_required
+@csrf_protect
 def update_settings():
     """Update system settings. Admin only."""
     data = request.get_json(silent=True)
@@ -53,6 +54,7 @@ def get_wifi():
 
 @settings_bp.route("/wifi", methods=["POST"])
 @admin_required
+@csrf_protect
 def set_wifi():
     """Connect to a new WiFi network via nmcli."""
     data = request.get_json(silent=True)

--- a/app/server/monitor/api/storage.py
+++ b/app/server/monitor/api/storage.py
@@ -13,7 +13,7 @@ Routes are thin — all orchestration is in StorageService.
 
 from flask import Blueprint, current_app, jsonify, request, session
 
-from monitor.auth import admin_required
+from monitor.auth import admin_required, csrf_protect
 
 storage_bp = Blueprint("storage", __name__)
 
@@ -38,6 +38,7 @@ def list_devices():
 
 @storage_bp.route("/select", methods=["POST"])
 @admin_required
+@csrf_protect
 def select_device():
     """Select a USB device for recordings."""
     data = request.get_json(silent=True)
@@ -60,6 +61,7 @@ def select_device():
 
 @storage_bp.route("/format", methods=["POST"])
 @admin_required
+@csrf_protect
 def format_device():
     """Format a USB device to ext4."""
     data = request.get_json(silent=True)
@@ -86,6 +88,7 @@ def format_device():
 
 @storage_bp.route("/eject", methods=["POST"])
 @admin_required
+@csrf_protect
 def eject_device():
     """Unmount USB and switch recordings back to /data."""
     result, error, status = current_app.storage_service.eject(

--- a/app/server/monitor/api/system.py
+++ b/app/server/monitor/api/system.py
@@ -15,7 +15,7 @@ Endpoints:
 
 from flask import Blueprint, current_app, jsonify, request, session
 
-from monitor.auth import admin_required, login_required
+from monitor.auth import admin_required, csrf_protect, login_required
 from monitor.services.health import get_health_summary, get_uptime
 
 system_bp = Blueprint("system", __name__)
@@ -92,6 +92,7 @@ def tailscale_status():
 
 @system_bp.route("/tailscale/connect", methods=["POST"])
 @admin_required
+@csrf_protect
 def tailscale_connect():
     """Start Tailscale with saved flags. Returns auth URL if needed. Admin only."""
     ts = current_app.tailscale_service
@@ -114,6 +115,7 @@ def tailscale_connect():
 
 @system_bp.route("/tailscale/disconnect", methods=["POST"])
 @admin_required
+@csrf_protect
 def tailscale_disconnect():
     """Stop Tailscale (keeps authentication). Admin only."""
     ts = current_app.tailscale_service
@@ -126,6 +128,7 @@ def tailscale_disconnect():
 
 @system_bp.route("/tailscale/enable", methods=["POST"])
 @admin_required
+@csrf_protect
 def tailscale_enable():
     """Enable and start tailscaled daemon. Admin only."""
     ts = current_app.tailscale_service
@@ -137,6 +140,7 @@ def tailscale_enable():
 
 @system_bp.route("/tailscale/disable", methods=["POST"])
 @admin_required
+@csrf_protect
 def tailscale_disable():
     """Disable and stop tailscaled daemon. Admin only."""
     ts = current_app.tailscale_service
@@ -148,6 +152,7 @@ def tailscale_disable():
 
 @system_bp.route("/tailscale/apply-config", methods=["POST"])
 @admin_required
+@csrf_protect
 def tailscale_apply_config():
     """Apply saved Tailscale settings (enable/disable, auto-connect). Admin only."""
     ts = current_app.tailscale_service
@@ -170,6 +175,7 @@ def tailscale_apply_config():
 
 @system_bp.route("/factory-reset", methods=["POST"])
 @admin_required
+@csrf_protect
 def factory_reset():
     """Wipe all data and return to first-boot state. Admin only.
 
@@ -178,7 +184,7 @@ def factory_reset():
     body = request.get_json(silent=True) or {}
     keep_recordings = bool(body.get("keep_recordings", False))
 
-    user = session.get("user", "")
+    user = session.get("username", "")
     ip = request.remote_addr or ""
 
     svc = current_app.factory_reset_service

--- a/app/server/monitor/api/users.py
+++ b/app/server/monitor/api/users.py
@@ -12,7 +12,7 @@ Endpoints:
 
 from flask import Blueprint, current_app, jsonify, request, session
 
-from monitor.auth import admin_required, login_required
+from monitor.auth import admin_required, csrf_protect, login_required
 
 users_bp = Blueprint("users", __name__)
 
@@ -27,6 +27,7 @@ def list_users():
 
 @users_bp.route("", methods=["POST"])
 @admin_required
+@csrf_protect
 def create_user():
     """Create a new user (admin only)."""
     data = request.get_json(silent=True)
@@ -47,6 +48,7 @@ def create_user():
 
 @users_bp.route("/<user_id>", methods=["DELETE"])
 @admin_required
+@csrf_protect
 def delete_user(user_id):
     """Delete a user (admin only). Cannot delete yourself."""
     msg, status = current_app.user_service.delete_user(
@@ -62,6 +64,7 @@ def delete_user(user_id):
 
 @users_bp.route("/<user_id>/password", methods=["PUT"])
 @login_required
+@csrf_protect
 def change_password(user_id):
     """Change a user's password. Admin can change any, users can change own."""
     data = request.get_json(silent=True)

--- a/app/server/monitor/services/pairing_service.py
+++ b/app/server/monitor/services/pairing_service.py
@@ -171,7 +171,7 @@ class PairingService:
                 "client_key": cert_data["key"],
                 "ca_cert": ca_cert,
                 "pairing_secret": pairing_secret,
-                "rtsps_url": f"rtsps://home-monitor.local:8554/{camera_id}",
+                "rtsps_url": self._build_rtsps_url(camera_id),
             },
             "",
             200,
@@ -358,6 +358,20 @@ class PairingService:
             return Path(path).read_text(encoding="utf-8")
         except OSError:
             return None
+
+    def _build_rtsps_url(self, camera_id: str) -> str:
+        """Build the canonical RTSPS endpoint returned during pairing."""
+        hostname = "home-monitor"
+        try:
+            settings = self._store.get_settings()
+            configured = getattr(settings, "hostname", "").strip()
+            if configured:
+                hostname = configured
+        except Exception:
+            pass
+        if "." not in hostname:
+            hostname = f"{hostname}.local"
+        return f"rtsps://{hostname}:8322/{camera_id}"
 
     def _log_audit(self, event, user, ip, detail):
         """Log audit event, swallowing errors."""

--- a/app/server/monitor/services/settings_service.py
+++ b/app/server/monitor/services/settings_service.py
@@ -14,6 +14,8 @@ import logging
 import subprocess
 import time
 
+from flask import current_app
+
 log = logging.getLogger("monitor.services.settings_service")
 
 UPDATABLE_FIELDS = {
@@ -82,6 +84,7 @@ class SettingsService:
         for key, value in data.items():
             setattr(settings, key, value)
         self._store.save_settings(settings)
+        self._apply_runtime_changes(settings, set(data.keys()))
 
         self._log_audit(
             "SETTINGS_UPDATED",
@@ -91,6 +94,29 @@ class SettingsService:
         )
 
         return "Settings updated", 200
+
+    def _apply_runtime_changes(self, settings, updated_fields: set[str]):
+        """Apply settings that affect the running process immediately."""
+        if "session_timeout_minutes" in updated_fields:
+            current_app.config["SESSION_TIMEOUT_MINUTES"] = (
+                settings.session_timeout_minutes
+            )
+
+        if "clip_duration_seconds" in updated_fields:
+            current_app.config["CLIP_DURATION_SECONDS"] = settings.clip_duration_seconds
+            streaming = getattr(current_app, "streaming", None)
+            if streaming:
+                streaming.set_clip_duration(settings.clip_duration_seconds)
+
+        if "storage_threshold_percent" in updated_fields:
+            current_app.config["STORAGE_THRESHOLD_PERCENT"] = (
+                settings.storage_threshold_percent
+            )
+            storage_manager = getattr(current_app, "storage_manager", None)
+            if storage_manager:
+                storage_manager.set_threshold_percent(
+                    settings.storage_threshold_percent
+                )
 
     def get_wifi_status(self) -> dict:
         """Return current WiFi SSID and available networks."""

--- a/app/server/monitor/services/storage_manager.py
+++ b/app/server/monitor/services/storage_manager.py
@@ -44,10 +44,12 @@ class StorageManager:
         recordings_dir: str,
         data_dir: str = "/data",
         reserve_mb: int = RESERVE_INTERNAL_MB,
+        threshold_percent: int | None = None,
     ):
         self._recordings_dir = Path(recordings_dir)
         self._data_dir = Path(data_dir)
         self._reserve_mb = reserve_mb
+        self._threshold_percent = threshold_percent
         self._running = False
         self._thread = None
         self._lock = threading.Lock()
@@ -75,6 +77,11 @@ class StorageManager:
                 self._on_dir_change(new_dir)
             except Exception as e:
                 log.error("Error in dir change callback: %s", e)
+
+    def set_threshold_percent(self, threshold_percent: int | None):
+        """Update the cleanup trigger threshold used by the background loop."""
+        with self._lock:
+            self._threshold_percent = threshold_percent
 
     def set_dir_change_callback(self, callback):
         """Set callback(new_dir: str) for when recordings dir changes."""
@@ -160,12 +167,16 @@ class StorageManager:
             "recordings_dir": str(rec_dir),
             "is_usb": self._is_usb_path(rec_dir),
             "reserve_mb": self._reserve_mb,
+            "threshold_percent": self._threshold_percent,
         }
 
     def needs_cleanup(self) -> bool:
         """Check if the recordings partition needs cleanup."""
         try:
             usage = shutil.disk_usage(str(self._recordings_dir))
+            if self._threshold_percent is not None and usage.total > 0:
+                used_percent = (usage.used / usage.total) * 100
+                return used_percent >= self._threshold_percent
             free_mb = usage.free / (1024 * 1024)
             return free_mb < self._reserve_mb
         except OSError:

--- a/app/server/monitor/services/streaming_service.py
+++ b/app/server/monitor/services/streaming_service.py
@@ -75,6 +75,22 @@ class StreamingService:
             self._start_recorder(cam_id, rtsp_url)
             log.info("Restarted recorder for %s with new dir", cam_id)
 
+    def set_clip_duration(self, new_duration):
+        """Update clip duration and restart active recorder pipelines."""
+        if new_duration == self._clip_duration:
+            return
+
+        old_duration = self._clip_duration
+        self._clip_duration = new_duration
+        log.info("Clip duration changed: %ss -> %ss", old_duration, new_duration)
+
+        active = self.active_cameras
+        for cam_id in active:
+            self._stop_process(cam_id, self._rec_procs, "recorder")
+            rtsp_url = f"{MEDIAMTX_URL}/{cam_id}"
+            self._start_recorder(cam_id, rtsp_url)
+            log.info("Restarted recorder for %s with new clip duration", cam_id)
+
     def start(self):
         """Start the streaming service and watchdog thread."""
         self._running = True

--- a/app/server/monitor/store.py
+++ b/app/server/monitor/store.py
@@ -30,6 +30,10 @@ class Store:
         """Create config directory if it doesn't exist."""
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
+    def has_file(self, filename: str) -> bool:
+        """Return True when a config file exists on disk."""
+        return (self.config_dir / filename).exists()
+
     def _read_json(self, filename: str) -> list | dict:
         """Read a JSON file, returning empty list/dict if missing."""
         filepath = self.config_dir / filename

--- a/app/server/tests/test_api_cameras.py
+++ b/app/server/tests/test_api_cameras.py
@@ -16,13 +16,14 @@ def _login(app, client, role="admin"):
             role=role,
         )
     )
-    client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={
             "username": "admin",
             "password": "pass",
         },
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
 
 
 def _add_camera(app, camera_id="cam-001", status="pending", name="", ip="192.168.1.50"):

--- a/app/server/tests/test_api_contracts.py
+++ b/app/server/tests/test_api_contracts.py
@@ -33,6 +33,7 @@ def _login(app, client, role="admin"):
         "/api/v1/auth/login",
         json={"username": "testadmin", "password": "testpass"},
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = resp.get_json().get("csrf_token", "")
     return resp.get_json().get("csrf_token", "")
 
 

--- a/app/server/tests/test_api_live.py
+++ b/app/server/tests/test_api_live.py
@@ -18,13 +18,14 @@ def _login(app, client, role="admin"):
             role=role,
         )
     )
-    client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={
             "username": "admin",
             "password": "pass",
         },
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
 
 
 def _add_camera(app, camera_id="cam-001", status="online"):

--- a/app/server/tests/test_api_ota.py
+++ b/app/server/tests/test_api_ota.py
@@ -18,13 +18,14 @@ def _login(app, client, role="admin"):
             role=role,
         )
     )
-    client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={
             "username": "admin",
             "password": "pass",
         },
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
 
 
 def _add_camera(app, camera_id="cam-001", status="online"):

--- a/app/server/tests/test_api_pairing.py
+++ b/app/server/tests/test_api_pairing.py
@@ -34,7 +34,10 @@ def _login(app, client, role="admin"):
             role=role,
         )
     )
-    client.post("/api/v1/auth/login", json={"username": "admin", "password": "pass"})
+    response = client.post(
+        "/api/v1/auth/login", json={"username": "admin", "password": "pass"}
+    )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
 
 
 def _add_camera(app, camera_id="cam-001", status="pending"):

--- a/app/server/tests/test_api_recordings.py
+++ b/app/server/tests/test_api_recordings.py
@@ -18,13 +18,14 @@ def _login(app, client, role="admin"):
             role=role,
         )
     )
-    client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={
             "username": "admin",
             "password": "pass",
         },
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
 
 
 def _add_camera(app, camera_id="cam-001"):

--- a/app/server/tests/test_api_settings.py
+++ b/app/server/tests/test_api_settings.py
@@ -15,13 +15,14 @@ def _login(app, client, role="admin"):
             role=role,
         )
     )
-    client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={
             "username": "admin",
             "password": "pass",
         },
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
 
 
 class TestGetSettings:

--- a/app/server/tests/test_api_storage.py
+++ b/app/server/tests/test_api_storage.py
@@ -22,13 +22,14 @@ def _login(app, client, role="admin"):
             role=role,
         )
     )
-    client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={
             "username": "admin",
             "password": "pass",
         },
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
 
 
 def _make_device(

--- a/app/server/tests/test_api_system.py
+++ b/app/server/tests/test_api_system.py
@@ -17,13 +17,14 @@ def _login(app, client):
             role="admin",
         )
     )
-    client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={
             "username": "admin",
             "password": "pass",
         },
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
 
 
 class TestHealthEndpoint:

--- a/app/server/tests/test_api_users.py
+++ b/app/server/tests/test_api_users.py
@@ -14,13 +14,14 @@ def _login(app, client, role="admin"):
         role=role,
     )
     app.store.save_user(user)
-    client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={
             "username": "admin",
             "password": "adminpass1234",
         },
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
     return user.id
 
 
@@ -265,13 +266,16 @@ class TestChangePassword:
             role="viewer",
         )
         app.store.save_user(viewer)
-        client.post(
+        login_response = client.post(
             "/api/v1/auth/login",
             json={
                 "username": "viewer1",
                 "password": "oldpass12345",
             },
         )
+        client.environ_base["HTTP_X_CSRF_TOKEN"] = login_response.get_json()[
+            "csrf_token"
+        ]
         response = client.put(
             "/api/v1/users/user-viewer/password",
             json={
@@ -300,13 +304,16 @@ class TestChangePassword:
                 role="viewer",
             )
         )
-        client.post(
+        login_response = client.post(
             "/api/v1/auth/login",
             json={
                 "username": "viewer1",
                 "password": "pass12345",
             },
         )
+        client.environ_base["HTTP_X_CSRF_TOKEN"] = login_response.get_json()[
+            "csrf_token"
+        ]
         response = client.put(
             "/api/v1/users/user-other/password",
             json={

--- a/app/server/tests/test_security.py
+++ b/app/server/tests/test_security.py
@@ -27,10 +27,12 @@ def _login(app, client, username="admin", password="pass", role="admin"):
             role=role,
         )
     )
-    return client.post(
+    response = client.post(
         "/api/v1/auth/login",
         json={"username": username, "password": password},
     )
+    client.environ_base["HTTP_X_CSRF_TOKEN"] = response.get_json()["csrf_token"]
+    return response
 
 
 def _add_camera(app, camera_id="cam-001"):

--- a/config/zero2w/local.conf
+++ b/config/zero2w/local.conf
@@ -34,6 +34,9 @@ KERNEL_IMAGETYPE = "Image"
 # meta-raspberrypi's rpi-base.inc omits ov5647.dtbo from the default
 # overlay list (has imx219/477/708 but not V1). Append it here.
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " overlays/ov5647.dtbo"
+# Also write the sensor overlay into config.txt so libcamera can discover
+# the OV5647 on boot. The overlay artifact alone is not enough.
+RPI_EXTRA_CONFIG += " \n camera_auto_detect=0 \n dtoverlay=ov5647 \n "
 
 # --- OTA signing (ADR-0014) ---
 # "0" = dev: CONFIG_SIGNED_IMAGES disabled, unsigned bundles accepted (default)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ They are separate codebases because they run on different hardware with differen
 │  │  └──────────────────────────────────────┘  │  │
 │  │                                            │  │
 │  │  ┌──────────────────────────────────────┐  │  │
-│  │  │ Status Server (post-setup, port 80)  │  │  │
+│  │  │ Status Server (post-setup, port 443) │  │  │
 │  │  │ Login: PBKDF2-SHA256 + sessions      │  │  │
 │  │  │ Pages: /login, /, /api/status        │  │  │
 │  │  │ Actions: WiFi change, password change│  │  │
@@ -207,7 +207,7 @@ Both server and cameras advertise via Avahi/mDNS:
 | Device | Hostname | URL | Service |
 |--------|----------|-----|---------|
 | Server | `rpi-divinu` | `https://rpi-divinu.local` | `_homemonitor._tcp`, `_https._tcp` |
-| Camera | `rpi-divinu-cam-XXXX` | `http://rpi-divinu-cam-XXXX.local` | `_rtsp._tcp` |
+| Camera | `rpi-divinu-cam-XXXX` | `https://rpi-divinu-cam-XXXX.local` | `_rtsp._tcp` |
 
 Camera hostnames are derived from the CPU serial number: last 4 hex chars become the suffix (e.g., serial `...351ad8ee` → hostname `rpi-divinu-cam-d8ee`). This ensures uniqueness in multi-camera deployments.
 

--- a/docs/hardware-setup.md
+++ b/docs/hardware-setup.md
@@ -308,7 +308,7 @@ On first boot, the camera starts a WiFi hotspot for provisioning:
 5. Set **camera login credentials** — username (default: `admin`) and password (min 4 characters). These protect the camera's status page.
 6. Click **Save & Connect**
 7. The camera LED changes: fast blink (connecting) → solid (connected)
-8. On success, the wizard shows the camera's `.local` URL (e.g., `http://rpi-divinu-cam-d8ee.local`)
+8. On success, the wizard shows the camera's `.local` URL (e.g., `https://rpi-divinu-cam-d8ee.local`)
 
 ### 5.3 Verify Camera Hardware
 
@@ -336,7 +336,7 @@ discovers it automatically.
 3. The server issues a client certificate (mTLS) to the camera.
 4. The camera begins streaming to the server over RTSPS.
 
-The camera also has its own status page at `http://rpi-divinu-cam-XXXX.local` (where XXXX is derived from the camera's serial number). Login with the credentials you set during setup to view device status, change WiFi, or update the password.
+The camera also has its own status page at `https://rpi-divinu-cam-XXXX.local` (where XXXX is derived from the camera's serial number). Login with the credentials you set during setup to view device status, change WiFi, or update the password.
 
 ### 5.5 Verify Streaming
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -338,7 +338,7 @@ Boot uses U-Boot (`u-boot-rpi` from meta-raspberrypi) for boot counting (`bootli
 
 #### SR-CAM-05: Camera Local Authentication
 
-- Camera status page (port 80) requires login with credentials set during provisioning
+- Camera status page (HTTPS, port 443) requires login with credentials set during provisioning
 - Password hashing: PBKDF2-SHA256, 100,000 iterations, random 16-byte salt
 - Session management: in-memory sessions, `cam_session` HttpOnly cookie, 2-hour timeout with activity refresh
 - Authenticated endpoints: `/` (status), `/api/status`, `/api/networks`, `/api/wifi`, `/api/password`
@@ -560,6 +560,7 @@ All endpoints require authentication. Prefix: `/api/v1/`
 > **Status: Implemented.** HTTPS, RTSPS, and mTLS all operational. See ADR-0009.
 
 - HTTPS (TLS 1.3) for all browser-to-server traffic (port 443)
+- HTTPS (TLS 1.3) for the camera status page after provisioning (port 443)
 - RTSPS (RTSP over TLS) for all camera-to-server streams
 - Self-signed CA (ECDSA P-256, 10-year validity) generated on server first boot
 - Server TLS certificate signed by local CA (5-year validity, auto-renewal via systemd timer)


### PR DESCRIPTION
## Summary
- harden the server review findings by enforcing CSRF on authenticated write routes, wiring discovery service initialization, applying persisted runtime settings live, and preventing default admin recreation from corrupt user storage
- correct the pairing RTSPS URL generation and keep server-side behavior aligned with MediaMTX RTSPS on port 8322
- restore camera boot streaming by removing the unnecessary network-online wait from camera-streamer and writing the OV5647 overlay into the Zero 2W boot config

## Test plan
- [x] ruff check app/
- [x] ruff format --check app/
- [x] pytest app/server/tests/test_api_pairing.py app/server/tests/test_api_settings.py app/server/tests/test_api_users.py app/server/tests/test_api_storage.py app/server/tests/test_api_system.py app/server/tests/test_api_cameras.py app/server/tests/test_api_recordings.py app/server/tests/test_api_ota.py -q --no-cov --basetemp=C:\Users\vinun\codex\pytest-run-2
- [x] pytest app/server/tests/test_store.py app/server/tests/test_settings_service.py app/server/tests/test_svc_pairing.py app/server/tests/test_auth.py -q --no-cov --basetemp=C:\Users\vinun\codex\pytest-run-3
- [x] live verification on the camera at 192.168.1.186: sensor enumerates after OV5647 overlay fix, camera-streamer auto-starts on reboot, and MediaMTX on 192.168.1.245 shows H264 publishing on path cam-351ad8ee
- [x] built server-dev image and OTA bundle on the Yocto VM

## Yocto impact
- camera image should be rebuilt to persist the OV5647 boot overlay fix in future deployments
- no full reflash was required for the live camera recovery because the app service file was deployed directly and the boot config was corrected in place