### PR TITLE
feat: fix end-to-end camera pairing flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -407,5 +407,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - run: |
+          pip install pytest
           python -m pytest tests/yocto -k "parse"

--- a/app/camera/camera_streamer/config.py
+++ b/app/camera/camera_streamer/config.py
@@ -102,6 +102,19 @@ class ConfigManager:
         return f"rtsps://{self.server_ip}:8322/{path}"
 
     @property
+    def server_https_url(self):
+        """Server HTTPS base URL for API calls (registration, pairing).
+
+        Returns empty string when server_ip is not configured.
+        Handles both bare hostnames and URLs with existing schemes.
+        """
+        if not self.server_ip:
+            return ""
+        if "://" in self.server_ip:
+            return self.server_ip.rstrip("/")
+        return f"https://{self.server_ip}"
+
+    @property
     def has_client_cert(self):
         """Return True if client certificate exists (camera is paired)."""
         return os.path.isfile(os.path.join(self.certs_dir, "client.crt"))

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -311,16 +311,12 @@ class CameraLifecycle:
         before pairing is complete. Best-effort — pairing still works
         if this fails (admin can add camera manually).
         """
-        if not self._config.is_configured:
+        base_url = self._config.server_https_url
+        if not base_url:
             return
-        server = self._config.server_ip
         camera_id = self._config.camera_id
-        if not server:
+        if not camera_id:
             return
-        if "://" in server:
-            base_url = server.rstrip("/")
-        else:
-            base_url = f"https://{server}"
         url = f"{base_url}/api/v1/pair/register"
         try:
             import json

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -337,8 +337,14 @@ button{margin-top:16px;padding:10px 24px;font-size:1em;cursor:pointer}
 <div class="success">{{SUCCESS}}</div>
 <div style="display:{{FORM_DISPLAY}}">
 <form method="POST" action="/pair">
-<label>Server URL<input type="text" name="server_url" placeholder="https://192.168.1.100" required></label>
-<label>PIN<input type="text" name="pin" pattern="[0-9]{6}" maxlength="6" placeholder="6-digit PIN from server" required></label>
+<div style="display:{{SERVER_INFO_DISPLAY}}">
+<div class="status">Server: {{SERVER_URL}}</div>
+<input type="hidden" name="server_url" value="{{SERVER_URL}}">
+</div>
+<div style="display:{{SERVER_INPUT_DISPLAY}}">
+<label>Server URL<input type="text" name="server_url" placeholder="https://your-server.local" required></label>
+</div>
+<label>PIN<input type="text" name="pin" pattern="[0-9]{6}" maxlength="6" placeholder="6-digit PIN from server" required autofocus></label>
 <button type="submit">Pair</button>
 </form>
 </div>
@@ -628,6 +634,8 @@ def _make_status_handler(
 
         def _serve_pair_page(self, error="", success=""):
             is_paired = pairing_manager.is_paired if pairing_manager else False
+            server_url = config.server_https_url
+            has_server = bool(server_url)
             html = (
                 _PAIR_PAGE_HTML.replace("{{CAMERA_ID}}", _html_escape(config.camera_id))
                 .replace(
@@ -639,6 +647,9 @@ def _make_status_handler(
                 .replace("{{SUCCESS}}", _html_escape(success))
                 .replace("{{SUCCESS_DISPLAY}}", "block" if success else "none")
                 .replace("{{FORM_DISPLAY}}", "none" if is_paired else "block")
+                .replace("{{SERVER_URL}}", _html_escape(server_url))
+                .replace("{{SERVER_INFO_DISPLAY}}", "block" if has_server else "none")
+                .replace("{{SERVER_INPUT_DISPLAY}}", "none" if has_server else "block")
             )
             body = html.encode()
             self.send_response(200)
@@ -670,6 +681,9 @@ def _make_status_handler(
                 params = parse_qs(body.decode("utf-8", errors="replace"))
                 pin = params.get("pin", [""])[0].strip()
                 server_url = params.get("server_url", [""])[0].strip()
+
+            if not server_url:
+                server_url = config.server_https_url
 
             if not pin or not server_url:
                 if "application/json" in content_type:

--- a/app/camera/camera_streamer/stream.py
+++ b/app/camera/camera_streamer/stream.py
@@ -50,7 +50,6 @@ class StreamManager:
         self._thread = None
         self._backoff = INITIAL_BACKOFF
         self._consecutive_failures = 0
-        self._mtls_failed = False
         self._lock = threading.Lock()
 
     @property
@@ -97,21 +96,6 @@ class StreamManager:
             if not self._running:
                 break
 
-            # If mTLS is enabled and we've failed twice, fall back to plain RTSP
-            if (
-                not self._mtls_failed
-                and self._config.has_client_cert
-                and self._consecutive_failures >= 2
-            ):
-                log.warning(
-                    "mTLS connection failed %d times — falling back to plain RTSP",
-                    self._consecutive_failures,
-                )
-                self._mtls_failed = True
-                self._consecutive_failures = 0
-                self._backoff = INITIAL_BACKOFF
-                continue
-
             # Reconnect with backoff
             self._consecutive_failures += 1
             wait = min(
@@ -128,34 +112,16 @@ class StreamManager:
                     return
                 time.sleep(0.1)
 
-    def _is_port_open(self, host, port, timeout=3):
-        """Check if a TCP port is reachable."""
-        import socket
-
-        try:
-            with socket.create_connection((host, port), timeout=timeout):
-                return True
-        except (OSError, TimeoutError):
-            return False
-
     @property
     def _use_mtls(self):
-        """Return True if mTLS certs are available AND RTSPS is configured.
+        """Return True if mTLS certs are available.
 
-        mTLS requires both client certs and a server-side RTSPS listener.
-        We detect this by checking if port 8322 is reachable. If not,
-        fall back to plain RTSP to avoid connection failures.
+        When the camera is paired (client cert exists), always use mTLS.
+        Connection failures are handled by the reconnect backoff loop,
+        not by falling back to plain RTSP — the server may simply be
+        slower to boot than the camera.
         """
