### PR TITLE
docs: clarify OTA roadmap and signing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RPi Home Monitor runs **Home Monitor OS**, a custom Linux distribution built wit
 - **Security by design.** HTTPS for web, mTLS camera streaming, encrypted storage (LUKS), firewall-hardened OS, bcrypt auth with rate limiting, PIN-based camera pairing.
 - **Built on real hardware.** Runs on a $35 Raspberry Pi 4B (server) and $15 Zero 2W (cameras). No proprietary hardware required.
 - **Automatic camera discovery.** Plug in a camera node, connect it to WiFi, and it appears in your dashboard via mDNS.
-- **OTA updates with rollback.** A/B partition scheme means failed updates automatically roll back. No bricked devices.
+- **OTA design includes rollback.** The target system uses A/B rollback; dev update flows are working now, while the full production OTA path is still being validated.
 - **Tapo-style recording.** Continuous 3-minute MP4 clips organized by camera and date, with timeline playback.
 - **Fully open source.** Inspect every line, from the OS image to the web dashboard. AGPL-3.0 licensed.
 
@@ -85,7 +85,7 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 | HTTPS (TLS) | **Implemented** | Self-signed certs, NGINX terminates TLS |
 | bcrypt auth + CSRF | **Implemented** | Cost 12, rate limiting (warn at 5, block at 10) |
 | Session management | **Implemented** | 30min idle / 24hr absolute timeout |
-| LUKS encryption | **Implemented** | /data partition encrypted at rest |
+| LUKS encryption | **Partial** | Design and implementation work exist, but production-grade validation is still in progress |
 | nftables firewall | **Implemented** | Default DROP, minimal open ports |
 | Audit logging | **Implemented** | Append-only JSON, all admin actions |
 | Default admin warning | **Implemented** | `admin`/`admin` created on first boot, must change during setup |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 | Role-Based Access | Admin (full control) and Viewer (read-only) roles |
 | System Health | CPU temp, memory, disk usage, uptime monitoring |
 | Storage Management | Automatic cleanup of oldest clips when disk is full |
-| OTA Updates | Signed firmware updates with A/B rollback |
+| OTA Updates | Dev path works today; production-signed OTA with A/B rollback is designed but not yet fully hardware-validated |
 | Audit Logging | All admin actions logged (append-only) |
 | Encrypted Storage | LUKS-encrypted /data partition for recordings and config |
 | Firewall | nftables — cameras can only talk to server, minimal open ports |
@@ -92,7 +92,7 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 | RTSPS (mTLS) | **Implemented** | Camera streams over RTSPS with mTLS client certs after pairing |
 | mTLS camera pairing | **Implemented** | PIN-based pairing with certificate exchange (ADR-0009) |
 | Factory reset | **Implemented** | WiFi wipe, config reset, returns to first-boot state |
-| OTA updates | **Implemented** | Server OTA service (verify, stage, install) + camera OTA agent (port 8080, mTLS) |
+| OTA updates | **Partial** | Dev-oriented flow exists; production signing and full end-to-end OTA validation are still in progress. See `docs/update-roadmap.md` |
 
 ## Quick Start
 

--- a/docs/adr/0008-swupdate-ab-rollback.md
+++ b/docs/adr/0008-swupdate-ab-rollback.md
@@ -1,10 +1,10 @@
 # ADR-0008: SWUpdate with A/B Rollback and Multi-Mode Delivery
 
 ## Status
-Proposed
+Accepted (implementation in progress)
 
 ## Context
-The partition layout (WKS files) provisions A/B root partitions on both server and camera, but no update engine, image format, delivery pipeline, or rollback mechanism is implemented. The OTA API (`ota.py`) stages `.swu` files and tracks status, but the install path is stubbed. The camera `ota_agent.py` is a placeholder.
+The partition layout (WKS files) provisions A/B root partitions on both server and camera. Since this ADR was first drafted, parts of the OTA stack have been implemented, but the full production-grade update path is still incomplete and not yet fully validated on real hardware. The repo uses this ADR as the target architecture; see `docs/update-roadmap.md` for current status.
 
 ### Hardware (measured 2026-04-11)
 

