### PR TITLE
feat: server-to-camera control channel (ADR-0015)

### DIFF
--- a/app/camera/camera_streamer/config.py
+++ b/app/camera/camera_streamer/config.py
@@ -29,6 +29,12 @@ DEFAULTS = {
     "WIDTH": "1920",
     "HEIGHT": "1080",
     "FPS": "25",
+    "BITRATE": "4000000",
+    "H264_PROFILE": "high",
+    "KEYFRAME_INTERVAL": "30",
+    "ROTATION": "0",
+    "HFLIP": "false",
+    "VFLIP": "false",
     "CAMERA_ID": "",
     "ADMIN_USERNAME": "admin",  # default username
     "ADMIN_PASSWORD": "",  # salt:hash (PBKDF2-SHA256)
@@ -67,6 +73,30 @@ class ConfigManager:
     @property
     def fps(self):
         return int(self._values["FPS"])
+
+    @property
+    def bitrate(self):
+        return int(self._values["BITRATE"])
+
+    @property
+    def h264_profile(self):
+        return self._values["H264_PROFILE"]
+
+    @property
+    def keyframe_interval(self):
+        return int(self._values["KEYFRAME_INTERVAL"])
+
+    @property
+    def rotation(self):
+        return int(self._values["ROTATION"])
+
+    @property
+    def hflip(self):
+        return self._values["HFLIP"].lower() == "true"
+
+    @property
+    def vflip(self):
+        return self._values["VFLIP"].lower() == "true"
 
     @property
     def camera_id(self):

--- a/app/camera/camera_streamer/control.py
+++ b/app/camera/camera_streamer/control.py
@@ -114,7 +114,7 @@ class ControlHandler:
             "vflip": self._config.vflip,
         }
 
-    def set_config(self, params, request_id=0):
+    def set_config(self, params, request_id=0, origin="server"):
         """Validate and apply configuration changes.
 
         Args:
@@ -189,6 +189,7 @@ class ControlHandler:
                 "restart_required": restart_required,
                 "restarted": restarted,
                 "status": "ok",
+                "origin": origin,
             },
             "",
             200,

--- a/app/camera/camera_streamer/control.py
+++ b/app/camera/camera_streamer/control.py
@@ -1,0 +1,275 @@
+"""
+Camera control API handler — processes configuration commands from the server.
+
+The server pushes stream parameter changes via HTTPS to this handler.
+Authentication is via mTLS (server presents its certificate signed by
+the same CA used during pairing). See ADR-0015.
+
+Controllable parameters (all require stream pipeline restart):
+  width, height, fps, bitrate, h264_profile, keyframe_interval,
+  rotation, hflip, vflip
+
+OV5647 sensor modes (libcamera on RPi Zero 2W):
+  640x480   @ up to 58 fps
+  1296x972  @ up to 43 fps
+  1920x1080 @ up to 30 fps
+  2592x1944 @ up to 15 fps
+"""
+
+import json
+import logging
+import time
+
+log = logging.getLogger("camera-streamer.control")
+
+# OV5647 sensor: validated resolution+fps combinations.
+# Max FPS per resolution from libcamera --list-cameras output.
+SENSOR_MODES = {
+    (640, 480): 58,
+    (1296, 972): 43,
+    (1920, 1080): 30,
+    (2592, 1944): 15,
+}
+
+VALID_RESOLUTIONS = set(SENSOR_MODES.keys())
+
+PARAM_SCHEMA = {
+    "width": {"type": int, "allowed": [w for w, _ in VALID_RESOLUTIONS]},
+    "height": {"type": int, "allowed": [h for _, h in VALID_RESOLUTIONS]},
+    "fps": {"type": int, "min": 1, "max": 58},
+    "bitrate": {"type": int, "min": 500000, "max": 8000000},
+    "h264_profile": {"type": str, "allowed": ["baseline", "main", "high"]},
+    "keyframe_interval": {"type": int, "min": 1, "max": 120},
+    "rotation": {"type": int, "allowed": [0, 180]},
+    "hflip": {"type": bool},
+    "vflip": {"type": bool},
+}
+
+# Rate limit: minimum seconds between config changes
+RATE_LIMIT_SECONDS = 5
+
+
+class ControlHandler:
+    """Handles server control API requests.
+
+    Validates parameters against OV5647 hardware capabilities,
+    applies changes to ConfigManager, and restarts stream if needed.
+
+    Args:
+        config: ConfigManager instance.
+        stream_manager: StreamManager instance (or None in tests).
+    """
+
+    def __init__(self, config, stream_manager=None):
+        self._config = config
+        self._stream = stream_manager
+        self._last_request_id = 0
+        self._last_change_time = 0.0
+
+    def get_capabilities(self):
+        """Return supported parameter ranges for this camera hardware."""
+        return {
+            "sensor": "OV5647",
+            "sensor_modes": [
+                {
+                    "width": w,
+                    "height": h,
+                    "max_fps": max_fps,
+                }
+                for (w, h), max_fps in sorted(SENSOR_MODES.items())
+            ],
+            "parameters": {
+                "width": {
+                    "type": "int",
+                    "allowed": sorted({w for w, _ in VALID_RESOLUTIONS}),
+                },
+                "height": {
+                    "type": "int",
+                    "allowed": sorted({h for _, h in VALID_RESOLUTIONS}),
+                },
+                "fps": {"type": "int", "min": 1, "max": 58},
+                "bitrate": {"type": "int", "min": 500000, "max": 8000000},
+                "h264_profile": {
+                    "type": "string",
+                    "allowed": ["baseline", "main", "high"],
+                },
+                "keyframe_interval": {"type": "int", "min": 1, "max": 120},
+                "rotation": {"type": "int", "allowed": [0, 180]},
+                "hflip": {"type": "bool"},
+                "vflip": {"type": "bool"},
+            },
+        }
+
+    def get_config(self):
+        """Return current stream configuration."""
+        return {
+            "width": self._config.width,
+            "height": self._config.height,
+            "fps": self._config.fps,
+            "bitrate": self._config.bitrate,
+            "h264_profile": self._config.h264_profile,
+            "keyframe_interval": self._config.keyframe_interval,
+            "rotation": self._config.rotation,
+            "hflip": self._config.hflip,
+            "vflip": self._config.vflip,
+        }
+
+    def set_config(self, params, request_id=0):
+        """Validate and apply configuration changes.
+
+        Args:
+            params: Dict of parameter names to new values.
+            request_id: Monotonic request ID for replay protection.
+
+        Returns:
+            (result_dict, error_string, http_status_code)
+        """
+        # Replay protection
+        if request_id and request_id <= self._last_request_id:
+            return None, "Stale request_id (replay rejected)", 409
+
+        # Rate limiting
+        now = time.monotonic()
+        elapsed = now - self._last_change_time
+        if self._last_change_time > 0 and elapsed < RATE_LIMIT_SECONDS:
+            wait = RATE_LIMIT_SECONDS - elapsed
+            return None, f"Rate limited, retry after {wait:.0f}s", 429
+
+        if not params:
+            return None, "No parameters provided", 400
+
+        # Validate all params first (reject entire request on any error)
+        error = self._validate_params(params)
+        if error:
+            return None, error, 400
+
+        # Check which params actually changed
+        current = self.get_config()
+        changes = {}
+        for key, value in params.items():
+            if current.get(key) != value:
+                changes[key] = value
+
+        if not changes:
+            return (
+                {"applied": {}, "restart_required": False, "status": "unchanged"},
+                "",
+                200,
+            )
+
+        # Apply changes to config
+        config_updates = {}
+        for key, value in changes.items():
+            config_key = key.upper()
+            config_updates[config_key] = (
+                str(value).lower() if isinstance(value, bool) else str(value)
+            )
+
+        old_values = {k: current[k] for k in changes}
+        self._config.update(**config_updates)
+
+        # Log the change
+        for key, new_val in changes.items():
+            log.info("Config changed: %s = %s (was %s)", key, new_val, old_values[key])
+
+        # Restart stream if needed
+        restart_required = True
+        restarted = False
+        if self._stream:
+            restarted = self._stream.restart()
+
+        # Update state
+        if request_id:
+            self._last_request_id = request_id
+        self._last_change_time = time.monotonic()
+
+        return (
+            {
+                "applied": changes,
+                "restart_required": restart_required,
+                "restarted": restarted,
+                "status": "ok",
+            },
+            "",
+            200,
+        )
+
+    def get_status(self):
+        """Return live operational status."""
+        streaming = False
+        if self._stream:
+            streaming = self._stream.is_streaming
+
+        return {
+            "streaming": streaming,
+            "consecutive_failures": self._stream.consecutive_failures
+            if self._stream
+            else 0,
+            "config": self.get_config(),
+            "camera_id": self._config.camera_id,
+            "paired": self._config.has_client_cert,
+        }
+
+    def _validate_params(self, params):
+        """Validate parameters against schema and hardware constraints.
+
+        Returns error string or empty string on success.
+        """
+        unknown = set(params.keys()) - set(PARAM_SCHEMA.keys())
+        if unknown:
+            return f"Unknown parameters: {', '.join(sorted(unknown))}"
+
+        for key, value in params.items():
+            schema = PARAM_SCHEMA[key]
+            expected_type = schema["type"]
+
+            if not isinstance(value, expected_type):
+                return f"{key}: expected {expected_type.__name__}, got {type(value).__name__}"
+
+            if "allowed" in schema and value not in schema["allowed"]:
+                return f"{key}: must be one of {schema['allowed']}, got {value}"
+
+            if "min" in schema and value < schema["min"]:
+                return f"{key}: minimum is {schema['min']}, got {value}"
+
+            if "max" in schema and value > schema["max"]:
+                return f"{key}: maximum is {schema['max']}, got {value}"
+
+        # Cross-field validation: width+height must form valid resolution pair
+        width = params.get("width", self._config.width)
+        height = params.get("height", self._config.height)
+        if ("width" in params or "height" in params) and (
+            width,
+            height,
+        ) not in VALID_RESOLUTIONS:
+            valid = ", ".join(f"{w}x{h}" for w, h in sorted(VALID_RESOLUTIONS))
+            return f"Invalid resolution {width}x{height}. Valid: {valid}"
+
+        # Cross-field: fps must not exceed sensor mode max
+        fps = params.get("fps", self._config.fps)
+        if (width, height) in SENSOR_MODES:
+            max_fps = SENSOR_MODES[(width, height)]
+            if fps > max_fps:
+                return f"FPS {fps} exceeds maximum {max_fps} for {width}x{height}"
+
+        return ""
+
+
+def parse_control_request(body):
+    """Parse a control API request body.
+
+    Returns (params_dict, request_id, error_string).
+    """
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return None, 0, "Invalid JSON"
+
+    if not isinstance(data, dict):
+        return None, 0, "Expected JSON object"
+
+    request_id = data.pop("request_id", 0)
+    if not isinstance(request_id, int):
+        return None, 0, "request_id must be integer"
+
+    return data, request_id, ""

--- a/app/camera/camera_streamer/control.py
+++ b/app/camera/camera_streamer/control.py
@@ -9,11 +9,14 @@ Controllable parameters (all require stream pipeline restart):
   width, height, fps, bitrate, h264_profile, keyframe_interval,
   rotation, hflip, vflip
 
-OV5647 sensor modes (libcamera on RPi Zero 2W):
+OV5647 sensor modes usable for H264 streaming (libcamera on RPi Zero 2W):
   640x480   @ up to 58 fps
   1296x972  @ up to 43 fps
   1920x1080 @ up to 30 fps
-  2592x1944 @ up to 15 fps
+
+Note: 2592x1944 (full 5MP) is a valid sensor mode but the Pi Zero 2W
+cannot encode it fast enough for real-time H264 streaming — ffmpeg
+fails to detect codec parameters. Excluded from allowed resolutions.
 """
 
 import json
@@ -28,7 +31,6 @@ SENSOR_MODES = {
     (640, 480): 58,
     (1296, 972): 43,
     (1920, 1080): 30,
-    (2592, 1944): 15,
 }
 
 VALID_RESOLUTIONS = set(SENSOR_MODES.keys())

