### PR TITLE
config: move camera overlay into machine config

### DIFF
--- a/config/zero2w/local.conf
+++ b/config/zero2w/local.conf
@@ -7,7 +7,7 @@
 # =============================================================
 
 # --- Machine ---
-MACHINE = "raspberrypi0-2w-64"
+MACHINE = "home-monitor-camera"
 
 # --- Distribution ---
 DISTRO = "home-monitor"
@@ -28,15 +28,6 @@ GPU_MEM = "128"
 RASPBERRYPI_CAMERA = "1"
 MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-rpidistro-bcm43436s"
 KERNEL_IMAGETYPE = "Image"
-
-# --- Camera support ---
-# PiHut ZeroCam uses OV5647 sensor (RPi Camera V1).
-# meta-raspberrypi's rpi-base.inc omits ov5647.dtbo from the default
-# overlay list (has imx219/477/708 but not V1). Append it here.
-RPI_KERNEL_DEVICETREE_OVERLAYS:append = " overlays/ov5647.dtbo"
-# Also write the sensor overlay into config.txt so libcamera can discover
-# the OV5647 on boot. The overlay artifact alone is not enough.
-RPI_EXTRA_CONFIG += " \n camera_auto_detect=0 \n dtoverlay=ov5647 \n "
 
 # --- OTA signing (ADR-0014) ---
 # "0" = dev: CONFIG_SIGNED_IMAGES disabled, unsigned bundles accepted (default)

--- a/docs/build-setup.md
+++ b/docs/build-setup.md
@@ -34,10 +34,10 @@ This single script:
 1. Installs all Yocto build dependencies (apt packages)
 2. Installs Python test dependencies (pytest, pytest-cov)
 3. Sets the locale to `en_US.UTF-8`
-4. Creates 8 GB swap file (if not already present)
-5. Fixes Ubuntu 24.04 AppArmor restriction for bitbake
+4. Creates an 8 GB swap file if one is not already present
+5. Fixes the Ubuntu 24.04 AppArmor restriction for bitbake
 
-After it completes, you're ready to build.
+After it completes, you are ready to build.
 
 ---
 
@@ -45,7 +45,7 @@ After it completes, you're ready to build.
 
 ### System Packages (apt)
 
-```
+```text
 gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat
 cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping
 python3-git python3-jinja2 libegl1 libsdl1.2-dev pylint xterm