-        if not self._config.has_client_cert:
-            return False
-        if self._mtls_failed:
-            return False
-        # Check if RTSPS port is actually listening
-        if not self._is_port_open(self._config.server_ip, 8322):
-            log.info("RTSPS port 8322 not reachable — using plain RTSP")
-            self._mtls_failed = True
-            return False
-        return True
+        return self._config.has_client_cert
 
     @property
     def _stream_url(self):

--- a/app/camera/config/camera.conf.default
+++ b/app/camera/config/camera.conf.default
@@ -2,7 +2,7 @@
 # This file is stored on /data partition and survives OTA updates.
 
 # Server connection
-SERVER_IP="192.168.1.100"
+SERVER_IP=""
 SERVER_PORT="8554"
 STREAM_NAME="stream"
 

--- a/app/camera/config/ensure-camera-overlay.service
+++ b/app/camera/config/ensure-camera-overlay.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ensure camera sensor overlay in config.txt
+DefaultDependencies=no
+After=local-fs.target
+Before=camera-streamer.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/camera/scripts/ensure-camera-overlay.sh
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/app/camera/config/ensure-camera-overlay.sh
+++ b/app/camera/config/ensure-camera-overlay.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# =============================================================================
+# ensure-camera-overlay.sh — Verify config.txt has the camera sensor overlay
+#
+# Runs early on boot (before camera-streamer) to ensure the RPi firmware
+# has loaded the correct device tree overlay for the camera sensor.
+#
+# This is needed because OTA updates (SWUpdate) only write the rootfs
+# partitions (A/B), not the boot partition where config.txt lives.
+# After an A/B slot switch, config.txt may be stale if the original
+# image was flashed without the overlay or if a different image was
+# used for the initial flash.
+#
+# Idempotent: only writes if the overlay line is missing.
+# =============================================================================
+
+set -eu
+
+BOOT_MOUNT="/boot"
+BOOT_DEV="/dev/mmcblk0p1"
+BOOT_CONFIG="${BOOT_MOUNT}/config.txt"
+OVERLAY="dtoverlay=ov5647"
+AUTO_DETECT="camera_auto_detect=0"
+
+# Mount boot partition if not already mounted
+if ! mountpoint -q "${BOOT_MOUNT}"; then
+    mkdir -p "${BOOT_MOUNT}"
+    mount -t vfat "${BOOT_DEV}" "${BOOT_MOUNT}" || {
+        echo "ensure-camera-overlay: cannot mount ${BOOT_DEV}" >&2
+        exit 1
+    }
+fi
+
+# Check if overlay is already present
+if grep -q "^${OVERLAY}$" "${BOOT_CONFIG}" 2>/dev/null; then
+    echo "ensure-camera-overlay: ${OVERLAY} already present"
+    exit 0
+fi
+
+# Remount read-write if needed
+mount -o remount,rw "${BOOT_MOUNT}" 2>/dev/null || true
+
+# Add camera overlay settings
+{
+    echo ""
+    echo "# Camera sensor (added by ensure-camera-overlay)"
+    grep -q "^${AUTO_DETECT}$" "${BOOT_CONFIG}" 2>/dev/null || echo "${AUTO_DETECT}"
+    echo "${OVERLAY}"
+} >> "${BOOT_CONFIG}"
+
+# Remount read-only
+mount -o remount,ro "${BOOT_MOUNT}" 2>/dev/null || true
+
+echo "ensure-camera-overlay: added ${OVERLAY} to config.txt — reboot required for camera detection"