--- a/app/camera/camera_streamer/server_notifier.py
+++ b/app/camera/camera_streamer/server_notifier.py
@@ -1,0 +1,111 @@
+"""
+Notify the paired server when camera stream config changes locally.
+
+Uses HMAC-SHA256 signed requests with the pairing_secret for
+authentication. Fire-and-forget — failures are logged but not retried.
+The server's next dashboard poll will eventually sync regardless.
+
+Part of the bidirectional config sync (ADR-0015).
+"""
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import ssl
+import time
+import urllib.error
+import urllib.request
+
+log = logging.getLogger("camera-streamer.server-notifier")
+
+NOTIFY_TIMEOUT = 10  # seconds
+
+
+def _build_signature(secret_hex, camera_id, timestamp, body_bytes):
+    """Compute HMAC-SHA256(secret, camera_id:timestamp:sha256(body))."""
+    body_hash = hashlib.sha256(body_bytes).hexdigest()
+    message = f"{camera_id}:{timestamp}:{body_hash}"
+    return hmac.new(
+        bytes.fromhex(secret_hex),
+        message.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _ssl_context(certs_dir):
+    """Build SSL context with camera's client cert for TLS."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE  # server uses self-signed cert
+
+    cert = os.path.join(certs_dir, "client.crt")
+    key = os.path.join(certs_dir, "client.key")
+    if os.path.isfile(cert) and os.path.isfile(key):
+        ctx.load_cert_chain(cert, key)
+
+    return ctx
+
+
+def notify_config_change(config, pairing_manager):
+    """POST current stream config to the paired server.
+
+    Called from a daemon thread after a local config change succeeds.
+    Args:
+        config: ConfigManager instance (has server_ip, camera_id, certs_dir).
+        pairing_manager: PairingManager instance (has get_pairing_secret()).
+    """
+    server_ip = config.server_ip
+    if not server_ip:
+        log.debug("No server IP configured, skipping config notification")
+        return
+
+    secret = pairing_manager.get_pairing_secret()
+    if not secret:
+        log.debug("No pairing secret, skipping config notification")
+        return
+
+    camera_id = config.camera_id
+    timestamp = str(int(time.time()))
+
+    stream_config = {
+        "width": config.width,
+        "height": config.height,
+        "fps": config.fps,
+        "bitrate": config.bitrate,
+        "h264_profile": config.h264_profile,
+        "keyframe_interval": config.keyframe_interval,
+        "rotation": config.rotation,
+        "hflip": config.hflip,
+        "vflip": config.vflip,
+    }
+
+    body = json.dumps(stream_config).encode()
+    signature = _build_signature(secret, camera_id, timestamp, body)
+
+    url = f"https://{server_ip}/api/v1/cameras/config-notify"
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "X-Camera-ID": camera_id,
+            "X-Timestamp": timestamp,
+            "X-Signature": signature,
+        },
+    )
+
+    try:
+        ctx = _ssl_context(config.certs_dir)
+        with urllib.request.urlopen(req, context=ctx, timeout=NOTIFY_TIMEOUT) as resp:
+            log.info(
+                "Config notification sent to server (%s): HTTP %d",
+                server_ip,
+                resp.status,
+            )
+    except urllib.error.HTTPError as e:
+        log.warning("Config notification rejected by server: HTTP %d", e.code)
+    except (urllib.error.URLError, OSError) as e:
+        log.warning("Config notification failed (server %s): %s", server_ip, e)

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -20,6 +20,7 @@ import threading
 import time
 
 from camera_streamer import wifi
+from camera_streamer.control import ControlHandler, parse_control_request
 from camera_streamer.factory_reset import FactoryResetService
 
 log = logging.getLogger("camera-streamer.status-server")
@@ -171,10 +172,24 @@ def _ensure_tls_material(config):
 
 
 def _wrap_https_server(server, config):
-    """Wrap the status server socket with TLS."""
+    """Wrap the status server socket with TLS.
+
+    If a CA certificate exists (camera is paired), enables CERT_OPTIONAL
+    so the server can verify mTLS client certificates from the paired
+    server for control API requests. Browser clients without certs
+    still work for human-facing endpoints.
+    """
     cert_path, key_path = _ensure_tls_material(config)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(cert_path, key_path)
+
+    # Enable optional client cert verification if CA cert exists (paired)
+    ca_path = os.path.join(config.certs_dir, "ca.crt")
+    if os.path.isfile(ca_path):
+        ctx.load_verify_locations(ca_path)
+        ctx.verify_mode = ssl.CERT_OPTIONAL
+        log.info("mTLS enabled for control API (CA: %s)", ca_path)
+
     server.socket = ctx.wrap_socket(server.socket, server_side=True)
     return server
 
@@ -274,6 +289,7 @@ class CameraStatusServer:
         self._wifi_interface = wifi_interface
         self._thermal_path = thermal_path
         self._pairing = pairing_manager
+        self._control = ControlHandler(config, stream_manager)
         self._server = None
         self._thread = None
 
@@ -286,6 +302,7 @@ class CameraStatusServer:
             self._wifi_interface,
             self._thermal_path,
             self._pairing,
+            self._control,
         )
         try:
             self._server = http.server.HTTPServer(("0.0.0.0", LISTEN_PORT), handler)
@@ -355,13 +372,39 @@ button{margin-top:16px;padding:10px 24px;font-size:1em;cursor:pointer}
 
 
 def _make_status_handler(
-    config, stream_manager, status_server, wifi_interface, thermal_path, pairing_manager
+    config,
+    stream_manager,
+    status_server,
+    wifi_interface,
+    thermal_path,
+    pairing_manager,
+    control_handler=None,
 ):
     """Create HTTP handler for the camera status page."""
 
     class StatusHandler(http.server.BaseHTTPRequestHandler):
         def log_message(self, format, *args):
             log.debug("Status HTTPS: " + format % args)
+
+        def _has_mtls_client_cert(self):
+            """Check if request has a valid mTLS client certificate.
+
+            Returns True if the client presented a certificate that was
+            verified by the TLS stack against our CA. Used for control
+            API endpoints (ADR-0015).
+            """
+            try:
+                peer_cert = self.request.getpeercert()
+                return peer_cert is not None and len(peer_cert) > 0
+            except (AttributeError, ValueError):
+                return False
+
+        def _require_mtls(self):
+            """Require mTLS client certificate for control API endpoints."""
+            if self._has_mtls_client_cert():
+                return True
+            self._json_response({"error": "Client certificate required"}, 401)
+            return False
 
         def do_HEAD(self):
             if self.path == "/login":
@@ -401,6 +444,7 @@ def _make_status_handler(
             return _check_session(token)
 
         def _require_auth(self):
+            """Require session auth OR mTLS for non-control API paths."""
             if self._is_authenticated():
                 return True
             if self.path.startswith("/api/"):
@@ -412,6 +456,23 @@ def _make_status_handler(
             return False
 
         def do_GET(self):
+            # Control API — mTLS auth
+            if self.path == "/api/v1/control/config":
+                if not self._require_mtls():
+                    return
+                self._json_response(control_handler.get_config())
+                return
+            if self.path == "/api/v1/control/capabilities":
+                if not self._require_mtls():
+                    return
+                self._json_response(control_handler.get_capabilities())
+                return
+            if self.path == "/api/v1/control/status":
+                if not self._require_mtls():
+                    return
+                self._json_response(control_handler.get_status())
+                return
+
             if self.path == "/login":
                 self._serve_login_page()
             elif self.path == "/logout":
@@ -442,9 +503,39 @@ def _make_status_handler(
                 self.send_header("Location", "/")
                 self.end_headers()
 
+        def do_PUT(self):
+            content_len = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_len) if content_len > 0 else b""
+
+            if self.path == "/api/v1/control/config":
+                if not self._require_mtls():
+                    return
+                params, request_id, err = parse_control_request(body)
+                if err:
+                    self._json_response({"error": err}, 400)
+                    return
+                result, error, status = control_handler.set_config(params, request_id)
+                if error:
+                    self._json_response({"error": error}, status)
+                else:
+                    self._json_response(result, status)
+            else:
+                self.send_error(404)
+
         def do_POST(self):
             content_len = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(content_len) if content_len > 0 else b""
+
+            # Control API — restart stream
+            if self.path == "/api/v1/control/restart-stream":
+                if not self._require_mtls():
+                    return
+                if stream_manager:
+                    ok = stream_manager.restart()
+                    self._json_response({"restarted": ok, "status": "ok"})
+                else:
+                    self._json_response({"error": "Stream manager not available"}, 503)
+                return
 
             if self.path == "/login":
                 self._handle_login(body)
@@ -597,6 +688,16 @@ def _make_status_handler(
                 "uptime": uptime,
                 "memory_total_mb": mem_total,
                 "memory_used_mb": mem_used,
+                "stream_config": {
+                    "width": config.width,
+                    "height": config.height,
+                    "fps": config.fps,
+                    "bitrate": config.bitrate,
+                    "h264_profile": config.h264_profile,
+                    "rotation": config.rotation,
+                    "hflip": config.hflip,
+                    "vflip": config.vflip,
+                },
             }
 
         def _json_response(self, data, code=200):

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -22,6 +22,7 @@ import time
 from camera_streamer import wifi
 from camera_streamer.control import ControlHandler, parse_control_request
 from camera_streamer.factory_reset import FactoryResetService
+from camera_streamer.server_notifier import notify_config_change
 
 log = logging.getLogger("camera-streamer.status-server")
 
@@ -519,6 +520,35 @@ def _make_status_handler(
                     self._json_response({"error": error}, status)
                 else:
                     self._json_response(result, status)
+            elif self.path == "/api/stream-config":
+                if not self._require_auth():
+                    return
+                params, _, err = parse_control_request(body)
+                if err:
+                    self._json_response({"error": err}, 400)
+                    return
+                result, error, status = control_handler.set_config(
+                    params, request_id=0, origin="local"
+                )
+                if error:
+                    self._json_response({"error": error}, status)
+                    return
+                self._json_response(result, status)
+                # Notify server of local config change (fire-and-forget)
+                if (
+                    result
+                    and result.get("origin") == "local"
+                    and result.get("status") == "ok"
+                    and pairing_manager
+                    and pairing_manager.is_paired
+                    and config.server_ip
+                ):
+                    threading.Thread(
+                        target=notify_config_change,
+                        args=(config, pairing_manager),
+                        daemon=True,
+                        name="config-notify",
+                    ).start()
             else:
                 self.send_error(404)
 

--- a/app/camera/camera_streamer/stream.py
+++ b/app/camera/camera_streamer/stream.py
@@ -84,6 +84,17 @@ class StreamManager:
             self._thread.join(timeout=10)
         log.info("Stream manager stopped")
 
+    def restart(self):
+        """Restart the streaming pipeline with current config values.
+
+        Stops the existing pipeline and starts a new one. The config
+        should already be updated before calling this method.
+        Returns True if restart was initiated successfully.
+        """
+        log.info("Restarting stream pipeline...")
+        self.stop()
+        return self.start()
+
     def _stream_loop(self):
         """Main loop: start ffmpeg, monitor, reconnect on failure."""
         while self._running:
@@ -184,19 +195,27 @@ class StreamManager:
             "--codec",
             "h264",
             "--profile",
-            "high",
+            cfg.h264_profile,
             "--level",
             "4.2",
             "--bitrate",
-            "4000000",  # 4 Mbps
+            str(cfg.bitrate),
             "--inline",  # SPS/PPS with every keyframe
             "--intra",
-            "30",  # keyframe every 30 frames (~1.2s at 25fps)
+            str(cfg.keyframe_interval),
             "--nopreview",
             "--listen",  # TCP server mode
             "-o",
             f"tcp://0.0.0.0:{tcp_port}",
         ]
+        # Rotation and flip (OV5647 supports 0 and 180 via --rotation,
+        # plus independent --hflip and --vflip)
+        if cfg.rotation == 180:
+            libcamera_cmd.extend(["--rotation", "180"])
+        if cfg.hflip:
+            libcamera_cmd.append("--hflip")
+        if cfg.vflip:
+            libcamera_cmd.append("--vflip")
         # ffmpeg: read H.264 from TCP, push to RTSP
         # Key: probesize must be large enough for ffmpeg to see a keyframe
         # with SPS/PPS from libcamera-vid. At 4Mbps + 25fps, a keyframe

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -260,7 +260,6 @@ body {
                     <option value="640x480">640x480 (max 58 fps)</option>
                     <option value="1296x972">1296x972 (max 43 fps)</option>
                     <option value="1920x1080">1920x1080 (max 30 fps)</option>
-                    <option value="2592x1944">2592x1944 (max 15 fps)</option>
                 </select>
             </div>
             <div class="form-group">
@@ -657,7 +656,7 @@ function doReset() {
     });
 }
 
-var _resMaxFps = {'640x480': 58, '1296x972': 43, '1920x1080': 30, '2592x1944': 15};
+var _resMaxFps = {'640x480': 58, '1296x972': 43, '1920x1080': 30};
 var _streamConfig = null;
 
 function toggleStreamEdit() {

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -225,26 +225,84 @@ body {
 
     <!-- Stream Settings -->
     <div class="card">
-        <div class="card__title">Stream Settings</div>
-        <div class="info-row">
-            <span class="info-row__label">Resolution</span>
-            <span class="info-row__value" id="s-resolution">--</span>
+        <div class="card__title" style="display:flex;justify-content:space-between;align-items:center">
+            Stream Settings
+            <button class="btn btn--secondary btn--small" id="btn-stream-edit" onclick="toggleStreamEdit()">Edit</button>
         </div>
-        <div class="info-row">
-            <span class="info-row__label">Framerate</span>
-            <span class="info-row__value" id="s-fps">--</span>
+        <!-- Read-only view -->
+        <div id="stream-view">
+            <div class="info-row">
+                <span class="info-row__label">Resolution</span>
+                <span class="info-row__value" id="s-resolution">--</span>
+            </div>
+            <div class="info-row">
+                <span class="info-row__label">Framerate</span>
+                <span class="info-row__value" id="s-fps">--</span>
+            </div>
+            <div class="info-row">
+                <span class="info-row__label">Bitrate</span>
+                <span class="info-row__value" id="s-bitrate">--</span>
+            </div>
+            <div class="info-row">
+                <span class="info-row__label">H.264 Profile</span>
+                <span class="info-row__value" id="s-profile">--</span>
+            </div>
+            <div class="info-row">
+                <span class="info-row__label">Orientation</span>
+                <span class="info-row__value" id="s-orientation">--</span>
+            </div>
         </div>
-        <div class="info-row">
-            <span class="info-row__label">Bitrate</span>
-            <span class="info-row__value" id="s-bitrate">--</span>
-        </div>
-        <div class="info-row">
-            <span class="info-row__label">H.264 Profile</span>
-            <span class="info-row__value" id="s-profile">--</span>
-        </div>
-        <div class="info-row">
-            <span class="info-row__label">Orientation</span>
-            <span class="info-row__value" id="s-orientation">--</span>
+        <!-- Edit form -->
+        <div id="stream-edit" style="display:none">
+            <div class="form-group">
+                <label class="form-label">Resolution</label>
+                <select class="form-input" id="se-resolution" onchange="onResChange()">
+                    <option value="640x480">640x480 (max 58 fps)</option>
+                    <option value="1296x972">1296x972 (max 43 fps)</option>
+                    <option value="1920x1080">1920x1080 (max 30 fps)</option>
+                    <option value="2592x1944">2592x1944 (max 15 fps)</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label class="form-label">FPS</label>
+                <input class="form-input" type="number" id="se-fps" min="1" max="58">
+            </div>
+            <div class="form-group">
+                <label class="form-label">Bitrate (Mbps)</label>
+                <input class="form-input" type="number" id="se-bitrate" min="0.5" max="8" step="0.5">
+            </div>
+            <div class="form-group">
+                <label class="form-label">H.264 Profile</label>
+                <select class="form-input" id="se-profile">
+                    <option value="baseline">Baseline</option>
+                    <option value="main">Main</option>
+                    <option value="high">High</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label class="form-label">Keyframe Interval</label>
+                <input class="form-input" type="number" id="se-keyframe" min="1" max="120">
+            </div>
+            <div class="form-group">
+                <label class="form-label">Rotation</label>
+                <select class="form-input" id="se-rotation">
+                    <option value="0">0 (Normal)</option>
+                    <option value="180">180</option>
+                </select>
+            </div>
+            <div class="form-group" style="display:flex;gap:var(--space-4)">
+                <label style="display:flex;align-items:center;gap:var(--space-1)">
+                    <input type="checkbox" id="se-hflip"> H-Flip
+                </label>
+                <label style="display:flex;align-items:center;gap:var(--space-1)">
+                    <input type="checkbox" id="se-vflip"> V-Flip
+                </label>
+            </div>
+            <div style="display:flex;gap:var(--space-2);margin-top:var(--space-3)">
+                <button class="btn btn--primary" id="btn-stream-save" onclick="saveStreamConfig()">Save</button>
+                <button class="btn btn--secondary" onclick="toggleStreamEdit()">Cancel</button>
+            </div>
+            <div id="stream-result"></div>
         </div>
     </div>
 
@@ -376,6 +434,7 @@ function loadStatus() {
 
             // Update stream settings
             if (d.stream_config) {
+                _streamConfig = d.stream_config;
                 var sc = d.stream_config;
                 $('s-resolution').textContent = sc.width + 'x' + sc.height;
                 $('s-fps').textContent = sc.fps + ' fps';
@@ -595,6 +654,92 @@ function doReset() {
     .catch(function() {
         $('reset-result').innerHTML = '<div class="msg msg--err">Request failed</div>';
         cancelReset();
+    });
+}
+
+var _resMaxFps = {'640x480': 58, '1296x972': 43, '1920x1080': 30, '2592x1944': 15};
+var _streamConfig = null;
+
+function toggleStreamEdit() {
+    var view = $('stream-view');
+    var edit = $('stream-edit');
+    var btn = $('btn-stream-edit');
+    if (edit.style.display === 'none') {
+        // Populate form from current config
+        if (_streamConfig) {
+            var sc = _streamConfig;
+            $('se-resolution').value = sc.width + 'x' + sc.height;
+            $('se-fps').value = sc.fps;
+            $('se-bitrate').value = (sc.bitrate / 1000000).toFixed(1);
+            $('se-profile').value = sc.h264_profile || 'high';
+            $('se-keyframe').value = sc.keyframe_interval || 30;
+            $('se-rotation').value = String(sc.rotation || 0);
+            $('se-hflip').checked = !!sc.hflip;
+            $('se-vflip').checked = !!sc.vflip;
+            onResChange();
+        }
+        view.style.display = 'none';
+        edit.style.display = 'block';
+        btn.style.display = 'none';
+        $('stream-result').innerHTML = '';
+    } else {
+        view.style.display = 'block';
+        edit.style.display = 'none';
+        btn.style.display = '';
+    }
+}
+
+function onResChange() {
+    var res = $('se-resolution').value;
+    var maxFps = _resMaxFps[res] || 30;
+    var fpsInput = $('se-fps');
+    fpsInput.max = maxFps;
+    if (parseInt(fpsInput.value) > maxFps) {
+        fpsInput.value = maxFps;
+    }
+}
+
+function saveStreamConfig() {
+    var res = $('se-resolution').value.split('x');
+    var payload = {
+        width: parseInt(res[0]),
+        height: parseInt(res[1]),
+        fps: parseInt($('se-fps').value),
+        bitrate: Math.round(parseFloat($('se-bitrate').value) * 1000000),
+        h264_profile: $('se-profile').value,
+        keyframe_interval: parseInt($('se-keyframe').value),
+        rotation: parseInt($('se-rotation').value),
+        hflip: $('se-hflip').checked,
+        vflip: $('se-vflip').checked
+    };
+
+    $('btn-stream-save').disabled = true;
+    $('btn-stream-save').textContent = 'Saving...';
+    $('stream-result').innerHTML = '';
+
+    fetch('/api/stream-config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+        $('btn-stream-save').disabled = false;
+        $('btn-stream-save').textContent = 'Save';
+        if (d.error) {
+            $('stream-result').innerHTML = '<div class="msg msg--err">' + esc(d.error) + '</div>';
+        } else {
+            $('stream-result').innerHTML = '<div class="msg msg--ok">Settings applied. Stream restarting...</div>';
+            setTimeout(function() {
+                toggleStreamEdit();
+                loadStatus();
+            }, 1500);
+        }
+    })
+    .catch(function() {
+        $('btn-stream-save').disabled = false;
+        $('btn-stream-save').textContent = 'Save';
+        $('stream-result').innerHTML = '<div class="msg msg--err">Request failed</div>';
     });
 }
 

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -223,6 +223,31 @@ body {
         </div>
     </div>
 
+    <!-- Stream Settings -->
+    <div class="card">
+        <div class="card__title">Stream Settings</div>
+        <div class="info-row">
+            <span class="info-row__label">Resolution</span>
+            <span class="info-row__value" id="s-resolution">--</span>
+        </div>
+        <div class="info-row">
+            <span class="info-row__label">Framerate</span>
+            <span class="info-row__value" id="s-fps">--</span>
+        </div>
+        <div class="info-row">
+            <span class="info-row__label">Bitrate</span>
+            <span class="info-row__value" id="s-bitrate">--</span>
+        </div>
+        <div class="info-row">
+            <span class="info-row__label">H.264 Profile</span>
+            <span class="info-row__value" id="s-profile">--</span>
+        </div>
+        <div class="info-row">
+            <span class="info-row__label">Orientation</span>
+            <span class="info-row__value" id="s-orientation">--</span>
+        </div>
+    </div>
+
     <!-- System Health -->
     <div class="card">
         <div class="card__title">System Health</div>
@@ -348,6 +373,21 @@ function loadStatus() {
             var memPct = d.memory_total_mb > 0 ? Math.round(d.memory_used_mb / d.memory_total_mb * 100) : 0;
             $('s-mem').textContent = d.memory_used_mb + ' / ' + d.memory_total_mb + ' MB (' + memPct + '%)';
             $('s-uptime').textContent = d.uptime || '--';
+
+            // Update stream settings
+            if (d.stream_config) {
+                var sc = d.stream_config;
+                $('s-resolution').textContent = sc.width + 'x' + sc.height;
+                $('s-fps').textContent = sc.fps + ' fps';
+                var brMbps = (sc.bitrate / 1000000).toFixed(1);
+                $('s-bitrate').textContent = brMbps + ' Mbps';
+                $('s-profile').textContent = sc.h264_profile || '--';
+                var orient = [];
+                if (sc.rotation === 180) orient.push('180\u00B0');
+                if (sc.hflip) orient.push('H-Flip');
+                if (sc.vflip) orient.push('V-Flip');
+                $('s-orientation').textContent = orient.length > 0 ? orient.join(', ') : 'Normal';
+            }
 
             // Update pairing section
             updatePairingUI(d);

--- a/app/camera/tests/contracts/test_api_contracts.py
+++ b/app/camera/tests/contracts/test_api_contracts.py
@@ -307,6 +307,7 @@ STATUS_API_FIELDS = {
     "uptime",
     "memory_total_mb",
     "memory_used_mb",
+    "stream_config",
 }
 
 

--- a/app/camera/tests/contracts/test_api_contracts.py
+++ b/app/camera/tests/contracts/test_api_contracts.py
@@ -80,6 +80,27 @@ def _json_post(path, body, headers=None, scheme="http"):
         raise
 
 
+def _json_put(path, body, headers=None, scheme="http"):
+    """PUT JSON to an endpoint on localhost:TEST_PORT."""
+    data = json.dumps(body).encode()
+    req = Request(
+        f"{scheme}://127.0.0.1:{TEST_PORT}{path}",
+        data=data,
+        headers={"Content-Type": "application/json", **(headers or {})},
+        method="PUT",
+    )
+    kwargs = {"timeout": 5}
+    if scheme == "https":
+        kwargs["context"] = TLS_CONTEXT
+    try:
+        with urlopen(req, **kwargs) as resp:
+            return json.loads(resp.read()), resp.status
+    except Exception as e:
+        if hasattr(e, "read"):
+            return json.loads(e.read()), e.code
+        raise
+
+
 def _head(path, scheme="http"):
     """HEAD request to localhost:TEST_PORT."""
     req = Request(f"{scheme}://127.0.0.1:{TEST_PORT}{path}", method="HEAD")
@@ -462,6 +483,47 @@ class TestStatusServerLoginContract:
         try:
             status = _head("/", scheme="https")
             assert status in {200, 302}
+        finally:
+            server.stop()
+
+
+STREAM_CONFIG_SUCCESS_FIELDS = {
+    "applied",
+    "restart_required",
+    "restarted",
+    "status",
+    "origin",
+}
+
+
+class TestStatusServerStreamConfigContract:
+    """PUT /api/stream-config on status server (session auth)."""
+
+    def test_requires_auth(self, noauth_config):
+        """Without password, /api/stream-config works without auth."""
+        server = CameraStatusServer(noauth_config)
+        server.start()
+        try:
+            data, status = _json_put(
+                "/api/stream-config",
+                {"fps": 20},
+                scheme="https",
+            )
+            _assert_has_fields(data, {"applied", "status"})
+        finally:
+            server.stop()
+
+    def test_error_on_invalid_param(self, noauth_config):
+        """Invalid param returns {error}."""
+        server = CameraStatusServer(noauth_config)
+        server.start()
+        try:
+            data, status = _json_put(
+                "/api/stream-config",
+                {"unknown_field": 42},
+                scheme="https",
+            )
+            _assert_fields(data, {"error"})
         finally:
             server.stop()
 

--- a/app/camera/tests/unit/test_control.py
+++ b/app/camera/tests/unit/test_control.py
@@ -205,6 +205,18 @@ class TestSetConfigApply:
         assert status == 200
         assert result["restarted"] is False
 
+    def test_origin_defaults_to_server(self, control):
+        result, err, status = control.set_config({"fps": 15})
+        assert result["origin"] == "server"
+
+    def test_origin_local(self, control):
+        result, err, status = control.set_config({"fps": 15}, origin="local")
+        assert result["origin"] == "local"
+
+    def test_origin_server_explicit(self, control):
+        result, err, status = control.set_config({"fps": 15}, origin="server")
+        assert result["origin"] == "server"
+
 
 # --- rate limiting ---
 

--- a/app/camera/tests/unit/test_control.py
+++ b/app/camera/tests/unit/test_control.py
@@ -1,0 +1,311 @@
+"""Unit tests for camera control handler (ADR-0015)."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from camera_streamer.control import (
+    SENSOR_MODES,
+    ControlHandler,
+    parse_control_request,
+)
+
+
+@pytest.fixture
+def control(camera_config):
+    """ControlHandler with mock stream manager."""
+    stream = MagicMock()
+    stream.is_streaming = True
+    stream.consecutive_failures = 0
+    stream.restart.return_value = True
+    return ControlHandler(camera_config, stream)
+
+
+@pytest.fixture
+def control_no_stream(camera_config):
+    """ControlHandler without stream manager."""
+    return ControlHandler(camera_config, None)
+
+
+# --- get_capabilities ---
+
+
+class TestGetCapabilities:
+    def test_returns_sensor_info(self, control):
+        caps = control.get_capabilities()
+        assert caps["sensor"] == "OV5647"
+        assert len(caps["sensor_modes"]) == 4
+
+    def test_sensor_modes_match_constants(self, control):
+        caps = control.get_capabilities()
+        for mode in caps["sensor_modes"]:
+            key = (mode["width"], mode["height"])
+            assert key in SENSOR_MODES
+            assert mode["max_fps"] == SENSOR_MODES[key]
+
+    def test_parameters_list_all_params(self, control):
+        caps = control.get_capabilities()
+        params = caps["parameters"]
+        expected = {
+            "width",
+            "height",
+            "fps",
+            "bitrate",
+            "h264_profile",
+            "keyframe_interval",
+            "rotation",
+            "hflip",
+            "vflip",
+        }
+        assert set(params.keys()) == expected
+
+
+# --- get_config ---
+
+
+class TestGetConfig:
+    def test_returns_current_values(self, control):
+        cfg = control.get_config()
+        assert cfg["width"] == 1920
+        assert cfg["height"] == 1080
+        assert cfg["fps"] == 25
+        assert cfg["h264_profile"] == "high"
+
+    def test_all_keys_present(self, control):
+        cfg = control.get_config()
+        expected = {
+            "width",
+            "height",
+            "fps",
+            "bitrate",
+            "h264_profile",
+            "keyframe_interval",
+            "rotation",
+            "hflip",
+            "vflip",
+        }
+        assert set(cfg.keys()) == expected
+
+
+# --- set_config validation ---
+
+
+class TestSetConfigValidation:
+    def test_rejects_unknown_param(self, control):
+        result, err, status = control.set_config({"unknown_field": 42})
+        assert status == 400
+        assert "Unknown parameters" in err
+
+    def test_rejects_wrong_type_int(self, control):
+        result, err, status = control.set_config({"fps": "fast"})
+        assert status == 400
+        assert "expected int" in err
+
+    def test_rejects_wrong_type_bool(self, control):
+        result, err, status = control.set_config({"hflip": "yes"})
+        assert status == 400
+        assert "expected bool" in err
+
+    def test_rejects_invalid_resolution(self, control):
+        result, err, status = control.set_config({"width": 1920, "height": 480})
+        assert status == 400
+        assert "Invalid resolution" in err
+
+    def test_rejects_fps_exceeding_sensor_max(self, control):
+        # 2592x1944 max is 15 fps
+        result, err, status = control.set_config(
+            {"width": 2592, "height": 1944, "fps": 30}
+        )
+        assert status == 400
+        assert "exceeds maximum" in err
+
+    def test_rejects_fps_below_min(self, control):
+        result, err, status = control.set_config({"fps": 0})
+        assert status == 400
+        assert "minimum is 1" in err
+
+    def test_rejects_fps_above_max(self, control):
+        result, err, status = control.set_config({"fps": 100})
+        assert status == 400
+        assert "maximum is 58" in err
+
+    def test_rejects_invalid_rotation(self, control):
+        result, err, status = control.set_config({"rotation": 90})
+        assert status == 400
+        assert "must be one of" in err
+
+    def test_rejects_invalid_h264_profile(self, control):
+        result, err, status = control.set_config({"h264_profile": "ultra"})
+        assert status == 400
+        assert "must be one of" in err
+
+    def test_rejects_bitrate_too_low(self, control):
+        result, err, status = control.set_config({"bitrate": 100})
+        assert status == 400
+        assert "minimum is 500000" in err
+
+    def test_rejects_bitrate_too_high(self, control):
+        result, err, status = control.set_config({"bitrate": 99000000})
+        assert status == 400
+        assert "maximum is 8000000" in err
+
+    def test_rejects_empty_params(self, control):
+        result, err, status = control.set_config({})
+        assert status == 400
+        assert "No parameters" in err
+
+
+# --- set_config success ---
+
+
+class TestSetConfigApply:
+    def test_applies_fps_change(self, control):
+        result, err, status = control.set_config({"fps": 15})
+        assert status == 200
+        assert err == ""
+        assert result["applied"]["fps"] == 15
+        assert result["restart_required"] is True
+
+    def test_applies_resolution_change(self, control):
+        result, err, status = control.set_config({"width": 1296, "height": 972})
+        assert status == 200
+        assert result["applied"]["width"] == 1296
+        assert result["applied"]["height"] == 972
+
+    def test_no_change_returns_unchanged(self, control):
+        # Config already has fps=25
+        result, err, status = control.set_config({"fps": 25})
+        assert status == 200
+        assert result["status"] == "unchanged"
+        assert result["applied"] == {}
+
+    def test_restarts_stream(self, control):
+        control.set_config({"fps": 15})
+        control._stream.restart.assert_called_once()
+
+    def test_persists_to_config(self, control, camera_config):
+        control.set_config({"fps": 20})
+        assert camera_config.fps == 20
+
+    def test_applies_bool_param(self, control):
+        result, err, status = control.set_config({"hflip": True})
+        assert status == 200
+        assert result["applied"]["hflip"] is True
+
+    def test_applies_multiple_params(self, control):
+        result, err, status = control.set_config(
+            {"width": 640, "height": 480, "fps": 30, "bitrate": 2000000}
+        )
+        assert status == 200
+        assert len(result["applied"]) == 4
+
+    def test_no_stream_manager(self, control_no_stream):
+        result, err, status = control_no_stream.set_config({"fps": 15})
+        assert status == 200
+        assert result["restarted"] is False
+
+
+# --- rate limiting ---
+
+
+class TestRateLimiting:
+    def test_rate_limits_rapid_changes(self, control):
+        control.set_config({"fps": 15})
+        result, err, status = control.set_config({"fps": 20})
+        assert status == 429
+        assert "Rate limited" in err
+
+    def test_allows_after_cooldown(self, control):
+        control.set_config({"fps": 15})
+        # Manually reset the timer
+        control._last_change_time = time.monotonic() - 10
+        result, err, status = control.set_config({"fps": 20})
+        assert status == 200
+
+
+# --- replay protection ---
+
+
+class TestReplayProtection:
+    def test_rejects_stale_request_id(self, control):
+        control.set_config({"fps": 15}, request_id=5)
+        control._last_change_time = 0  # bypass rate limit
+        result, err, status = control.set_config({"fps": 20}, request_id=3)
+        assert status == 409
+        assert "replay" in err.lower()
+
+    def test_accepts_higher_request_id(self, control):
+        control.set_config({"fps": 15}, request_id=5)
+        control._last_change_time = 0
+        result, err, status = control.set_config({"fps": 20}, request_id=6)
+        assert status == 200
+
+
+# --- get_status ---
+
+
+class TestGetStatus:
+    def test_returns_status(self, control):
+        status = control.get_status()
+        assert status["streaming"] is True
+        assert status["consecutive_failures"] == 0
+        assert "config" in status
+
+    def test_no_stream_manager(self, control_no_stream):
+        status = control_no_stream.get_status()
+        assert status["streaming"] is False
+
+
+# --- parse_control_request ---
+
+
+class TestParseControlRequest:
+    def test_valid_json(self):
+        params, rid, err = parse_control_request(b'{"fps": 15}')
+        assert err == ""
+        assert params == {"fps": 15}
+        assert rid == 0
+
+    def test_with_request_id(self):
+        params, rid, err = parse_control_request(b'{"fps": 15, "request_id": 42}')
+        assert rid == 42
+        assert "request_id" not in params
+
+    def test_invalid_json(self):
+        _, _, err = parse_control_request(b"not json")
+        assert "Invalid JSON" in err
+
+    def test_not_dict(self):
+        _, _, err = parse_control_request(b"[1, 2, 3]")
+        assert "Expected JSON object" in err
+
+    def test_invalid_request_id_type(self):
+        _, _, err = parse_control_request(b'{"request_id": "abc"}')
+        assert "request_id must be integer" in err
+
+
+# --- cross-field validation ---
+
+
+class TestCrossFieldValidation:
+    def test_fps_validated_against_new_resolution(self, control):
+        """If changing to 2592x1944, fps must not exceed 15."""
+        result, err, status = control.set_config(
+            {"width": 2592, "height": 1944, "fps": 16}
+        )
+        assert status == 400
+        assert "exceeds maximum 15" in err
+
+    def test_fps_validated_against_current_resolution(self, control):
+        """If only changing fps, validate against current resolution."""
+        # Current is 1920x1080, max 30
+        result, err, status = control.set_config({"fps": 31})
+        assert status == 400
+        assert "exceeds maximum 30" in err
+
+    def test_valid_resolution_fps_combo(self, control):
+        result, err, status = control.set_config(
+            {"width": 640, "height": 480, "fps": 58}
+        )
+        assert status == 200