@@ -57,7 +57,7 @@ These are the [Yocto Project required packages](https://docs.yoctoproject.org/re
 
 ### Python Test Packages (pip)
 
-```
+```text
 pytest >= 8.0
 pytest-cov >= 5.0
 flask >= 3.0
@@ -101,8 +101,8 @@ Installed automatically by the setup script for running unit tests.
 |--------|---------------|
 | server-dev | `build/tmp/deploy/images/raspberrypi4-64/home-monitor-image-dev-*.wic.bz2` |
 | server-prod | `build/tmp/deploy/images/raspberrypi4-64/home-monitor-image-prod-*.wic.bz2` |
-| camera-dev | `build-zero2w/tmp/deploy/images/raspberrypi0-2w-64/home-camera-image-dev-*.wic.bz2` |
-| camera-prod | `build-zero2w/tmp/deploy/images/raspberrypi0-2w-64/home-camera-image-prod-*.wic.bz2` |
+| camera-dev | `build-zero2w/tmp-glibc/deploy/images/raspberrypi0-2w-64/home-camera-image-dev-*.wic.bz2` |
+| camera-prod | `build-zero2w/tmp-glibc/deploy/images/raspberrypi0-2w-64/home-camera-image-prod-*.wic.bz2` |
 
 ### 4.4 Build Times
 
@@ -117,7 +117,7 @@ Installed automatically by the setup script for running unit tests.
 
 ## 5. Custom Distro: `home-monitor`
 
-We use a **custom distribution** instead of the reference `poky` distro. This is industry best practice for product development.
+We use a custom distribution instead of the reference `poky` distro. This is industry best practice for product development.
 
 **What the distro controls** (in `meta-home-monitor/conf/distro/home-monitor.conf`):
 - Init system: systemd (not sysvinit)
@@ -128,22 +128,30 @@ We use a **custom distribution** instead of the reference `poky` distro. This is
 - Build settings: SPDX license manifests, rm_work
 
 **What local.conf controls** (machine-specific only):
-- `MACHINE` — which board to build for
-- `GPU_MEM` — GPU memory split
-- `MACHINE_EXTRA_RRECOMMENDS` — WiFi firmware for specific chip
+- `MACHINE` - which board or project-owned machine variant to build for
+- `GPU_MEM` - GPU memory split
+- `MACHINE_EXTRA_RRECOMMENDS` - WiFi firmware for a specific chip
 - CPU threads for parallel build
 
 ### Multi-Machine Build
 
 Both boards share `bblayers.conf` and the `home-monitor` distro. Only `local.conf` differs:
 
-```
+```text
 config/bblayers.conf        shared (identical layers for both)
 config/rpi4b/local.conf     MACHINE="raspberrypi4-64", GPU_MEM=128
-config/zero2w/local.conf    MACHINE="raspberrypi0-2w-64", GPU_MEM=64
+config/zero2w/local.conf    MACHINE="home-monitor-camera", GPU_MEM=64
 ```
 
-Shared `downloads/` and `sstate-cache/` — the second board reuses most compiled artifacts.
+The `home-monitor-camera` machine in `meta-home-monitor/conf/machine/`
+extends `raspberrypi0-2w-64` and carries the permanent OV5647 sensor
+policy for the PiHut ZeroCam.
+
+Yocto still publishes the final camera image artifacts under the upstream
+`raspberrypi0-2w-64` deploy directory, so use that path when collecting
+`.wic.bz2` and rootfs outputs from the build VM.
+
+Shared `downloads/` and `sstate-cache/` mean the second board reuses most compiled artifacts.
 
 ---
 
@@ -162,7 +170,7 @@ Shared `downloads/` and `sstate-cache/` — the second board reuses most compile
 
 ## 7. Development Workflow
 
-### Fast iteration (app changes — seconds)
+### Fast iteration (app changes - seconds)
 
 ```bash
 rsync -av app/server/monitor/ root@<rpi4b-ip>:/opt/monitor/monitor/
@@ -205,7 +213,7 @@ nmcli device wifi connect "SSID" password "pass"
 
 ### Build fails with "No space left on device"
 
-Yocto builds need ~100GB. Free up disk or resize your VM disk.
+Yocto builds need about 100 GB. Free up disk or resize your VM disk.
 
 ```bash
 # Check disk usage
@@ -234,17 +242,17 @@ The setup script does this automatically.
 
 ### Slow builds
 
-- Increase CPU cores: edit `BB_NUMBER_THREADS` and `PARALLEL_MAKE` in local.conf
-- Add more RAM (or swap)
-- Use an SSD, not HDD
-- Don't run other heavy processes during the build
+- Increase CPU cores by editing `BB_NUMBER_THREADS` and `PARALLEL_MAKE` in `local.conf`
+- Add more RAM or swap
+- Use an SSD, not an HDD
+- Do not run other heavy processes during the build
 
 ### "do_fetch" failures
 
 Network issues downloading source tarballs. Retry:
 
 ```bash
-bitbake home-monitor-image-dev  # Just re-run, it resumes
+bitbake home-monitor-image-dev
 ```
 
-Or if a mirror is down, wait and retry later. Downloaded sources are cached in `downloads/`.
+Bitbake resumes where it left off. Downloaded sources are cached in `downloads/`.

--- a/meta-home-monitor/conf/machine/home-monitor-camera.conf
+++ b/meta-home-monitor/conf/machine/home-monitor-camera.conf
@@ -1,0 +1,10 @@
+#@TYPE: Machine
+#@NAME: Home Monitor Camera (Raspberry Pi Zero 2 W)
+#@DESCRIPTION: Home Monitor camera machine based on raspberrypi0-2w-64 with the OV5647 ZeroCam sensor enabled.
+
+require conf/machine/raspberrypi0-2w-64.conf
+
+# PiHut ZeroCam uses the legacy OV5647 sensor. This is product hardware
+# policy, so keep it in the machine config rather than in developer local.conf.
+RPI_KERNEL_DEVICETREE_OVERLAYS:append = " overlays/ov5647.dtbo"
+RPI_EXTRA_CONFIG += " \n camera_auto_detect=0 \n dtoverlay=ov5647 \n "


### PR DESCRIPTION
## Summary
- move the ZeroCam OV5647 overlay policy from \\config/zero2w/local.conf\\ into a Home Monitor-owned Yocto machine config
- switch the Zero 2W build to use the new \\home-monitor-camera\\ machine while preserving current camera behavior
- update build docs to describe the machine split and the actual camera artifact path on the build VM

## Test plan
- [x] ruff check app/
- [x] ruff format --check app/
- [x] bitbake -p home-camera-image-dev
- [x] bitbake -g home-camera-image-dev
- [x] full camera Yocto build on the VM