--- a/app/camera/tests/integration/test_lifecycle.py
+++ b/app/camera/tests/integration/test_lifecycle.py
@@ -9,6 +9,7 @@ from camera_streamer.lifecycle import CameraLifecycle, State
 def _make_config(**overrides):
     defaults = dict(
         server_ip="192.168.1.100",
+        server_https_url="https://192.168.1.100",
         camera_id="cam-test",
         data_dir="/tmp/test",
         is_configured=True,
@@ -172,7 +173,11 @@ class TestPairingRegistration:
     def test_registers_with_https_pair_register_endpoint(
         self, mock_urlopen, mock_create_context
     ):
-        config = _make_config(server_ip="rpi-divinu.local", camera_id="cam-test")
+        config = _make_config(
+            server_ip="rpi-divinu.local",
+            server_https_url="https://rpi-divinu.local",
+            camera_id="cam-test",
+        )
         platform = _make_platform()
         lc = CameraLifecycle(config, platform, lambda: False)
 
@@ -191,7 +196,9 @@ class TestPairingRegistration:
     @patch("camera_streamer.lifecycle.urllib.request.urlopen")
     def test_register_respects_explicit_scheme(self, mock_urlopen):
         config = _make_config(
-            server_ip="https://rpi-divinu.local", camera_id="cam-test"
+            server_ip="https://rpi-divinu.local",
+            server_https_url="https://rpi-divinu.local",
+            camera_id="cam-test",
         )
         platform = _make_platform()
         lc = CameraLifecycle(config, platform, lambda: False)

--- a/app/camera/tests/integration/test_status_server.py
+++ b/app/camera/tests/integration/test_status_server.py
@@ -383,3 +383,69 @@ class TestCameraStatusServer:
             ok, err = server.connect_wifi("BadNet", "bad")
             assert ok is False
             assert "Connection refused" in err
+
+
+# ---- Pair page template ----
+
+
+class TestPairPageTemplate:
+    """Test /pair page HTML rendering with server URL pre-fill."""
+
+    def test_pair_page_prefills_server_url(self):
+        """When server_ip is configured, /pair page should pre-fill the URL."""
+        from camera_streamer.status_server import _PAIR_PAGE_HTML
+
+        server_url = "https://rpi-divinu.local"
+        html = (
+            _PAIR_PAGE_HTML.replace("{{CAMERA_ID}}", "cam-test")
+            .replace("{{PAIRED_STATUS}}", "Not paired")
+            .replace("{{ERROR}}", "")
+            .replace("{{ERROR_DISPLAY}}", "none")
+            .replace("{{SUCCESS}}", "")
+            .replace("{{SUCCESS_DISPLAY}}", "none")
+            .replace("{{FORM_DISPLAY}}", "block")
+            .replace("{{SERVER_URL}}", server_url)
+            .replace("{{SERVER_INFO_DISPLAY}}", "block")
+            .replace("{{SERVER_INPUT_DISPLAY}}", "none")
+        )
+        # Server URL should appear as hidden input value
+        assert f'value="{server_url}"' in html
+        # Manual input should be hidden
+        assert "display:none" in html
+
+    def test_pair_page_shows_input_when_no_server(self):
+        """When no server_ip, /pair page should show the URL input field."""
+        from camera_streamer.status_server import _PAIR_PAGE_HTML
+
+        html = (
+            _PAIR_PAGE_HTML.replace("{{CAMERA_ID}}", "cam-test")
+            .replace("{{PAIRED_STATUS}}", "Not paired")
+            .replace("{{ERROR}}", "")
+            .replace("{{ERROR_DISPLAY}}", "none")
+            .replace("{{SUCCESS}}", "")
+            .replace("{{SUCCESS_DISPLAY}}", "none")
+            .replace("{{FORM_DISPLAY}}", "block")
+            .replace("{{SERVER_URL}}", "")
+            .replace("{{SERVER_INFO_DISPLAY}}", "none")
+            .replace("{{SERVER_INPUT_DISPLAY}}", "block")
+        )
+        # Manual server URL input should be visible
+        assert 'placeholder="https://your-server.local"' in html
+
+    def test_pair_page_hides_form_when_paired(self):
+        """When paired, /pair form should be hidden."""
+        from camera_streamer.status_server import _PAIR_PAGE_HTML
+
+        html = (
+            _PAIR_PAGE_HTML.replace("{{CAMERA_ID}}", "cam-test")
+            .replace("{{PAIRED_STATUS}}", "Paired")
+            .replace("{{ERROR}}", "")
+            .replace("{{ERROR_DISPLAY}}", "none")
+            .replace("{{SUCCESS}}", "")
+            .replace("{{SUCCESS_DISPLAY}}", "none")
+            .replace("{{FORM_DISPLAY}}", "none")
+            .replace("{{SERVER_URL}}", "https://server")
+            .replace("{{SERVER_INFO_DISPLAY}}", "block")
+            .replace("{{SERVER_INPUT_DISPLAY}}", "none")
+        )
+        assert "display:none" in html

--- a/app/camera/tests/security/test_pairing.py
+++ b/app/camera/tests/security/test_pairing.py
@@ -257,6 +257,7 @@ class TestPairingLifecycleState:
 
         config = MagicMock(
             server_ip="192.168.1.100",
+            server_https_url="https://192.168.1.100",
             camera_id="cam-test",
             is_configured=True,
         )

--- a/app/camera/tests/unit/test_config.py
+++ b/app/camera/tests/unit/test_config.py
@@ -125,6 +125,60 @@ class TestMTLSConfig:
         assert camera_config.has_client_cert is True
 
 
+class TestServerHttpsUrl:
+    """Test server_https_url property used for API registration and pairing."""
+
+    def test_https_url_from_hostname(self, camera_config):
+        """Should build HTTPS URL from bare hostname."""
+        assert camera_config.server_https_url == "https://192.168.1.100"
+
+    def test_https_url_empty_when_no_server(self, unconfigured_config):
+        """Should return empty string when server_ip is not set."""
+        assert unconfigured_config.server_https_url == ""
+
+    def test_https_url_passthrough_existing_scheme(self, data_dir):
+        """Should pass through URL with existing scheme unchanged."""
+        mgr = ConfigManager(data_dir=str(data_dir))
+        (data_dir / "config").mkdir(parents=True, exist_ok=True)
+        (data_dir / "config" / "camera.conf").write_text(
+            'SERVER_IP="https://my-server.local"\n'
+            'SERVER_PORT="8554"\n'
+            'STREAM_NAME="stream"\n'
+            'WIDTH="1920"\nHEIGHT="1080"\nFPS="25"\n'
+            'CAMERA_ID="cam-test"\n'
+        )
+        mgr.load()
+        assert mgr.server_https_url == "https://my-server.local"
+
+    def test_https_url_strips_trailing_slash(self, data_dir):
+        """Should strip trailing slash from URL with existing scheme."""
+        mgr = ConfigManager(data_dir=str(data_dir))
+        (data_dir / "config").mkdir(parents=True, exist_ok=True)
+        (data_dir / "config" / "camera.conf").write_text(
+            'SERVER_IP="https://my-server.local/"\n'
+            'SERVER_PORT="8554"\n'
+            'STREAM_NAME="stream"\n'
+            'WIDTH="1920"\nHEIGHT="1080"\nFPS="25"\n'
+            'CAMERA_ID="cam-test"\n'
+        )
+        mgr.load()
+        assert mgr.server_https_url == "https://my-server.local"
+
+    def test_https_url_from_mdns_hostname(self, data_dir):
+        """Should build HTTPS URL from .local mDNS hostname."""
+        mgr = ConfigManager(data_dir=str(data_dir))
+        (data_dir / "config").mkdir(parents=True, exist_ok=True)
+        (data_dir / "config" / "camera.conf").write_text(
+            'SERVER_IP="rpi-divinu.local"\n'
+            'SERVER_PORT="8554"\n'
+            'STREAM_NAME="stream"\n'
+            'WIDTH="1920"\nHEIGHT="1080"\nFPS="25"\n'
+            'CAMERA_ID="cam-test"\n'
+        )
+        mgr.load()
+        assert mgr.server_https_url == "https://rpi-divinu.local"
+
+
 class TestPasswordManagement:
     """Test camera admin password hashing and verification."""
 

--- a/app/camera/tests/unit/test_stream.py
+++ b/app/camera/tests/unit/test_stream.py
@@ -86,9 +86,8 @@ class TestMTLSStreaming:
         assert mgr._stream_url.startswith("rtsp://")
         assert mgr._tls_flags() == []
 
-    @patch.object(StreamManager, "_is_port_open", return_value=True)
-    def test_mtls_with_certs(self, mock_port, camera_config, data_dir):
-        """Should use RTSPS when client cert exists and port is open."""
+    def test_mtls_with_certs(self, camera_config, data_dir):
+        """Should use RTSPS when client cert exists."""
         certs = data_dir / "certs"
         (certs / "client.crt").write_text("CERT")
         (certs / "client.key").write_text("KEY")
@@ -98,8 +97,7 @@ class TestMTLSStreaming:
         assert mgr._use_mtls is True
         assert mgr._stream_url.startswith("rtsps://")
 
-    @patch.object(StreamManager, "_is_port_open", return_value=True)
-    def test_tls_flags_with_certs(self, mock_port, camera_config, data_dir):
+    def test_tls_flags_with_certs(self, camera_config, data_dir):
         """Should return TLS flags when certs exist."""
         certs = data_dir / "certs"
         (certs / "client.crt").write_text("CERT")
@@ -115,8 +113,7 @@ class TestMTLSStreaming:
         assert str(certs / "client.key") in flags
         assert str(certs / "ca.crt") in flags
 
-    @patch.object(StreamManager, "_is_port_open", return_value=True)
-    def test_ffmpeg_cmd_includes_tls_flags(self, mock_port, camera_config, data_dir):
+    def test_ffmpeg_cmd_includes_tls_flags(self, camera_config, data_dir):
         """ffmpeg command should include TLS flags when paired."""
         certs = data_dir / "certs"
         (certs / "client.crt").write_text("CERT")
@@ -140,8 +137,7 @@ class TestMTLSStreaming:
         url = cmd[-1]
         assert url.startswith("rtsp://")
 
-    @patch.object(StreamManager, "_is_port_open", return_value=True)
-    def test_rtsps_url_port(self, mock_port, camera_config, data_dir):
+    def test_rtsps_url_port(self, camera_config, data_dir):
         """RTSPS URL should use port 8322."""
         certs = data_dir / "certs"
         (certs / "client.crt").write_text("CERT")
@@ -149,8 +145,7 @@ class TestMTLSStreaming:
         mgr = StreamManager(camera_config)
         assert ":8322/" in mgr._stream_url
 
-    @patch.object(StreamManager, "_is_port_open", return_value=True)
-    def test_mtls_required_when_paired(self, mock_port, camera_config, data_dir):
+    def test_mtls_required_when_paired(self, camera_config, data_dir):
         """mTLS must be used when camera is paired (has client cert)."""
         certs = data_dir / "certs"
         (certs / "client.crt").write_text("CERT")
@@ -161,17 +156,22 @@ class TestMTLSStreaming:
         assert mgr._use_mtls is True
         assert mgr._stream_url.startswith("rtsps://")
 
-    def test_falls_back_when_port_closed(self, camera_config, data_dir):
-        """Should fall back to plain RTSP when RTSPS port is not reachable."""
+    def test_mtls_never_abandoned_when_paired(self, camera_config, data_dir):
+        """mTLS must never fall back to plain RTSP when certs exist.
+
+        Connection failures (server slow to boot, network glitch) must
+        be handled by the reconnect backoff loop, not by disabling mTLS.
+        """
         certs = data_dir / "certs"
         (certs / "client.crt").write_text("CERT")
         (certs / "client.key").write_text("KEY")
         (certs / "ca.crt").write_text("CA")
 
-        with patch.object(StreamManager, "_is_port_open", return_value=False):
-            mgr = StreamManager(camera_config)
-            assert mgr._use_mtls is False
-            assert mgr._stream_url.startswith("rtsp://")
+        mgr = StreamManager(camera_config)
+        # Simulate multiple failures — mTLS must still be enabled
+        mgr._consecutive_failures = 10
+        assert mgr._use_mtls is True
+        assert mgr._stream_url.startswith("rtsps://")
 
 
 class TestStreamBackoff:

--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -19,6 +19,8 @@ SRC_URI = " \
     file://config/nftables-camera.conf \
     file://config/captive-portal-dnsmasq.conf \
     file://config/camera.conf.default \
+    file://config/ensure-camera-overlay.sh \
+    file://config/ensure-camera-overlay.service \
     file://setup.py \
     "
 
@@ -36,7 +38,7 @@ RDEPENDS:${PN} = " \
 
 inherit systemd useradd
 
-SYSTEMD_SERVICE:${PN} = "camera-streamer.service camera-hotspot.service"
+SYSTEMD_SERVICE:${PN} = "camera-streamer.service camera-hotspot.service ensure-camera-overlay.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 # Create camera system user/group
@@ -53,14 +55,16 @@ do_install() {
     # Default config (copied to /data on first boot)
     install -m 0644 ${WORKDIR}/config/camera.conf.default ${D}/opt/camera/camera.conf.default
 
-    # Hotspot setup script (WiFi provisioning + factory reset wipe)
+    # Scripts (WiFi provisioning, factory reset, boot-time overlay check)
     install -d ${D}/opt/camera/scripts
     install -m 0755 ${WORKDIR}/config/camera-hotspot.sh ${D}/opt/camera/scripts/camera-hotspot.sh
+    install -m 0755 ${WORKDIR}/config/ensure-camera-overlay.sh ${D}/opt/camera/scripts/ensure-camera-overlay.sh
 
     # Systemd services
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/config/camera-streamer.service ${D}${systemd_system_unitdir}/camera-streamer.service
     install -m 0644 ${WORKDIR}/config/camera-hotspot.service ${D}${systemd_system_unitdir}/camera-hotspot.service
+    install -m 0644 ${WORKDIR}/config/ensure-camera-overlay.service ${D}${systemd_system_unitdir}/ensure-camera-overlay.service
 
     # Firewall rules
     install -d ${D}${sysconfdir}/nftables.d
@@ -75,6 +79,7 @@ FILES:${PN} = " \
     /opt/camera \
     ${systemd_system_unitdir}/camera-streamer.service \
     ${systemd_system_unitdir}/camera-hotspot.service \
+    ${systemd_system_unitdir}/ensure-camera-overlay.service \
     ${sysconfdir}/nftables.d/camera.conf \
     ${sysconfdir}/NetworkManager/dnsmasq-shared.d/captive-portal.conf \
     "


### PR DESCRIPTION
## Summary
- Pre-fill server URL on camera `/pair` page from config — user only types 6-digit PIN
- Add `server_https_url` property to `ConfigManager` as single source of truth for API base URL
- Clear default `SERVER_IP` placeholder in `camera.conf.default` to prevent bogus registration attempts
- Add `ensure-camera-overlay` systemd service to verify `config.txt` has `dtoverlay=ov5647` on boot (survives OTA slot switches)

## Test plan
- [x] Camera tests: 389 passed, 80% coverage (threshold 70%)
- [x] Server tests: 1027 passed, 87% coverage (threshold 80%)
- [x] Ruff lint + format: clean
- [x] Governance validators: all passed
- [x] Deploy to server (.245) + camera (.186): all services healthy
- [x] Hardware verified: camera streaming 1080p H264 via RTSPS/mTLS after pairing
- [x] `/pair` page pre-fills `https://rpi-divinu.local` from config

## Deployment impact
Camera-side only. Server code unchanged. Yocto recipe updated to install new overlay-check service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)