--- a/app/camera/tests/unit/test_control.py
+++ b/app/camera/tests/unit/test_control.py
@@ -35,7 +35,7 @@ class TestGetCapabilities:
     def test_returns_sensor_info(self, control):
         caps = control.get_capabilities()
         assert caps["sensor"] == "OV5647"
-        assert len(caps["sensor_modes"]) == 4
+        assert len(caps["sensor_modes"]) == 3
 
     def test_sensor_modes_match_constants(self, control):
         caps = control.get_capabilities()
@@ -113,10 +113,8 @@ class TestSetConfigValidation:
         assert "Invalid resolution" in err
 
     def test_rejects_fps_exceeding_sensor_max(self, control):
-        # 2592x1944 max is 15 fps
-        result, err, status = control.set_config(
-            {"width": 2592, "height": 1944, "fps": 30}
-        )
+        # 1920x1080 max is 30 fps
+        result, err, status = control.set_config({"fps": 31})
         assert status == 400
         assert "exceeds maximum" in err
 
@@ -302,12 +300,12 @@ class TestParseControlRequest:
 
 class TestCrossFieldValidation:
     def test_fps_validated_against_new_resolution(self, control):
-        """If changing to 2592x1944, fps must not exceed 15."""
+        """If changing to 1296x972, fps must not exceed 43."""
         result, err, status = control.set_config(
-            {"width": 2592, "height": 1944, "fps": 16}
+            {"width": 1296, "height": 972, "fps": 44}
         )
         assert status == 400
