### PR TITLE
fix: store camera IP during pairing exchange

### DIFF
--- a/app/server/monitor/api/pairing.py
+++ b/app/server/monitor/api/pairing.py
@@ -92,7 +92,9 @@ def exchange_certs():
     if not pin or not camera_id:
         return jsonify({"error": "pin and camera_id are required"}), 400
 
-    result, error, status = current_app.pairing_service.exchange_certs(pin, camera_id)
+    result, error, status = current_app.pairing_service.exchange_certs(
+        pin, camera_id, ip=request.remote_addr or ""
+    )
     if error:
         return jsonify({"error": error}), status
     return jsonify(result), 200

--- a/app/server/monitor/services/pairing_service.py
+++ b/app/server/monitor/services/pairing_service.py
@@ -99,7 +99,7 @@ class PairingService:
 
         return pin, "", 200
 
-    def exchange_certs(self, pin, camera_id):
+    def exchange_certs(self, pin, camera_id, ip=""):
         """Validate PIN and return certs + pairing_secret.
 
         Returns (result_dict, error, status_code).
@@ -153,6 +153,8 @@ class PairingService:
         camera.status = "online"
         camera.cert_serial = cert_data["serial"]
         camera.pairing_secret = pairing_secret
+        if ip:
+            camera.ip = ip
         self._store.save_camera(camera)
 
         # Clean up pending state


### PR DESCRIPTION
## Summary
- Camera IP was never saved during PIN exchange — `exchange_certs()` set status to online but left `camera.ip` empty, showing `--` in the live view sidebar
- Pass `request.remote_addr` from the `/pair/exchange` endpoint to the service, which stores it on the camera record

## Test plan
- [x] All 52 pairing tests pass (unit + integration)
- [x] Full server suite: 1038 passed, 84% coverage
- [x] Ruff clean

## Deployment impact
None — backward compatible, adds optional `ip` parameter to `exchange_certs()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)