### PR TITLE
fix: tighten camera pairing flow

### DIFF
--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -19,8 +19,11 @@ Design patterns:
 import logging
 import os
 import socket
+import ssl
 import subprocess
 import time
+import urllib.error
+import urllib.request
 
 from camera_streamer import led
 from camera_streamer.capture import CaptureManager
@@ -183,9 +186,6 @@ class CameraLifecycle:
         log.info("Camera not paired — starting status server for /pair endpoint")
         led.setup_mode()
 
-        # Register with server so it appears in the dashboard
-        self._register_with_server()
-
         # Start status server so /pair endpoint is accessible
         self._status_server = CameraStatusServer(
             self._config,
@@ -197,7 +197,12 @@ class CameraLifecycle:
         self._status_server.start()
 
         # Poll until paired or shutdown
+        last_registration_attempt = 0.0
         while not self._is_shutdown():
+            now = time.monotonic()
+            if now - last_registration_attempt >= 10:
+                self._register_with_server()
+                last_registration_attempt = now
             if self._pairing.is_paired:
                 log.info("Pairing complete — certificates stored")
                 self._status_server.stop()
@@ -310,19 +315,29 @@ class CameraLifecycle:
             return
         server = self._config.server_ip
         camera_id = self._config.camera_id
-        url = f"http://{server}:5000/api/v1/pair/register"
+        if not server:
+            return
+        if "://" in server:
+            base_url = server.rstrip("/")
+        else:
+            base_url = f"https://{server}"
+        url = f"{base_url}/api/v1/pair/register"
         try:
             import json
-            import urllib.request
 
             data = json.dumps({"camera_id": camera_id}).encode()
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
             req = urllib.request.Request(
                 url, data=data, headers={"Content-Type": "application/json"}
             )
-            with urllib.request.urlopen(req, timeout=10) as resp:
+            with urllib.request.urlopen(req, context=ctx, timeout=10) as resp:
                 log.info("Registered with server as pending (status=%d)", resp.status)
-        except Exception as e:
-            log.debug("Server registration failed (will retry via mDNS): %s", e)
+        except urllib.error.HTTPError as e:
+            log.debug("Server registration rejected by %s: HTTP %s", url, e.code)
+        except (urllib.error.URLError, OSError) as e:
+            log.debug("Server registration failed for %s: %s", url, e)
 
     HOTSPOT_SCRIPT = "/opt/camera/scripts/camera-hotspot.sh"
 

--- a/app/camera/tests/test_lifecycle.py
+++ b/app/camera/tests/test_lifecycle.py
@@ -164,6 +164,48 @@ class TestConnecting:
         mock_revert.assert_called_once()
 
 
+class TestPairingRegistration:
+    """Test best-effort camera registration during pairing state."""
+
+    @patch("camera_streamer.lifecycle.ssl.create_default_context")
+    @patch("camera_streamer.lifecycle.urllib.request.urlopen")
+    def test_registers_with_https_pair_register_endpoint(
+        self, mock_urlopen, mock_create_context
+    ):
+        config = _make_config(server_ip="rpi-divinu.local", camera_id="cam-test")
+        platform = _make_platform()
+        lc = CameraLifecycle(config, platform, lambda: False)
+
+        mock_response = MagicMock()
+        mock_response.__enter__.return_value.status = 200
+        mock_urlopen.return_value = mock_response
+
+        lc._register_with_server()
+
+        request = mock_urlopen.call_args.args[0]
+        context = mock_urlopen.call_args.kwargs["context"]
+        assert request.full_url == "https://rpi-divinu.local/api/v1/pair/register"
+        assert context is mock_create_context.return_value
+        assert mock_create_context.return_value.check_hostname is False
+
+    @patch("camera_streamer.lifecycle.urllib.request.urlopen")
+    def test_register_respects_explicit_scheme(self, mock_urlopen):
+        config = _make_config(
+            server_ip="https://rpi-divinu.local", camera_id="cam-test"
+        )
+        platform = _make_platform()
+        lc = CameraLifecycle(config, platform, lambda: False)
+
+        mock_response = MagicMock()
+        mock_response.__enter__.return_value.status = 200
+        mock_urlopen.return_value = mock_response
+
+        lc._register_with_server()
+
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == "https://rpi-divinu.local/api/v1/pair/register"
+
+
 class TestValidating:
     """Test VALIDATING state — camera hardware check."""
 

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -128,7 +128,7 @@ class CameraService:
             return None, "Camera not found", 404
 
         if camera.status != "pending":
-            return None, "Camera is already confirmed", 400
+            return self._confirmed_result(camera), "", 200
 
         camera.name = name or camera.name or camera_id
         camera.location = location or camera.location
@@ -149,16 +149,7 @@ class CameraService:
             f"confirmed camera {camera_id} as '{camera.name}'",
         )
 