-        assert "exceeds maximum 15" in err
+        assert "exceeds maximum 43" in err
 
     def test_fps_validated_against_current_resolution(self, control):
         """If only changing fps, validate against current resolution."""

--- a/app/camera/tests/unit/test_server_notifier.py
+++ b/app/camera/tests/unit/test_server_notifier.py
@@ -1,0 +1,158 @@
+"""Unit tests for camera server_notifier module."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import MagicMock, patch
+
+from camera_streamer.server_notifier import (
+    _build_signature,
+    notify_config_change,
+)
+
+
+class TestBuildSignature:
+    """Test HMAC-SHA256 signature computation."""
+
+    def test_deterministic(self):
+        secret = "ab" * 32
+        sig1 = _build_signature(secret, "cam-01", "12345", b'{"fps":25}')
+        sig2 = _build_signature(secret, "cam-01", "12345", b'{"fps":25}')
+        assert sig1 == sig2
+
+    def test_different_body_different_sig(self):
+        secret = "ab" * 32
+        sig1 = _build_signature(secret, "cam-01", "12345", b'{"fps":25}')
+        sig2 = _build_signature(secret, "cam-01", "12345", b'{"fps":30}')
+        assert sig1 != sig2
+
+    def test_different_camera_different_sig(self):
+        secret = "ab" * 32
+        sig1 = _build_signature(secret, "cam-01", "12345", b'{"fps":25}')
+        sig2 = _build_signature(secret, "cam-02", "12345", b'{"fps":25}')
+        assert sig1 != sig2
+
+    def test_different_timestamp_different_sig(self):
+        secret = "ab" * 32
+        sig1 = _build_signature(secret, "cam-01", "12345", b'{"fps":25}')
+        sig2 = _build_signature(secret, "cam-01", "12346", b'{"fps":25}')
+        assert sig1 != sig2
+
+    def test_matches_manual_computation(self):
+        secret = "ab" * 32
+        body = b'{"fps":25}'
+        camera_id = "cam-01"
+        timestamp = "12345"
+
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"{camera_id}:{timestamp}:{body_hash}"
+        expected = hmac.new(
+            bytes.fromhex(secret), message.encode(), hashlib.sha256
+        ).hexdigest()
+
+        assert _build_signature(secret, camera_id, timestamp, body) == expected
+
+
+class TestNotifyConfigChange:
+    """Test fire-and-forget notification logic."""
+
+    def test_skips_when_no_server_ip(self):
+        config = MagicMock()
+        config.server_ip = ""
+        pairing = MagicMock()
+        # Should not raise
+        notify_config_change(config, pairing)
+        pairing.get_pairing_secret.assert_not_called()
+
+    def test_skips_when_no_pairing_secret(self):
+        config = MagicMock()
+        config.server_ip = "192.168.1.245"
+        pairing = MagicMock()
+        pairing.get_pairing_secret.return_value = ""
+        notify_config_change(config, pairing)
+
+    @staticmethod
+    def _mock_config():
+        """Create a mock config with stream properties."""
+        cfg = MagicMock()
+        cfg.server_ip = "192.168.1.245"
+        cfg.camera_id = "cam-test01"
+        cfg.certs_dir = "/tmp/certs"
+        cfg.width = 1920
+        cfg.height = 1080
+        cfg.fps = 25
+        cfg.bitrate = 4000000
+        cfg.h264_profile = "high"
+        cfg.keyframe_interval = 30
+        cfg.rotation = 0
+        cfg.hflip = False
+        cfg.vflip = False
+        return cfg
+
+    @patch("camera_streamer.server_notifier.urllib.request.urlopen")
+    def test_sends_correct_headers(self, mock_urlopen):
+        config = self._mock_config()
+        pairing = MagicMock()
+        pairing.get_pairing_secret.return_value = "ab" * 32
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        notify_config_change(config, pairing)
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("X-camera-id") == "cam-test01"
+        assert req.get_header("X-timestamp")
+        assert req.get_header("X-signature")
+        assert req.get_header("Content-type") == "application/json"
+        assert req.get_method() == "POST"
+        assert "192.168.1.245" in req.full_url
+
+    @patch("camera_streamer.server_notifier.urllib.request.urlopen")
+    def test_sends_stream_config_body(self, mock_urlopen):
+        config = self._mock_config()
+        pairing = MagicMock()
+        pairing.get_pairing_secret.return_value = "ab" * 32
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        notify_config_change(config, pairing)
+
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data)
+        assert body["width"] == 1920
+        assert body["height"] == 1080
+        assert body["fps"] == 25
+
+    @patch("camera_streamer.server_notifier.urllib.request.urlopen")
+    def test_handles_http_error_gracefully(self, mock_urlopen):
+        import urllib.error
+
+        config = self._mock_config()
+        pairing = MagicMock()
+        pairing.get_pairing_secret.return_value = "ab" * 32
+
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "url", 401, "Unauthorized", {}, None
+        )
+        # Should not raise
+        notify_config_change(config, pairing)
+
+    @patch("camera_streamer.server_notifier.urllib.request.urlopen")
+    def test_handles_network_error_gracefully(self, mock_urlopen):
+        import urllib.error
+
+        config = self._mock_config()
+        pairing = MagicMock()
+        pairing.get_pairing_secret.return_value = "ab" * 32
+
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        # Should not raise
+        notify_config_change(config, pairing)

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -14,6 +14,7 @@ from flask import Flask
 
 from monitor.logging_config import configure_logging
 from monitor.services.audit import AuditLogger
+from monitor.services.camera_control_client import CameraControlClient
 from monitor.services.camera_service import CameraService
 from monitor.services.cert_service import CertService
 from monitor.services.discovery import DiscoveryService
@@ -181,11 +182,17 @@ def _init_services(app):
         clip_duration=app.config.get("CLIP_DURATION_SECONDS", 180),
     )
 
+    # Camera control client — pushes config to cameras via mTLS (ADR-0015)
+    app.camera_control_client = CameraControlClient(
+        certs_dir=app.config["CERTS_DIR"],
+    )
+
     # Camera service — orchestrates store + streaming + audit
     app.camera_service = CameraService(
         store=app.store,
         streaming=app.streaming,
         audit=app.audit,
+        control_client=app.camera_control_client,
     )
 
     # Storage service — orchestrates USB + storage manager + store + audit

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -8,13 +8,21 @@ Endpoints:
   PUT    /cameras/<id>         - update name, location, recording mode (admin)
   DELETE /cameras/<id>         - remove camera and revoke cert (admin)
   GET    /cameras/<id>/status  - live status (online, fps, uptime)
+  POST   /cameras/config-notify - accept config push from camera (HMAC auth)
 
 Routes are thin — all orchestration is in CameraService.
 """
 
+import hashlib
+import hmac
+import time
+
 from flask import Blueprint, current_app, jsonify, request, session
 
 from monitor.auth import admin_required, csrf_protect, login_required
+
+# Max age for HMAC timestamp (seconds)
+_HMAC_MAX_AGE = 300
 
 cameras_bp = Blueprint("cameras", __name__)
 
@@ -41,6 +49,59 @@ def add_camera():
     if error:
         return jsonify({"error": error}), status
     return jsonify(result), status
