### PR TITLE
security: redirect HTTP to HTTPS except setup endpoints

### DIFF
--- a/app/server/config/nginx-monitor.conf
+++ b/app/server/config/nginx-monitor.conf
@@ -28,8 +28,8 @@ server {
         return 200 '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="3"><title>Starting...</title><style>body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}.card{background:#16213e;border-radius:12px;padding:32px;text-align:center;max-width:320px}h2{color:#fff;margin-bottom:12px}.spinner{width:32px;height:32px;border:3px solid rgba(255,255,255,.2);border-top-color:#e94560;border-radius:50%;animation:s .7s linear infinite;margin:0 auto 16px}@keyframes s{to{transform:rotate(360deg)}}</style></head><body><div class="card"><div class="spinner"></div><h2>Starting Up</h2><p>Home Monitor is loading...<br>This page will refresh automatically.</p></div></body></html>';
     }
 
-    # Proxy to Flask app
-    location / {
+    # Setup wizard — must stay on HTTP (hotspot has no TLS cert)
+    location /api/v1/setup/ {
         proxy_pass http://127.0.0.1:5000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -37,12 +37,19 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Static assets
+    # Static assets — needed for setup page styling
     location /static/ {
         alias /opt/monitor/monitor/static/;
         expires 1d;
         gzip on;
         gzip_types text/css application/javascript;
+    }
+
+    # Everything else: redirect to HTTPS (login, dashboard, API, etc.)
+    # During setup the phone connects via hotspot (HTTP only, no cert).
+    # After setup, users access via HTTPS where session cookies work.
+    location / {
+        return 301 https://$host$request_uri;
     }
 
     # Upload size for OTA images


### PR DESCRIPTION
## Summary
- HTTP port 80 now redirects all non-setup paths to HTTPS via 301
- Setup endpoints (`/api/v1/setup/`) stay on HTTP (hotspot has no TLS cert)
- Fixes infinite login loop when accessing via `http://` — `SESSION_COOKIE_SECURE=True` meant the cookie was set but never sent back over HTTP

## Test plan
- [x] `http://server/login` → 301 redirect to `https://server/login`
- [x] `http://server/api/v1/setup/status` → 200 (stays HTTP for hotspot)
- [x] `https://server` login + dashboard → works with session cookie
- [x] nginx -t passes

## Deployment impact
Users accessing via HTTP will be redirected to HTTPS. Setup flow on hotspot (HTTP only) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)