--- a/docs/adr/0009-camera-pairing-mtls.md
+++ b/docs/adr/0009-camera-pairing-mtls.md
@@ -1,10 +1,10 @@
 # ADR-0009: Camera Pairing and mTLS
 
 ## Status
-Proposed
+Accepted
 
 ## Context
-Camera-to-server communication currently uses plaintext RTSP. The architecture (Section 3) specifies mTLS for camera identity and RTSPS for stream encryption, but `pairing.py` is a stub. Without mutual authentication, any device on the LAN can impersonate a camera and inject video, or eavesdrop on streams.
+This ADR defined the pairing and mTLS design for camera identity, RTSPS encryption, and OTA trust establishment. Core pairing and certificate exchange behavior now exists in the codebase and on dev hardware, and this document remains the architectural reference for that design.
 
 The pairing flow must also produce the client certificates used for OTA push authentication (ADR-0008) and establish the trust relationship that LUKS key derivation relies on for the camera (ADR-0010).
 

--- a/docs/adr/0010-luks-data-encryption.md
+++ b/docs/adr/0010-luks-data-encryption.md
@@ -1,10 +1,10 @@
 # ADR-0010: LUKS Data Partition Encryption
 
 ## Status
-Proposed
+Accepted (implementation in progress)
 
 ## Context
-Both server and camera store sensitive data on the `/data` partition: video recordings, WiFi credentials, user passwords (hashed), session secrets, the CA private key (server), and client certs (camera). Physical theft of an SD card should not expose this data.
+Both server and camera store sensitive data on the `/data` partition: video recordings, WiFi credentials, user passwords (hashed), session secrets, the CA private key (server), and client certs (camera). Physical theft of an SD card should not expose this data. This ADR is the target design; implementation exists in parts, but full production validation is still in progress.
 
 Neither device has a TPM, HSM, or secure enclave — the RPi 4B and Zero 2W have no hardware key storage. Neither has AES hardware acceleration. The LUKS key must be derived from something the device knows or the user provides, and the cipher must perform well in software.
 

--- a/docs/adr/0014-swupdate-signing-dev-prod.md
+++ b/docs/adr/0014-swupdate-signing-dev-prod.md
@@ -20,6 +20,14 @@ OTA bundle signing is **disabled for dev builds** and **enabled for production b
 - **`SWUPDATE_SIGNING = "0"` (default):** `CONFIG_SIGNED_IMAGES` is patched out of the swupdate defconfig at build time. The daemon accepts any bundle without signature verification. No cert is required in the image or at build time.
 - **`SWUPDATE_SIGNING = "1"` (prod):** `CONFIG_SIGNED_IMAGES=y` and `CONFIG_SIGALG_CMS=y` remain in the defconfig. The public signing certificate (`swupdate-public.crt`) is baked into the image at `/etc/swupdate-public.crt`. The swupdate daemon is configured via `/etc/swupdate/conf.d/00-home-monitor` to pass `-k /etc/swupdate-public.crt` at startup.
 
+## Current validation status
+
+- **Dev signing bypass:** actively used and intentional
+- **Production signing design:** implemented in the build/config pipeline
+- **Production signing on real hardware:** not yet fully validated end-to-end
+
+The repo must not describe production OTA signing as fully proven until that hardware validation is complete. See `docs/update-roadmap.md`.
+
 ## Implementation
 
 **`meta-home-monitor/recipes-support/swupdate/swupdate_%.bbappend`**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -607,7 +607,7 @@ Server browses:
 
 ### 6.3 OTA Update Flow
 
-> **Status: Implemented.** Server OTA service (verify, stage, install), camera OTA agent (port 8080, mTLS), and USB detection are operational. See ADR-0008.
+> **Status: Partially implemented.** The target OTA architecture is defined and major pieces exist, but the full production path (signed bundles, full-system update, rollback, USB/import modes) is not yet fully validated on real hardware. See [update-roadmap.md](./update-roadmap.md), ADR-0008, and ADR-0014.
 
 **Delivery modes** (all feed into single `inbox → verify → staging → install` pipeline):
 ```
@@ -620,7 +620,7 @@ Server browses:
 
 **Full-system update (.swu):**
 ```
-1. Ed25519 signature verification in inbox
+1. Ed25519 signature verification in inbox (production target; dev builds may bypass signing per ADR-0014)
 2. SWUpdate installs to inactive rootfs (A→B or B→A)
 3. U-Boot env: upgrade_available=1, boot_count=0, bootlimit=3
 4. Reboot into new partition
