### PR TITLE
ci: fix pre-commit on main and sync repo owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,22 +2,22 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default: project maintainer reviews everything
-* @vinu-engineer
+* @vinu-dev
 
 # Server application
-app/server/ @vinu-engineer
+app/server/ @vinu-dev
 
 # Camera application
-app/camera/ @vinu-engineer
+app/camera/ @vinu-dev
 
 # Yocto layer
-meta-home-monitor/ @vinu-engineer
+meta-home-monitor/ @vinu-dev
 
 # CI/CD and tooling
-.github/ @vinu-engineer
-pyproject.toml @vinu-engineer
-.pre-commit-config.yaml @vinu-engineer
+.github/ @vinu-dev
+pyproject.toml @vinu-dev
+.pre-commit-config.yaml @vinu-dev
 
 # Documentation
-docs/ @vinu-engineer
-CLAUDE.md @vinu-engineer
+docs/ @vinu-dev
+CLAUDE.md @vinu-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
   pre-commit:
     name: Pre-commit
     runs-on: ubuntu-latest
+    env:
+      SKIP: no-commit-to-branch
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RPi Home Monitor
 
-[![CI](https://github.com/vinu-engineer/rpi-home-monitor/actions/workflows/test.yml/badge.svg)](https://github.com/vinu-engineer/rpi-home-monitor/actions/workflows/test.yml)
+[![CI](https://github.com/vinu-dev/rpi-home-monitor/actions/workflows/test.yml/badge.svg)](https://github.com/vinu-dev/rpi-home-monitor/actions/workflows/test.yml)
 
 **A self-hosted home security camera system built on Raspberry Pi.** Open-source alternative to Ring, Tapo, and Nest — with no cloud subscriptions, no vendor lock-in, and complete control over your data.
 
@@ -98,7 +98,7 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 
 ```bash
 # Clone
-git clone git@github.com:vinu-engineer/rpi-home-monitor.git ~/yocto
+git clone git@github.com:vinu-dev/rpi-home-monitor.git ~/yocto
 cd ~/yocto
 
 # Install prerequisites (Ubuntu 24.04)
@@ -131,7 +131,7 @@ cd app/server && pytest    # threshold: 80% coverage
 cd app/camera && pytest    # threshold: 55% coverage
 ```
 
-Results and coverage reports are available in the [CI workflow](https://github.com/vinu-engineer/rpi-home-monitor/actions).
+Results and coverage reports are available in the [CI workflow](https://github.com/vinu-dev/rpi-home-monitor/actions).
 
 ## Documentation
 

--- a/app/camera/config/camera-hotspot.service
+++ b/app/camera/config/camera-hotspot.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Camera WiFi Setup Hotspot
-Documentation=https://github.com/vinu-engineer/rpi-home-monitor
+Documentation=https://github.com/vinu-dev/rpi-home-monitor
 After=NetworkManager.service local-fs.target sys-subsystem-net-devices-wlan0.device gpio-trigger.service
 Wants=NetworkManager.service
 Before=camera-streamer.service

--- a/app/server/config/gpio-trigger.service
+++ b/app/server/config/gpio-trigger.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=GPIO Trigger Detection (Provisioning / Factory Reset)
-Documentation=https://github.com/vinu-engineer/rpi-home-monitor
+Documentation=https://github.com/vinu-dev/rpi-home-monitor
 After=local-fs.target
 Before=monitor-hotspot.service camera-hotspot.service monitor.service camera-streamer.service
 DefaultDependencies=no

--- a/app/server/config/monitor-hotspot.service
+++ b/app/server/config/monitor-hotspot.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Home Monitor WiFi Setup Hotspot
-Documentation=https://github.com/vinu-engineer/rpi-home-monitor
+Documentation=https://github.com/vinu-dev/rpi-home-monitor
 After=NetworkManager.service local-fs.target sys-subsystem-net-devices-wlan0.device gpio-trigger.service
 Wants=NetworkManager.service
 Before=monitor.service

--- a/app/server/config/monitor-wifi-watchdog.service
+++ b/app/server/config/monitor-wifi-watchdog.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Home Monitor WiFi Watchdog — fallback to setup hotspot if WiFi fails
-Documentation=https://github.com/vinu-engineer/rpi-home-monitor
+Documentation=https://github.com/vinu-dev/rpi-home-monitor
 After=network-online.target NetworkManager-wait-online.service
 Wants=network-online.target
 

--- a/docs/build-setup.md
+++ b/docs/build-setup.md
@@ -25,7 +25,7 @@ GCP, AWS, or a local VM all work. The setup script handles everything.
 ## 2. One-Command Setup
 
 ```bash
-git clone git@github.com:vinu-engineer/rpi-home-monitor.git ~/yocto
+git clone git@github.com:vinu-dev/rpi-home-monitor.git ~/yocto
 cd ~/yocto
 ./scripts/setup-env.sh
 ```

--- a/docs/hardware-setup.md
+++ b/docs/hardware-setup.md
@@ -149,7 +149,7 @@ Buy one set per camera location.
 
 **Option A: Download pre-built images**
 
-Go to [GitHub Releases](https://github.com/vinu-engineer/rpi-home-monitor/releases) and download:
+Go to [GitHub Releases](https://github.com/vinu-dev/rpi-home-monitor/releases) and download:
 - `home-monitor-image-dev-*.wic.bz2` — Server (RPi 4B) development image
 - `home-camera-image-dev-*.wic.bz2` — Camera (Zero 2W) development image
 

--- a/meta-home-monitor/recipes-core/os-release/os-release.bbappend
+++ b/meta-home-monitor/recipes-core/os-release/os-release.bbappend
@@ -10,7 +10,7 @@ NAME = "Home Monitor OS"
 ID = "home-monitor"
 VERSION_ID = "${DISTRO_VERSION}"
 PRETTY_NAME = "Home Monitor OS ${DISTRO_VERSION} (${DISTRO_CODENAME})"
-HOME_URL = "https://github.com/vinu-engineer/rpi-home-monitor"
+HOME_URL = "https://github.com/vinu-dev/rpi-home-monitor"
 
 # BUILD_ID uses ISO 8601 date format (industry standard for build identification)
 BUILD_ID = "${DATE}"


### PR DESCRIPTION
## Summary
- skip the local-only no-commit-to-branch hook in CI so merge commits on main pass pre-commit
- update repo-owned references from vinu-engineer to vinu-dev
- keep local and VM remotes aligned with the renamed GitHub owner

## Validation
- python scripts/ai/validate_repo_ai_setup.py
- python scripts/ai/check_doc_links.py
- python scripts/ai/check_shell_scripts.py
- pre-commit run --all-files