+
+
+@cameras_bp.route("/config-notify", methods=["POST"])
+def config_notify():
+    """Accept config notification from a camera.
+
+    Auth: HMAC-SHA256 signature using pairing_secret.
+    No session/CSRF — this is machine-to-machine (ADR-0015).
+    """
+    camera_id = request.headers.get("X-Camera-ID", "")
+    timestamp_str = request.headers.get("X-Timestamp", "")
+    signature = request.headers.get("X-Signature", "")
+
+    if not camera_id or not timestamp_str or not signature:
+        return jsonify({"error": "Missing auth headers"}), 401
+
+    # Validate timestamp freshness
+    try:
+        ts = int(timestamp_str)
+    except ValueError:
+        return jsonify({"error": "Invalid timestamp"}), 400
+
+    now = int(time.time())
+    if abs(now - ts) > _HMAC_MAX_AGE:
+        return jsonify({"error": "Timestamp expired"}), 401
+
+    # Look up camera and its pairing secret
+    camera = current_app.store.get_camera(camera_id)
+    if not camera or not camera.pairing_secret:
+        return jsonify({"error": "Unknown camera"}), 401
+
+    # Verify HMAC
+    body = request.get_data()
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{camera_id}:{timestamp_str}:{body_hash}"
+    expected = hmac.new(
+        bytes.fromhex(camera.pairing_secret),
+        message.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+    if not hmac.compare_digest(signature, expected):
+        return jsonify({"error": "Invalid signature"}), 401
+
+    # Parse and accept config
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    error, status = current_app.camera_service.accept_camera_config(camera_id, data)
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify({"message": "Config accepted"}), 200
 
 
 @cameras_bp.route("/<camera_id>/confirm", methods=["POST"])

--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -32,6 +32,16 @@ class Camera:
     firmware_version: str = ""
     cert_serial: str = ""
     pairing_secret: str = ""  # hex-encoded, for camera LUKS key derivation (ADR-0010)
+    # Stream parameters (ADR-0015: server-camera control channel)
+    width: int = 1920
+    height: int = 1080
+    bitrate: int = 4000000
+    h264_profile: str = "high"
+    keyframe_interval: int = 30
+    rotation: int = 0
+    hflip: bool = False
+    vflip: bool = False
+    config_sync: str = "unknown"  # synced | pending | error | unknown
 
 
 @dataclass

--- a/app/server/monitor/services/camera_control_client.py
+++ b/app/server/monitor/services/camera_control_client.py
@@ -1,0 +1,138 @@
+"""
+Camera control client — pushes configuration to cameras via their control API.
+
+Uses server mTLS credentials to authenticate with the camera's HTTPS
+status server. The camera verifies the server certificate against the
+CA established during pairing (ADR-0009, ADR-0015).
+
+Design patterns:
+- Constructor Injection (certs_dir injected)
+- Fail-Graceful (returns error instead of raising)
+"""
+
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.request
+
+log = logging.getLogger("monitor.camera_control_client")
+
+# Timeout for control API requests (seconds)
+REQUEST_TIMEOUT = 15
+
+
+class CameraControlClient:
+    """Push configuration to cameras via their control API.
+
+    Args:
+        certs_dir: Path to server certificate directory containing
+            server.crt, server.key, and ca.crt.
+    """
+
+    def __init__(self, certs_dir):
+        self._certs_dir = certs_dir
+
+    def _ssl_context(self):
+        """Build an SSL context with server mTLS credentials.
+
+        The server presents its certificate (signed by the CA) to the
+        camera, which verifies it against ca.crt received during pairing.
+        We disable hostname verification because the camera's status
+        server uses a self-signed cert with its own hostname.
+        """
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE  # camera uses self-signed status cert
+
+        # Load server's mTLS client credentials
+        cert_path = os.path.join(self._certs_dir, "server.crt")
+        key_path = os.path.join(self._certs_dir, "server.key")
+        if os.path.isfile(cert_path) and os.path.isfile(key_path):
+            ctx.load_cert_chain(cert_path, key_path)
+
+        return ctx
+
+    def get_config(self, camera_ip):
+        """GET /api/v1/control/config from camera.
+
+        Returns (config_dict, error_string).
+        """
+        return self._request("GET", camera_ip, "/api/v1/control/config")
+
+    def set_config(self, camera_ip, params, request_id=0):
+        """PUT /api/v1/control/config on camera.
+
+        Args:
+            camera_ip: Camera IP address.
+            params: Dict of parameter names to new values.
+            request_id: Monotonic request ID for replay protection.
+
+        Returns (result_dict, error_string).
+        """
+        body = dict(params)
+        if request_id:
+            body["request_id"] = request_id
+        return self._request("PUT", camera_ip, "/api/v1/control/config", body)
+
+    def get_capabilities(self, camera_ip):
+        """GET /api/v1/control/capabilities from camera.
+
+        Returns (capabilities_dict, error_string).
+        """
+        return self._request("GET", camera_ip, "/api/v1/control/capabilities")
+
+    def get_status(self, camera_ip):
+        """GET /api/v1/control/status from camera.
+
+        Returns (status_dict, error_string).
+        """
+        return self._request("GET", camera_ip, "/api/v1/control/status")
+
+    def restart_stream(self, camera_ip):
+        """POST /api/v1/control/restart-stream on camera.
+
+        Returns (result_dict, error_string).
+        """
+        return self._request("POST", camera_ip, "/api/v1/control/restart-stream")
+
+    def _request(self, method, camera_ip, path, body=None):
+        """Make an HTTPS request to the camera's control API.
+
+        Returns (response_dict, error_string). Error is empty on success.
+        """
+        url = f"https://{camera_ip}{path}"
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode()
+
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={"Content-Type": "application/json"} if data else {},
+        )
+
+        try:
+            ctx = self._ssl_context()
+            with urllib.request.urlopen(
+                req, context=ctx, timeout=REQUEST_TIMEOUT
+            ) as resp:
+                resp_body = resp.read()
+                result = json.loads(resp_body) if resp_body else {}
+                return result, ""
+        except urllib.error.HTTPError as e:
+            try:
+                err_body = json.loads(e.read())
+                err_msg = err_body.get("error", f"HTTP {e.code}")
+            except (json.JSONDecodeError, AttributeError):
+                err_msg = f"HTTP {e.code}"
+            log.warning("Control request %s %s failed: %s", method, url, err_msg)
+            return None, err_msg
+        except urllib.error.URLError as e:
+            log.warning("Control request %s %s unreachable: %s", method, url, e.reason)
+            return None, f"Camera unreachable: {e.reason}"
+        except (OSError, json.JSONDecodeError) as e:
+            log.warning("Control request %s %s error: %s", method, url, e)
+            return None, str(e)

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -330,8 +330,8 @@ class CameraService:
 
         if "fps" in data:
             fps = data["fps"]
-            if not isinstance(fps, int) or fps < 1 or fps > 58:
-                return "fps must be an integer between 1 and 58"
+            if not isinstance(fps, int) or fps < 1 or fps > 30:
+                return "fps must be an integer between 1 and 30"
 
         if "name" in data:
             name = data["name"]

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -19,6 +19,19 @@ log = logging.getLogger("monitor.camera_service")
 VALID_RECORDING_MODES = {"continuous", "off"}
 VALID_RESOLUTIONS = {"720p", "1080p"}
 
+# Stream parameters that should be pushed to the camera (ADR-0015)
+STREAM_PARAMS = {
+    "width",
+    "height",
+    "fps",
+    "bitrate",
+    "h264_profile",
+    "keyframe_interval",
+    "rotation",
+    "hflip",
+    "vflip",
+}
+
 
 class CameraService:
     """Orchestrates camera CRUD operations across store, streaming, and audit.
@@ -29,10 +42,11 @@ class CameraService:
         audit: Security audit logger (AuditLogger instance or None).
     """
 
-    def __init__(self, store, streaming=None, audit=None):
+    def __init__(self, store, streaming=None, audit=None, control_client=None):
         self._store = store
         self._streaming = streaming
         self._audit = audit
+        self._control = control_client
 
     def add_camera(
         self, camera_id: str, name: str = "", location: str = ""
@@ -83,6 +97,15 @@ class CameraService:
                 "paired_at": c.paired_at,
                 "last_seen": c.last_seen,
                 "firmware_version": c.firmware_version,
+                "width": c.width,
+                "height": c.height,
+                "bitrate": c.bitrate,
+                "h264_profile": c.h264_profile,
+                "keyframe_interval": c.keyframe_interval,
+                "rotation": c.rotation,
+                "hflip": c.hflip,
+                "vflip": c.vflip,
+                "config_sync": c.config_sync,
             }
             for c in cameras
         ]
@@ -106,6 +129,15 @@ class CameraService:
             "resolution": camera.resolution,
             "fps": camera.fps,
             "recording_mode": camera.recording_mode,