@@ -630,7 +630,7 @@ Server browses:
 
 **App-only update (.tar.zst + .sig):**
 ```
-1. Ed25519 signature verification
+1. Signature verification in production; dev builds may bypass signing per ADR-0014
 2. Extract to /opt/monitor/releases/<version>/
 3. Symlink swap: current → new version
 4. systemctl restart <service>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,7 +229,7 @@ The server dashboard shows clickable `.local` links for each camera's status pag
 | SD card theft (server) | Physical access to RPi 4B | All recordings, WiFi creds, user passwords | LUKS encryption on /data partition |
 | SD card theft (camera) | Physical access to Zero 2W | WiFi password, server address | LUKS encryption on /data partition |
 | Default credentials | SSH as root with no password | Full device control | No debug-tweaks in production, key-only SSH |
-| Rogue firmware update | Push malicious update to device | Persistent backdoor | Signed OTA images (Ed25519) |
+| Rogue firmware update | Push malicious update to device | Persistent backdoor | Signed OTA images (production target; dev builds may bypass signing) |
 | Network scanning | Port scan from compromised device on LAN | Discover attack surface | nftables firewall, minimal open ports |
 | Session hijacking | Steal session cookie | Access dashboard as victim | Secure/HttpOnly/SameSite cookies, HTTPS only |
 | CSRF attack | Trick admin into clicking malicious link | Change settings, delete clips | CSRF tokens on all state-changing requests |

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -562,11 +562,13 @@ When changing one, check if the others need updating:
 
 ### 6.2 OTA Updates
 
-- **All OTA images must be signed** with Ed25519 (`scripts/sign-image.sh`).
-- **Never push an unsigned image.** Devices will reject it.
+- **Production OTA images must be signed** with Ed25519 (`scripts/sign-image.sh`).
+- **Dev builds may intentionally bypass signing** via `SWUPDATE_SIGNING = "0"` to remove iteration friction in the lab.
+- **Unsigned OTA is never production-ready.**
 - **Test OTA on a dev device first** before pushing to prod.
 - **The signing private key is never committed to git.** It lives in `~/.monitor-keys/` on the build machine only.
 - **Rollback:** If a new rootfs fails to boot 3 times, the device automatically rolls back. Never disable this.
+- **Current limitation:** the production signing/update path is designed but not yet fully validated on real hardware. See `docs/update-roadmap.md`.
 
 ### 6.3 Secrets Management
 

--- a/docs/hardware-setup.md
+++ b/docs/hardware-setup.md
@@ -482,8 +482,10 @@ MicroSD cards degrade with writes. Signs of failure:
 
 ### 8.3 Firmware Updates (OTA)
 
+> **Current status:** dev builds are the primary tested update path right now. Production signing and full production OTA validation are not yet fully proven on real hardware. See [update-roadmap.md](./update-roadmap.md).
+
 ```bash