-        return (
-            {
-                "id": camera.id,
-                "name": camera.name,
-                "status": camera.status,
-                "paired_at": camera.paired_at,
-            },
-            "",
-            200,
-        )
+        return self._confirmed_result(camera), "", 200
 
     def update(
         self, camera_id: str, data: dict, user: str = "", ip: str = ""
@@ -257,6 +248,16 @@ class CameraService:
                 return "name must be 1-64 characters"
 
         return ""
+
+    @staticmethod
+    def _confirmed_result(camera) -> dict:
+        """Serialize the minimal dashboard payload for a confirmed camera."""
+        return {
+            "id": camera.id,
+            "name": camera.name or camera.id,
+            "status": camera.status,
+            "paired_at": camera.paired_at,
+        }
 
     def _log_audit(self, event, user, ip, detail):
         """Log audit event, swallowing errors."""

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -44,8 +44,8 @@
 <div class="section-header">
     Cameras
     <span style="float:right;margin-top:-4px;display:flex;gap:8px;">
-        <button class="btn btn--secondary btn--small" @click="scanCameras()" :disabled="scanning">
-            <span x-show="!scanning">Scan</span>
+        <button class="btn btn--secondary btn--small" @click="refreshCameras()" :disabled="scanning">
+            <span x-show="!scanning">Refresh</span>
             <span x-show="scanning">Scanning...</span>
         </button>
         <button class="btn btn--primary btn--small" @click="showAddForm = !showAddForm" x-text="showAddForm ? 'Cancel' : 'Add Camera'"></button>
@@ -117,7 +117,6 @@
                 <template x-if="cam.status === 'pending'">
                     <div class="camera-card__btns">
                         <button class="btn btn--primary btn--small" @click.stop="initPairing(cam.id)">Pair</button>
-                        <button class="btn btn--secondary btn--small" @click.stop="confirmCamera(cam.id)">Confirm</button>
                         <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
                     </div>
                 </template>
@@ -178,7 +177,7 @@ function dashboardPage() {
             } catch(e) {}
         },
 
-        async scanCameras() {
+        async refreshCameras() {
             this.scanning = true;
             await this.loadCameras();
             // Brief delay so user sees the scanning state
@@ -209,15 +208,6 @@ function dashboardPage() {
                 this.pairingCameraId = camId;
             } catch(e) {
                 alert(e.message || 'Failed to initiate pairing');
-            }
-        },
-
-        async confirmCamera(camId) {
-            try {
-                await window.HM.api.post('/api/v1/cameras/' + encodeURIComponent(camId) + '/confirm', {});
-                await this.loadCameras();
-            } catch(e) {
-                alert(e.message || 'Failed to confirm camera');
             }
         },
 

--- a/app/server/tests/test_api_cameras.py
+++ b/app/server/tests/test_api_cameras.py
@@ -156,7 +156,8 @@ class TestConfirmCamera:
         _login(app, client)
         _add_camera(app, "cam-001", "online")
         response = client.post("/api/v1/cameras/cam-001/confirm")
-        assert response.status_code == 400
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "online"
 
     def test_confirm_nonexistent(self, app, client):
         _login(app, client)

--- a/app/server/tests/test_camera_service.py
+++ b/app/server/tests/test_camera_service.py
@@ -207,9 +207,21 @@ class TestConfirm:
         store.get_camera.return_value = cam
         svc = CameraService(store)
         result, error, status = svc.confirm("cam-001")
-        assert status == 400
-        assert error == "Camera is already confirmed"
-        assert result is None
+        assert status == 200
+        assert error == ""
+        assert result["status"] == "online"
+        store.save_camera.assert_not_called()
+
+    def test_confirm_is_idempotent_for_offline_camera(self):
+        cam = _make_camera(status="offline", paired_at="2026-04-11T10:00:00Z")
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        result, error, status = svc.confirm("cam-001")
+        assert status == 200
+        assert error == ""
+        assert result["status"] == "offline"
+        assert result["paired_at"] == "2026-04-11T10:00:00Z"
         store.save_camera.assert_not_called()
 
     def test_returns_404_when_camera_not_found(self):


### PR DESCRIPTION
## Summary
- fix camera self-registration to use the server HTTPS pairing endpoint and retry during pairing
- make camera confirmation idempotent so stale dashboard state does not trap the user
- simplify the dashboard pairing UI by removing the conflicting pending-camera confirm action

## Testing
- pytest app/server/tests -q --no-cov
- pytest app/camera/tests -q --no-cov