+            "width": camera.width,
+            "height": camera.height,
+            "bitrate": camera.bitrate,
+            "h264_profile": camera.h264_profile,
+            "keyframe_interval": camera.keyframe_interval,
+            "rotation": camera.rotation,
+            "hflip": camera.hflip,
+            "vflip": camera.vflip,
+            "config_sync": camera.config_sync,
         }, ""
 
     def confirm(
@@ -178,6 +210,18 @@ class CameraService:
         for key, value in data.items():
             setattr(camera, key, value)
 
+        # Push stream params to camera if any changed (ADR-0015)
+        stream_changes = {k: v for k, v in data.items() if k in STREAM_PARAMS}
+        if stream_changes and camera.ip and self._control:
+            result, err = self._control.set_config(camera.ip, stream_changes)
+            if err:
+                log.warning("Failed to push config to camera %s: %s", camera_id, err)
+                camera.config_sync = "pending"
+            else:
+                camera.config_sync = "synced"
+        elif stream_changes and not camera.ip:
+            camera.config_sync = "pending"
+
         self._store.save_camera(camera)
 
         # Handle recording mode transitions
@@ -220,7 +264,21 @@ class CameraService:
 
     def _validate_update(self, data: dict) -> str:
         """Validate camera update fields. Returns error string or empty."""
-        allowed = {"name", "location", "recording_mode", "resolution", "fps"}
+        allowed = {
+            "name",
+            "location",
+            "recording_mode",
+            "resolution",
+            "fps",
+            "width",
+            "height",
+            "bitrate",
+            "h264_profile",
+            "keyframe_interval",
+            "rotation",
+            "hflip",
+            "vflip",
+        }
         unknown = set(data.keys()) - allowed
         if unknown:
             return f"Unknown fields: {', '.join(sorted(unknown))}"
@@ -239,13 +297,49 @@ class CameraService:
 
         if "fps" in data:
             fps = data["fps"]
-            if not isinstance(fps, int) or fps < 1 or fps > 30:
-                return "fps must be an integer between 1 and 30"
+            if not isinstance(fps, int) or fps < 1 or fps > 58:
+                return "fps must be an integer between 1 and 58"
 
         if "name" in data:
             name = data["name"]
             if not isinstance(name, str) or len(name) < 1 or len(name) > 64:
                 return "name must be 1-64 characters"
+
+        if "width" in data and (
+            not isinstance(data["width"], int) or data["width"] < 1
+        ):
+            return "width must be a positive integer"
+
+        if "height" in data and (
+            not isinstance(data["height"], int) or data["height"] < 1
+        ):
+            return "height must be a positive integer"
+
+        if "bitrate" in data:
+            br = data["bitrate"]
+            if not isinstance(br, int) or br < 500000 or br > 8000000:
+                return "bitrate must be between 500000 and 8000000"
+
+        if "keyframe_interval" in data:
+            ki = data["keyframe_interval"]
+            if not isinstance(ki, int) or ki < 1 or ki > 120:
+                return "keyframe_interval must be between 1 and 120"
+
+        if "h264_profile" in data and data["h264_profile"] not in (
+            "baseline",
+            "main",
+            "high",
+        ):
+            return "h264_profile must be one of: baseline, main, high"
+
+        if "rotation" in data and data["rotation"] not in (0, 180):
+            return "rotation must be 0 or 180"
+
+        if "hflip" in data and not isinstance(data["hflip"], bool):
+            return "hflip must be a boolean"
+
+        if "vflip" in data and not isinstance(data["vflip"], bool):
+            return "vflip must be a boolean"
 
         return ""
 

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -240,6 +240,39 @@ class CameraService:
 
         return "", 200
 
+    def accept_camera_config(
+        self, camera_id: str, stream_config: dict
+    ) -> tuple[str, int]:
+        """Accept a config notification from the camera (source of truth).
+
+        Updates stored config without pushing back to camera.
+        Returns (error_string, http_status_code).
+        """
+        camera = self._store.get_camera(camera_id)
+        if not camera:
+            return "Camera not found", 404
+
+        # Only accept known stream params
+        for key in stream_config:
+            if key not in STREAM_PARAMS:
+                return f"Unknown parameter: {key}", 400
+
+        for key, value in stream_config.items():
+            setattr(camera, key, value)
+
+        camera.config_sync = "synced"
+        self._store.save_camera(camera)
+
+        self._log_audit(
+            "CAMERA_CONFIG_RECEIVED",
+            "camera",
+            "",
+            f"config notification from {camera_id}: "
+            f"{', '.join(f'{k}={v}' for k, v in stream_config.items())}",
+        )
+
+        return "", 200
+
     def delete(self, camera_id: str, user: str = "", ip: str = "") -> tuple[str, int]:
         """Remove a camera and stop its video pipelines.
 

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -930,6 +930,38 @@ select.form-input {
     }
 }
 
+/* --- Modal Overlay --- */
+.modal-overlay {
+    position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0, 0, 0, 0.6); z-index: 200;
+    display: flex; align-items: center; justify-content: center;
+    padding: var(--space-4);
+}
+.modal-card {
+    width: 100%; max-width: 420px; max-height: 90vh;
+    overflow-y: auto; animation: modalIn 0.15s ease-out;
+}
+.modal-card__header {
+    display: flex; justify-content: space-between; align-items: center;
+    margin-bottom: var(--space-4); padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--color-border);
+}
+@keyframes modalIn {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* --- Camera Card Meta --- */
+.camera-card__meta {
+    display: flex; gap: var(--space-2); align-items: center;
+    margin-top: 2px;
+}
+
+/* --- Messages --- */
+.msg { padding: 8px 12px; border-radius: var(--radius-sm); font-size: var(--text-sm); }
+.msg--ok { background: rgba(46, 204, 113, 0.15); border: 1px solid var(--color-success); color: var(--color-success); }
+.msg--err { background: rgba(231, 76, 60, 0.15); border: 1px solid var(--color-danger); color: var(--color-danger); }
+
 /* --- Utility --- */
 .hidden { display: none !important; }
 .mt-8 { margin-top: var(--space-2); }
@@ -939,6 +971,9 @@ select.form-input {
 .text-center { text-align: center; }
 .text-muted { color: var(--color-text-muted); }
 .text-small { font-size: var(--text-sm); }
+.text-success { color: var(--color-success); }
+.text-warning { color: var(--color-warning); }
+.text-danger { color: var(--color-danger); }
 .gap-8 { gap: var(--space-2); }
 .flex { display: flex; }
 .flex-between {

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -104,10 +104,19 @@
         </div>
     </template>
     <template x-for="cam in cameras" :key="cam.id">
-        <div class="card camera-card">
+        <div class="card camera-card" :data-cam-id="cam.id">
             <div class="camera-card__info" @click="cam.status === 'online' && (window.location.href = '/live?camera=' + encodeURIComponent(cam.id))" :style="cam.status === 'online' ? 'cursor:pointer' : ''">
                 <div class="camera-card__name" x-text="cam.name || cam.id"></div>
                 <div class="camera-card__location" x-text="cam.location || 'No location set'"></div>
+                <div class="camera-card__meta">
+                    <span class="text-small text-muted" x-text="cam.width + 'x' + cam.height + ' @ ' + cam.fps + 'fps'"></span>
+                    <span class="text-small" :class="{
+                        'text-success': cam.config_sync === 'synced',
+                        'text-warning': cam.config_sync === 'pending',
+                        'text-danger': cam.config_sync === 'error',
+                        'text-muted': cam.config_sync === 'unknown'
+                    }" x-show="cam.status !== 'pending'" x-text="cam.config_sync === 'synced' ? '\u2713 synced' : cam.config_sync === 'pending' ? '\u231B pending' : ''"></span>
+                </div>
                 <div class="camera-card__last-seen" x-text="cam.last_seen ? 'Last seen: ' + new Date(cam.last_seen).toLocaleString() : ''"></div>
             </div>
             <div class="camera-card__actions">
@@ -123,8 +132,76 @@
                     </div>
                 </template>
                 <template x-if="cam.status !== 'pending'">
-                    <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
+                    <div class="camera-card__btns">
+                        <button class="btn btn--secondary btn--small" @click.stop="openStreamSettings(cam)">Settings</button>
+                        <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
+                    </div>
                 </template>
+            </div>
+        </div>
+    </template>
+
+    <!-- Stream Settings Modal -->
+    <template x-if="editCam">
+        <div class="modal-overlay" @click.self="editCam = null">
+            <div class="card modal-card">
+                <div class="modal-card__header">
+                    <span style="font-weight:600" x-text="'Stream Settings \u2014 ' + (editCam.name || editCam.id)"></span>
+                    <button class="btn btn--secondary btn--small btn--icon" @click="editCam = null">&#x2715;</button>
+                </div>
+                <div class="form-group">
+                    <label>Resolution</label>
+                    <select class="form-input" x-model="editForm.resolution" @change="onResolutionChange()">
+                        <option value="640x480">640x480 (max 58 fps)</option>
+                        <option value="1296x972">1296x972 (max 43 fps)</option>
+                        <option value="1920x1080">1920x1080 (max 30 fps)</option>
+                        <option value="2592x1944">2592x1944 (max 15 fps)</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label>Framerate (fps)</label>
+                    <input type="number" class="form-input" x-model.number="editForm.fps" min="1" :max="editForm.maxFps">
+                    <div class="text-small text-muted" x-text="'Max: ' + editForm.maxFps + ' fps for this resolution'"></div>
+                </div>
+                <div class="form-group">
+                    <label>Bitrate (Mbps)</label>
+                    <input type="number" class="form-input" x-model.number="editForm.bitrateMbps" min="0.5" max="8" step="0.5">
+                </div>
+                <div class="form-group">
+                    <label>H.264 Profile</label>
+                    <select class="form-input" x-model="editForm.h264_profile">
+                        <option value="baseline">Baseline</option>
+                        <option value="main">Main</option>
+                        <option value="high">High</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label>Keyframe Interval (frames)</label>
+                    <input type="number" class="form-input" x-model.number="editForm.keyframe_interval" min="1" max="120">
+                </div>
+                <div class="form-group">
+                    <label>Rotation</label>
+                    <select class="form-input" x-model.number="editForm.rotation">
+                        <option value="0">0&deg; (Normal)</option>
+                        <option value="180">180&deg;</option>
+                    </select>
+                </div>
+                <div class="form-group" style="display:flex;gap:16px;">
+                    <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+                        <input type="checkbox" x-model="editForm.hflip"> Horizontal Flip
+                    </label>
+                    <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+                        <input type="checkbox" x-model="editForm.vflip"> Vertical Flip
+                    </label>
+                </div>
+                <div style="display:flex;gap:8px;margin-top:12px;">
+                    <button class="btn btn--primary" @click="saveStreamSettings()" :disabled="savingStream">
+                        <span x-text="savingStream ? 'Saving...' : 'Save & Apply'"></span>
+                    </button>
+                    <button class="btn btn--secondary" @click="editCam = null">Cancel</button>
+                </div>
+                <div class="text-small text-muted" style="margin-top:8px;">Changing settings will briefly interrupt the stream (~2-5s).</div>
+                <div x-show="streamSaveMsg" class="msg mt-8" :class="streamSaveOk ? 'msg--ok' : 'msg--err'" x-text="streamSaveMsg"></div>
             </div>
         </div>
     </template>
@@ -143,6 +220,11 @@ function dashboardPage() {
         pairingPin: '',
         pairingCameraId: '',
         scanning: false,
+        editCam: null,
+        editForm: { resolution: '1920x1080', fps: 25, bitrateMbps: 4, h264_profile: 'high', keyframe_interval: 30, rotation: 0, hflip: false, vflip: false, maxFps: 30 },
+        savingStream: false,
+        streamSaveMsg: '',
+        streamSaveOk: false,
         _healthInterval: null,
         _cameraInterval: null,
 
@@ -223,6 +305,63 @@ function dashboardPage() {
                 await this.loadCameras();
             } catch(e) {
                 alert(e.message || 'Failed to remove camera');
+            }
+        },
+
+        // --- Stream Settings (ADR-0015) ---
+        _resMaxFps: { '640x480': 58, '1296x972': 43, '1920x1080': 30, '2592x1944': 15 },
+
+        openStreamSettings(cam) {
+            this.editCam = cam;
+            var resKey = cam.width + 'x' + cam.height;
+            this.editForm = {
+                resolution: resKey,
+                fps: cam.fps,
+                bitrateMbps: (cam.bitrate / 1000000),
+                h264_profile: cam.h264_profile || 'high',
+                keyframe_interval: cam.keyframe_interval || 30,
+                rotation: cam.rotation || 0,
+                hflip: cam.hflip || false,
+                vflip: cam.vflip || false,
+                maxFps: this._resMaxFps[resKey] || 30,
+            };
+            this.streamSaveMsg = '';
+        },
+
+        onResolutionChange() {
+            this.editForm.maxFps = this._resMaxFps[this.editForm.resolution] || 30;
+            if (this.editForm.fps > this.editForm.maxFps) {
+                this.editForm.fps = this.editForm.maxFps;
+            }
+        },
+
+        async saveStreamSettings() {
+            if (!this.editCam) return;
+            this.savingStream = true;
+            this.streamSaveMsg = '';
+            var parts = this.editForm.resolution.split('x');
+            var payload = {
+                width: parseInt(parts[0]),
+                height: parseInt(parts[1]),
+                fps: this.editForm.fps,
+                bitrate: Math.round(this.editForm.bitrateMbps * 1000000),
+                h264_profile: this.editForm.h264_profile,
+                keyframe_interval: this.editForm.keyframe_interval,
+                rotation: parseInt(this.editForm.rotation),
+                hflip: this.editForm.hflip,
+                vflip: this.editForm.vflip,
+            };
+            try {
+                await window.HM.api.put('/api/v1/cameras/' + encodeURIComponent(this.editCam.id), payload);
+                this.streamSaveOk = true;
+                this.streamSaveMsg = 'Settings saved and pushed to camera.';
+                await this.loadCameras();
+                setTimeout(() => { this.editCam = null; }, 1500);
+            } catch(e) {
+                this.streamSaveOk = false;
+                this.streamSaveMsg = e.message || 'Failed to save settings';
+            } finally {
+                this.savingStream = false;
             }
         },
 

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -155,7 +155,6 @@
                         <option value="640x480">640x480 (max 58 fps)</option>
                         <option value="1296x972">1296x972 (max 43 fps)</option>
                         <option value="1920x1080">1920x1080 (max 30 fps)</option>
-                        <option value="2592x1944">2592x1944 (max 15 fps)</option>
                     </select>
                 </div>
                 <div class="form-group">
@@ -309,7 +308,7 @@ function dashboardPage() {
         },
 
         // --- Stream Settings (ADR-0015) ---
-        _resMaxFps: { '640x480': 58, '1296x972': 43, '1920x1080': 30, '2592x1944': 15 },
+        _resMaxFps: { '640x480': 58, '1296x972': 43, '1920x1080': 30 },
 
         openStreamSettings(cam) {
             this.editCam = cam;

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -142,6 +142,15 @@ CAMERA_LIST_FIELDS = {
     "paired_at",
     "last_seen",
     "firmware_version",
+    "width",
+    "height",
+    "bitrate",
+    "h264_profile",
+    "keyframe_interval",
+    "rotation",
+    "hflip",
+    "vflip",
+    "config_sync",
 }
 
 

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -854,3 +854,69 @@ class TestErrorResponseConsistency:
         assert resp.status_code == 400
         data = resp.get_json()
         assert "error" in data
+
+
+class TestConfigNotifyContract:
+    """POST /api/v1/cameras/config-notify (HMAC auth from camera)."""
+
+    def test_missing_headers_returns_401(self, app, client):
+        _add_camera(app)
+        resp = client.post(
+            "/api/v1/cameras/config-notify",
+            json={"fps": 15},
+        )
+        assert resp.status_code == 401
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_invalid_signature_returns_401(self, app, client):
+        import time
+
+        _add_camera(app, "cam-001")
+        cam = app.store.get_camera("cam-001")
+        cam.pairing_secret = "ab" * 32
+        app.store.save_camera(cam)
+
+        resp = client.post(
+            "/api/v1/cameras/config-notify",
+            json={"fps": 15},
+            headers={
+                "X-Camera-ID": "cam-001",
+                "X-Timestamp": str(int(time.time())),
+                "X-Signature": "bad_signature",
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_valid_signature_returns_200(self, app, client):
+        import hashlib
+        import hmac
+        import json
+        import time
+
+        _add_camera(app, "cam-001")
+        cam = app.store.get_camera("cam-001")
+        cam.pairing_secret = "ab" * 32
+        app.store.save_camera(cam)
+
+        body = json.dumps({"fps": 15}).encode()
+        timestamp = str(int(time.time()))
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"cam-001:{timestamp}:{body_hash}"
+        sig = hmac.new(
+            bytes.fromhex("ab" * 32), message.encode(), hashlib.sha256
+        ).hexdigest()
+
+        resp = client.post(
+            "/api/v1/cameras/config-notify",
+            data=body,
+            content_type="application/json",
+            headers={
+                "X-Camera-ID": "cam-001",
+                "X-Timestamp": timestamp,
+                "X-Signature": sig,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "message" in data

--- a/app/server/tests/unit/test_camera_control_client.py
+++ b/app/server/tests/unit/test_camera_control_client.py
@@ -1,0 +1,204 @@
+"""Unit tests for CameraControlClient (ADR-0015)."""
+
+import pytest
+
+from monitor.services.camera_control_client import CameraControlClient
+
+
+@pytest.fixture
+def client(data_dir):
+    """CameraControlClient with test certs dir."""
+    certs_dir = data_dir / "certs"
+    return CameraControlClient(str(certs_dir))
+
+
+class TestCameraControlClientUnit:
+    """Unit tests that don't require a running server."""
+
+    def test_init_stores_certs_dir(self, client, data_dir):
+        assert client._certs_dir == str(data_dir / "certs")
+
+    def test_ssl_context_no_certs(self, client):
+        """SSL context works even without cert files."""
+        ctx = client._ssl_context()
+        assert ctx is not None
+
+    def test_get_config_unreachable(self, client):
+        """Returns error when camera is unreachable."""
+        result, err = client.get_config("192.168.99.99")
+        assert result is None
+        assert "unreachable" in err.lower() or "refused" in err.lower() or err
+
+    def test_set_config_unreachable(self, client):
+        result, err = client.set_config("192.168.99.99", {"fps": 15})
+        assert result is None
+        assert err  # some error message
+
+    def test_get_capabilities_unreachable(self, client):
+        result, err = client.get_capabilities("192.168.99.99")
+        assert result is None
+
+    def test_get_status_unreachable(self, client):
+        result, err = client.get_status("192.168.99.99")
+        assert result is None
+
+    def test_restart_stream_unreachable(self, client):
+        result, err = client.restart_stream("192.168.99.99")
+        assert result is None
+
+
+class TestCameraServiceWithControl:
+    """Test CameraService integration with control client."""
+
+    def test_update_pushes_stream_params(self, app, cameras_json):
+        """CameraService.update() pushes stream params to camera."""
+        with app.app_context():
+            from unittest.mock import MagicMock
+
+            mock_control = MagicMock()
+            mock_control.set_config.return_value = ({"applied": {"fps": 15}}, "")
+            app.camera_service._control = mock_control
+
+            err, status = app.camera_service.update(
+                "cam-abc123",
+                {"fps": 15},
+                user="admin",
+                ip="127.0.0.1",
+            )
+            assert status == 200
+            assert err == ""
+            mock_control.set_config.assert_called_once_with("192.168.1.50", {"fps": 15})
+
+    def test_update_marks_pending_on_push_failure(self, app, cameras_json):
+        """Config sync marked pending when push fails."""
+        with app.app_context():
+            from unittest.mock import MagicMock
+
+            mock_control = MagicMock()
+            mock_control.set_config.return_value = (None, "Camera unreachable")
+            app.camera_service._control = mock_control
+
+            app.camera_service.update(
+                "cam-abc123",
+                {"fps": 15},
+                user="admin",
+                ip="127.0.0.1",
+            )
+
+            camera = app.store.get_camera("cam-abc123")
+            assert camera.config_sync == "pending"
+
+    def test_update_marks_synced_on_push_success(self, app, cameras_json):
+        """Config sync marked synced when push succeeds."""
+        with app.app_context():
+            from unittest.mock import MagicMock
+
+            mock_control = MagicMock()
+            mock_control.set_config.return_value = ({"applied": {"fps": 15}}, "")
+            app.camera_service._control = mock_control
+
+            app.camera_service.update(
+                "cam-abc123",
+                {"fps": 15},
+                user="admin",
+                ip="127.0.0.1",
+            )
+
+            camera = app.store.get_camera("cam-abc123")
+            assert camera.config_sync == "synced"
+
+    def test_update_non_stream_params_no_push(self, app, cameras_json):
+        """Non-stream params (name, location) don't trigger push."""
+        with app.app_context():
+            from unittest.mock import MagicMock
+
+            mock_control = MagicMock()
+            app.camera_service._control = mock_control
+
+            app.camera_service.update(
+                "cam-abc123",
+                {"name": "Back Yard"},
+                user="admin",
+                ip="127.0.0.1",
+            )
+
+            mock_control.set_config.assert_not_called()
+
+    def test_update_validates_new_stream_fields(self, app, cameras_json):
+        """New stream fields are validated."""
+        with app.app_context():
+            # Invalid bitrate
+            err, status = app.camera_service.update(
+                "cam-abc123",
+                {"bitrate": 100},
+                user="admin",
+                ip="127.0.0.1",
+            )
+            assert status == 400
+            assert "bitrate" in err
+
+    def test_update_validates_rotation(self, app, cameras_json):
+        with app.app_context():
+            err, status = app.camera_service.update(
+                "cam-abc123",
+                {"rotation": 90},
+                user="admin",
+                ip="127.0.0.1",
+            )
+            assert status == 400
+            assert "rotation" in err
+
+    def test_update_validates_h264_profile(self, app, cameras_json):
+        with app.app_context():
+            err, status = app.camera_service.update(
+                "cam-abc123",
+                {"h264_profile": "ultra"},
+                user="admin",
+                ip="127.0.0.1",
+            )
+            assert status == 400
+            assert "h264_profile" in err
+
+    def test_update_validates_hflip_type(self, app, cameras_json):
+        with app.app_context():
+            err, status = app.camera_service.update(
+                "cam-abc123",
+                {"hflip": "yes"},
+                user="admin",
+                ip="127.0.0.1",
+            )
+            assert status == 400
+            assert "hflip" in err
+
+
+class TestCameraModelNewFields:
+    """Test Camera model has new fields with correct defaults."""
+
+    def test_default_stream_params(self, sample_camera):
+        assert sample_camera.width == 1920
+        assert sample_camera.height == 1080
+        assert sample_camera.bitrate == 4000000
+        assert sample_camera.h264_profile == "high"
+        assert sample_camera.keyframe_interval == 30
+        assert sample_camera.rotation == 0
+        assert sample_camera.hflip is False
+        assert sample_camera.vflip is False
+        assert sample_camera.config_sync == "unknown"
+
+    def test_list_cameras_includes_stream_fields(self, app, cameras_json):
+        """list_cameras response includes new stream fields."""
+        with app.app_context():
+            cameras = app.camera_service.list_cameras()
+            cam = cameras[0]
+            assert "width" in cam
+            assert "height" in cam
+            assert "bitrate" in cam
+            assert "config_sync" in cam
+
+    def test_camera_status_includes_stream_fields(self, app, cameras_json):
+        """get_camera_status response includes new stream fields."""
+        with app.app_context():
+            result, err = app.camera_service.get_camera_status("cam-abc123")
+            assert err == ""
+            assert "width" in result
+            assert "config_sync" in result

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -341,7 +341,7 @@ class TestUpdate:
         store = MagicMock()
         store.get_camera.return_value = cam
         svc = CameraService(store)
-        error, status = svc.update("cam-001", {"fps": 59})
+        error, status = svc.update("cam-001", {"fps": 31})
         assert status == 400
         assert "fps" in error
 

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -508,3 +508,60 @@ class TestAuditLogging:
         svc = CameraService(store, audit=None)
         result, error, status = svc.confirm("cam-001")
         assert status == 200
+
+
+class TestAcceptCameraConfig:
+    """Test accept_camera_config (camera-initiated config push)."""
+
+    def test_updates_stream_params(self):
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        error, status = svc.accept_camera_config(
+            "cam-001", {"width": 640, "height": 480, "fps": 30}
+        )
+        assert status == 200
+        assert error == ""
+        assert cam.width == 640
+        assert cam.height == 480
+        assert cam.fps == 30
+        assert cam.config_sync == "synced"
+        store.save_camera.assert_called_once_with(cam)
+
+    def test_rejects_unknown_camera(self):
+        store = MagicMock()
+        store.get_camera.return_value = None
+        svc = CameraService(store)
+        error, status = svc.accept_camera_config("cam-nope", {"fps": 15})
+        assert status == 404
+        assert "not found" in error.lower()
+
+    def test_rejects_unknown_param(self):
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        error, status = svc.accept_camera_config("cam-001", {"unknown": 42})
+        assert status == 400
+        assert "Unknown" in error
+
+    def test_does_not_push_back_to_camera(self):
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        control = MagicMock()
+        svc = CameraService(store, control_client=control)
+        svc.accept_camera_config("cam-001", {"fps": 15})
+        control.set_config.assert_not_called()
+
+    def test_logs_audit_event(self):
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        audit = MagicMock()
+        svc = CameraService(store, audit=audit)
+        svc.accept_camera_config("cam-001", {"fps": 15})
+        audit.log_event.assert_called_once()
+        call_args = audit.log_event.call_args
+        assert call_args[0][0] == "CAMERA_CONFIG_RECEIVED"

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -21,6 +21,15 @@ def _make_camera(**overrides):
         "last_seen": "2026-04-11T10:00:00Z",
         "firmware_version": "1.0.0",
         "rtsp_url": "",
+        "width": 1920,
+        "height": 1080,
+        "bitrate": 4000000,
+        "h264_profile": "high",
+        "keyframe_interval": 30,
+        "rotation": 0,
+        "hflip": False,
+        "vflip": False,
+        "config_sync": "unknown",
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -332,7 +341,7 @@ class TestUpdate:
         store = MagicMock()
         store.get_camera.return_value = cam
         svc = CameraService(store)
-        error, status = svc.update("cam-001", {"fps": 31})
+        error, status = svc.update("cam-001", {"fps": 59})
         assert status == 400
         assert "fps" in error
 

--- a/docs/adr/0015-server-camera-control-channel.md
+++ b/docs/adr/0015-server-camera-control-channel.md
@@ -1,8 +1,8 @@
 # ADR-0015: Server-to-Camera Control Channel
 
-**Status:** Proposed  
-**Date:** 2026-04-15  
-**Deciders:** Vinu  
+**Status:** Proposed
+**Date:** 2026-04-15
+**Deciders:** Vinu
 **Relates to:** ADR-0004 (camera lifecycle), ADR-0006 (modular monolith), ADR-0009 (mTLS pairing)
 
 ## Context
@@ -375,5 +375,33 @@ Strongly typed APIs with code generation. But: adds protobuf dependency, `grpcio
 | `app/server/monitor/services/camera_control_client.py` | **New** — HTTP client with mTLS |
 | `app/server/monitor/services/camera_service.py` | Push config on update, sync state tracking |
 | `app/server/monitor/models.py` | Add `config_sync` field to Camera |
-| `app/camera/tests/` | Unit + integration tests for control API |
-| `app/server/tests/` | Unit + integration tests for control client |
+| `app/camera/camera_streamer/server_notifier.py` | **New** — HMAC-signed camera→server config push |
+| `app/camera/camera_streamer/templates/status.html` | Editable stream settings form |
+| `app/server/monitor/api/cameras.py` | `POST /config-notify` endpoint with HMAC auth |
+| `app/camera/tests/` | Unit + contract tests for control API + notifier |
+| `app/server/tests/` | Unit + contract tests for control client + config-notify |
+
+## 8. Bidirectional Sync
+
+### Camera→Server Notification
+
+When the camera admin changes stream settings via the camera's own status page,
+the camera notifies the server using HMAC-SHA256 authentication:
+
+1. Camera applies config locally via `ControlHandler.set_config(origin="local")`
+2. Camera POSTs to `https://<server_ip>/api/v1/cameras/config-notify`
+3. Request signed with `HMAC-SHA256(pairing_secret, camera_id:timestamp:sha256(body))`
+4. Server verifies HMAC + 5-minute timestamp window
+5. Server updates stored camera config, marks `config_sync=synced`
+
+### Ping-Pong Prevention
+
+`ControlHandler.set_config()` accepts an `origin` parameter:
+- `origin="server"` (default) — change came from server push, no notification
+- `origin="local"` — change from camera GUI, triggers server notification
+
+### Conflict Resolution
+
+Camera is always source of truth. If both sides change simultaneously,
+the camera's rate limiter (5s cooldown) rejects the server push. The camera's
+local change succeeds and its notification overwrites the server's stored copy.

--- a/docs/adr/0015-server-camera-control-channel.md
+++ b/docs/adr/0015-server-camera-control-channel.md
@@ -1,0 +1,379 @@
+# ADR-0015: Server-to-Camera Control Channel
+
+**Status:** Proposed  
+**Date:** 2026-04-15  
+**Deciders:** Vinu  
+**Relates to:** ADR-0004 (camera lifecycle), ADR-0006 (modular monolith), ADR-0009 (mTLS pairing)
+
+## Context
+
+The server can receive video from paired cameras (RTSPS push) and display health status, but it **cannot send commands back**. The server stores camera settings (resolution, fps, recording_mode) in `cameras.json`, but changes never reach the actual camera. An admin who changes resolution on the dashboard is editing a local database entry — the camera keeps streaming at its original settings.
+
+This gap blocks several product goals:
+
+- **Remote camera configuration** — change resolution, framerate, bitrate, rotation from the dashboard without logging into each camera individually
+- **Coordinated recording** — server tells camera to switch to a lower resolution when disk is full, or to a higher one when motion is detected (Phase 2)
+- **Fleet management** — apply settings across multiple cameras from one place (Phase 2)
+- **Live image controls** — brightness, contrast, saturation, exposure adjustments without restarting the stream
+
+### What we need
+
+A private, authenticated channel where the server (RPi 4B) can push configuration to the camera (RPi Zero 2W) and receive confirmation of the result.
+
+## Research Summary
+
+### Industry patterns
+
+| System | How it controls cameras |
+|--------|------------------------|
+| **Frigate NVR** | Does NOT push settings. Consumes whatever stream the camera already provides. Camera config is done through the camera's own ONVIF/web UI. |
+| **Synology Surveillance Station** | Same — camera's own UI for encoding settings. NVR selects from available streams. |
+| **Blue Iris** | Same pattern. Camera owners set resolution on the camera. |
+| **ONVIF (Profile S/T)** | SOAP/XML over HTTP. Controls resolution, encoding, bitrate, PTZ, imaging. Designed for vendor interoperability across thousands of camera models. |
+| **ESPHome** | Hub (Home Assistant) connects to device's TCP server, pushes commands, receives state. Hub-initiated, device-executes. |
+| **Tasmota** | MQTT pub/sub — hub publishes to `cmnd/<device>/COMMAND`, device subscribes and executes. |
+| **Home Assistant** | Mix of HTTP REST, MQTT, WebSocket depending on integration. |
+
+### Protocol comparison (for LAN-only embedded Linux)
+
+| Protocol | Pros | Cons | Fit |
+|----------|------|------|-----|
+| **HTTP REST** | Already have HTTPS server on camera (port 443), Python stdlib, mTLS ready, no new dependencies | Synchronous, no server-push notification | Best |
+| **MQTT** | Pub/sub, async, QoS levels | Requires broker process (mosquitto), new dependency, complexity for 1-4 cameras | Overkill |
+| **CoAP** | Low overhead, UDP-based | Loses TCP reliability, new library, no mTLS (uses DTLS) | Poor fit |
+| **gRPC** | Typed APIs, streaming | Heavy runtime for Zero 2W (512 MB), protobuf dependency | Overkill |
+| **WebSocket** | Persistent connection, bidirectional | Camera's Python `http.server` doesn't support it, would need library | Unnecessary |
+| **RTSP SET_PARAMETER** | In-band with video | Rarely implemented, MediaMTX doesn't support it, read-only SDP | Not viable |
+
+### libcamera parameter changeability
+
+| Parameter type | Can change at runtime? | Interruption |
+|----------------|----------------------|--------------|
+| **Controls** (brightness, contrast, saturation, exposure, AWB, sharpness, gain) | Yes — `set_controls()` per-frame | None |
+| **Configuration** (resolution, sensor mode, framerate, pixel format) | Requires stop/reconfigure/start | ~1-2s stream gap |
+
+Since we use `libcamera-vid` (CLI, not picamera2 library), all parameter changes require restarting the `libcamera-vid` process. The stream gap is ~2-5s (sensor init + TCP reconnect + ffmpeg probe).
+
+## Decision
+
+### 1. Protocol: HTTP REST on the existing camera HTTPS server
+
+Add new API endpoints to the camera's existing status server (`status_server.py`, port 443). The server (RPi 4B) pushes configuration by making HTTPS requests to the camera. No new protocols, no broker, no additional ports.
+
+**Why this is the right choice:**
+
+- Camera already runs an HTTPS server with session auth and self-signed TLS
+- Both devices are on the same LAN with sub-millisecond latency
+- The ESPHome pattern (hub connects to device's server) maps directly to our architecture
+- Adding REST endpoints to `status_server.py` costs zero new infrastructure
+- mTLS can be layered on for the control channel (server presents its cert, camera verifies against CA)
+
+### 2. Authentication: mTLS with server certificate verification
+
+The control channel uses **mutual TLS** — the same trust infrastructure established during pairing (ADR-0009):
+
+- **Server → Camera requests:** Server presents its `server.crt` (signed by server CA). Camera verifies against `ca.crt` received during pairing.
+- **No session cookies needed:** Certificate identity replaces username/password for machine-to-machine calls.
+- **Human admin access** (via camera status page) continues using password + session cookies on the same server.
+
+This means the camera's HTTPS server accepts two authentication methods:
+1. **Session cookie** — for human admin via browser (existing)
+2. **mTLS client certificate** — for server control channel (new)
+
+Request routing:
+
+```
+Camera HTTPS (port 443)
+  ├── /login, /, /status, /api/status, /api/wifi, /api/password
+  │     → session cookie auth (human admin, existing)
+  ├── /pair
+  │     → PIN auth (pairing ceremony, existing)
+  └── /api/v1/control/*
+        → mTLS auth (server only, new)
+```
+
+### 3. Camera-side API endpoints
+
+```
+GET  /api/v1/control/config
+     → Returns current camera configuration (all parameters)
+     Auth: mTLS (server cert)
+
+PUT  /api/v1/control/config
+     Body: {"width": 1920, "height": 1080, "fps": 25, "bitrate": 4000000, ...}
+     → Validates parameters, applies changes, restarts stream if needed
+     → Returns: {"applied": {...}, "restart_required": true, "status": "ok"}
+     Auth: mTLS (server cert)
+
+GET  /api/v1/control/capabilities
+     → Returns supported parameter ranges for this camera hardware
+     → {"width": [640, 1280, 1920], "height": [480, 720, 1080],
+        "fps": {"min": 1, "max": 30}, "bitrate": {"min": 500000, "max": 8000000}, ...}
+     Auth: mTLS (server cert)
+
+GET  /api/v1/control/status
+     → Returns live operational status (streaming, health, errors)
+     → Superset of existing /api/status with stream pipeline details
+     Auth: mTLS (server cert)
+
+POST /api/v1/control/restart-stream
+     → Force restart of the streaming pipeline (no config change)
+     Auth: mTLS (server cert)
+```
+
+### 4. Controllable parameters
+
+#### Stream parameters (require pipeline restart, ~2-5s gap)
+
+| Parameter | Key | Type | Values | Default |
+|-----------|-----|------|--------|---------|
+| Width | `width` | int | 640, 1280, 1920 | 1920 |
+| Height | `height` | int | 480, 720, 1080 | 1080 |
+| Framerate | `fps` | int | 1-30 | 25 |
+| Bitrate | `bitrate` | int | 500000-8000000 (bps) | 4000000 |
+| H.264 profile | `h264_profile` | string | "baseline", "main", "high" | "high" |
+| Keyframe interval | `keyframe_interval` | int | 1-120 (frames) | 30 |
+| Rotation | `rotation` | int | 0, 180 | 0 |
+| Horizontal flip | `hflip` | bool | true/false | false |
+| Vertical flip | `vflip` | bool | true/false | false |
+
+#### Image controls (future, when migrating to picamera2 — no restart)
+
+| Parameter | Key | Type | Range | Default |
+|-----------|-----|------|-------|---------|
+| Brightness | `brightness` | float | -1.0 to 1.0 | 0.0 |
+| Contrast | `contrast` | float | 0.0 to 2.0 | 1.0 |
+| Saturation | `saturation` | float | 0.0 to 2.0 | 1.0 |
+| Sharpness | `sharpness` | float | 0.0 to 2.0 | 1.0 |
+| Auto white balance | `awb_mode` | string | "auto", "daylight", "cloudy", ... | "auto" |
+| Exposure mode | `exposure_mode` | string | "auto", "short", "long" | "auto" |
+
+Image controls are Phase 2 (require picamera2 migration). Documenting them now for forward compatibility.
+
+### 5. Server-side integration
+
+The server's `CameraService.update()` method currently saves settings to `cameras.json` but never pushes them. The change:
+
+```python
+# In camera_service.py update() — after saving to store:
+if self._needs_camera_push(data):
+    result = self._push_config_to_camera(camera, data)
+    if not result.ok:
+        # Save succeeded, push failed — mark camera as "config_pending"
+        camera.config_sync = "pending"
+        self._store.save_camera(camera)
+```
+
+New `CameraControlClient` service (server-side):
+
+```python
+class CameraControlClient:
+    """Push configuration to cameras via their control API.
+
+    Uses server mTLS credentials to authenticate with the camera.
+    """
+    def __init__(self, cert_service):
+        self._cert_service = cert_service
+
+    def get_config(self, camera_ip: str) -> dict:
+        """GET /api/v1/control/config with mTLS."""
+
+    def set_config(self, camera_ip: str, params: dict) -> dict:
+        """PUT /api/v1/control/config with mTLS."""
+
+    def get_capabilities(self, camera_ip: str) -> dict:
+        """GET /api/v1/control/capabilities with mTLS."""
+```
+
+### 6. Config sync model
+
+Camera configuration has a single source of truth: **the camera itself**. The server stores a cached copy for display and for pushing desired state.
+
+```
+Admin changes resolution on dashboard
+  → Server saves desired state to cameras.json
+  → Server pushes PUT /api/v1/control/config to camera
+  → Camera validates, applies, persists to camera.conf
+  → Camera responds with applied config
+  → Server updates cameras.json with confirmed state
+  → If push fails: server marks config_sync="pending", retries on next health check
+```
+
+**Conflict resolution:** Camera always wins. If the camera rejects a parameter (e.g., unsupported resolution for its sensor), the server accepts the rejection and updates its stored value to match what the camera reports.
+
+### 7. Security hardening
+
+| Measure | Implementation |
+|---------|---------------|
+| **mTLS authentication** | Camera verifies server cert against `ca.crt` from pairing. Only the paired server can control this camera. |
+| **Input validation** | Whitelist of allowed parameter names and value ranges. Reject unknown fields. |
+| **Rate limiting** | Max 1 config change per 5 seconds per camera. Prevents rapid restart loops. |
+| **Audit logging** | Camera logs every config change to `/data/logs/control.log` (timestamp, parameter, old → new, requester cert CN). Server logs to `/data/logs/audit.log`. |
+| **Replay protection** | Include monotonic `request_id` (incrementing integer) in each request. Camera rejects requests with `request_id` <= last seen. Reset on reboot is acceptable (mTLS prevents replay across sessions). |
+| **No escalation** | Control endpoints cannot change WiFi, passwords, or trigger factory reset. Those remain admin-password-protected only. |
+
+### 8. Camera-side implementation sketch
+
+New module: `app/camera/camera_streamer/control.py`
+
+```python
+class ControlHandler:
+    """Handles server control API requests.
+
+    Validates mTLS client certificate, parses parameters,
+    applies changes to ConfigManager, restarts stream if needed.
+    """
+    def __init__(self, config, stream_manager, capabilities):
+        self._config = config
+        self._stream = stream_manager
+        self._capabilities = capabilities
+        self._last_request_id = 0
+        self._last_change_time = 0
+        self._rate_limit_seconds = 5
+```
+
+Integration into `status_server.py`:
+
+```python
+# In StatusHandler.do_GET / do_PUT:
+if self.path.startswith("/api/v1/control/"):
+    if not self._require_mtls():  # verify client cert
+        return
+    # Route to ControlHandler
+```
+
+mTLS verification in the camera's HTTPS server:
+
+```python
+def _require_mtls(self):
+    """Verify the request comes from a client with a cert signed by our CA."""
+    # ssl.SSLSocket.getpeercert() returns cert info if client presented one
+    # Camera's SSL context needs: ctx.verify_mode = ssl.CERT_OPTIONAL
+    # (CERT_OPTIONAL so browser clients without certs still work on other endpoints)
+    peer_cert = self.request.getpeercert()
+    if not peer_cert:
+        self._json_response({"error": "Client certificate required"}, 401)
+        return False
+    # Verify issuer matches our CA (defense in depth — TLS already verified chain)
+    return True
+```
+
+### 9. Network and firewall considerations
+
+The camera's nftables firewall (ADR-0009) already allows inbound HTTPS (port 443) from the server IP. No firewall changes needed.
+
+```
+# Existing camera nftables rule:
+tcp dport 443 ip saddr $SERVER_IP accept  # status page + control API
+```
+
+### 10. Parameter validation rules
+
+```python
+STREAM_PARAMS = {
+    "width":              {"type": int, "allowed": [640, 1280, 1920]},
+    "height":             {"type": int, "allowed": [480, 720, 1080]},
+    "fps":                {"type": int, "min": 1, "max": 30},
+    "bitrate":            {"type": int, "min": 500000, "max": 8000000},
+    "h264_profile":       {"type": str, "allowed": ["baseline", "main", "high"]},
+    "keyframe_interval":  {"type": int, "min": 1, "max": 120},
+    "rotation":           {"type": int, "allowed": [0, 180]},
+    "hflip":              {"type": bool},
+    "vflip":              {"type": bool},
+}
+
+RESOLUTION_PAIRS = {
+    (640, 480), (1280, 720), (1920, 1080),
+}
+```
+
+Width and height must form a valid resolution pair. Sending `{"width": 1920, "height": 480}` is rejected.
+
+### 11. Stream restart behavior
+
+When a stream parameter changes:
+
+1. Camera receives `PUT /api/v1/control/config`
+2. Validates all parameters
+3. Persists new values to `camera.conf`
+4. Calls `stream_manager.stop()`
+5. Waits for ffmpeg + libcamera-vid to terminate (~1s)
+6. Calls `stream_manager.start()` (picks up new config values)
+7. Returns response to server
+8. Total interruption: ~2-5s (sensor init 3s + ffmpeg probe 1-2s)
+
+The server should expect the RTSPS stream to drop and reconnect. MediaMTX handles this gracefully — the stream source disappears and reappears. HLS clients see a brief stall; WebRTC clients reconnect automatically.
+
+## Alternatives Considered
+
+### A. MQTT broker between server and cameras
+
+Adds mosquitto process, configuration, another port (1883/8883), TLS setup for MQTT, and a subscription model. For 1-4 cameras on a LAN with <1ms latency, pub/sub adds complexity without benefit. MQTT shines at scale (100+ devices, fan-out, unreliable networks) — none of which apply here.
+
+### B. Camera polls server for config changes
+
+Camera periodically GETs desired config from server. Simpler for the camera (no inbound connections needed), but: increases latency (polling interval), wastes bandwidth, and the camera already accepts inbound HTTPS. Polling is the right pattern when devices are behind NAT or firewalls — our cameras are on the same LAN with firewall rules already allowing server access.
+
+### C. ONVIF implementation
+
+Would provide interoperability with third-party NVRs, but ONVIF is a SOAP/XML protocol with complex WSDL schemas. We control both endpoints — the interop benefit is zero. ONVIF implementation effort is disproportionate to the value for a system with 1-4 custom cameras.
+
+### D. WebSocket persistent connection
+
+Provides server-push and bidirectional communication. But the camera's `http.server.HTTPServer` doesn't support WebSocket upgrade — would need `websockets` library or a switch to a framework. REST request/response is sufficient for configuration push (not a real-time streaming use case).
+
+### E. gRPC with protobuf
+
+Strongly typed APIs with code generation. But: adds protobuf dependency, `grpcio` is heavy (~30 MB) for Zero 2W's constrained storage, and HTTP REST with JSON is equally expressive for our parameter set. gRPC's streaming RPCs would be useful if we needed continuous telemetry — but health monitoring already works via mDNS + polling.
+
+## Consequences
+
+### Positive
+
+- **Zero new infrastructure** — reuses existing HTTPS server, mTLS certs, port 443
+- **Familiar pattern** — REST API consistent with existing camera and server endpoints
+- **Strong auth** — mTLS means only the paired server can control the camera
+- **Auditable** — every change logged on both sides
+- **Forward-compatible** — image controls (brightness, etc.) added later with same API
+- **Testable** — HTTP endpoints are trivially testable with `pytest` + `requests`
+
+### Negative
+
+- **~2-5s stream gap on parameter changes** — unavoidable with libcamera-vid CLI (mitigated: users expect brief interruption when changing resolution)
+- **Camera must be reachable** — server needs network path to camera IP (already true for health checks; blocked if camera is offline → config_sync="pending")
+- **Two auth methods on one server** — session cookies (humans) + mTLS (server). Adds routing complexity in `status_server.py` (mitigated: clear URL prefix separation `/api/v1/control/*`)
+- **Server stores cached copy** — config can drift if camera is modified directly via its status page (mitigated: server refreshes from camera on health check cycle)
+
+## Implementation Plan
+
+### Phase 1 (this PR)
+
+1. Add `control.py` module to camera with parameter validation and stream restart logic
+2. Add mTLS verification to camera's HTTPS server (CERT_OPTIONAL mode)
+3. Add `/api/v1/control/config`, `/api/v1/control/capabilities`, `/api/v1/control/status` endpoints
+4. Add `CameraControlClient` to server
+5. Wire `CameraService.update()` to push config to camera after saving
+6. Add `config_sync` field to Camera model ("synced", "pending", "error")
+7. Add rate limiting and audit logging
+8. Tests: unit + integration for both sides, contract tests for the API
+
+### Phase 2 (future)
+
+- Image controls (brightness, contrast, etc.) after picamera2 migration
+- Bulk config push (apply settings to all cameras)
+- Config sync indicator on dashboard (green check / yellow warning)
+- Server-initiated stream quality adaptation (auto-lower resolution when disk is low)
+
+## File Changes (Estimated)
+
+| File | Change |
+|------|--------|
+| `app/camera/camera_streamer/control.py` | **New** — ControlHandler, validation, capabilities |
+| `app/camera/camera_streamer/status_server.py` | Add mTLS support, route `/api/v1/control/*` |
+| `app/camera/camera_streamer/stream.py` | Add `restart()` method |
+| `app/camera/camera_streamer/config.py` | Add bitrate, h264_profile, rotation, flip params to DEFAULTS |
+| `app/server/monitor/services/camera_control_client.py` | **New** — HTTP client with mTLS |
+| `app/server/monitor/services/camera_service.py` | Push config on update, sync state tracking |
+| `app/server/monitor/models.py` | Add `config_sync` field to Camera |
+| `app/camera/tests/` | Unit + integration tests for control API |
+| `app/server/tests/` | Unit + integration tests for control client |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -670,7 +670,7 @@ Server                              Camera
 
 | Parameter | Values | Default |
 |-----------|--------|---------|
-| Resolution (width x height) | 640x480, 1296x972, 1920x1080, 2592x1944 | 1920x1080 |
+| Resolution (width x height) | 640x480, 1296x972, 1920x1080 | 1920x1080 |
 | Framerate (fps) | 1-58 (limited by sensor mode) | 25 |
 | Bitrate | 0.5-8 Mbps | 4 Mbps |
 | H.264 Profile | baseline, main, high | high |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -643,6 +643,47 @@ Admin triggers push → server sends artifact to camera OTA agent (port 8080, mT
 Camera runs same inbox → verify → install pipeline locally
 ```
 
+### 6.4 Server-to-Camera Control Channel (ADR-0015)
+
+The server pushes stream configuration to cameras via HTTPS REST calls to
+the camera's existing status server (port 443). Authentication uses mTLS —
+the server presents its certificate (signed by the server CA), and the
+camera verifies it against the `ca.crt` received during pairing.
+
+```
+Server                              Camera
+┌──────────────┐                   ┌──────────────────┐
+│ Dashboard UI │                   │ Status Server    │
+│   (admin)    │                   │ (port 443, HTTPS)│
+│      │       │    PUT /api/v1/   │      │           │
+│      └───────│────control/config─│──────┤           │
+│              │    (mTLS)         │      ▼           │
+│              │                   │ ControlHandler   │
+│              │                   │   • validate     │
+│              │                   │   • persist conf │
+│              │   200 {applied}   │   • restart      │
+│   ◄──────────│───────────────────│──── stream       │
+└──────────────┘                   └──────────────────┘
+```
+
+**Controllable parameters** (all require ~2-5s stream restart):
+
+| Parameter | Values | Default |
+|-----------|--------|---------|
+| Resolution (width x height) | 640x480, 1296x972, 1920x1080, 2592x1944 | 1920x1080 |
+| Framerate (fps) | 1-58 (limited by sensor mode) | 25 |
+| Bitrate | 0.5-8 Mbps | 4 Mbps |
+| H.264 Profile | baseline, main, high | high |
+| Keyframe Interval | 1-120 frames | 30 |
+| Rotation | 0, 180 | 0 |
+| Horizontal/Vertical Flip | true/false | false |
+
+Supported resolutions are auto-detected from the OV5647 sensor hardware.
+
+**Config sync model:** Camera is source of truth. Server stores a cached
+copy. If push fails, server marks `config_sync=pending` and retries on
+next health check cycle.
+
 ---
 
 ## 7. Directory Structure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -684,6 +684,13 @@ Supported resolutions are auto-detected from the OV5647 sensor hardware.
 copy. If push fails, server marks `config_sync=pending` and retries on
 next health check cycle.
 
+**Bidirectional sync:** Camera GUI can also edit stream settings. When
+changed locally, the camera notifies the server via HMAC-signed POST to
+`/api/v1/cameras/config-notify`. The server verifies the HMAC using the
+shared `pairing_secret` and updates its stored copy. Ping-pong prevention:
+server-originated changes use `origin="server"` (no notification back),
+camera-originated changes use `origin="local"` (notification triggered).
+
 ---
 
 ## 7. Directory Structure


### PR DESCRIPTION
## Summary
- Add REST control API on camera's HTTPS status server for remote stream configuration (resolution, FPS, bitrate, H.264 profile, keyframe interval, rotation, flip)
- Server pushes config changes to camera over mTLS using pairing-established certificates
- Full config sync tracking (synced/pending/unknown), rate limiting (5s cooldown), replay protection, and cross-field validation against OV5647 sensor capabilities
- Dashboard settings modal with resolution dropdown (4 sensor modes with max FPS labels), auto-capping FPS on resolution change
- Camera status page shows stream settings card

## Changes
**Camera** (5 files modified, 2 new):
- `control.py` — ControlHandler with get/set config, capabilities, status; SENSOR_MODES validation
- `status_server.py` — mTLS support (CERT_OPTIONAL), `/api/v1/control/*` routes
- `config.py` — New stream params (bitrate, h264_profile, keyframe_interval, rotation, hflip, vflip)
- `stream.py` — `restart()` method, dynamic libcamera flags from config
- `templates/status.html` — Stream Settings card

**Server** (6 files modified, 2 new):
- `camera_control_client.py` — HTTP client with mTLS for camera control API
- `camera_service.py` — Push-on-update for stream params, validation, config_sync tracking
- `models.py` — Camera dataclass: 9 new fields with defaults
- `__init__.py` — Wire CameraControlClient into service layer
- `templates/dashboard.html` — Stream settings modal (Alpine.js)
- `static/css/style.css` — Modal and status indicator styles

**Docs** (2 new/modified):
- `docs/adr/0015-server-camera-control-channel.md` — Full ADR
- `docs/architecture.md` — Section 6.4 with ASCII diagram

## Test plan
- [x] 428 camera tests pass (39 new control tests)
- [x] 1056 server tests pass (18 new control/client tests)
- [x] Contract tests updated for new API fields
- [x] Ruff lint + format clean
- [ ] Manual: open dashboard, click Settings on a camera, change resolution, verify push
- [ ] Manual: verify camera status page shows stream settings card
- [ ] Manual: verify mTLS rejects requests without valid server cert

## Deployment impact
- Camera firmware update required (new control.py, updated status_server)
- Server update required (new client, updated service layer)
- No migration needed — new Camera model fields have defaults
- Backwards compatible — cameras without control API just show config_sync="unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)