-# On your build machine, sign the update:
+# Production build: sign the update
 ./scripts/sign-image.sh build/tmp/deploy/images/raspberrypi4-64/home-monitor-image-prod-*.wic.bz2
 
 # Upload via the web dashboard: System → OTA Update

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -348,7 +348,7 @@ Boot uses U-Boot (`u-boot-rpi` from meta-raspberrypi) for boot counting (`bootli
 
 #### SR-CAM-06: OTA Update Support
 
-> **Status: Implemented.** Camera OTA agent at `app/camera/camera_streamer/ota_agent.py` (HTTP server on port 8080, mTLS). See ADR-0008.
+> **Status: Partially implemented.** Camera OTA agent and supporting code exist, but the full production update path is not yet fully validated on real hardware. Dev builds intentionally allow signing bypass. See [update-roadmap.md](./update-roadmap.md), ADR-0008, and ADR-0014.
 
 - Dual rootfs partitions (A/B layout) using SWUpdate + U-Boot boot counting (`bootlimit=3`)
 - Accept update images pushed from server over HTTPS (mTLS authenticated, ADR-0009)
@@ -356,7 +356,8 @@ Boot uses U-Boot (`u-boot-rpi` from meta-raspberrypi) for boot counting (`bootli
 - App-only updates use symlink swap (`/opt/camera/releases/<version>/` with `current` symlink), no reboot
 - Automatic rollback if new rootfs fails health check within 90 seconds
 - Report current firmware version to server via mDNS TXT record
-- Ed25519 signature verification before any install (public key in rootfs)
+- Production target: signature verification before install (public key in rootfs)
+- Dev policy: signing may be disabled to reduce iteration friction
 
 #### SR-CAM-07: System Watchdog
 
@@ -448,7 +449,7 @@ Boot uses U-Boot (`u-boot-rpi` from meta-raspberrypi) for boot counting (`bootli
 
 #### SR-SRV-10: OTA Update Management
 
-> **Status: Implemented.** Server OTA service at `app/server/monitor/services/ota_service.py` with API at `app/server/monitor/api/ota.py`. See ADR-0008.
+> **Status: Partially implemented.** Server OTA service and API exist, but the production-grade end-to-end path (signed full-system update, rollback, USB/import validation) is not yet fully proven on real hardware. See [update-roadmap.md](./update-roadmap.md), ADR-0008, and ADR-0014.
 
 - Dual rootfs partitions (A/B layout) using SWUpdate + U-Boot boot counting (`bootlimit=3`)
 - **Multi-mode delivery** (5 modes, single `inbox → verify → staging → install` pipeline):
@@ -460,7 +461,8 @@ Boot uses U-Boot (`u-boot-rpi` from meta-raspberrypi) for boot counting (`bootli
 - **Two artifact types:**
   - `.swu` — full-system A/B rootfs update (requires reboot)
   - `.tar.zst` + detached `.sig` — app-only update (symlink swap, no reboot)
-- Ed25519 signature verification before any install (source is never trust)
+- Production target: signature verification before any install (source is never trust)
+- Dev policy: signing may be disabled on dev images to support fast lab iteration
 - Artifact naming: `hm-<target>-<type>-<version>.<ext>` (e.g., `hm-server-system-1.2.0.swu`)
 - Update status tracking: idle, downloading, verifying, staging, installing, rebooting, confirming, success, failed, rolled-back
 - Automatic rollback on failed boot (3-attempt threshold) or failed health check (90s window)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -279,7 +279,7 @@ Camera Node                    Server                          Client
 
 ### 4.7 Partition Scheme (OTA-ready, SWUpdate A/B with U-Boot)
 
-> **Status: Implemented.** A/B partition layout defined in WKS files with U-Boot boot counting (see ADR-0008).
+> **Status: Partially implemented.** The partition layout is defined in WKS files, but the full U-Boot/SWUpdate production path is still being validated on hardware. See [update-roadmap.md](./update-roadmap.md) and ADR-0008.
 
 | Partition | Type | Size (Server) | Size (Camera) | Purpose |
 |-----------|------|---------------|---------------|---------|
@@ -582,7 +582,7 @@ All endpoints require authentication. Prefix: `/api/v1/`
 
 #### SR-SEC-03: Encryption at Rest
 
-> **Status: Implemented.** LUKS2 with Adiantum cipher on `/data` partition. See ADR-0010.
+> **Status: Partially implemented.** The LUKS design and supporting plumbing exist, but production-grade validation is still in progress. Dev builds intentionally skip encryption for iteration speed. See ADR-0010.
 
 - `/data` partition encrypted with LUKS2 (`xchacha20,aes-adiantum-plain64`) — 2-3.5x faster than AES on ARM without hardware acceleration
 - **Server:** passphrase set during first-boot setup wizard, argon2id KDF (1 GB memory, 4 iterations, 4 parallelism). Optional auto-unlock keyfile or Dropbear SSH unlock for headless operation
@@ -631,14 +631,14 @@ All endpoints require authentication. Prefix: `/api/v1/`
 
 #### SR-SEC-09: Signed OTA Updates
 
-> **Status: Implemented.** Ed25519 signature verification in OTA service. See ADR-0008.
+> **Status: Partially implemented.** The signing design exists, but dev builds may bypass signing and the full production signing path is not yet fully hardware-validated. See [update-roadmap.md](./update-roadmap.md), ADR-0008, and ADR-0014.
 
-- All artifacts signed with Ed25519 keypair (both `.swu` and `.tar.zst` app bundles)
+- Production target: all artifacts signed with Ed25519 keypair (both `.swu` and `.tar.zst` app bundles)
 - Build machine holds private signing key (never on devices)
 - Devices hold public verification key (in rootfs, not `/data` — survives factory reset)
-- Update rejected if signature verification fails — source is never trust, only signature
+- Production target: update rejected if signature verification fails — source is never trust, only signature
 - Artifact naming convention: `hm-<target>-<type>-<version>.<ext>` with detached `.sig` for app bundles
-- Prevents installation of malicious firmware regardless of delivery mode (USB, upload, push, SCP)
+- Production goal: prevents installation of malicious firmware regardless of delivery mode (USB, upload, push, SCP)
 
 #### SR-SEC-10: Camera Pairing Protocol
 

--- a/docs/update-roadmap.md
+++ b/docs/update-roadmap.md
@@ -1,0 +1,172 @@
+# Update Roadmap and Current Status
+
+Version: 1.0
+Date: 2026-04-14
+
+---
+
+## 1. Purpose
+
+This document is the source of truth for software update design and delivery status.
+
+It separates:
+- what is implemented on current dev hardware
+- what is partially implemented or only lab-validated
+- what is planned but not yet finished
+
+If this file conflicts with older wording in the repo, this file wins.
+
+---
+
+## 2. Product Goal
+
+The update system is designed to support all of the following through one consistent pipeline:
+
+1. Full-system OS updates for server and camera
+2. App-only updates without reflashing the whole OS
+3. Automatic rollback on failed boot or failed health check
+4. Multiple delivery modes:
+   - dashboard upload
+   - USB import
+   - server-pushed camera updates
+   - developer SCP/inbox flow
+   - future repository polling
+5. U-Boot-managed A/B slot switching for rootfs updates
+
+The intended trust model is:
+- source is never trust
+- verification is shared
+- signing is the trust anchor for production
+
+---
+
+## 3. Current Status Summary
+
+### 3.1 Overall
+
+| Area | Status | Notes |
+|---|---|---|
+| OTA API surface | Partial | Server API endpoints exist, but not every documented flow is proven end-to-end on hardware |
+| App-only hot deploy for development | Working | We use direct app sync in the lab today; this is practical but not the final signed OTA path |
+| Full-system SWUpdate flow | Partial | Design is strong; end-to-end production-grade validation is still incomplete |
+| A/B rollback with U-Boot | Partial | Planned and partially wired in Yocto/docs; not yet fully validated across real upgrade/rollback cycles |
+| USB update flow | Partial | Inbox/import model is designed; must be validated end-to-end on hardware |
+| Camera OTA push via server | Partial | Agent/service pieces exist; needs stronger end-to-end validation and release hardening |
+| Production signing flow | Partial / not field-validated | Signing design exists, but production-signing workflow is not yet fully tested on real hardware |
+
+### 3.2 Delivery Mode Status
+
+| Delivery mode | Intended use | Status |
+|---|---|---|
+| Dashboard upload | Server/admin driven updates | Partial |
+| USB import | Offline/field updates | Partial |
+| Server push to camera | Production camera updates | Partial |
+| SCP to inbox | Dev/lab only | Working for development workflow |
+| Repository polling (Suricatta) | Future managed updates | Planned, not implemented |
+
+### 3.3 Artifact Status
+
+| Artifact type | Status | Notes |
+|---|---|---|
+| `.swu` full-system bundle | Partial | Intended final production path |
+| `.tar.zst` app-only bundle | Partial | Design exists; repo still uses lab hot-deploy for day-to-day iteration |
+
+---
+
+## 4. Dev vs Production Policy
+
+### 4.1 Dev Builds
+
+Dev builds are intentionally optimized for iteration speed.
+
+- `SWUPDATE_SIGNING = "0"` is the default for dev builds
+- dev devices may accept unsigned OTA bundles
+- developer SCP/inbox flows are allowed in the lab
+- direct app hot-deploy is allowed in the lab
+
+This is intentional. It avoids signing friction during normal development.
+
+### 4.2 Production Builds
+
+Production builds are intended to be stricter:
+
+- production OTA bundles must be signed
+- production devices should verify signatures before install
+- production updates should go through the supported OTA pipeline, not manual file sync
+- production rollback behavior must be validated on real hardware before being called release-ready
+
+### 4.3 Important Current Limitation
+
+Production OTA signing and the full production update pipeline are **not yet fully tested on real hardware**.
+
+That means:
+- the design exists
+- some implementation exists
+- the repo should not claim the production OTA/signing path is fully validated today
+
+---
+
+## 5. Current Working Rules
+
+Until the production OTA path is fully validated:
+
+1. Use dev builds for software iteration and hardware debugging
+2. Use direct app hot-deploy only for lab/dev devices
+3. Do not describe unsigned dev OTA as production-ready
+4. Do not describe production signing as field-proven yet
+5. Treat USB/import/server-push flows as release work that still requires dedicated validation
+
+---
+
+## 6. Execution Plan
+
+### Phase 1: Truth and Documentation
+
+- Align README, requirements, architecture, and development guide with actual status
+- Mark production OTA/signing as not yet fully hardware-validated
+- Keep dev-signing bypass explicit and intentional
+
+### Phase 2: Stabilize App-Only Update Path
+
+- Replace ad-hoc manual hot deploy with a scripted app-only deploy flow
+- Preserve ownership, permissions, service restart, and smoke validation
+- Use that as the standard dev workflow
+
+### Phase 3: Validate Full-System Updates
+
+- Build signed prod bundles
+- Validate server full-system update on real hardware
+- Validate camera full-system update on real hardware
+- Validate rollback after forced bad boot
+- Validate post-update health confirmation
+
+### Phase 4: Validate Delivery Modes
+
+- USB import end-to-end
+- dashboard upload end-to-end
+- server-push camera update end-to-end
+- downgrade/reject rules
+- compatibility checks and history/audit behavior
+
+### Phase 5: Production Readiness Gate
+
+Production OTA should only be called fully implemented when all of the following are proven on hardware:
+
+- signed server update succeeds
+- signed camera update succeeds
+- failed update rolls back automatically
+- U-Boot slot state is correct before and after rollback
+- health-check confirmation clears rollback flags
+- USB path works
+- dashboard upload path works
+- camera push path works
+
+---
+
+## 7. References
+
+- [docs/adr/0008-swupdate-ab-rollback.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/adr/0008-swupdate-ab-rollback.md)
+- [docs/adr/0014-swupdate-signing-dev-prod.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/adr/0014-swupdate-signing-dev-prod.md)
+- [docs/architecture.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/architecture.md)
+- [docs/requirements.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/requirements.md)
+- [docs/development-guide.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/development-guide.md)

--- a/docs/update-roadmap.md
+++ b/docs/update-roadmap.md
@@ -165,8 +165,8 @@ Production OTA should only be called fully implemented when all of the following
 
 ## 7. References
 
-- [docs/adr/0008-swupdate-ab-rollback.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/adr/0008-swupdate-ab-rollback.md)
-- [docs/adr/0014-swupdate-signing-dev-prod.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/adr/0014-swupdate-signing-dev-prod.md)
-- [docs/architecture.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/architecture.md)
-- [docs/requirements.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/requirements.md)
-- [docs/development-guide.md](/C:/Users/vinun/codex/rpi-home-monitor/docs/development-guide.md)
+- [ADR-0008](./adr/0008-swupdate-ab-rollback.md)
+- [ADR-0014](./adr/0014-swupdate-signing-dev-prod.md)
+- [Architecture](./architecture.md)
+- [Requirements](./requirements.md)
+- [Development Guide](./development-guide.md)


### PR DESCRIPTION
## Summary
- add a canonical OTA/update roadmap doc
- separate implemented, partial, and planned update capabilities
- make dev signing bypass explicit and intentional
- clearly mark production OTA signing and full production validation as not yet fully hardware-tested
- align README, architecture, requirements, hardware setup, and ADRs with the real status

## Validation
- python scripts/ai/check_doc_links.py
- python scripts/ai/validate_repo_ai_setup.py
- pre-commit run --files README.md docs/update-roadmap.md docs/architecture.md docs/requirements.md docs/development-guide.md docs/hardware-setup.md docs/adr/0008-swupdate-ab-rollback.md docs/adr/0014-swupdate-signing-dev-prod.md