### PR TITLE
fix: ProxyFix + rtsp_url set during pairing (streaming after fresh setup)

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -11,6 +11,7 @@ import socket
 import subprocess
 
 from flask import Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from monitor.logging_config import configure_logging
 from monitor.services.audit import AuditLogger
@@ -91,6 +92,9 @@ def create_app(config=None):
     log.info("Monitor server starting")
 
     app = Flask(__name__)
+    # nginx sets X-Real-IP and X-Forwarded-For — trust one proxy hop
+    # so request.remote_addr returns the real client IP, not 127.0.0.1
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
     config_dir = os.environ.get("MONITOR_CONFIG_DIR", "/data/config")
     explicit_config_keys = set(config.keys()) if config else set()
 

--- a/app/server/monitor/api/pairing.py
+++ b/app/server/monitor/api/pairing.py
@@ -48,6 +48,13 @@ def unpair_camera(camera_id):
     )
     if error:
         return jsonify({"error": error}), status
+
+    # Stop streaming pipeline when camera is unpaired
+    try:
+        current_app.streaming.stop_camera(camera_id)
+    except Exception:
+        pass
+
     return jsonify({"message": "Camera unpaired"}), 200
 
 
@@ -97,4 +104,14 @@ def exchange_certs():
     )
     if error:
         return jsonify({"error": error}), status
+
+    # Start streaming immediately if camera is set to continuous recording.
+    # Without this, streaming only starts on server restart — breaking fresh pairs.
+    try:
+        camera = current_app.store.get_camera(camera_id)
+        if camera and camera.recording_mode == "continuous":
+            current_app.streaming.start_camera(camera_id)
+    except Exception:
+        pass  # Non-fatal: streaming can be started from dashboard
+
     return jsonify(result), 200

--- a/app/server/monitor/services/pairing_service.py
+++ b/app/server/monitor/services/pairing_service.py
@@ -155,6 +155,13 @@ class PairingService:
         camera.pairing_secret = pairing_secret
         if ip:
             camera.ip = ip
+        # Set RTSP URL so streaming/recording works immediately after pairing
+        if not camera.rtsp_url:
+            camera.rtsp_url = f"rtsp://127.0.0.1:8554/{camera.id}"
+        if not camera.paired_at:
+            from datetime import UTC, datetime
+
+            camera.paired_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         self._store.save_camera(camera)
 
         # Clean up pending state

--- a/app/server/tests/integration/test_api_pairing.py
+++ b/app/server/tests/integration/test_api_pairing.py
@@ -111,6 +111,24 @@ class TestUnpairCamera:
         resp = client.post("/api/v1/cameras/nonexistent/unpair")
         assert resp.status_code == 404
 
+    def test_unpair_stops_streaming(self, app, client):
+        """Unpair should stop the streaming pipeline."""
+        from unittest.mock import MagicMock
+
+        _login(app, client)
+        _add_camera(app, status="online")
+        app.streaming.stop_camera = MagicMock()
+
+        resp = client.post("/api/v1/cameras/cam-001/unpair")
+        assert resp.status_code == 200
+        app.streaming.stop_camera.assert_called_once_with("cam-001")
+
+    def test_unpair_unknown_camera(self, app, client):
+        """Unpair non-existent camera returns 404."""
+        _login(app, client)
+        resp = client.post("/api/v1/cameras/no-such-cam/unpair")
+        assert resp.status_code == 404
+
 
 class TestExchangeCerts:
     """Test POST /api/v1/pair/exchange."""
@@ -173,6 +191,60 @@ class TestExchangeCerts:
             assert "ca_cert" in data
             assert "pairing_secret" in data
             assert "rtsps_url" in data
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_exchange_starts_streaming_for_continuous_camera(
+        self, mock_gen, app, client
+    ):
+        """Streaming pipeline starts automatically after successful pairing."""
+        from unittest.mock import MagicMock
+
+        _login(app, client)
+        cam = _add_camera(app)
+        cam.recording_mode = "continuous"
+        app.store.save_camera(cam)
+        mock_gen.return_value = (
+            {"cert": "CERT", "key": "KEY", "serial": "S1"},
+            "",
+        )
+        app.streaming.start_camera = MagicMock()
+
+        resp = client.post("/api/v1/cameras/cam-001/pair")
+        pin = resp.get_json()["pin"]
+
+        with app.test_client() as camera_client:
+            camera_client.post(
+                "/api/v1/pair/exchange",
+                json={"pin": pin, "camera_id": "cam-001"},
+            )
+
+        app.streaming.start_camera.assert_called_once_with("cam-001")
+
+    @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
+    def test_exchange_skips_streaming_for_on_demand_camera(self, mock_gen, app, client):
+        """Streaming pipeline does NOT start if recording_mode is on_demand."""
+        from unittest.mock import MagicMock
+
+        _login(app, client)
+        cam = _add_camera(app)
+        cam.recording_mode = "on_demand"
+        app.store.save_camera(cam)
+        mock_gen.return_value = (
+            {"cert": "CERT", "key": "KEY", "serial": "S2"},
+            "",
+        )
+        app.streaming.start_camera = MagicMock()
+
+        resp = client.post("/api/v1/cameras/cam-001/pair")
+        pin = resp.get_json()["pin"]
+
+        with app.test_client() as camera_client:
+            camera_client.post(
+                "/api/v1/pair/exchange",
+                json={"pin": pin, "camera_id": "cam-001"},
+            )
+
+        app.streaming.start_camera.assert_not_called()
 
     @patch("monitor.services.pairing_service.PairingService._generate_client_cert")
     def test_wrong_pin_rejected(self, mock_gen, app, client):


### PR DESCRIPTION
## Summary
- Add werkzeug `ProxyFix` middleware so `request.remote_addr` returns the real camera IP (not `127.0.0.1` from nginx proxy)
- Set `rtsp_url` and `paired_at` during pairing exchange, not just during confirm

## Root Cause
After fresh install / factory reset / OS update, streaming never worked because:
1. nginx proxies all requests to Flask on localhost
2. `request.remote_addr` always returned `127.0.0.1`
3. Camera IP stored as `127.0.0.1` → control channel, HLS, recordings all broken
4. `rtsp_url` was only set in `confirm()` (admin action), not during pairing exchange

## Test plan
- [x] 1064 server tests pass
- [x] Ruff lint clean
- [ ] Factory reset camera, go through setup + pair, verify camera.ip is real IP (not 127.0.0.1)
- [ ] Verify streaming works immediately after pairing without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)