### PR TITLE
fix: pass swupdate cert during ota install

### DIFF
--- a/app/camera/camera_streamer/ota_agent.py
+++ b/app/camera/camera_streamer/ota_agent.py
@@ -254,6 +254,17 @@ class OTAAgent:
         except OSError as e:
             return False, str(e)
 
+    def _install_command(self, bundle_path):
+        """Build the swupdate install command for the current environment."""
+        public_cert = "/etc/swupdate-public.crt"
+        if not os.path.isfile(public_cert):
+            public_cert = os.path.join(self._config.certs_dir, "swupdate-public.crt")
+
+        cmd = ["swupdate", "-i", bundle_path]
+        if os.path.isfile(public_cert):
+            cmd.extend(["-k", public_cert])
+        return cmd
+
     def _install_bundle(self, bundle_path):
         """Install a .swu bundle via swupdate.
 
@@ -262,7 +273,7 @@ class OTAAgent:
         """
         try:
             result = subprocess.run(
-                ["swupdate", "-i", bundle_path],
+                self._install_command(bundle_path),
                 capture_output=True,
                 text=True,
                 timeout=600,

--- a/app/camera/tests/test_ota_agent.py
+++ b/app/camera/tests/test_ota_agent.py
@@ -143,7 +143,51 @@ class TestInstallBundle:
     """Test bundle installation via swupdate."""
 
     @patch("camera_streamer.ota_agent.subprocess.run")
-    def test_install_success(self, mock_run, agent, tmp_path):
+    def test_install_success(self, mock_run, agent, config, tmp_path):
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+        key_path = os.path.join(config.certs_dir, "swupdate-public.crt")
+        with open(key_path, "w") as f:
+            f.write("PUBLIC KEY")
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ok, err = agent._install_bundle(bundle)
+        assert ok is True
+        assert err == ""
+        assert mock_run.call_args[0][0] == [
+            "swupdate",
+            "-i",
+            bundle,
+            "-k",
+            key_path,
+        ]
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_install_failure(self, mock_run, agent, config, tmp_path):
+        bundle = str(tmp_path / "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+        key_path = os.path.join(config.certs_dir, "swupdate-public.crt")
+        with open(key_path, "w") as f:
+            f.write("PUBLIC KEY")
+
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="write failed"
+        )
+        ok, err = agent._install_bundle(bundle)
+        assert ok is False
+        assert "write failed" in err
+        assert mock_run.call_args[0][0] == [
+            "swupdate",
+            "-i",
+            bundle,
+            "-k",
+            key_path,
+        ]
+
+    @patch("camera_streamer.ota_agent.subprocess.run")
+    def test_install_without_key_uses_plain_command(self, mock_run, agent, tmp_path):
         bundle = str(tmp_path / "test.swu")
         with open(bundle, "wb") as f:
             f.write(b"test")
@@ -152,19 +196,7 @@ class TestInstallBundle:
         ok, err = agent._install_bundle(bundle)
         assert ok is True
         assert err == ""
-
-    @patch("camera_streamer.ota_agent.subprocess.run")
-    def test_install_failure(self, mock_run, agent, tmp_path):
-        bundle = str(tmp_path / "test.swu")
-        with open(bundle, "wb") as f:
-            f.write(b"test")
-
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr="write failed"
-        )
-        ok, err = agent._install_bundle(bundle)
-        assert ok is False
-        assert "write failed" in err
+        assert mock_run.call_args[0][0] == ["swupdate", "-i", bundle]
 
     @patch("camera_streamer.ota_agent.subprocess.run")
     def test_install_not_found(self, mock_run, agent, tmp_path):

--- a/app/server/monitor/services/ota_service.py
+++ b/app/server/monitor/services/ota_service.py
@@ -206,6 +206,13 @@ class OTAService:
         except OSError as e:
             return False, str(e)
 
+    def _install_command(self, bundle_path):
+        """Build the swupdate install command for the current environment."""
+        cmd = ["swupdate", "-i", bundle_path]
+        if os.path.isfile(self._public_key_path):
+            cmd.extend(["-k", self._public_key_path])
+        return cmd
+
     def install_bundle(self, bundle_path, user="", ip=""):
         """Install a verified .swu bundle via swupdate.
 
@@ -228,7 +235,7 @@ class OTAService:
 
         try:
             result = subprocess.run(
-                ["swupdate", "-i", bundle_path],
+                self._install_command(bundle_path),
                 capture_output=True,
                 text=True,
                 timeout=600,  # 10 minute timeout for large images

--- a/app/server/tests/test_svc_ota.py
+++ b/app/server/tests/test_svc_ota.py
@@ -212,17 +212,31 @@ class TestInstallBundle:
         bundle = os.path.join(data_dir, "test.swu")
         with open(bundle, "wb") as f:
             f.write(b"test")
+        key = os.path.join(data_dir, "certs", "swupdate-public.crt")
+        with open(key, "w") as f:
+            f.write("PUBLIC KEY")
 
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         ok, err = svc.install_bundle(bundle, user="admin", ip="1.2.3.4")
         assert ok is True
         assert svc.get_status("server")["state"] == "installed"
+        mock_run.assert_called_once()
+        assert mock_run.call_args[0][0] == [
+            "swupdate",
+            "-i",
+            bundle,
+            "-k",
+            key,
+        ]
 
     @patch("monitor.services.ota_service.subprocess.run")
     def test_install_failure(self, mock_run, svc, data_dir):
         bundle = os.path.join(data_dir, "test.swu")
         with open(bundle, "wb") as f:
             f.write(b"test")
+        key = os.path.join(data_dir, "certs", "swupdate-public.crt")
+        with open(key, "w") as f:
+            f.write("PUBLIC KEY")
 
         mock_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="write failed"
@@ -230,6 +244,25 @@ class TestInstallBundle:
         ok, err = svc.install_bundle(bundle)
         assert ok is False
         assert svc.get_status("server")["state"] == "error"
+        assert mock_run.call_args[0][0] == [
+            "swupdate",
+            "-i",
+            bundle,
+            "-k",
+            key,
+        ]
+
+    @patch("monitor.services.ota_service.subprocess.run")
+    def test_install_without_key_uses_plain_command(self, mock_run, svc, data_dir):
+        bundle = os.path.join(data_dir, "test.swu")
+        with open(bundle, "wb") as f:
+            f.write(b"test")
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ok, err = svc.install_bundle(bundle)
+        assert ok is True
+        assert err == ""
+        assert mock_run.call_args[0][0] == ["swupdate", "-i", bundle]
 
     @patch("monitor.services.ota_service.subprocess.run")
     def test_install_swupdate_not_found(self, mock_run, svc, data_dir):


### PR DESCRIPTION
## What\n- pass the SWUpdate verification cert during signed install, not just verify\n- fix both server OTA service and camera OTA agent\n- add focused regression tests\n\n## Why\nSigned prod devices could stage and verify bundles but failed on install with: SWUpdate is built for signed images, provide a public key file.\n\n## How to test\n- pytest app/server/tests/test_svc_ota.py -q --no-cov\n- pytest app/camera/tests/test_ota_agent.py -q --no-cov\n\n## Yocto impact\n- no image recipe changes\n- affects live OTA install behavior for signed devices