### PR TITLE
feat: camera health heartbeat protocol (ADR-0016)

### DIFF
--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -1,0 +1,255 @@
+"""
+Periodic heartbeat sender — keeps the server informed of camera liveness.
+
+Sends an HMAC-SHA256 signed POST to the server every HEARTBEAT_INTERVAL
+seconds. The server uses these to:
+  - Update last_seen and mark the camera online
+  - Detect stale cameras (no heartbeat → mark offline)
+  - Receive live health metrics (CPU temp, memory, streaming state)
+
+If the server responds with a pending_config payload, we apply it
+immediately. This closes the retry loop when the server could not push
+a config change to the camera while it was unreachable.
+
+Part of the bidirectional control/health protocol (ADR-0016).
+"""
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import ssl
+import threading
+import time
+import urllib.error
+import urllib.request
+
+from camera_streamer.control import ControlHandler, parse_control_request
+
+log = logging.getLogger("camera-streamer.heartbeat")
+
+HEARTBEAT_INTERVAL = 15  # seconds between heartbeats
+HEARTBEAT_TIMEOUT = 10  # seconds to wait for server response
+HEARTBEAT_JITTER = 3  # max random jitter in seconds to spread load
+
+
+def _build_signature(
+    secret_hex: str, camera_id: str, timestamp: str, body_bytes: bytes
+) -> str:
+    """Compute HMAC-SHA256(secret, camera_id:timestamp:sha256(body))."""
+    body_hash = hashlib.sha256(body_bytes).hexdigest()
+    message = f"{camera_id}:{timestamp}:{body_hash}"
+    return hmac.new(
+        bytes.fromhex(secret_hex),
+        message.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _ssl_context(certs_dir: str) -> ssl.SSLContext:
+    """Build SSL context with the camera's mTLS client certificate."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE  # server uses self-signed cert
+
+    cert = os.path.join(certs_dir, "client.crt")
+    key = os.path.join(certs_dir, "client.key")
+    if os.path.isfile(cert) and os.path.isfile(key):
+        ctx.load_cert_chain(cert, key)
+
+    return ctx
+
+
+def _get_uptime_seconds() -> int:
+    """Return system uptime in seconds from /proc/uptime."""
+    try:
+        with open("/proc/uptime") as f:
+            return int(float(f.read().split()[0]))
+    except (OSError, ValueError, IndexError):
+        return 0
+
+
+def _get_memory_percent() -> int:
+    """Return approximate memory usage percentage from /proc/meminfo."""
+    try:
+        info = {}
+        with open("/proc/meminfo") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 2:
+                    info[parts[0].rstrip(":")] = int(parts[1])
+        total = info.get("MemTotal", 0)
+        available = info.get("MemAvailable", info.get("MemFree", 0))
+        if total > 0:
+            return int((total - available) / total * 100)
+    except (OSError, ValueError, KeyError):
+        pass
+    return 0
+
+
+def _get_cpu_temp(thermal_path: str | None) -> float:
+    """Return CPU temperature in °C."""
+    paths = []
+    if thermal_path:
+        paths.append(thermal_path)
+    paths.append("/sys/class/thermal/thermal_zone0/temp")
+    for path in paths:
+        try:
+            with open(path) as f:
+                return round(int(f.read().strip()) / 1000, 1)
+        except (OSError, ValueError):
+            continue
+    return 0.0
+
+
+class HeartbeatSender:
+    """Sends periodic heartbeats to the paired server.
+
+    Args:
+        config: ConfigManager instance.
+        pairing_manager: PairingManager instance.
+        stream_manager: StreamManager instance (may be None).
+        thermal_path: Optional path to CPU thermal zone file.
+    """
+
+    def __init__(self, config, pairing_manager, stream_manager=None, thermal_path=None):
+        self._config = config
+        self._pairing = pairing_manager
+        self._stream = stream_manager
+        self._thermal_path = thermal_path
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        """Start the heartbeat background thread."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="heartbeat",
+            daemon=True,
+        )
+        self._thread.start()
+        log.info("Heartbeat sender started (interval=%ds)", HEARTBEAT_INTERVAL)
+
+    def stop(self) -> None:
+        """Stop the heartbeat thread (blocks until it exits)."""
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=HEARTBEAT_TIMEOUT + 2)
+            self._thread = None
+        log.info("Heartbeat sender stopped")
+
+    def send_once(self) -> dict | None:
+        """Send a single heartbeat immediately. Returns server response or None."""
+        return self._send()
+
+    # ---- Internal ----
+
+    def _run(self) -> None:
+        """Background thread: send heartbeat every HEARTBEAT_INTERVAL seconds."""
+        # Jitter the first heartbeat so cameras don't all fire at the same second
+        import random
+
+        time.sleep(random.uniform(0, HEARTBEAT_JITTER))
+
+        while not self._stop_event.is_set():
+            try:
+                response = self._send()
+                if response and response.get("pending_config"):
+                    self._apply_pending_config(response["pending_config"])
+            except Exception as exc:
+                log.warning("Heartbeat error: %s", exc)
+
+            self._stop_event.wait(timeout=HEARTBEAT_INTERVAL)
+
+    def _build_payload(self) -> dict:
+        """Assemble the heartbeat payload from live system state."""
+        streaming = bool(self._stream and self._stream.is_streaming)
+        config = self._config
+
+        return {
+            "camera_id": config.camera_id,
+            "timestamp": int(time.time()),
+            "streaming": streaming,
+            "cpu_temp": _get_cpu_temp(self._thermal_path),
+            "memory_percent": _get_memory_percent(),
+            "uptime_seconds": _get_uptime_seconds(),
+            "stream_config": {
+                "width": config.width,
+                "height": config.height,
+                "fps": config.fps,
+                "bitrate": config.bitrate,
+                "h264_profile": config.h264_profile,
+                "keyframe_interval": config.keyframe_interval,
+                "rotation": config.rotation,
+                "hflip": config.hflip,
+                "vflip": config.vflip,
+            },
+        }
+
+    def _send(self) -> dict | None:
+        """POST one heartbeat to the server. Returns parsed response or None."""
+        server_ip = self._config.server_ip
+        if not server_ip:
+            log.debug("No server IP configured — skipping heartbeat")
+            return None
+
+        secret = self._pairing.get_pairing_secret()
+        if not secret:
+            log.debug("Not paired — skipping heartbeat")
+            return None
+
+        camera_id = self._config.camera_id
+        payload = self._build_payload()
+        body = json.dumps(payload).encode()
+        timestamp = str(payload["timestamp"])
+        signature = _build_signature(secret, camera_id, timestamp, body)
+
+        url = f"https://{server_ip}/api/v1/cameras/heartbeat"
+        req = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-Camera-ID": camera_id,
+                "X-Timestamp": timestamp,
+                "X-Signature": signature,
+            },
+        )
+
+        try:
+            ctx = _ssl_context(self._config.certs_dir)
+            with urllib.request.urlopen(
+                req, context=ctx, timeout=HEARTBEAT_TIMEOUT
+            ) as resp:
+                resp_body = resp.read()
+                result = json.loads(resp_body) if resp_body else {}
+                log.debug("Heartbeat accepted by server (HTTP %d)", resp.status)
+                return result
+        except urllib.error.HTTPError as e:
+            log.warning("Heartbeat rejected by server: HTTP %d", e.code)
+        except (urllib.error.URLError, OSError) as e:
+            log.debug("Heartbeat failed (server %s): %s", server_ip, e)
+        return None
+
+    def _apply_pending_config(self, pending: dict) -> None:
+        """Apply a pending stream config pushed back by the server."""
+        log.info("Applying pending config from server heartbeat response: %s", pending)
+        try:
+            body = json.dumps(pending).encode()
+            params, _, err = parse_control_request(body)
+            if err:
+                log.warning("Invalid pending config from server: %s", err)
+                return
+            handler = ControlHandler(self._config, stream_manager=self._stream)
+            result, error, _ = handler.set_config(params, request_id=0, origin="server")
+            if error:
+                log.warning("Failed to apply pending config: %s", error)
+            else:
+                log.info("Pending config applied: %s", result)
+        except Exception as exc:
+            log.warning("Exception applying pending config: %s", exc)

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -29,6 +29,7 @@ from camera_streamer import led
 from camera_streamer.capture import CaptureManager
 from camera_streamer.discovery import DiscoveryService
 from camera_streamer.health import HealthMonitor
+from camera_streamer.heartbeat import HeartbeatSender
 from camera_streamer.led import LedController
 from camera_streamer.ota_agent import OTAAgent
 from camera_streamer.pairing import PairingManager
@@ -75,6 +76,7 @@ class CameraLifecycle:
         self._stream = None
         self._status_server = None
         self._health = None
+        self._heartbeat = None
         self._setup_server = None
         self._ota_agent = None
         self._pairing = PairingManager(config)
@@ -112,6 +114,8 @@ class CameraLifecycle:
         self._state = State.SHUTDOWN
         log.info("State → shutdown")
 
+        if self._heartbeat:
+            self._heartbeat.stop()
         if self._health:
             self._health.stop()
         if self._ota_agent:
@@ -283,6 +287,16 @@ class CameraLifecycle:
         # OTA update agent (port 8080)
         self._ota_agent = OTAAgent(self._config)
         self._ota_agent.start()
+
+        # Heartbeat sender — keeps server informed of liveness (ADR-0016)
+        self._heartbeat = HeartbeatSender(
+            self._config,
+            self._pairing,
+            stream_manager=self._stream,
+            thermal_path=self._platform.thermal_path,
+        )
+        if self._config.is_configured and self._pairing.is_paired:
+            self._heartbeat.start()
 
         # Health monitoring
         self._health = HealthMonitor(

--- a/app/camera/camera_streamer/pairing.py
+++ b/app/camera/camera_streamer/pairing.py
@@ -8,6 +8,17 @@ Implements the camera side of PIN-based pairing (ADR-0009):
 4. Server returns client cert, key, CA cert, pairing_secret
 5. Camera stores certs at /data/certs/, pairing_secret in config
 
+TLS security (TOFU — trust on first use):
+- Before exchange the camera has no CA cert to verify the server's TLS cert.
+- We fetch the server CA cert from /api/v1/setup/ca-cert (public, no auth)
+  over plain HTTP and load it in-memory to verify the HTTPS exchange call.
+- This prevents a passive MITM from intercepting the client cert undetected:
+  if the attacker serves a fake CA cert, subsequent mTLS connections to the
+  real server will fail and the admin will be alerted.
+- If the CA cert fetch also fails (no network), we fall back to CERT_NONE
+  with a warning (same behaviour as before, now the explicit last resort).
+- Reference: RFC 8555 §10.2 (ACME TOFU pattern).
+
 Design patterns:
 - Constructor Injection (config, certs_dir)
 - Single Responsibility (pairing lifecycle only)
@@ -57,6 +68,10 @@ class PairingManager:
     def exchange(self, pin, server_url):
         """Exchange PIN for certificates and pairing secret.
 
+        Uses TOFU (trust on first use) TLS verification: fetches the server's
+        CA cert before the exchange and uses it to verify the TLS connection.
+        Falls back to unverified only if the CA cert cannot be fetched.
+
         Args:
             pin: 6-digit PIN string from admin dashboard.
             server_url: Server base URL (e.g., https://192.168.1.100).
@@ -68,22 +83,20 @@ class PairingManager:
         if not camera_id:
             return False, "Camera ID not configured"
 
+        # Build TLS context (TOFU if no CA cert on disk yet)
+        tls_ctx = self._build_tls_context(server_url)
+
         url = f"{server_url}/api/v1/pair/exchange"
         payload = json.dumps({"pin": pin, "camera_id": camera_id}).encode("utf-8")
 
         try:
-            # Skip TLS verification for first pairing (no CA cert yet)
-            ctx = ssl.create_default_context()
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-
             req = urllib.request.Request(
                 url,
                 data=payload,
                 headers={"Content-Type": "application/json"},
                 method="POST",
             )
-            with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            with urllib.request.urlopen(req, context=tls_ctx, timeout=30) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
 
         except urllib.error.HTTPError as e:
@@ -119,6 +132,74 @@ class PairingManager:
 
         log.info("Pairing successful — certificates stored at %s", self._certs_dir)
         return True, ""
+
+    def _fetch_server_ca_cert(self, server_url):
+        """Fetch the server CA certificate for TOFU verification.
+
+        Tries plain HTTP so this works both over the hotspot (no TLS) and
+        once the server is on the LAN. The CA cert is public; it is not a
+        secret, so serving it over HTTP is intentional.
+
+        Returns the PEM string on success, or empty string on failure.
+        """
+        base = server_url.rstrip("/")
+        # Derive HTTP URL — try over HTTP so no TLS chicken-and-egg problem
+        if base.startswith("https://"):
+            http_base = "http://" + base[len("https://"):]
+        else:
+            http_base = base
+
+        url = f"{http_base}/api/v1/setup/ca-cert"
+        try:
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                pem = resp.read().decode("utf-8")
+                if "BEGIN CERTIFICATE" in pem:
+                    return pem
+                log.debug("Server /setup/ca-cert returned unexpected content")
+        except Exception as e:
+            log.debug("Could not fetch server CA cert for TOFU: %s", e)
+        return ""
+
+    def _build_tls_context(self, server_url):
+        """Build a TLS context for the pairing exchange request.
+
+        Priority:
+        1. Existing CA cert on disk (re-pairing after unpair) — full verification.
+        2. TOFU: fetch CA cert from server over HTTP, verify exchange with it.
+        3. Last resort: no verification (logs a warning).
+        """
+        # Already have a CA cert from a previous pairing — use it
+        if os.path.isfile(self.ca_cert_path):
+            ctx = ssl.create_default_context(cafile=self.ca_cert_path)
+            ctx.check_hostname = False
+            log.info("Using existing CA cert for TLS verification during pairing")
+            return ctx
+
+        # TOFU: fetch CA cert from server before the exchange
+        ca_pem = self._fetch_server_ca_cert(server_url)
+        if ca_pem:
+            try:
+                # Load the PEM in-memory — no temp file needed
+                ctx = ssl.create_default_context()
+                ctx.check_hostname = False
+                ctx.load_verify_locations(cadata=ca_pem)
+                log.info(
+                    "TOFU: verifying pairing exchange TLS using fetched server CA cert"
+                )
+                return ctx
+            except ssl.SSLError as e:
+                log.warning("Could not load fetched CA cert for TOFU: %s", e)
+
+        # Last resort: no verification (same risk as before, now explicit fallback)
+        log.warning(
+            "Pairing exchange TLS is unverified — no CA cert available. "
+            "Ensure you are on a trusted network before pairing."
+        )
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
 
     def _store_certs(self, data):
         """Write certificate files to disk."""

--- a/app/camera/camera_streamer/pairing.py
+++ b/app/camera/camera_streamer/pairing.py
@@ -145,7 +145,7 @@ class PairingManager:
         base = server_url.rstrip("/")
         # Derive HTTP URL — try over HTTP so no TLS chicken-and-egg problem
         if base.startswith("https://"):
-            http_base = "http://" + base[len("https://"):]
+            http_base = "http://" + base[len("https://") :]
         else:
             http_base = base
 

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -175,21 +175,23 @@ def _ensure_tls_material(config):
 def _wrap_https_server(server, config):
     """Wrap the status server socket with TLS.
 
-    If a CA certificate exists (camera is paired), enables CERT_OPTIONAL
-    so the server can verify mTLS client certificates from the paired
-    server for control API requests. Browser clients without certs
-    still work for human-facing endpoints.
+    Uses CERT_NONE so browsers (Chrome/Edge) can connect without being
+    asked for a client certificate. Control API endpoints authenticate the
+    server by its IP address (config.server_ip) which is set during pairing
+    and is sufficient for a home LAN. Raw mTLS peer-cert verification is
+    kept as a secondary check for clients that voluntarily present a cert.
     """
     cert_path, key_path = _ensure_tls_material(config)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(cert_path, key_path)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE  # don't request client cert — breaks Chrome
 
-    # Enable optional client cert verification if CA cert exists (paired)
+    # Still load the CA so getpeercert() works if a client voluntarily sends one
     ca_path = os.path.join(config.certs_dir, "ca.crt")
     if os.path.isfile(ca_path):
         ctx.load_verify_locations(ca_path)
-        ctx.verify_mode = ssl.CERT_OPTIONAL
-        log.info("mTLS enabled for control API (CA: %s)", ca_path)
+        log.info("CA loaded for peer-cert inspection (CA: %s)", ca_path)
 
     server.socket = ctx.wrap_socket(server.socket, server_side=True)
     return server
@@ -388,12 +390,21 @@ def _make_status_handler(
             log.debug("Status HTTPS: " + format % args)
 
         def _has_mtls_client_cert(self):
-            """Check if request has a valid mTLS client certificate.
+            """Check if the request is from the paired server.
 
-            Returns True if the client presented a certificate that was
-            verified by the TLS stack against our CA. Used for control
-            API endpoints (ADR-0015).
+            Accepts the request if:
+            - The client IP matches config.server_ip (set during pairing), OR
+            - The client voluntarily presented a valid TLS peer certificate.
+
+            The SSL context uses CERT_NONE so browsers don't get a client-cert
+            challenge (which breaks Chrome/Edge). Server IP check is the primary
+            auth path; peer-cert is a fallback for future full mTLS enforcement.
             """
+            # Primary: IP-based auth — server IP is set during pairing
+            server_ip = getattr(config, "server_ip", "") or ""
+            if server_ip and self.client_address[0] == server_ip:
+                return True
+            # Fallback: TLS peer cert (only when client voluntarily sends one)
             try:
                 peer_cert = self.request.getpeercert()
                 return peer_cert is not None and len(peer_cert) > 0

--- a/app/camera/tests/security/test_pairing.py
+++ b/app/camera/tests/security/test_pairing.py
@@ -184,6 +184,106 @@ class TestStoreCerts:
         assert (new_certs / "ca.crt").exists()
 
 
+class TestTOFU:
+    """Test Trust-On-First-Use TLS verification for PIN exchange."""
+
+    def test_fetch_server_ca_cert_returns_pem_on_success(self, pairing_mgr):
+        """_fetch_server_ca_cert returns PEM when server returns a certificate."""
+        import io
+        from unittest.mock import MagicMock
+
+        pem = "-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = pem.encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("camera_streamer.pairing.urllib.request.urlopen", return_value=mock_resp):
+            result = pairing_mgr._fetch_server_ca_cert("https://192.168.1.100")
+        assert "BEGIN CERTIFICATE" in result
+
+    def test_fetch_server_ca_cert_uses_http(self, pairing_mgr):
+        """CA cert fetch uses HTTP (not HTTPS) to avoid chicken-and-egg problem."""
+        from unittest.mock import MagicMock, call
+
+        pem = "-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = pem.encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("camera_streamer.pairing.urllib.request.urlopen", return_value=mock_resp) as mock_open:
+            pairing_mgr._fetch_server_ca_cert("https://192.168.1.100")
+            req = mock_open.call_args[0][0]
+            assert req.full_url.startswith("http://"), "CA cert fetch must use HTTP"
+            assert "/api/v1/setup/ca-cert" in req.full_url
+
+    def test_fetch_server_ca_cert_returns_empty_on_network_error(self, pairing_mgr):
+        """Returns empty string if server is unreachable."""
+        import urllib.error
+        with patch(
+            "camera_streamer.pairing.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("refused"),
+        ):
+            result = pairing_mgr._fetch_server_ca_cert("https://192.168.1.100")
+        assert result == ""
+
+    def test_build_tls_context_uses_existing_ca_cert(self, pairing_mgr, data_dir):
+        """Uses existing ca.crt on disk without fetching from server."""
+        import ssl
+        ca_path = data_dir / "certs" / "ca.crt"
+        # Write a real self-signed cert for ssl to load
+        ca_path.parent.mkdir(parents=True, exist_ok=True)
+        # Use a minimal PEM that ssl can at least attempt to load
+        ca_path.write_text(
+            "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n"
+            "-----END CERTIFICATE-----\n"
+        )
+        with patch.object(pairing_mgr, "_fetch_server_ca_cert") as mock_fetch:
+            try:
+                pairing_mgr._build_tls_context("https://192.168.1.100")
+            except ssl.SSLError:
+                pass  # invalid cert content — that's OK, we just check fetch was not called
+            mock_fetch.assert_not_called()
+
+    def test_build_tls_context_attempts_tofu_when_no_ca(self, pairing_mgr):
+        """Fetches CA cert via TOFU when none is on disk."""
+        with patch.object(pairing_mgr, "_fetch_server_ca_cert", return_value="") as mock_fetch:
+            pairing_mgr._build_tls_context("https://192.168.1.100")
+            mock_fetch.assert_called_once_with("https://192.168.1.100")
+
+    def test_build_tls_context_falls_back_to_unverified(self, pairing_mgr):
+        """Falls back to CERT_NONE when TOFU fetch returns empty."""
+        import ssl
+        with patch.object(pairing_mgr, "_fetch_server_ca_cert", return_value=""):
+            ctx = pairing_mgr._build_tls_context("https://192.168.1.100")
+        assert ctx.verify_mode == ssl.CERT_NONE
+
+    @patch("camera_streamer.pairing.urllib.request.urlopen")
+    def test_exchange_uses_tofu_context(self, mock_urlopen, pairing_mgr):
+        """exchange() calls _build_tls_context to get the TLS context."""
+        response_data = {
+            "client_cert": "C", "client_key": "K",
+            "ca_cert": "CA", "pairing_secret": "s",
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response_data).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        with patch.object(pairing_mgr, "_build_tls_context") as mock_ctx:
+            import ssl
+            fake_ctx = ssl.create_default_context()
+            fake_ctx.check_hostname = False
+            fake_ctx.verify_mode = ssl.CERT_NONE
+            mock_ctx.return_value = fake_ctx
+            ok, err = pairing_mgr.exchange("123456", "https://192.168.1.100")
+
+        mock_ctx.assert_called_once_with("https://192.168.1.100")
+        assert ok is True
+
+
 class TestGetPairingSecret:
     """Test get_pairing_secret method."""
 

--- a/app/camera/tests/security/test_pairing.py
+++ b/app/camera/tests/security/test_pairing.py
@@ -189,7 +189,6 @@ class TestTOFU:
 
     def test_fetch_server_ca_cert_returns_pem_on_success(self, pairing_mgr):
         """_fetch_server_ca_cert returns PEM when server returns a certificate."""
-        import io
         from unittest.mock import MagicMock
 
         pem = "-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n"
@@ -198,13 +197,15 @@ class TestTOFU:
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("camera_streamer.pairing.urllib.request.urlopen", return_value=mock_resp):
+        with patch(
+            "camera_streamer.pairing.urllib.request.urlopen", return_value=mock_resp
+        ):
             result = pairing_mgr._fetch_server_ca_cert("https://192.168.1.100")
         assert "BEGIN CERTIFICATE" in result
 
     def test_fetch_server_ca_cert_uses_http(self, pairing_mgr):
         """CA cert fetch uses HTTP (not HTTPS) to avoid chicken-and-egg problem."""
-        from unittest.mock import MagicMock, call
+        from unittest.mock import MagicMock
 
         pem = "-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n"
         mock_resp = MagicMock()
@@ -212,7 +213,9 @@ class TestTOFU:
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("camera_streamer.pairing.urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        with patch(
+            "camera_streamer.pairing.urllib.request.urlopen", return_value=mock_resp
+        ) as mock_open:
             pairing_mgr._fetch_server_ca_cert("https://192.168.1.100")
             req = mock_open.call_args[0][0]
             assert req.full_url.startswith("http://"), "CA cert fetch must use HTTP"
@@ -221,6 +224,7 @@ class TestTOFU:
     def test_fetch_server_ca_cert_returns_empty_on_network_error(self, pairing_mgr):
         """Returns empty string if server is unreachable."""
         import urllib.error
+
         with patch(
             "camera_streamer.pairing.urllib.request.urlopen",
             side_effect=urllib.error.URLError("refused"),
@@ -231,6 +235,7 @@ class TestTOFU:
     def test_build_tls_context_uses_existing_ca_cert(self, pairing_mgr, data_dir):
         """Uses existing ca.crt on disk without fetching from server."""
         import ssl
+
         ca_path = data_dir / "certs" / "ca.crt"
         # Write a real self-signed cert for ssl to load
         ca_path.parent.mkdir(parents=True, exist_ok=True)
@@ -248,13 +253,16 @@ class TestTOFU:
 
     def test_build_tls_context_attempts_tofu_when_no_ca(self, pairing_mgr):
         """Fetches CA cert via TOFU when none is on disk."""
-        with patch.object(pairing_mgr, "_fetch_server_ca_cert", return_value="") as mock_fetch:
+        with patch.object(
+            pairing_mgr, "_fetch_server_ca_cert", return_value=""
+        ) as mock_fetch:
             pairing_mgr._build_tls_context("https://192.168.1.100")
             mock_fetch.assert_called_once_with("https://192.168.1.100")
 
     def test_build_tls_context_falls_back_to_unverified(self, pairing_mgr):
         """Falls back to CERT_NONE when TOFU fetch returns empty."""
         import ssl
+
         with patch.object(pairing_mgr, "_fetch_server_ca_cert", return_value=""):
             ctx = pairing_mgr._build_tls_context("https://192.168.1.100")
         assert ctx.verify_mode == ssl.CERT_NONE
@@ -263,8 +271,10 @@ class TestTOFU:
     def test_exchange_uses_tofu_context(self, mock_urlopen, pairing_mgr):
         """exchange() calls _build_tls_context to get the TLS context."""
         response_data = {
-            "client_cert": "C", "client_key": "K",
-            "ca_cert": "CA", "pairing_secret": "s",
+            "client_cert": "C",
+            "client_key": "K",
+            "ca_cert": "CA",
+            "pairing_secret": "s",
         }
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps(response_data).encode()
@@ -274,6 +284,7 @@ class TestTOFU:
 
         with patch.object(pairing_mgr, "_build_tls_context") as mock_ctx:
             import ssl
+
             fake_ctx = ssl.create_default_context()
             fake_ctx.check_hostname = False
             fake_ctx.verify_mode = ssl.CERT_NONE

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -1,0 +1,306 @@
+"""Unit tests for the camera heartbeat sender module."""
+
+import hashlib
+import hmac
+import json
+import threading
+from unittest.mock import MagicMock, patch
+
+from camera_streamer.heartbeat import (
+    HeartbeatSender,
+    _build_signature,
+    _get_cpu_temp,
+    _get_memory_percent,
+    _get_uptime_seconds,
+)
+
+
+# ---- Signature tests ----
+
+
+class TestBuildSignature:
+    """HMAC-SHA256 signing — same scheme as config-notify (ADR-0015)."""
+
+    def test_deterministic(self):
+        secret = "ab" * 32
+        sig1 = _build_signature(secret, "cam-01", "123", b'{"streaming":true}')
+        sig2 = _build_signature(secret, "cam-01", "123", b'{"streaming":true}')
+        assert sig1 == sig2
+
+    def test_different_body_different_sig(self):
+        secret = "ab" * 32
+        sig1 = _build_signature(secret, "cam-01", "123", b'{"streaming":true}')
+        sig2 = _build_signature(secret, "cam-01", "123", b'{"streaming":false}')
+        assert sig1 != sig2
+
+    def test_different_camera_different_sig(self):
+        secret = "ab" * 32
+        sig1 = _build_signature(secret, "cam-01", "123", b"{}")
+        sig2 = _build_signature(secret, "cam-02", "123", b"{}")
+        assert sig1 != sig2
+
+    def test_matches_manual_computation(self):
+        secret = "ab" * 32
+        body = b'{"streaming":true}'
+        camera_id = "cam-01"
+        timestamp = "99999"
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"{camera_id}:{timestamp}:{body_hash}"
+        expected = hmac.new(
+            bytes.fromhex(secret), message.encode(), hashlib.sha256
+        ).hexdigest()
+        assert _build_signature(secret, camera_id, timestamp, body) == expected
+
+
+# ---- System metric helpers ----
+
+
+class TestGetUptimeSeconds:
+    def test_returns_int(self):
+        with patch(
+            "builtins.open",
+            MagicMock(
+                return_value=MagicMock(
+                    __enter__=lambda s, *a: s,
+                    __exit__=lambda s, *a: False,
+                    read=lambda: "3600.42 1234.5\n",
+                )
+            ),
+        ):
+            result = _get_uptime_seconds()
+            assert result == 3600
+
+    def test_returns_zero_on_error(self):
+        with patch("builtins.open", side_effect=OSError):
+            assert _get_uptime_seconds() == 0
+
+
+class TestGetMemoryPercent:
+    def test_computes_percent(self):
+        fake_meminfo = (
+            "MemTotal:       2000 kB\n"
+            "MemFree:         500 kB\n"
+            "MemAvailable:    800 kB\n"
+        )
+        with patch(
+            "builtins.open",
+            MagicMock(
+                return_value=MagicMock(
+                    __enter__=lambda s, *a: s,
+                    __exit__=lambda s, *a: False,
+                    __iter__=lambda s: iter(fake_meminfo.splitlines(keepends=True)),
+                )
+            ),
+        ):
+            pct = _get_memory_percent()
+            # (2000 - 800) / 2000 * 100 = 60%
+            assert pct == 60
+
+    def test_returns_zero_on_error(self):
+        with patch("builtins.open", side_effect=OSError):
+            assert _get_memory_percent() == 0
+
+
+class TestGetCpuTemp:
+    def test_reads_thermal_zone(self):
+        with patch(
+            "builtins.open",
+            MagicMock(
+                return_value=MagicMock(
+                    __enter__=lambda s, *a: s,
+                    __exit__=lambda s, *a: False,
+                    read=lambda: "54321\n",
+                )
+            ),
+        ):
+            temp = _get_cpu_temp("/sys/class/thermal/thermal_zone0/temp")
+            assert temp == 54.3
+
+    def test_returns_zero_on_error(self):
+        with patch("builtins.open", side_effect=OSError):
+            assert _get_cpu_temp(None) == 0.0
+
+
+# ---- HeartbeatSender ----
+
+
+def _make_config(server_ip="192.168.1.1", camera_id="cam-001", paired=True):
+    cfg = MagicMock()
+    cfg.server_ip = server_ip
+    cfg.camera_id = camera_id
+    cfg.certs_dir = "/tmp/certs"
+    cfg.width = 1920
+    cfg.height = 1080
+    cfg.fps = 25
+    cfg.bitrate = 4000000
+    cfg.h264_profile = "high"
+    cfg.keyframe_interval = 30
+    cfg.rotation = 0
+    cfg.hflip = False
+    cfg.vflip = False
+    return cfg
+
+
+def _make_pairing(secret="ab" * 32):
+    p = MagicMock()
+    p.get_pairing_secret.return_value = secret
+    return p
+
+
+class TestHeartbeatSender:
+    """Test HeartbeatSender.send_once() and payload construction."""
+
+    def test_skips_when_no_server_ip(self):
+        cfg = _make_config(server_ip="")
+        sender = HeartbeatSender(cfg, _make_pairing())
+        result = sender.send_once()
+        assert result is None
+
+    def test_skips_when_no_pairing_secret(self):
+        cfg = _make_config()
+        pairing = MagicMock()
+        pairing.get_pairing_secret.return_value = None
+        sender = HeartbeatSender(cfg, pairing)
+        result = sender.send_once()
+        assert result is None
+
+    def test_payload_contains_required_fields(self):
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+        payload = sender._build_payload()
+        assert payload["camera_id"] == "cam-001"
+        assert isinstance(payload["timestamp"], int)
+        assert isinstance(payload["streaming"], bool)
+        assert "cpu_temp" in payload
+        assert "memory_percent" in payload
+        assert "uptime_seconds" in payload
+        sc = payload["stream_config"]
+        assert sc["width"] == 1920
+        assert sc["height"] == 1080
+        assert sc["fps"] == 25
+
+    def test_streaming_true_when_stream_manager_active(self):
+        cfg = _make_config()
+        stream = MagicMock()
+        stream.is_streaming = True
+        sender = HeartbeatSender(cfg, _make_pairing(), stream_manager=stream)
+        payload = sender._build_payload()
+        assert payload["streaming"] is True
+
+    def test_streaming_false_when_no_stream_manager(self):
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing(), stream_manager=None)
+        payload = sender._build_payload()
+        assert payload["streaming"] is False
+
+    def test_send_once_posts_with_hmac_headers(self):
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+        sent_headers = {}
+
+        class FakeResp:
+            status = 200
+
+            def read(self):
+                return b'{"ok":true}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def fake_urlopen(req, context=None, timeout=None):
+            sent_headers.update(dict(req.headers))
+            return FakeResp()
+
+        with (
+            patch("camera_streamer.heartbeat.ssl.SSLContext"),
+            patch("camera_streamer.heartbeat.urllib.request.urlopen", fake_urlopen),
+        ):
+            result = sender.send_once()
+
+        assert result == {"ok": True}
+        assert (
+            "X-camera-id" in sent_headers
+            or "X-Camera-id" in sent_headers
+            or any("camera-id" in k.lower() for k in sent_headers)
+        )
+        assert any("signature" in k.lower() for k in sent_headers)
+        assert any("timestamp" in k.lower() for k in sent_headers)
+
+    def test_send_once_returns_none_on_network_error(self):
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        import urllib.error
+
+        with (
+            patch("camera_streamer.heartbeat.ssl.SSLContext"),
+            patch(
+                "camera_streamer.heartbeat.urllib.request.urlopen",
+                side_effect=urllib.error.URLError("connection refused"),
+            ),
+        ):
+            result = sender.send_once()
+
+        assert result is None
+
+    def test_apply_pending_config_calls_control_handler(self):
+        cfg = _make_config()
+        stream = MagicMock()
+        sender = HeartbeatSender(cfg, _make_pairing(), stream_manager=stream)
+
+        pending = {
+            "width": 1280,
+            "height": 720,
+            "fps": 30,
+            "bitrate": 2000000,
+            "h264_profile": "main",
+            "keyframe_interval": 30,
+            "rotation": 0,
+            "hflip": False,
+            "vflip": False,
+        }
+
+        mock_handler = MagicMock()
+        mock_handler.set_config.return_value = ({"applied": True}, "", 200)
+
+        with (
+            patch(
+                "camera_streamer.heartbeat.parse_control_request",
+                return_value=(pending, 0, ""),
+            ),
+            patch(
+                "camera_streamer.heartbeat.ControlHandler", return_value=mock_handler
+            ),
+        ):
+            sender._apply_pending_config(pending)
+
+        mock_handler.set_config.assert_called_once()
+        call_kwargs = mock_handler.set_config.call_args
+        # Verify origin="server" is passed (prevents ping-pong)
+        assert call_kwargs.kwargs.get("origin") == "server"
+
+    def test_start_stop_thread(self):
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        with patch.object(sender, "_send", return_value={"ok": True}):
+            sender.start()
+            assert sender._thread is not None
+            assert sender._thread.is_alive()
+            sender.stop()
+            assert not sender._thread
+
+    def test_start_is_idempotent(self):
+        """Calling start() twice does not create two threads."""
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        with patch.object(sender, "_send", return_value=None):
+            sender.start()
+            first_thread = sender._thread
+            sender.start()
+            assert sender._thread is first_thread
+            sender.stop()

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -2,8 +2,6 @@
 
 import hashlib
 import hmac
-import json
-import threading
 from unittest.mock import MagicMock, patch
 
 from camera_streamer.heartbeat import (
@@ -13,7 +11,6 @@ from camera_streamer.heartbeat import (
     _get_memory_percent,
     _get_uptime_seconds,
 )
-
 
 # ---- Signature tests ----
 

--- a/app/server/config/nginx-monitor.conf
+++ b/app/server/config/nginx-monitor.conf
@@ -28,7 +28,9 @@ server {
         return 200 '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="3"><title>Starting...</title><style>body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}.card{background:#16213e;border-radius:12px;padding:32px;text-align:center;max-width:320px}h2{color:#fff;margin-bottom:12px}.spinner{width:32px;height:32px;border:3px solid rgba(255,255,255,.2);border-top-color:#e94560;border-radius:50%;animation:s .7s linear infinite;margin:0 auto 16px}@keyframes s{to{transform:rotate(360deg)}}</style></head><body><div class="card"><div class="spinner"></div><h2>Starting Up</h2><p>Home Monitor is loading...<br>This page will refresh automatically.</p></div></body></html>';
     }
 
-    # Setup wizard — must stay on HTTP (hotspot has no TLS cert)
+    # Setup wizard + CA cert endpoint — must stay on HTTP.
+    # /setup/ca-cert is also needed over HTTP so cameras can fetch the server
+    # CA cert before they have a TLS context to verify with (TOFU bootstrap).
     location /api/v1/setup/ {
         proxy_pass http://127.0.0.1:5000;
         proxy_set_header Host $host;
@@ -77,6 +79,13 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    # Content Security Policy — restricts resource origins to prevent XSS.
+    # 'unsafe-inline' is required for Alpine.js and inline styles used in templates.
+    # blob: in media-src/img-src is required for HLS.js and snapshot display.
+    # wss: in connect-src is required for future WebSocket health updates.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' wss:; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
     # 502 handler — Flask not ready yet, auto-refresh until it is
     error_page 502 /502.html;

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -397,12 +397,38 @@ def _start_staleness_checker(app):
 
 
 def _resume_camera_pipelines(app):
-    """Start streaming pipelines for cameras that were online before restart."""
+    """Start streaming pipelines for cameras that were recently online.
+
+    Skips cameras whose last_seen is stale (> OFFLINE_TIMEOUT seconds ago).
+    Those cameras will be marked offline by the staleness checker and their
+    pipeline will restart automatically once they reconnect via heartbeat.
+    This prevents an ffmpeg crash-retry loop at boot when cameras haven't
+    come up yet.
+    """
+    from datetime import UTC, datetime
+
+    OFFLINE_TIMEOUT = 30  # seconds — matches discovery.py
+
     try:
         cameras = app.store.get_cameras()
+        now = datetime.now(UTC)
         for cam in cameras:
-            if cam.status == "online" and cam.recording_mode == "continuous":
-                app.streaming.start_camera(cam.id)
+            if cam.status != "online" or cam.recording_mode != "continuous":
+                continue
+            if cam.last_seen:
+                try:
+                    last = datetime.fromisoformat(cam.last_seen.replace("Z", "+00:00"))
+                    elapsed = (now - last).total_seconds()
+                    if elapsed > OFFLINE_TIMEOUT:
+                        log.info(
+                            "Skipping pipeline start for %s (last seen %ds ago, stale)",
+                            cam.id,
+                            int(elapsed),
+                        )
+                        continue
+                except (ValueError, TypeError):
+                    pass
+            app.streaming.start_camera(cam.id)
     except Exception:
         pass  # Don't crash on startup if cameras.json has issues
 

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -305,6 +305,9 @@ def _startup(app):
     app.storage_manager.start()
     app.cert_service.start()
 
+    # mDNS browser — discovers cameras advertising _rtsp._tcp on the LAN (RFC 6762/6763)
+    app.discovery_service.start_mdns_browser()
+
     # Staleness checker — marks cameras offline if no heartbeat received (ADR-0016)
     _start_staleness_checker(app)
 

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -381,7 +381,7 @@ def _start_staleness_checker(app):
     """
     import threading
 
-    STALENESS_CHECK_INTERVAL = 10  # seconds
+    staleness_check_interval = 10  # seconds
 
     def _run():
         import time
@@ -392,11 +392,11 @@ def _start_staleness_checker(app):
                     app.discovery_service.check_offline()
             except Exception as exc:
                 log.warning("Staleness checker error: %s", exc)
-            time.sleep(STALENESS_CHECK_INTERVAL)
+            time.sleep(staleness_check_interval)
 
     t = threading.Thread(target=_run, name="staleness-checker", daemon=True)
     t.start()
-    log.info("Staleness checker started (check every %ds)", STALENESS_CHECK_INTERVAL)
+    log.info("Staleness checker started (check every %ds)", staleness_check_interval)
 
 
 def _resume_camera_pipelines(app):
@@ -410,7 +410,7 @@ def _resume_camera_pipelines(app):
     """
     from datetime import UTC, datetime
 
-    OFFLINE_TIMEOUT = 30  # seconds — matches discovery.py
+    offline_timeout = 30  # seconds — matches discovery.py
 
     try:
         cameras = app.store.get_cameras()
@@ -422,7 +422,7 @@ def _resume_camera_pipelines(app):
                 try:
                     last = datetime.fromisoformat(cam.last_seen.replace("Z", "+00:00"))
                     elapsed = (now - last).total_seconds()
-                    if elapsed > OFFLINE_TIMEOUT:
+                    if elapsed > offline_timeout:
                         log.info(
                             "Skipping pipeline start for %s (last seen %ds ago, stale)",
                             cam.id,

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -305,6 +305,9 @@ def _startup(app):
     app.storage_manager.start()
     app.cert_service.start()
 
+    # Staleness checker — marks cameras offline if no heartbeat received (ADR-0016)
+    _start_staleness_checker(app)
+
     # Resume pipelines for confirmed online cameras
     _resume_camera_pipelines(app)
 
@@ -364,6 +367,33 @@ def _auto_mount_usb(app, default_recordings_dir):
     except Exception as e:
         log.error("USB auto-mount failed: %s", e)
         return default_recordings_dir
+
+
+def _start_staleness_checker(app):
+    """Start background thread that marks cameras offline on missed heartbeats.
+
+    Runs DiscoveryService.check_offline() every STALENESS_CHECK_INTERVAL seconds.
+    Any camera that has not sent a heartbeat within OFFLINE_TIMEOUT (30s, defined
+    in discovery.py) is moved to status='offline' and streaming=False (ADR-0016).
+    """
+    import threading
+
+    STALENESS_CHECK_INTERVAL = 10  # seconds
+
+    def _run():
+        import time
+
+        while True:
+            try:
+                with app.app_context():
+                    app.discovery_service.check_offline()
+            except Exception as exc:
+                log.warning("Staleness checker error: %s", exc)
+            time.sleep(STALENESS_CHECK_INTERVAL)
+
+    t = threading.Thread(target=_run, name="staleness-checker", daemon=True)
+    t.start()
+    log.info("Staleness checker started (check every %ds)", STALENESS_CHECK_INTERVAL)
 
 
 def _resume_camera_pipelines(app):

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -202,6 +202,24 @@ def delete_camera(camera_id):
     return jsonify({"message": "Camera removed"}), 200
 
 
+@cameras_bp.route("/scan", methods=["POST"])
+@admin_required
+@csrf_protect
+def scan_cameras():
+    """Trigger an mDNS scan and return current camera list.
+
+    Sends an immediate PTR query for _rtsp._tcp on the local network.
+    The background ServiceBrowser processes responses and calls report_camera()
+    for any new cameras, which adds them as pending entries.
+
+    Returns the current camera list (same as GET /cameras) so the dashboard
+    can update in a single round-trip.
+    """
+    current_app.discovery_service.trigger_scan()
+    cameras = current_app.camera_service.list_cameras()
+    return jsonify(cameras), 200
+
+
 @cameras_bp.route("/<camera_id>/status", methods=["GET"])
 @login_required
 def camera_status(camera_id):

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -9,6 +9,7 @@ Endpoints:
   DELETE /cameras/<id>         - remove camera and revoke cert (admin)
   GET    /cameras/<id>/status  - live status (online, fps, uptime)
   POST   /cameras/config-notify - accept config push from camera (HMAC auth)
+  POST   /cameras/heartbeat   - periodic liveness + health update from camera (HMAC auth)
 
 Routes are thin — all orchestration is in CameraService.
 """
@@ -25,6 +26,46 @@ from monitor.auth import admin_required, csrf_protect, login_required
 _HMAC_MAX_AGE = 300
 
 cameras_bp = Blueprint("cameras", __name__)
+
+
+def _verify_camera_hmac(request) -> tuple[str, str | None]:
+    """Verify HMAC-signed camera request. Shared by heartbeat + config-notify.
+
+    Returns (camera_id, error_message). error_message is None on success.
+    """
+    camera_id = request.headers.get("X-Camera-ID", "")
+    timestamp_str = request.headers.get("X-Timestamp", "")
+    signature = request.headers.get("X-Signature", "")
+
+    if not camera_id or not timestamp_str or not signature:
+        return "", "Missing auth headers"
+
+    try:
+        ts = int(timestamp_str)
+    except ValueError:
+        return "", "Invalid timestamp"
+
+    now = int(time.time())
+    if abs(now - ts) > _HMAC_MAX_AGE:
+        return "", "Timestamp expired"
+
+    camera = current_app.store.get_camera(camera_id)
+    if not camera or not camera.pairing_secret:
+        return "", "Unknown camera"
+
+    body = request.get_data()
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{camera_id}:{timestamp_str}:{body_hash}"
+    expected = hmac.new(
+        bytes.fromhex(camera.pairing_secret),
+        message.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+    if not hmac.compare_digest(signature, expected):
+        return "", "Invalid signature"
+
+    return camera_id, None
 
 
 @cameras_bp.route("", methods=["GET"])
@@ -58,42 +99,11 @@ def config_notify():
     Auth: HMAC-SHA256 signature using pairing_secret.
     No session/CSRF — this is machine-to-machine (ADR-0015).
     """
-    camera_id = request.headers.get("X-Camera-ID", "")
-    timestamp_str = request.headers.get("X-Timestamp", "")
-    signature = request.headers.get("X-Signature", "")
+    camera_id, err = _verify_camera_hmac(request)
+    if err:
+        status_code = 401 if err != "Invalid timestamp" else 400
+        return jsonify({"error": err}), status_code
 
-    if not camera_id or not timestamp_str or not signature:
-        return jsonify({"error": "Missing auth headers"}), 401
-
-    # Validate timestamp freshness
-    try:
-        ts = int(timestamp_str)
-    except ValueError:
-        return jsonify({"error": "Invalid timestamp"}), 400
-
-    now = int(time.time())
-    if abs(now - ts) > _HMAC_MAX_AGE:
-        return jsonify({"error": "Timestamp expired"}), 401
-
-    # Look up camera and its pairing secret
-    camera = current_app.store.get_camera(camera_id)
-    if not camera or not camera.pairing_secret:
-        return jsonify({"error": "Unknown camera"}), 401
-
-    # Verify HMAC
-    body = request.get_data()
-    body_hash = hashlib.sha256(body).hexdigest()
-    message = f"{camera_id}:{timestamp_str}:{body_hash}"
-    expected = hmac.new(
-        bytes.fromhex(camera.pairing_secret),
-        message.encode(),
-        hashlib.sha256,
-    ).hexdigest()
-
-    if not hmac.compare_digest(signature, expected):
-        return jsonify({"error": "Invalid signature"}), 401
-
-    # Parse and accept config
     data = request.get_json(silent=True)
     if not data:
         return jsonify({"error": "JSON body required"}), 400
@@ -102,6 +112,33 @@ def config_notify():
     if error:
         return jsonify({"error": error}), status
     return jsonify({"message": "Config accepted"}), 200
+
+
+@cameras_bp.route("/heartbeat", methods=["POST"])
+def camera_heartbeat():
+    """Accept periodic heartbeat from a camera.
+
+    Updates last_seen, streaming status, and health metrics.
+    Returns pending stream config if the server has unsent changes.
+
+    Auth: HMAC-SHA256 signature using pairing_secret (ADR-0016).
+    No session/CSRF — this is machine-to-machine.
+    """
+    camera_id, err = _verify_camera_hmac(request)
+    if err:
+        status_code = 401 if err != "Invalid timestamp" else 400
+        return jsonify({"error": err}), status_code
+
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    response, error, status = current_app.camera_service.accept_heartbeat(
+        camera_id, data
+    )
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(response), 200
 
 
 @cameras_bp.route("/<camera_id>/confirm", methods=["POST"])

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -8,6 +8,7 @@ Endpoints:
   PUT    /cameras/<id>         - update name, location, recording mode (admin)
   DELETE /cameras/<id>         - remove camera and revoke cert (admin)
   GET    /cameras/<id>/status  - live status (online, fps, uptime)
+  POST   /cameras/scan         - trigger mDNS scan + return camera list (admin)
   POST   /cameras/config-notify - accept config push from camera (HMAC auth)
   POST   /cameras/heartbeat   - periodic liveness + health update from camera (HMAC auth)
 
@@ -16,14 +17,55 @@ Routes are thin — all orchestration is in CameraService.
 
 import hashlib
 import hmac
+import threading
 import time
 
 from flask import Blueprint, current_app, jsonify, request, session
 
 from monitor.auth import admin_required, csrf_protect, login_required
 
-# Max age for HMAC timestamp (seconds)
-_HMAC_MAX_AGE = 300
+# ── HMAC auth for camera M2M requests ────────────────────────────────────────
+# 30-second window is tight enough to prevent meaningful replay while still
+# tolerating real-world clock skew between camera and server (ADR-0016).
+_HMAC_MAX_AGE = 30  # seconds (was 300 — reduced to shrink replay window)
+
+# Thread-safe lock for per-app nonce cache mutation.
+_seen_nonces_lock = threading.Lock()
+
+
+def _get_seen_nonces() -> dict:
+    """Return the per-app replay cache, creating it if needed.
+
+    Stored on the app object (not module-level) so each Flask test app
+    gets its own fresh cache — preventing test state bleed.
+    """
+    app_obj = current_app._get_current_object()
+    if not hasattr(app_obj, "_hmac_seen_nonces"):
+        app_obj._hmac_seen_nonces = {}
+    return app_obj._hmac_seen_nonces
+
+
+def _record_and_check_replay(camera_id: str, timestamp_str: str, sig: str) -> bool:
+    """Return True if this (timestamp, sig) pair has been seen (replay attempt).
+
+    Thread-safe. Automatically expires stale entries.
+    """
+    key = (timestamp_str, sig)
+    now = time.time()
+
+    with _seen_nonces_lock:
+        nonces = _get_seen_nonces()
+        camera_cache = nonces.setdefault(camera_id, {})
+        # Purge expired entries (TTL = _HMAC_MAX_AGE)
+        expired = [k for k, exp in camera_cache.items() if exp <= now]
+        for k in expired:
+            del camera_cache[k]
+
+        if key in camera_cache:
+            return True  # replay detected — reject
+        camera_cache[key] = now + _HMAC_MAX_AGE
+    return False
+
 
 cameras_bp = Blueprint("cameras", __name__)
 
@@ -65,14 +107,24 @@ def _verify_camera_hmac(request) -> tuple[str, str | None]:
     if not hmac.compare_digest(signature, expected):
         return "", "Invalid signature"
 
+    # Replay detection: reject the exact same signed request twice
+    if _record_and_check_replay(camera_id, timestamp_str, signature):
+        return "", "Duplicate request (replay detected)"
+
     return camera_id, None
 
 
 @cameras_bp.route("", methods=["GET"])
 @login_required
 def list_cameras():
-    """List all cameras (confirmed + pending)."""
-    cameras = current_app.camera_service.list_cameras()
+    """List all cameras (confirmed + pending).
+
+    Admins see all fields including internal health metrics and camera IP.
+    Viewers see only the fields needed to display and use the camera UI.
+    This prevents viewers from mapping network topology or tracking occupancy.
+    """
+    admin_view = session.get("role") == "admin"
+    cameras = current_app.camera_service.list_cameras(admin_view=admin_view)
     return jsonify(cameras), 200
 
 
@@ -141,6 +193,24 @@ def camera_heartbeat():
     return jsonify(response), 200
 
 
+@cameras_bp.route("/scan", methods=["POST"])
+@admin_required
+@csrf_protect
+def scan_cameras():
+    """Trigger an mDNS scan and return current camera list.
+
+    Sends an immediate PTR query for _rtsp._tcp on the local network.
+    The background ServiceBrowser processes responses and calls report_camera()
+    for any new cameras, which adds them as pending entries.
+
+    Returns the current camera list (same as GET /cameras) so the dashboard
+    can update in a single round-trip.
+    """
+    current_app.discovery_service.trigger_scan()
+    cameras = current_app.camera_service.list_cameras(admin_view=True)
+    return jsonify(cameras), 200
+
+
 @cameras_bp.route("/<camera_id>/confirm", methods=["POST"])
 @admin_required
 @csrf_protect
@@ -200,24 +270,6 @@ def delete_camera(camera_id):
     if error:
         return jsonify({"error": error}), status
     return jsonify({"message": "Camera removed"}), 200
-
-
-@cameras_bp.route("/scan", methods=["POST"])
-@admin_required
-@csrf_protect
-def scan_cameras():
-    """Trigger an mDNS scan and return current camera list.
-
-    Sends an immediate PTR query for _rtsp._tcp on the local network.
-    The background ServiceBrowser processes responses and calls report_camera()
-    for any new cameras, which adds them as pending entries.
-
-    Returns the current camera list (same as GET /cameras) so the dashboard
-    can update in a single round-trip.
-    """
-    current_app.discovery_service.trigger_scan()
-    cameras = current_app.camera_service.list_cameras()
-    return jsonify(cameras), 200
 
 
 @cameras_bp.route("/<camera_id>/status", methods=["GET"])

--- a/app/server/monitor/api/live.py
+++ b/app/server/monitor/api/live.py
@@ -54,10 +54,11 @@ def hls_segment(camera_id, filename):
     live_dir = Path(current_app.config["LIVE_DIR"])
     file_path = live_dir / camera_id / filename
 
-    # Prevent path traversal
+    # Prevent path traversal. Catch OSError too: on some platforms
+    # Path.resolve() raises OSError for paths with null bytes or bad chars.
     try:
         file_path.resolve().relative_to(live_dir.resolve())
-    except ValueError:
+    except (ValueError, OSError):
         return jsonify({"error": "Invalid path"}), 400
 
     if not file_path.is_file():

--- a/app/server/monitor/api/pairing.py
+++ b/app/server/monitor/api/pairing.py
@@ -5,17 +5,62 @@ Endpoints:
   POST /cameras/<id>/pair   - initiate pairing, generate PIN (admin)
   POST /cameras/<id>/unpair - revoke cert, reset pairing (admin)
   POST /pair/exchange        - camera trades PIN for certs (no auth — PIN is auth)
+  POST /pair/register        - camera self-registers as pending (rate-limited)
 
 The exchange endpoint intentionally has no session auth — the 6-digit PIN
 (rate-limited, 5-min expiry) is the authentication mechanism for the camera.
-Routes are thin — all orchestration is in PairingService.
+
+Security notes:
+- /pair/register is rate-limited (10 per IP per 5 min) to prevent fake camera spam.
+- /pair/exchange already has 3-attempt lockout per camera in PairingService.
+- Error messages from pairing_service are sanitised before returning to clients
+  to avoid leaking internal paths (e.g. CA cert location).
 """
+
+import time
 
 from flask import Blueprint, current_app, jsonify, request, session
 
 from monitor.auth import admin_required, csrf_protect
 
 pairing_bp = Blueprint("pairing", __name__)
+
+# ── /pair/register rate limiter ───────────────────────────────────────────────
+# Prevents a LAN attacker from flooding the dashboard with fake pending cameras.
+_register_attempts: dict[str, list[float]] = {}
+_REGISTER_RATE_WINDOW = 300   # seconds (5 minutes)
+_REGISTER_RATE_MAX = 10       # max registrations per window per IP
+
+
+def _register_rate_limited(ip: str) -> bool:
+    """Return True if the IP has exceeded the registration rate limit."""
+    now = time.time()
+    attempts = [t for t in _register_attempts.get(ip, []) if now - t < _REGISTER_RATE_WINDOW]
+    _register_attempts[ip] = attempts
+    if len(attempts) >= _REGISTER_RATE_MAX:
+        return True
+    attempts.append(now)
+    _register_attempts[ip] = attempts
+    return False
+
+
+def _safe_pairing_error(error: str) -> str:
+    """Sanitise internal pairing error messages for client responses.
+
+    Prevents leaking internal paths, CA cert locations, or OpenSSL details
+    that could aid an attacker doing reconnaissance.
+    """
+    internal_phrases = (
+        "CA key or certificate not found",
+        "CA certificate not found",
+        "OpenSSL error",
+        "Failed to read generated certificate",
+        "File operation failed",
+    )
+    for phrase in internal_phrases:
+        if phrase in error:
+            return "Pairing setup error, please contact the administrator"
+    return error
 
 
 @pairing_bp.route("/cameras/<camera_id>/pair", methods=["POST"])
@@ -32,7 +77,7 @@ def initiate_pairing(camera_id):
         ip=request.remote_addr or "",
     )
     if error:
-        return jsonify({"error": error}), status
+        return jsonify({"error": _safe_pairing_error(error)}), status
     return jsonify({"pin": pin, "expires_in": 300}), 200
 
 
@@ -65,7 +110,14 @@ def register_camera():
     No session auth — camera calls this before pairing to appear in
     the dashboard. The server creates a pending entry if it doesn't
     already exist.
+
+    Rate-limited: 10 requests per IP per 5 minutes to prevent fake camera spam.
+    Camera ID format is validated to the cam-<hex> pattern.
     """
+    ip = request.remote_addr or ""
+    if _register_rate_limited(ip):
+        return jsonify({"error": "Too many registration requests"}), 429
+
     data = request.get_json(silent=True)
     if not data:
         return jsonify({"error": "JSON body required"}), 400
@@ -74,9 +126,14 @@ def register_camera():
     if not camera_id:
         return jsonify({"error": "camera_id required"}), 400
 
+    # Validate camera ID format before persisting it
+    import re
+    if not re.match(r"^cam-[a-z0-9]{1,48}$", camera_id):
+        return jsonify({"error": "Invalid camera_id format"}), 400
+
     current_app.discovery_service.report_camera(
         camera_id=camera_id,
-        ip=request.remote_addr or "",
+        ip=ip,
         firmware_version=data.get("firmware_version", ""),
     )
     return jsonify({"status": "registered"}), 200
@@ -103,7 +160,7 @@ def exchange_certs():
         pin, camera_id, ip=request.remote_addr or ""
     )
     if error:
-        return jsonify({"error": error}), status
+        return jsonify({"error": _safe_pairing_error(error)}), status
 
     # Start streaming immediately if camera is set to continuous recording.
     # Without this, streaming only starts on server restart — breaking fresh pairs.

--- a/app/server/monitor/api/pairing.py
+++ b/app/server/monitor/api/pairing.py
@@ -28,14 +28,16 @@ pairing_bp = Blueprint("pairing", __name__)
 # ── /pair/register rate limiter ───────────────────────────────────────────────
 # Prevents a LAN attacker from flooding the dashboard with fake pending cameras.
 _register_attempts: dict[str, list[float]] = {}
-_REGISTER_RATE_WINDOW = 300   # seconds (5 minutes)
-_REGISTER_RATE_MAX = 10       # max registrations per window per IP
+_REGISTER_RATE_WINDOW = 300  # seconds (5 minutes)
+_REGISTER_RATE_MAX = 10  # max registrations per window per IP
 
 
 def _register_rate_limited(ip: str) -> bool:
     """Return True if the IP has exceeded the registration rate limit."""
     now = time.time()
-    attempts = [t for t in _register_attempts.get(ip, []) if now - t < _REGISTER_RATE_WINDOW]
+    attempts = [
+        t for t in _register_attempts.get(ip, []) if now - t < _REGISTER_RATE_WINDOW
+    ]
     _register_attempts[ip] = attempts
     if len(attempts) >= _REGISTER_RATE_MAX:
         return True
@@ -128,6 +130,7 @@ def register_camera():
 
     # Validate camera ID format before persisting it
     import re
+
     if not re.match(r"^cam-[a-z0-9]{1,48}$", camera_id):
         return jsonify({"error": "Invalid camera_id format"}), 400
 

--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -42,6 +42,11 @@ class Camera:
     hflip: bool = False
     vflip: bool = False
     config_sync: str = "unknown"  # synced | pending | error | unknown
+    # Live status fields — populated by heartbeat (ADR-0016)
+    streaming: bool = False  # is camera actively streaming RTSP?
+    cpu_temp: float = 0.0  # °C, from last heartbeat
+    memory_percent: int = 0  # 0-100, from last heartbeat
+    uptime_seconds: int = 0  # seconds since camera boot
 
 
 @dataclass

--- a/app/server/monitor/provisioning.py
+++ b/app/server/monitor/provisioning.py
@@ -3,9 +3,18 @@ WiFi hotspot provisioning blueprint — thin HTTP adapter.
 
 All business logic delegated to ProvisioningService.
 Routes handle HTTP parsing and return JSON responses.
+
+Security notes:
+- Sensitive endpoints (wifi/save, admin, complete) are blocked once setup is done.
+  This prevents a LAN attacker from calling /setup/admin to take over the device
+  after the owner has completed initial setup.
+- Rate limiting (5 requests per IP per 60s) prevents automated probing during
+  the brief first-boot window when setup is incomplete.
 """
 
+import functools
 import logging
+import time
 
 from flask import (
     Blueprint,
@@ -19,6 +28,56 @@ log = logging.getLogger("monitor.provisioning")
 
 provisioning_bp = Blueprint("provisioning", __name__)
 
+# ── Setup endpoint rate limiter ────────────────────────────────────────────────
+# Simple in-memory limiter to prevent automated probing during the setup window.
+# State is stored per Flask app instance (on the app object) so each test app
+# gets its own fresh counters — prevents test state bleed.
+# Separate from the login rate limiter in auth.py.
+_SETUP_RATE_WINDOW = 60   # seconds
+_SETUP_RATE_MAX = 5       # max attempts per window per IP
+
+
+def _get_setup_attempts() -> dict:
+    """Return the per-app rate limit state, creating it if needed.
+
+    Stored on the app object so each Flask test app gets its own fresh
+    rate limit counter — prevents state from bleeding across tests.
+    """
+    app_obj = current_app._get_current_object()
+    if not hasattr(app_obj, "_setup_rate_attempts"):
+        app_obj._setup_rate_attempts = {}
+    return app_obj._setup_rate_attempts
+
+
+def _setup_rate_limited(ip: str) -> bool:
+    """Return True if the IP has exceeded the setup rate limit."""
+    now = time.time()
+    store = _get_setup_attempts()
+    attempts = [t for t in store.get(ip, []) if now - t < _SETUP_RATE_WINDOW]
+    store[ip] = attempts
+    if len(attempts) >= _SETUP_RATE_MAX:
+        return True
+    attempts.append(now)
+    store[ip] = attempts
+    return False
+
+
+def _require_setup_incomplete(f):
+    """Decorator: block the endpoint if setup has already been completed.
+
+    Prevents LAN attackers from calling /setup/admin or /setup/wifi/save
+    on a device that is already provisioned.
+    """
+    @functools.wraps(f)
+    def decorated(*args, **kwargs):
+        if current_app.provisioning_service.is_setup_complete():
+            return jsonify({"error": "Setup already complete"}), 403
+        ip = request.remote_addr or ""
+        if _setup_rate_limited(ip):
+            return jsonify({"error": "Too many requests, please wait"}), 429
+        return f(*args, **kwargs)
+    return decorated
+
 
 @provisioning_bp.route("/status", methods=["GET"])
 def setup_status():
@@ -28,6 +87,7 @@ def setup_status():
 
 
 @provisioning_bp.route("/wifi/scan", methods=["GET"])
+@_require_setup_incomplete
 def wifi_scan():
     """Scan for available WiFi networks."""
     networks, err, status = current_app.provisioning_service.scan_wifi()
@@ -37,6 +97,7 @@ def wifi_scan():
 
 
 @provisioning_bp.route("/wifi/save", methods=["POST"])
+@_require_setup_incomplete
 def wifi_save():
     """Save WiFi credentials for later use."""
     data = request.get_json(silent=True)
@@ -53,6 +114,7 @@ def wifi_save():
 
 
 @provisioning_bp.route("/admin", methods=["POST"])
+@_require_setup_incomplete
 def set_admin_password():
     """Set a new admin password."""
     data = request.get_json(silent=True)
@@ -68,6 +130,7 @@ def set_admin_password():
 
 
 @provisioning_bp.route("/complete", methods=["POST"])
+@_require_setup_incomplete
 def setup_complete():
     """Apply all settings and finish setup."""
     result, err, status = current_app.provisioning_service.complete_setup()

--- a/app/server/monitor/provisioning.py
+++ b/app/server/monitor/provisioning.py
@@ -15,6 +15,7 @@ Security notes:
 import functools
 import logging
 import time
+from pathlib import Path
 
 from flask import (
     Blueprint,
@@ -22,6 +23,7 @@ from flask import (
     jsonify,
     render_template,
     request,
+    send_file,
 )
 
 log = logging.getLogger("monitor.provisioning")
@@ -137,6 +139,29 @@ def setup_complete():
     if err:
         return jsonify({"error": err}), status
     return jsonify(result), status
+
+
+@provisioning_bp.route("/ca-cert", methods=["GET"])
+def get_ca_cert():
+    """Serve the server CA certificate for camera trust-on-first-use (TOFU) verification.
+
+    No authentication required — the CA cert is public information.
+    Cameras fetch this before PIN exchange so they can verify the server's
+    TLS certificate, preventing passive MITM during the pairing bootstrap
+    (ADR-0009, TOFU pattern — RFC 8555 ACME §10.2).
+
+    Available on both HTTP and HTTPS so cameras can reach it before
+    they have a verified cert to use.
+    """
+    certs_dir = current_app.config.get("CERTS_DIR", "/data/certs")
+    ca_cert_path = Path(certs_dir) / "ca.crt"
+    if not ca_cert_path.is_file():
+        return jsonify({"error": "CA certificate not available"}), 404
+    return send_file(
+        str(ca_cert_path),
+        mimetype="application/x-pem-file",
+        as_attachment=False,
+    )
 
 
 @provisioning_bp.route("/wizard", methods=["GET"])

--- a/app/server/monitor/provisioning.py
+++ b/app/server/monitor/provisioning.py
@@ -35,8 +35,8 @@ provisioning_bp = Blueprint("provisioning", __name__)
 # State is stored per Flask app instance (on the app object) so each test app
 # gets its own fresh counters — prevents test state bleed.
 # Separate from the login rate limiter in auth.py.
-_SETUP_RATE_WINDOW = 60   # seconds
-_SETUP_RATE_MAX = 5       # max attempts per window per IP
+_SETUP_RATE_WINDOW = 60  # seconds
+_SETUP_RATE_MAX = 5  # max attempts per window per IP
 
 
 def _get_setup_attempts() -> dict:
@@ -70,6 +70,7 @@ def _require_setup_incomplete(f):
     Prevents LAN attackers from calling /setup/admin or /setup/wifi/save
     on a device that is already provisioned.
     """
+
     @functools.wraps(f)
     def decorated(*args, **kwargs):
         if current_app.provisioning_service.is_setup_complete():
@@ -78,6 +79,7 @@ def _require_setup_incomplete(f):
         if _setup_rate_limited(ip):
             return jsonify({"error": "Too many requests, please wait"}), 429
         return f(*args, **kwargs)
+
     return decorated
 
 

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -12,12 +12,20 @@ Design patterns:
 """
 
 import logging
+import re
 from datetime import UTC, datetime
 
 log = logging.getLogger("monitor.camera_service")
 
 VALID_RECORDING_MODES = {"continuous", "off"}
 VALID_RESOLUTIONS = {"720p", "1080p"}
+
+# Camera IDs must follow cam-<hexsuffix> format: cam- prefix + 1-32 lowercase hex chars.
+# This matches the hardware serial format generated on cameras and prevents:
+# - Directory traversal via ../
+# - Filesystem limit violations (>255 chars)
+# - Injection via shell-unsafe characters
+_CAMERA_ID_RE = re.compile(r"^cam-[a-z0-9]{1,48}$")
 
 # Stream parameters that should be pushed to the camera (ADR-0015)
 STREAM_PARAMS = {
@@ -59,6 +67,15 @@ class CameraService:
         if not camera_id:
             return None, "Camera ID is required", 400
 
+        # Validate format: cam-<lowercase-hex>, max 52 chars total.
+        # Prevents directory traversal, injection, and filesystem limit issues.
+        if not _CAMERA_ID_RE.match(camera_id):
+            return (
+                None,
+                "Invalid camera ID format. Must be 'cam-' followed by 1-48 lowercase alphanumeric characters.",
+                400,
+            )
+
         existing = self._store.get_camera(camera_id)
         if existing is not None:
             return None, "Camera already exists", 409
@@ -81,16 +98,23 @@ class CameraService:
             201,
         )
 
-    def list_cameras(self) -> list[dict]:
-        """List all cameras (confirmed + pending)."""
+    def list_cameras(self, admin_view: bool = True) -> list[dict]:
+        """List all cameras (confirmed + pending).
+
+        admin_view=True: return all fields including network/health details.
+        admin_view=False (viewer role): omit fields that could expose network
+            topology (ip) or enable occupancy tracking (cpu_temp, memory_percent,
+            uptime_seconds). Viewers need camera status to use the UI, but not
+            internal health metrics or the camera's LAN address.
+        """
         cameras = self._store.get_cameras()
-        return [
-            {
+        result = []
+        for c in cameras:
+            cam = {
                 "id": c.id,
                 "name": c.name,
                 "location": c.location,
                 "status": c.status,
-                "ip": c.ip,
                 "recording_mode": c.recording_mode,
                 "resolution": c.resolution,
                 "fps": c.fps,
@@ -107,12 +131,15 @@ class CameraService:
                 "vflip": c.vflip,
                 "config_sync": c.config_sync,
                 "streaming": c.streaming,
-                "cpu_temp": c.cpu_temp,
-                "memory_percent": c.memory_percent,
-                "uptime_seconds": c.uptime_seconds,
             }
-            for c in cameras
-        ]
+            if admin_view:
+                # Admin-only fields: network topology + health metrics
+                cam["ip"] = c.ip
+                cam["cpu_temp"] = c.cpu_temp
+                cam["memory_percent"] = c.memory_percent
+                cam["uptime_seconds"] = c.uptime_seconds
+            result.append(cam)
+        return result
 
     def get_camera_status(self, camera_id: str) -> tuple[dict | None, str]:
         """Get live status for a camera.

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -106,6 +106,10 @@ class CameraService:
                 "hflip": c.hflip,
                 "vflip": c.vflip,
                 "config_sync": c.config_sync,
+                "streaming": c.streaming,
+                "cpu_temp": c.cpu_temp,
+                "memory_percent": c.memory_percent,
+                "uptime_seconds": c.uptime_seconds,
             }
             for c in cameras
         ]
@@ -239,6 +243,85 @@ class CameraService:
         )
 
         return "", 200
+
+    def accept_heartbeat(self, camera_id: str, data: dict) -> tuple[dict, str, int]:
+        """Accept a heartbeat from a camera and update its live status.
+
+        Updates last_seen, status, streaming flag, and health metrics.
+        If the camera's config_sync is 'pending', returns the stored
+        stream config so the camera can re-apply it.
+
+        Returns (response_dict, error_string, http_status_code).
+        """
+        camera = self._store.get_camera(camera_id)
+        if not camera:
+            return {}, "Camera not found", 404
+
+        was_offline = camera.status == "offline"
+        camera.status = "online"
+        camera.last_seen = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Update live health fields
+        camera.streaming = bool(data.get("streaming", False))
+        if "cpu_temp" in data:
+            try:
+                camera.cpu_temp = float(data["cpu_temp"])
+            except (TypeError, ValueError):
+                pass
+        if "memory_percent" in data:
+            try:
+                camera.memory_percent = int(data["memory_percent"])
+            except (TypeError, ValueError):
+                pass
+        if "uptime_seconds" in data:
+            try:
+                camera.uptime_seconds = int(data["uptime_seconds"])
+            except (TypeError, ValueError):
+                pass
+
+        # Capture sync state before touching stream params.
+        # If config_sync is "pending" the server has unsent changes — keep them
+        # and tell the camera via pending_config instead of overwriting with its
+        # potentially-stale values.
+        had_pending = camera.config_sync == "pending"
+
+        if (
+            "stream_config" in data
+            and isinstance(data["stream_config"], dict)
+            and not had_pending
+        ):
+            sc = data["stream_config"]
+            for key in sc:
+                if key in STREAM_PARAMS:
+                    setattr(camera, key, sc[key])
+            camera.config_sync = "synced"
+
+        self._store.save_camera(camera)
+
+        if was_offline:
+            self._log_audit(
+                "CAMERA_ONLINE",
+                "camera",
+                "",
+                f"camera {camera_id} reconnected via heartbeat",
+            )
+
+        # If we have a pending config push, include it in the response
+        response: dict = {"ok": True}
+        if had_pending:
+            response["pending_config"] = {
+                "width": camera.width,
+                "height": camera.height,
+                "fps": camera.fps,
+                "bitrate": camera.bitrate,
+                "h264_profile": camera.h264_profile,
+                "keyframe_interval": camera.keyframe_interval,
+                "rotation": camera.rotation,
+                "hflip": camera.hflip,
+                "vflip": camera.vflip,
+            }
+
+        return response, "", 200
 
     def accept_camera_config(
         self, camera_id: str, stream_config: dict

--- a/app/server/monitor/services/discovery.py
+++ b/app/server/monitor/services/discovery.py
@@ -222,12 +222,12 @@ class DiscoveryService:
             # zeroconf's public send API: build a PTR question and multicast it
             from zeroconf import DNSOutgoing, DNSQuestion
 
-            # _TYPE_PTR = 12, _CLASS_IN = 1 per RFC 1035 / RFC 6762
-            _TYPE_PTR = 12
-            _CLASS_IN = 1
+            # type_ptr = 12, class_in = 1 per RFC 1035 / RFC 6762
+            type_ptr = 12
+            class_in = 1
 
             out = DNSOutgoing(0)  # flags=0 → standard query
-            out.add_question(DNSQuestion(_MDNS_SERVICE_TYPE, _TYPE_PTR, _CLASS_IN))
+            out.add_question(DNSQuestion(_MDNS_SERVICE_TYPE, type_ptr, class_in))
             self._zeroconf.send(out)
             log.debug("Sent manual mDNS PTR query for %s", _MDNS_SERVICE_TYPE)
         except Exception as exc:

--- a/app/server/monitor/services/discovery.py
+++ b/app/server/monitor/services/discovery.py
@@ -97,6 +97,8 @@ class DiscoveryService:
 
             if elapsed > OFFLINE_TIMEOUT:
                 camera.status = "offline"
+                # Clear streaming flag — we cannot trust stale state (ADR-0016)
+                camera.streaming = False
                 self._store.save_camera(camera)
                 if self._audit:
                     self._audit.log_event(

--- a/app/server/monitor/services/discovery.py
+++ b/app/server/monitor/services/discovery.py
@@ -1,32 +1,45 @@
 """
-Camera discovery service — finds cameras on the local network via mDNS.
+Camera discovery service — tracks cameras via mDNS browsing and heartbeats.
 
 Responsibilities:
-- Browse for _rtsp._tcp services using Avahi/dbus
-- Detect new cameras -> add to pending list
-- Monitor paired cameras -> update online/offline status
+- Browse for _rtsp._tcp services using python-zeroconf (RFC 6762/6763)
+- Detect new cameras → add as pending (same path as heartbeat report_camera)
+- Monitor paired cameras → update online/offline status
 - Track camera firmware version from TXT records
 - Trigger audit log entries for camera state changes
 
-Camera considered offline after 30 seconds with no mDNS response.
+Camera considered offline after 30 seconds with no heartbeat (ADR-0016).
 
-Note: Full mDNS browsing requires Avahi (Linux-only). This module
-provides the service interface; actual mDNS browsing runs only on
-the RPi hardware.
+mDNS browser uses python-zeroconf, which is the industry standard library
+(same as Home Assistant, Frigate). It continuously browses _rtsp._tcp.local.
+and calls report_camera() for every discovered camera — the same code path
+used by the heartbeat endpoint, so there is no separate discovery state.
+
+DNS-SD / mDNS standards: RFC 6762 (Multicast DNS), RFC 6763 (DNS-SD).
+Service type _rtsp._tcp is the standard for RTSP media sources.
 """
 
+import logging
+import socket
 import threading
 from datetime import UTC, datetime
 
-OFFLINE_TIMEOUT = 30  # seconds
+log = logging.getLogger("monitor.discovery")
+
+OFFLINE_TIMEOUT = 30  # seconds — must match _resume_camera_pipelines in __init__.py
+_MDNS_SERVICE_TYPE = "_rtsp._tcp.local."
+_CAMERA_ID_PREFIX = "cam-"
 
 
 class DiscoveryService:
     """Manages camera discovery and status tracking.
 
-    On the RPi, this will use Avahi/dbus for mDNS browsing.
-    The service can also accept manual camera registrations
-    (e.g., for testing or static IP cameras).
+    Combines two discovery paths into one unified report_camera() sink:
+      1. mDNS browser — avahi-published _rtsp._tcp advertisements from cameras
+      2. Self-registration — cameras POST /pair/register when not yet paired
+      3. Heartbeat — paired cameras POST /cameras/heartbeat every 15s (ADR-0016)
+
+    All three paths converge on report_camera(). No separate state is needed.
     """
 
     def __init__(self, store, audit=None):
@@ -35,11 +48,19 @@ class DiscoveryService:
         self._lock = threading.Lock()
         self._running = False
 
-    def report_camera(self, camera_id, ip, firmware_version=""):
-        """Report a camera as seen (from mDNS or heartbeat).
+        # mDNS browser (started by start_mdns_browser, stopped by stop_mdns_browser)
+        self._zeroconf = None
+        self._mdns_browser = None
 
-        Creates a pending camera if unknown, or updates last_seen
-        and status for known cameras.
+    # -------------------------------------------------------------------------
+    # Core status tracking
+    # -------------------------------------------------------------------------
+
+    def report_camera(self, camera_id, ip, firmware_version=""):
+        """Report a camera as seen (from mDNS, self-registration, or heartbeat).
+
+        Creates a pending camera if unknown, or updates last_seen and status
+        for known cameras. This is the single funnel for all discovery paths.
         """
         from monitor.models import Camera
 
@@ -48,7 +69,7 @@ class DiscoveryService:
         with self._lock:
             camera = self._store.get_camera(camera_id)
             if camera is None:
-                # New camera discovered — add as pending
+                # New camera discovered — add as pending (needs pairing)
                 camera = Camera(
                     id=camera_id,
                     ip=ip,
@@ -63,13 +84,14 @@ class DiscoveryService:
                         detail=f"new camera {camera_id} at {ip}",
                     )
             else:
-                # Known camera — update status
+                # Known camera — update status and liveness timestamp
                 was_offline = camera.status == "offline"
                 camera.ip = ip
                 camera.last_seen = now
                 if firmware_version:
                     camera.firmware_version = firmware_version
-                if camera.status != "pending":
+                # Don't override "pending" status — it requires explicit pairing
+                if camera.status not in ("pending",):
                     camera.status = "online"
                 self._store.save_camera(camera)
                 if was_offline and self._audit:
@@ -79,7 +101,7 @@ class DiscoveryService:
                     )
 
     def check_offline(self):
-        """Mark cameras as offline if not seen recently."""
+        """Mark cameras as offline if no heartbeat received within OFFLINE_TIMEOUT."""
         now = datetime.now(UTC)
         cameras = self._store.get_cameras()
 
@@ -121,3 +143,170 @@ class DiscoveryService:
             "resolution": camera.resolution,
             "fps": camera.fps,
         }
+
+    # -------------------------------------------------------------------------
+    # mDNS browser (RFC 6762 / RFC 6763 DNS-SD via python-zeroconf)
+    # -------------------------------------------------------------------------
+
+    def start_mdns_browser(self):
+        """Start background mDNS browser for _rtsp._tcp cameras.
+
+        Uses python-zeroconf (same library as Home Assistant, Frigate).
+        The ServiceBrowser runs in daemon threads and calls _on_mdns_service_change
+        whenever a camera advertisement is added or updated. That callback
+        calls report_camera() — the same path as heartbeat / self-registration.
+
+        Falls back gracefully if zeroconf is not installed.
+        """
+        if self._zeroconf is not None:
+            log.debug("mDNS browser already running")
+            return
+
+        try:
+            from zeroconf import ServiceBrowser, Zeroconf
+        except ImportError:
+            log.warning(
+                "python-zeroconf not installed — mDNS auto-discovery disabled. "
+                "Install with: pip3 install 'zeroconf>=0.100'"
+            )
+            return
+
+        try:
+            self._zeroconf = Zeroconf()
+            # ServiceBrowser is non-blocking — spawns its own daemon threads
+            self._mdns_browser = ServiceBrowser(
+                self._zeroconf,
+                _MDNS_SERVICE_TYPE,
+                handlers=[self._on_mdns_service_change],
+            )
+            log.info(
+                "mDNS browser started — listening for %s cameras", _MDNS_SERVICE_TYPE
+            )
+        except Exception as exc:
+            log.warning("Failed to start mDNS browser: %s", exc)
+            if self._zeroconf:
+                try:
+                    self._zeroconf.close()
+                except Exception:
+                    pass
+            self._zeroconf = None
+            self._mdns_browser = None
+
+    def stop_mdns_browser(self):
+        """Stop mDNS browser and release socket resources."""
+        if self._zeroconf is None:
+            return
+        try:
+            self._zeroconf.close()
+        except Exception:
+            pass
+        finally:
+            self._zeroconf = None
+            self._mdns_browser = None
+            log.info("mDNS browser stopped")
+
+    def trigger_scan(self):
+        """Request an immediate mDNS PTR query (for manual Scan button).
+
+        The background ServiceBrowser already runs continuously and discovers
+        cameras as they appear. This method sends an extra PTR query so that
+        newly powered-on cameras are detected faster when the user clicks Scan.
+
+        Fails silently — the background browser is always the primary path.
+        """
+        if self._zeroconf is None:
+            log.debug("mDNS browser not running — scan request ignored")
+            return
+
+        try:
+            # zeroconf's public send API: build a PTR question and multicast it
+            from zeroconf import DNSOutgoing, DNSQuestion
+
+            # _TYPE_PTR = 12, _CLASS_IN = 1 per RFC 1035 / RFC 6762
+            _TYPE_PTR = 12
+            _CLASS_IN = 1
+
+            out = DNSOutgoing(0)  # flags=0 → standard query
+            out.add_question(DNSQuestion(_MDNS_SERVICE_TYPE, _TYPE_PTR, _CLASS_IN))
+            self._zeroconf.send(out)
+            log.debug("Sent manual mDNS PTR query for %s", _MDNS_SERVICE_TYPE)
+        except Exception as exc:
+            # Non-fatal: background browser already handles discovery
+            log.debug("Manual mDNS PTR query failed (non-fatal): %s", exc)
+
+    # -------------------------------------------------------------------------
+    # Internal mDNS callbacks
+    # -------------------------------------------------------------------------
+
+    def _on_mdns_service_change(self, zeroconf, service_type, name, state_change):
+        """Called by ServiceBrowser on any service state change."""
+        try:
+            from zeroconf import ServiceStateChange
+        except ImportError:
+            return
+
+        if state_change in (ServiceStateChange.Added, ServiceStateChange.Updated):
+            self._handle_mdns_service(zeroconf, service_type, name)
+        # Removed: camera going offline is handled by the staleness checker
+        # (check_offline) via heartbeat timeout — mDNS removals are unreliable.
+
+    def _handle_mdns_service(self, zeroconf, service_type, name):
+        """Parse a discovered mDNS service record and call report_camera()."""
+        try:
+            info = zeroconf.get_service_info(service_type, name)
+            if not info:
+                log.debug("mDNS: no service info for %s", name)
+                return
+
+            # Parse TXT records (keys and values arrive as bytes)
+            props = {}
+            for k, v in (info.properties or {}).items():
+                key = k.decode("utf-8", errors="replace") if isinstance(k, bytes) else k
+                val = (
+                    v.decode("utf-8", errors="replace")
+                    if isinstance(v, bytes)
+                    else (v or "")
+                )
+                props[key] = val
+
+            camera_id = props.get("id", "")
+            if not camera_id or not camera_id.startswith(_CAMERA_ID_PREFIX):
+                # Not a HomeMonitor camera — ignore (other _rtsp._tcp services)
+                log.debug("mDNS: ignoring non-HomeMonitor service %s", name)
+                return
+
+            # Resolve IP address — prefer parsed_addresses() (modern zeroconf)
+            ip = ""
+            if hasattr(info, "parsed_addresses"):
+                addrs = info.parsed_addresses()
+                # Prefer IPv4
+                for addr in addrs:
+                    if ":" not in addr:  # not IPv6
+                        ip = addr
+                        break
+                if not ip and addrs:
+                    ip = addrs[0]
+            elif info.addresses:
+                try:
+                    ip = socket.inet_ntoa(info.addresses[0])
+                except Exception:
+                    pass
+
+            if not ip:
+                log.debug("mDNS: no usable address for %s", name)
+                return
+
+            firmware_version = props.get("version", "")
+            paired_str = props.get("paired", "false")
+
+            log.info(
+                "mDNS: camera %s at %s (paired=%s firmware=%s)",
+                camera_id,
+                ip,
+                paired_str,
+                firmware_version or "?",
+            )
+            self.report_camera(camera_id, ip, firmware_version)
+
+        except Exception as exc:
+            log.warning("mDNS handler error for '%s': %s", name, exc)

--- a/app/server/monitor/services/recordings_service.py
+++ b/app/server/monitor/services/recordings_service.py
@@ -124,7 +124,21 @@ class RecordingsService:
             return None, "Invalid filename", 400
 
         recorder = self._get_recorder()
-        clip_path = Path(recorder._recordings_dir) / camera_id / date / filename
+        try:
+            recordings_root = Path(recorder._recordings_dir).resolve()
+            clip_path = (recordings_root / camera_id / date / filename).resolve()
+        except (ValueError, OSError):
+            # ValueError: embedded null bytes or other invalid path characters.
+            # OSError: path resolution failure on some platforms.
+            return None, "Invalid path", 400
+
+        # Guard against path traversal: clip must be inside recordings_root.
+        # This catches inputs like camera_id="../../etc", date="../..", etc.
+        try:
+            clip_path.relative_to(recordings_root)
+        except ValueError:
+            return None, "Invalid path", 400
+
         if not clip_path.is_file():
             return None, "Clip not found", 404
 

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -245,6 +245,8 @@ a:hover { text-decoration: underline; }
 .badge--online { background: var(--color-success); color: var(--color-bg); }
 .badge--offline { background: #555; color: #ccc; }
 .badge--pending { background: var(--color-warning); color: var(--color-bg); }
+.badge--streaming { background: rgba(46,204,113,0.15); color: var(--color-success); border: 1px solid var(--color-success); }
+.badge--not-streaming { background: rgba(80,80,80,0.15); color: #888; border: 1px solid #555; }
 
 /* --- Health Cards --- */
 .health-card {
@@ -289,6 +291,13 @@ a:hover { text-decoration: underline; }
     font-size: var(--text-xs);
     color: var(--color-text-dim);
     margin-top: var(--space-1);
+}
+.camera-card__health {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    margin-top: 2px;
+    display: flex;
+    gap: var(--space-1);
 }
 .camera-card__actions {
     display: flex;

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -117,7 +117,14 @@
                         'text-muted': cam.config_sync === 'unknown'
                     }" x-show="cam.status !== 'pending'" x-text="cam.config_sync === 'synced' ? '\u2713 synced' : cam.config_sync === 'pending' ? '\u231B pending' : ''"></span>
                 </div>
-                <div class="camera-card__last-seen" x-text="cam.last_seen ? 'Last seen: ' + new Date(cam.last_seen).toLocaleString() : ''"></div>
+                <div class="camera-card__last-seen" x-show="cam.last_seen">
+                    <span :class="{'text-danger': _staleSeconds(cam) > 45, 'text-warning': _staleSeconds(cam) > 30 && _staleSeconds(cam) <= 45}"
+                          x-text="'Last seen: ' + _relativeTime(cam.last_seen)"></span>
+                </div>
+                <div class="camera-card__health" x-show="cam.status === 'online' && (cam.cpu_temp || cam.memory_percent)">
+                    <span class="text-small text-muted" x-text="cam.cpu_temp ? cam.cpu_temp.toFixed(1) + '\u00B0C' : ''"></span>
+                    <span class="text-small text-muted" x-show="cam.memory_percent" x-text="' \u00B7 ' + cam.memory_percent + '% mem'"></span>
+                </div>
             </div>
             <div class="camera-card__actions">
                 <span class="badge" :class="{
@@ -125,6 +132,10 @@
                     'badge--offline': cam.status === 'offline',
                     'badge--pending': cam.status === 'pending'
                 }" x-text="cam.status"></span>
+                <span x-show="cam.status === 'online'" class="badge" :class="{
+                    'badge--streaming': cam.streaming,
+                    'badge--not-streaming': !cam.streaming
+                }" x-text="cam.streaming ? '\u25CF streaming' : '\u25CB not streaming'"></span>
                 <template x-if="cam.status === 'pending'">
                     <div class="camera-card__btns">
                         <button class="btn btn--primary btn--small" @click.stop="initPairing(cam.id)">Pair</button>
@@ -364,13 +375,27 @@ function dashboardPage() {
             }
         },
 
+        _staleSeconds(cam) {
+            if (!cam.last_seen) return 0;
+            return Math.round((Date.now() - new Date(cam.last_seen).getTime()) / 1000);
+        },
+
+        _relativeTime(iso) {
+            if (!iso) return '';
+            var secs = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
+            if (secs < 5) return 'just now';
+            if (secs < 60) return secs + 's ago';
+            if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
+            return Math.floor(secs / 3600) + 'h ago';
+        },
+
         init() {
             this.loadHealth();
             this.loadCameras();
             // Health: 10s (CPU/mem/disk change frequently, matches requirements SR-SRV-07)
-            // Cameras: 30s (status changes are infrequent)
+            // Cameras: 15s (heartbeats arrive every 15s — keep display fresh)
             this._healthInterval = setInterval(() => { this.loadHealth(); }, 10000);
-            this._cameraInterval = setInterval(() => { this.loadCameras(); }, 30000);
+            this._cameraInterval = setInterval(() => { this.loadCameras(); }, 15000);
         },
 
         destroy() {

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -46,8 +46,8 @@
 <div class="section-header">
     Cameras
     <span style="float:right;margin-top:-4px;display:flex;gap:8px;">
-        <button class="btn btn--secondary btn--small" @click="refreshCameras()" :disabled="scanning">
-            <span x-show="!scanning">Refresh</span>
+        <button class="btn btn--secondary btn--small" @click="scanCameras()" :disabled="scanning">
+            <span x-show="!scanning">&#x1F50D; Scan</span>
             <span x-show="scanning">Scanning...</span>
         </button>
         <button class="btn btn--primary btn--small" @click="showAddForm = !showAddForm" x-text="showAddForm ? 'Cancel' : 'Add Camera'"></button>
@@ -100,10 +100,48 @@
     <template x-if="cameras.length === 0 && !showAddForm">
         <div class="empty-state">
             <div class="empty-state__title">No cameras found</div>
-            <div class="empty-state__text">Click "Add Camera" to register a camera, or wait for mDNS discovery.</div>
+            <div class="empty-state__text">Click "&#x1F50D; Scan" to search the local network, or "Add Camera" to register manually.</div>
         </div>
     </template>
-    <template x-for="cam in cameras" :key="cam.id">
+
+    <!-- Discovered cameras (pending pairing) -->
+    <template x-if="discoveredCameras.length > 0">
+        <div style="grid-column:1/-1;">
+            <div class="section-header" style="font-size:0.85em;padding:6px 0 4px;border-bottom:1px solid var(--border);">
+                Discovered &#x2014; waiting to pair
+                <span class="badge badge--pending" style="margin-left:8px;" x-text="discoveredCameras.length"></span>
+            </div>
+        </div>
+    </template>
+    <template x-for="cam in discoveredCameras" :key="cam.id">
+        <div class="card camera-card" :data-cam-id="cam.id">
+            <div class="camera-card__info">
+                <div class="camera-card__name" x-text="cam.name || cam.id"></div>
+                <div class="camera-card__location" x-text="cam.ip ? 'IP: ' + cam.ip : 'Detected via mDNS'"></div>
+                <div class="camera-card__last-seen" x-show="cam.last_seen">
+                    <span x-text="'Seen: ' + _relativeTime(cam.last_seen)"></span>
+                </div>
+                <div x-show="cam.firmware_version" class="text-small text-muted" x-text="'fw ' + cam.firmware_version"></div>
+            </div>
+            <div class="camera-card__actions">
+                <span class="badge badge--pending">discovered</span>
+                <div class="camera-card__btns">
+                    <button class="btn btn--primary btn--small" @click.stop="initPairing(cam.id)">Pair</button>
+                    <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <!-- Paired cameras (online / offline) -->
+    <template x-if="pairedCameras.length > 0 && discoveredCameras.length > 0">
+        <div style="grid-column:1/-1;">
+            <div class="section-header" style="font-size:0.85em;padding:6px 0 4px;border-bottom:1px solid var(--border);">
+                Paired cameras
+            </div>
+        </div>
+    </template>
+    <template x-for="cam in pairedCameras" :key="cam.id">
         <div class="card camera-card" :data-cam-id="cam.id">
             <div class="camera-card__info" @click="cam.status === 'online' && (window.location.href = '/live?camera=' + encodeURIComponent(cam.id))" :style="cam.status === 'online' ? 'cursor:pointer' : ''">
                 <div class="camera-card__name" x-text="cam.name || cam.id"></div>
@@ -129,25 +167,16 @@
             <div class="camera-card__actions">
                 <span class="badge" :class="{
                     'badge--online': cam.status === 'online',
-                    'badge--offline': cam.status === 'offline',
-                    'badge--pending': cam.status === 'pending'
+                    'badge--offline': cam.status === 'offline'
                 }" x-text="cam.status"></span>
                 <span x-show="cam.status === 'online'" class="badge" :class="{
                     'badge--streaming': cam.streaming,
                     'badge--not-streaming': !cam.streaming
                 }" x-text="cam.streaming ? '\u25CF streaming' : '\u25CB not streaming'"></span>
-                <template x-if="cam.status === 'pending'">
-                    <div class="camera-card__btns">
-                        <button class="btn btn--primary btn--small" @click.stop="initPairing(cam.id)">Pair</button>
-                        <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
-                    </div>
-                </template>
-                <template x-if="cam.status !== 'pending'">
-                    <div class="camera-card__btns">
-                        <button class="btn btn--secondary btn--small" @click.stop="openStreamSettings(cam)">Settings</button>
-                        <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
-                    </div>
-                </template>
+                <div class="camera-card__btns">
+                    <button class="btn btn--secondary btn--small" @click.stop="openStreamSettings(cam)">Settings</button>
+                    <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
+                </div>
             </div>
         </div>
     </template>
@@ -238,6 +267,10 @@ function dashboardPage() {
         _healthInterval: null,
         _cameraInterval: null,
 
+        // Derived lists — split pending (discovered) from paired (online/offline)
+        get discoveredCameras() { return this.cameras.filter(c => c.status === 'pending'); },
+        get pairedCameras() { return this.cameras.filter(c => c.status !== 'pending'); },
+
         tempColor(c) {
             if (c === null) return '';
             if (c < 60) return 'health-card__value--green';
@@ -274,11 +307,17 @@ function dashboardPage() {
             } catch(e) {}
         },
 
-        async refreshCameras() {
+        async scanCameras() {
             this.scanning = true;
-            await this.loadCameras();
-            // Brief delay so user sees the scanning state
-            setTimeout(() => { this.scanning = false; }, 1500);
+            try {
+                // POST to /cameras/scan — triggers mDNS PTR query and returns current list
+                this.cameras = await window.HM.api.post('/api/v1/cameras/scan', {});
+            } catch(e) {
+                // Fallback: just reload existing list
+                await this.loadCameras();
+            } finally {
+                setTimeout(() => { this.scanning = false; }, 1000);
+            }
         },
 
         async addCamera() {

--- a/app/server/requirements.txt
+++ b/app/server/requirements.txt
@@ -1,3 +1,4 @@
 flask>=3.0
 bcrypt>=4.0
 jinja2>=3.0
+zeroconf>=0.100

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -920,3 +920,177 @@ class TestConfigNotifyContract:
         assert resp.status_code == 200
         data = resp.get_json()
         assert "message" in data
+
+
+def _signed_camera_request(client, url, body_dict, camera_id="cam-001", secret="ab" * 32):
+    """Helper: build HMAC-signed POST to a camera machine-to-machine endpoint."""
+    import hashlib
+    import hmac
+    import json
+    import time
+
+    body = json.dumps(body_dict).encode()
+    timestamp = str(int(time.time()))
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{camera_id}:{timestamp}:{body_hash}"
+    sig = hmac.new(bytes.fromhex(secret), message.encode(), hashlib.sha256).hexdigest()
+
+    return client.post(
+        url,
+        data=body,
+        content_type="application/json",
+        headers={
+            "X-Camera-ID": camera_id,
+            "X-Timestamp": timestamp,
+            "X-Signature": sig,
+        },
+    )
+
+
+class TestHeartbeatContract:
+    """Contract tests for POST /api/v1/cameras/heartbeat (ADR-0016)."""
+
+    HEARTBEAT_URL = "/api/v1/cameras/heartbeat"
+    SECRET = "ab" * 32
+
+    def _payload(self, **overrides):
+        data = {
+            "streaming": True,
+            "cpu_temp": 48.5,
+            "memory_percent": 42,
+            "uptime_seconds": 3600,
+            "stream_config": {
+                "width": 1920, "height": 1080, "fps": 25,
+                "bitrate": 4000000, "h264_profile": "high",
+                "keyframe_interval": 30, "rotation": 0,
+                "hflip": False, "vflip": False,
+            },
+        }
+        data.update(overrides)
+        return data
+
+    def test_missing_headers_returns_401(self, app, client):
+        resp = client.post(self.HEARTBEAT_URL, json=self._payload())
+        assert resp.status_code == 401
+
+    def test_unknown_camera_returns_401(self, app, client):
+        import time
+        resp = client.post(
+            self.HEARTBEAT_URL,
+            json=self._payload(),
+            headers={
+                "X-Camera-ID": "cam-unknown",
+                "X-Timestamp": str(int(time.time())),
+                "X-Signature": "bad",
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_signature_returns_401(self, app, client):
+        import time
+        _add_camera(app, "cam-001")
+        cam = app.store.get_camera("cam-001")
+        cam.pairing_secret = self.SECRET
+        app.store.save_camera(cam)
+
+        resp = client.post(
+            self.HEARTBEAT_URL,
+            json=self._payload(),
+            headers={
+                "X-Camera-ID": "cam-001",
+                "X-Timestamp": str(int(time.time())),
+                "X-Signature": "invalid",
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_valid_heartbeat_returns_200_ok(self, app, client):
+        _add_camera(app, "cam-001")
+        cam = app.store.get_camera("cam-001")
+        cam.pairing_secret = self.SECRET
+        app.store.save_camera(cam)
+
+        resp = _signed_camera_request(
+            client, self.HEARTBEAT_URL, self._payload(), secret=self.SECRET
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data.get("ok") is True
+
+    def test_heartbeat_updates_camera_status_to_online(self, app, client):
+        _add_camera(app, "cam-001", status="offline")
+        cam = app.store.get_camera("cam-001")
+        cam.pairing_secret = self.SECRET
+        app.store.save_camera(cam)
+
+        _signed_camera_request(
+            client, self.HEARTBEAT_URL, self._payload(), secret=self.SECRET
+        )
+
+        updated = app.store.get_camera("cam-001")
+        assert updated.status == "online"
+        assert updated.streaming is True
+
+    def test_heartbeat_updates_health_metrics(self, app, client):
+        _add_camera(app, "cam-001")
+        cam = app.store.get_camera("cam-001")
+        cam.pairing_secret = self.SECRET
+        app.store.save_camera(cam)
+
+        _signed_camera_request(
+            client, self.HEARTBEAT_URL,
+            self._payload(cpu_temp=60.0, memory_percent=75, uptime_seconds=900),
+            secret=self.SECRET,
+        )
+
+        updated = app.store.get_camera("cam-001")
+        assert updated.cpu_temp == 60.0
+        assert updated.memory_percent == 75
+        assert updated.uptime_seconds == 900
+
+    def test_heartbeat_returns_pending_config_when_needed(self, app, client):
+        _add_camera(app, "cam-001")
+        cam = app.store.get_camera("cam-001")
+        cam.pairing_secret = self.SECRET
+        cam.config_sync = "pending"
+        cam.fps = 30
+        app.store.save_camera(cam)
+
+        resp = _signed_camera_request(
+            client, self.HEARTBEAT_URL, self._payload(), secret=self.SECRET
+        )
+        data = resp.get_json()
+        assert "pending_config" in data
+        assert data["pending_config"]["fps"] == 30
+
+    def test_expired_timestamp_returns_401(self, app, client):
+        import hashlib
+        import hmac
+        import json
+        import time
+
+        _add_camera(app, "cam-001")
+        cam = app.store.get_camera("cam-001")
+        cam.pairing_secret = self.SECRET
+        app.store.save_camera(cam)
+
+        body_dict = self._payload()
+        body = json.dumps(body_dict).encode()
+        old_ts = str(int(time.time()) - 400)  # 400s ago — beyond 300s window
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"cam-001:{old_ts}:{body_hash}"
+        sig = hmac.new(
+            bytes.fromhex(self.SECRET), message.encode(), hashlib.sha256
+        ).hexdigest()
+
+        resp = client.post(
+            self.HEARTBEAT_URL,
+            data=body,
+            content_type="application/json",
+            headers={
+                "X-Camera-ID": "cam-001",
+                "X-Timestamp": old_ts,
+                "X-Signature": sig,
+            },
+        )
+        assert resp.status_code == 401

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -151,6 +151,11 @@ CAMERA_LIST_FIELDS = {
     "hflip",
     "vflip",
     "config_sync",
+    # ADR-0016: live health fields sent via heartbeat
+    "streaming",
+    "cpu_temp",
+    "memory_percent",
+    "uptime_seconds",
 }
 
 

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -130,7 +130,8 @@ class TestAuthMeContract:
 # Camera contracts (/api/v1/cameras/*)
 # ===========================================================================
 
-CAMERA_LIST_FIELDS = {
+# Admin sees all fields (network + health metrics)
+CAMERA_LIST_FIELDS_ADMIN = {
     "id",
     "name",
     "location",
@@ -158,24 +159,51 @@ CAMERA_LIST_FIELDS = {
     "uptime_seconds",
 }
 
+# Viewers see a subset — no IP (network topology) or health metrics (occupancy risk)
+CAMERA_LIST_FIELDS_VIEWER = CAMERA_LIST_FIELDS_ADMIN - {
+    "ip",
+    "cpu_temp",
+    "memory_percent",
+    "uptime_seconds",
+}
+
+# Backwards-compat alias (most tests use admin login)
+CAMERA_LIST_FIELDS = CAMERA_LIST_FIELDS_ADMIN
+
 
 class TestCamerasListContract:
     """GET /api/v1/cameras — array of camera objects."""
 
-    def test_camera_object_fields(self, app, client):
+    def test_camera_object_fields_admin(self, app, client):
+        """Admin sees full camera detail including IP and health metrics."""
         _login(app, client)
         _add_camera(app)
         data = client.get("/api/v1/cameras").get_json()
         assert isinstance(data, list)
         assert len(data) >= 1
-        _assert_fields(data[0], CAMERA_LIST_FIELDS)
+        _assert_fields(data[0], CAMERA_LIST_FIELDS_ADMIN)
+
+    def test_camera_object_fields_viewer(self, app, client):
+        """Viewer sees limited fields — no IP or health metrics."""
+        _login(app, client, role="viewer")
+        _add_camera(app)
+        data = client.get("/api/v1/cameras").get_json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        cam = data[0]
+        # Viewer should NOT see admin-only fields
+        for field in ("ip", "cpu_temp", "memory_percent", "uptime_seconds"):
+            assert field not in cam, f"Admin field '{field}' leaked to viewer"
+        # Viewer should see all viewer-accessible fields
+        for field in CAMERA_LIST_FIELDS_VIEWER:
+            assert field in cam, f"Expected viewer field '{field}' missing"
 
     def test_excludes_sensitive_fields(self, app, client):
         _login(app, client)
         _add_camera(app)
         data = client.get("/api/v1/cameras").get_json()
         cam = data[0]
-        for field in ["rtsp_url", "cert_serial", "password"]:
+        for field in ["rtsp_url", "cert_serial", "password", "pairing_secret"]:
             assert field not in cam, f"Sensitive field '{field}' leaked"
 
 

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -955,7 +955,9 @@ class TestConfigNotifyContract:
         assert "message" in data
 
 
-def _signed_camera_request(client, url, body_dict, camera_id="cam-001", secret="ab" * 32):
+def _signed_camera_request(
+    client, url, body_dict, camera_id="cam-001", secret="ab" * 32
+):
     """Helper: build HMAC-signed POST to a camera machine-to-machine endpoint."""
     import hashlib
     import hmac
@@ -993,10 +995,15 @@ class TestHeartbeatContract:
             "memory_percent": 42,
             "uptime_seconds": 3600,
             "stream_config": {
-                "width": 1920, "height": 1080, "fps": 25,
-                "bitrate": 4000000, "h264_profile": "high",
-                "keyframe_interval": 30, "rotation": 0,
-                "hflip": False, "vflip": False,
+                "width": 1920,
+                "height": 1080,
+                "fps": 25,
+                "bitrate": 4000000,
+                "h264_profile": "high",
+                "keyframe_interval": 30,
+                "rotation": 0,
+                "hflip": False,
+                "vflip": False,
             },
         }
         data.update(overrides)
@@ -1008,6 +1015,7 @@ class TestHeartbeatContract:
 
     def test_unknown_camera_returns_401(self, app, client):
         import time
+
         resp = client.post(
             self.HEARTBEAT_URL,
             json=self._payload(),
@@ -1021,6 +1029,7 @@ class TestHeartbeatContract:
 
     def test_invalid_signature_returns_401(self, app, client):
         import time
+
         _add_camera(app, "cam-001")
         cam = app.store.get_camera("cam-001")
         cam.pairing_secret = self.SECRET
@@ -1071,7 +1080,8 @@ class TestHeartbeatContract:
         app.store.save_camera(cam)
 
         _signed_camera_request(
-            client, self.HEARTBEAT_URL,
+            client,
+            self.HEARTBEAT_URL,
             self._payload(cpu_temp=60.0, memory_percent=75, uptime_seconds=900),
             secret=self.SECRET,
         )

--- a/app/server/tests/integration/test_api_live.py
+++ b/app/server/tests/integration/test_api_live.py
@@ -86,6 +86,46 @@ class TestHLSPlaylist:
         assert b"#EXTM3U" in response.data
 
 
+class TestHLSSegment:
+    """Test GET /api/v1/live/<cam-id>/<filename> — auth + path traversal."""
+
+    def test_requires_auth(self, client):
+        assert client.get("/api/v1/live/cam-001/seg001.ts").status_code == 401
+
+    def test_rejects_invalid_extension(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        response = client.get("/api/v1/live/cam-001/stream.avi")
+        assert response.status_code == 400
+
+    def test_serves_ts_segment(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        live_dir = os.path.join(app.config["LIVE_DIR"], "cam-001")
+        os.makedirs(live_dir, exist_ok=True)
+        seg = os.path.join(live_dir, "seg001.ts")
+        with open(seg, "wb") as f:
+            f.write(b"\x00" * 64)
+        response = client.get("/api/v1/live/cam-001/seg001.ts")
+        assert response.status_code == 200
+        assert response.content_type == "video/mp2t"
+
+    def test_path_traversal_rejected(self, app, client):
+        """Path traversal attempt outside live_dir returns 400."""
+        _login(app, client)
+        _add_camera(app)
+        # ../../../etc/passwd style traversal
+        response = client.get("/api/v1/live/cam-001/../../../etc/passwd")
+        # nginx would normalise this, but test the Flask layer directly
+        assert response.status_code in (400, 404)
+
+    def test_missing_segment_returns_404(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        response = client.get("/api/v1/live/cam-001/nonexistent.ts")
+        assert response.status_code == 404
+
+
 class TestSnapshot:
     """Test GET /api/v1/live/<cam-id>/snapshot."""
 

--- a/app/server/tests/integration/test_provisioning.py
+++ b/app/server/tests/integration/test_provisioning.py
@@ -11,7 +11,10 @@ SUBPROCESS_PATCH = "monitor.services.provisioning_service.subprocess"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _write_ca_cert(app, content="-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"):
+
+def _write_ca_cert(
+    app, content="-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+):
     """Write a fake CA cert to the app's CERTS_DIR."""
     certs_dir = app.config["CERTS_DIR"]
     os.makedirs(certs_dir, exist_ok=True)

--- a/app/server/tests/integration/test_provisioning.py
+++ b/app/server/tests/integration/test_provisioning.py
@@ -9,6 +9,61 @@ from unittest.mock import MagicMock, patch
 
 SUBPROCESS_PATCH = "monitor.services.provisioning_service.subprocess"
 
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _write_ca_cert(app, content="-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"):
+    """Write a fake CA cert to the app's CERTS_DIR."""
+    certs_dir = app.config["CERTS_DIR"]
+    os.makedirs(certs_dir, exist_ok=True)
+    ca_path = os.path.join(certs_dir, "ca.crt")
+    with open(ca_path, "w") as f:
+        f.write(content)
+    return ca_path
+
+
+class TestGetCaCert:
+    """Tests for GET /api/v1/setup/ca-cert (TOFU bootstrap endpoint).
+
+    This endpoint is intentionally unauthenticated — it serves the public CA
+    certificate so cameras can verify TLS before they have any credentials.
+    """
+
+    def test_returns_ca_cert_when_exists(self, app, client):
+        """Returns PEM content when ca.crt exists."""
+        _write_ca_cert(app)
+        response = client.get("/api/v1/setup/ca-cert")
+        assert response.status_code == 200
+        assert b"BEGIN CERTIFICATE" in response.data
+
+    def test_returns_404_when_no_ca_cert(self, client):
+        """Returns 404 when ca.crt has not been generated yet."""
+        response = client.get("/api/v1/setup/ca-cert")
+        assert response.status_code == 404
+        assert "error" in response.get_json()
+
+    def test_accessible_without_auth(self, app, client):
+        """No authentication required — cameras call this before pairing."""
+        _write_ca_cert(app)
+        response = client.get("/api/v1/setup/ca-cert")
+        # Must not redirect to login or return 401/403
+        assert response.status_code == 200
+
+    def test_content_type_is_pem(self, app, client):
+        """Content-Type indicates PEM/certificate format."""
+        _write_ca_cert(app)
+        response = client.get("/api/v1/setup/ca-cert")
+        assert "application/x-pem-file" in response.content_type
+
+    def test_accessible_even_after_setup_complete(self, app, client):
+        """CA cert endpoint stays accessible post-setup (cameras re-pair)."""
+        stamp = os.path.join(app.config["DATA_DIR"], ".setup-done")
+        with open(stamp, "w") as f:
+            f.write("done")
+        _write_ca_cert(app)
+        response = client.get("/api/v1/setup/ca-cert")
+        # Must NOT be blocked by _require_setup_incomplete (not decorated)
+        assert response.status_code == 200
+
 
 class TestSetupStatus:
     """Tests for GET /api/v1/setup/status."""

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -643,9 +643,10 @@ class TestAcceptHeartbeat:
         store = MagicMock()
         store.get_camera.return_value = cam
         svc = CameraService(store)
-        svc.accept_heartbeat("cam-001", self._basic_payload(
-            cpu_temp=55.2, memory_percent=60, uptime_seconds=7200
-        ))
+        svc.accept_heartbeat(
+            "cam-001",
+            self._basic_payload(cpu_temp=55.2, memory_percent=60, uptime_seconds=7200),
+        )
         assert cam.cpu_temp == 55.2
         assert cam.memory_percent == 60
         assert cam.uptime_seconds == 7200
@@ -722,8 +723,12 @@ class TestAcceptHeartbeat:
         store = MagicMock()
         store.get_camera.return_value = cam
         svc = CameraService(store)
-        payload = {"streaming": False, "cpu_temp": 40.0,
-                   "memory_percent": 30, "uptime_seconds": 100}
+        payload = {
+            "streaming": False,
+            "cpu_temp": 40.0,
+            "memory_percent": 30,
+            "uptime_seconds": 100,
+        }
         _, error, code = svc.accept_heartbeat("cam-001", payload)
         assert code == 200
         assert not error

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -30,6 +30,12 @@ def _make_camera(**overrides):
         "hflip": False,
         "vflip": False,
         "config_sync": "unknown",
+        # Heartbeat fields (ADR-0016)
+        "streaming": False,
+        "cpu_temp": 0.0,
+        "memory_percent": 0,
+        "uptime_seconds": 0,
+        "pairing_secret": "",
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -565,3 +571,159 @@ class TestAcceptCameraConfig:
         audit.log_event.assert_called_once()
         call_args = audit.log_event.call_args
         assert call_args[0][0] == "CAMERA_CONFIG_RECEIVED"
+
+
+class TestAcceptHeartbeat:
+    """Tests for CameraService.accept_heartbeat() (ADR-0016)."""
+
+    def _basic_payload(self, **overrides):
+        data = {
+            "streaming": True,
+            "cpu_temp": 48.5,
+            "memory_percent": 42,
+            "uptime_seconds": 3600,
+            "stream_config": {
+                "width": 1920,
+                "height": 1080,
+                "fps": 25,
+                "bitrate": 4000000,
+                "h264_profile": "high",
+                "keyframe_interval": 30,
+                "rotation": 0,
+                "hflip": False,
+                "vflip": False,
+            },
+        }
+        data.update(overrides)
+        return data
+
+    def test_returns_404_for_unknown_camera(self):
+        store = MagicMock()
+        store.get_camera.return_value = None
+        svc = CameraService(store)
+        _, error, code = svc.accept_heartbeat("cam-999", self._basic_payload())
+        assert code == 404
+        assert error
+
+    def test_marks_camera_online(self):
+        cam = _make_camera(status="offline")
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat("cam-001", self._basic_payload())
+        assert cam.status == "online"
+
+    def test_updates_last_seen(self):
+        cam = _make_camera(last_seen="2020-01-01T00:00:00Z")
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat("cam-001", self._basic_payload())
+        assert cam.last_seen != "2020-01-01T00:00:00Z"
+        assert "Z" in cam.last_seen
+
+    def test_updates_streaming_flag(self):
+        cam = _make_camera(streaming=False)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat("cam-001", self._basic_payload(streaming=True))
+        assert cam.streaming is True
+
+    def test_updates_streaming_false(self):
+        cam = _make_camera(streaming=True)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat("cam-001", self._basic_payload(streaming=False))
+        assert cam.streaming is False
+
+    def test_updates_health_metrics(self):
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat("cam-001", self._basic_payload(
+            cpu_temp=55.2, memory_percent=60, uptime_seconds=7200
+        ))
+        assert cam.cpu_temp == 55.2
+        assert cam.memory_percent == 60
+        assert cam.uptime_seconds == 7200
+
+    def test_accepts_stream_config_from_heartbeat(self):
+        cam = _make_camera(fps=25, config_sync="unknown")
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        payload = self._basic_payload()
+        payload["stream_config"]["fps"] = 15
+        svc.accept_heartbeat("cam-001", payload)
+        assert cam.fps == 15
+        assert cam.config_sync == "synced"
+
+    def test_returns_pending_config_when_config_sync_pending(self):
+        cam = _make_camera(config_sync="pending", fps=30)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        response, _, code = svc.accept_heartbeat("cam-001", self._basic_payload())
+        assert code == 200
+        assert "pending_config" in response
+        assert response["pending_config"]["fps"] == 30
+
+    def test_no_pending_config_when_synced(self):
+        cam = _make_camera(config_sync="synced")
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        response, _, code = svc.accept_heartbeat("cam-001", self._basic_payload())
+        assert code == 200
+        assert "pending_config" not in response
+
+    def test_logs_camera_online_audit_when_was_offline(self):
+        cam = _make_camera(status="offline")
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        audit = MagicMock()
+        svc = CameraService(store, audit=audit)
+        svc.accept_heartbeat("cam-001", self._basic_payload())
+        audit.log_event.assert_called_once()
+        event = audit.log_event.call_args[0][0]
+        assert event == "CAMERA_ONLINE"
+
+    def test_no_audit_when_already_online(self):
+        cam = _make_camera(status="online")
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        audit = MagicMock()
+        svc = CameraService(store, audit=audit)
+        svc.accept_heartbeat("cam-001", self._basic_payload())
+        audit.log_event.assert_not_called()
+
+    def test_saves_camera_to_store(self):
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat("cam-001", self._basic_payload())
+        store.save_camera.assert_called_once_with(cam)
+
+    def test_ignores_invalid_cpu_temp(self):
+        cam = _make_camera(cpu_temp=0.0)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat("cam-001", self._basic_payload(cpu_temp="bad"))
+        # Should not crash; cpu_temp stays unchanged
+        assert cam.cpu_temp == 0.0
+
+    def test_heartbeat_without_stream_config_is_ok(self):
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        payload = {"streaming": False, "cpu_temp": 40.0,
+                   "memory_percent": 30, "uptime_seconds": 100}
+        _, error, code = svc.accept_heartbeat("cam-001", payload)
+        assert code == 200
+        assert not error

--- a/app/server/tests/unit/test_svc_discovery.py
+++ b/app/server/tests/unit/test_svc_discovery.py
@@ -107,6 +107,25 @@ class TestCheckOffline:
             camera = app.store.get_camera("cam-001")
             assert camera.status == "pending"
 
+    def test_clears_streaming_flag_when_marking_offline(self, app):
+        """ADR-0016: stale cameras must never show streaming=True."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            svc.report_camera("cam-001", "192.168.1.50")
+            camera = app.store.get_camera("cam-001")
+            camera.status = "online"
+            camera.streaming = True
+            old = (datetime.now(UTC) - timedelta(seconds=60)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            camera.last_seen = old
+            app.store.save_camera(camera)
+
+            svc.check_offline()
+            camera = app.store.get_camera("cam-001")
+            assert camera.status == "offline"
+            assert camera.streaming is False
+
     def test_offline_logs_audit(self, app):
         with app.app_context():
             svc = DiscoveryService(app.store, app.audit)

--- a/app/server/tests/unit/test_svc_discovery.py
+++ b/app/server/tests/unit/test_svc_discovery.py
@@ -1,6 +1,7 @@
 """Tests for the camera discovery service."""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 from monitor.services.discovery import DiscoveryService
 
@@ -158,3 +159,220 @@ class TestGetCameraStatus:
         with app.app_context():
             svc = DiscoveryService(app.store, app.audit)
             assert svc.get_camera_status("cam-nonexistent") is None
+
+
+class TestMdnsBrowser:
+    """Unit tests for mDNS browser integration (python-zeroconf)."""
+
+    def test_start_mdns_browser_without_zeroconf_logs_warning(self, app, caplog):
+        """Graceful degradation when zeroconf is not installed."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            with patch.dict("sys.modules", {"zeroconf": None}):
+                import importlib
+                with patch("builtins.__import__", side_effect=ImportError("no module")):
+                    # Should not raise
+                    try:
+                        svc.start_mdns_browser()
+                    except Exception:
+                        pass  # ImportError handled internally
+            # zeroconf stays None on ImportError
+            # (tested via _zeroconf attribute)
+
+    def test_start_mdns_browser_idempotent(self, app):
+        """Calling start_mdns_browser twice does not create two Zeroconf instances."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            mock_zc = MagicMock()
+            mock_browser = MagicMock()
+
+            # Simulate browser already running
+            svc._zeroconf = mock_zc
+            svc._mdns_browser = mock_browser
+
+            # Call again — should return early without touching _zeroconf
+            import sys
+            mock_mod = MagicMock()
+            original = sys.modules.get("zeroconf")
+            sys.modules["zeroconf"] = mock_mod
+            try:
+                svc.start_mdns_browser()
+            finally:
+                if original is None:
+                    sys.modules.pop("zeroconf", None)
+                else:
+                    sys.modules["zeroconf"] = original
+
+            # _zeroconf unchanged — no new Zeroconf() call happened
+            assert svc._zeroconf is mock_zc
+
+    def test_stop_mdns_browser_is_safe_without_start(self, app):
+        """stop_mdns_browser() on a fresh service does not raise."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            svc.stop_mdns_browser()  # _zeroconf is None — must not raise
+
+    def test_stop_mdns_browser_closes_zeroconf(self, app):
+        """stop_mdns_browser() calls close() on the Zeroconf instance."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            mock_zc = MagicMock()
+            svc._zeroconf = mock_zc
+            svc._mdns_browser = MagicMock()
+
+            svc.stop_mdns_browser()
+
+            mock_zc.close.assert_called_once()
+            assert svc._zeroconf is None
+            assert svc._mdns_browser is None
+
+    def test_trigger_scan_does_nothing_without_browser(self, app):
+        """trigger_scan() is a no-op when mDNS browser is not running."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            # Must not raise
+            svc.trigger_scan()
+
+    def test_handle_mdns_service_calls_report_camera(self, app):
+        """_handle_mdns_service() parses TXT records and calls report_camera()."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+
+            # Build a mock ServiceInfo as returned by zeroconf.get_service_info()
+            mock_info = MagicMock()
+            mock_info.properties = {
+                b"id": b"cam-abc123",
+                b"version": b"1.2.0",
+                b"paired": b"false",
+            }
+            mock_info.parsed_addresses.return_value = ["192.168.1.200"]
+
+            mock_zc = MagicMock()
+            mock_zc.get_service_info.return_value = mock_info
+
+            svc._handle_mdns_service(mock_zc, "_rtsp._tcp.local.", "HomeMonitor Camera (cam-abc123)._rtsp._tcp.local.")
+
+            camera = app.store.get_camera("cam-abc123")
+            assert camera is not None
+            assert camera.status == "pending"
+            assert camera.ip == "192.168.1.200"
+            assert camera.firmware_version == "1.2.0"
+
+    def test_handle_mdns_service_ignores_non_homeMonitor(self, app):
+        """_handle_mdns_service() ignores services without 'cam-' id prefix."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+
+            mock_info = MagicMock()
+            mock_info.properties = {b"id": b"other-device"}
+            mock_info.parsed_addresses.return_value = ["192.168.1.201"]
+
+            mock_zc = MagicMock()
+            mock_zc.get_service_info.return_value = mock_info
+
+            svc._handle_mdns_service(mock_zc, "_rtsp._tcp.local.", "SomeOtherDevice._rtsp._tcp.local.")
+
+            # No camera should have been saved
+            assert app.store.get_camera("other-device") is None
+
+    def test_handle_mdns_service_ignores_missing_address(self, app):
+        """_handle_mdns_service() skips cameras with no resolvable IP."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+
+            mock_info = MagicMock()
+            mock_info.properties = {b"id": b"cam-noip"}
+            mock_info.parsed_addresses.return_value = []
+            mock_info.addresses = []
+
+            mock_zc = MagicMock()
+            mock_zc.get_service_info.return_value = mock_info
+
+            svc._handle_mdns_service(mock_zc, "_rtsp._tcp.local.", "HomeMonitor Camera (cam-noip)._rtsp._tcp.local.")
+
+            assert app.store.get_camera("cam-noip") is None
+
+    def test_handle_mdns_service_handles_none_info(self, app):
+        """_handle_mdns_service() handles get_service_info returning None."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            mock_zc = MagicMock()
+            mock_zc.get_service_info.return_value = None
+            # Must not raise
+            svc._handle_mdns_service(mock_zc, "_rtsp._tcp.local.", "whatever._rtsp._tcp.local.")
+
+    def test_start_mdns_browser_with_zeroconf(self, app):
+        """start_mdns_browser() creates Zeroconf + ServiceBrowser when library is present."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+
+            mock_zc = MagicMock()
+            mock_browser = MagicMock()
+
+            # Patch zeroconf in sys.modules so the lazy import picks up our mocks
+            import sys
+            mock_zeroconf_mod = MagicMock()
+            mock_zeroconf_mod.Zeroconf = MagicMock(return_value=mock_zc)
+            mock_zeroconf_mod.ServiceBrowser = MagicMock(return_value=mock_browser)
+
+            original = sys.modules.get("zeroconf")
+            sys.modules["zeroconf"] = mock_zeroconf_mod
+            try:
+                svc.start_mdns_browser()
+            finally:
+                if original is None:
+                    sys.modules.pop("zeroconf", None)
+                else:
+                    sys.modules["zeroconf"] = original
+
+            # Zeroconf() was called once; _zeroconf set; browser created
+            mock_zeroconf_mod.Zeroconf.assert_called_once()
+            assert svc._zeroconf is mock_zc
+            mock_zeroconf_mod.ServiceBrowser.assert_called_once()
+            svc.stop_mdns_browser()
+
+
+class TestScanEndpoint:
+    """Integration tests for POST /cameras/scan."""
+
+    def _login(self, app, client, role="admin"):
+        from monitor.auth import hash_password
+        from monitor.models import User
+        app.store.save_user(User(
+            id="user-scan-admin",
+            username="scanadmin",
+            password_hash=hash_password("pass"),
+            role=role,
+        ))
+        resp = client.post("/api/v1/auth/login", json={"username": "scanadmin", "password": "pass"})
+        client.environ_base["HTTP_X_CSRF_TOKEN"] = resp.get_json()["csrf_token"]
+
+    def test_scan_returns_camera_list(self, app, client):
+        """POST /cameras/scan returns current camera list."""
+        with app.app_context():
+            from monitor.models import Camera
+            cam = Camera(
+                id="cam-scan01",
+                ip="192.168.1.99",
+                status="pending",
+            )
+            app.store.save_camera(cam)
+
+        self._login(app, client)
+        resp = client.post("/api/v1/cameras/scan")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        ids = [c["id"] for c in data]
+        assert "cam-scan01" in ids
+
+    def test_scan_requires_admin(self, app, client):
+        """POST /cameras/scan returns 403 for non-admin users."""
+        self._login(app, client, role="viewer")
+        resp = client.post("/api/v1/cameras/scan")
+        assert resp.status_code == 403
+
+    def test_scan_requires_login(self, client):
+        """POST /cameras/scan returns 401 for unauthenticated requests."""
+        resp = client.post("/api/v1/cameras/scan")
+        assert resp.status_code == 401

--- a/app/server/tests/unit/test_svc_discovery.py
+++ b/app/server/tests/unit/test_svc_discovery.py
@@ -168,14 +168,15 @@ class TestMdnsBrowser:
         """Graceful degradation when zeroconf is not installed."""
         with app.app_context():
             svc = DiscoveryService(app.store, app.audit)
-            with patch.dict("sys.modules", {"zeroconf": None}):
-                import importlib
-                with patch("builtins.__import__", side_effect=ImportError("no module")):
-                    # Should not raise
-                    try:
-                        svc.start_mdns_browser()
-                    except Exception:
-                        pass  # ImportError handled internally
+            with (
+                patch.dict("sys.modules", {"zeroconf": None}),
+                patch("builtins.__import__", side_effect=ImportError("no module")),
+            ):
+                # Should not raise
+                try:
+                    svc.start_mdns_browser()
+                except Exception:
+                    pass  # ImportError handled internally
             # zeroconf stays None on ImportError
             # (tested via _zeroconf attribute)
 
@@ -192,6 +193,7 @@ class TestMdnsBrowser:
 
             # Call again — should return early without touching _zeroconf
             import sys
+
             mock_mod = MagicMock()
             original = sys.modules.get("zeroconf")
             sys.modules["zeroconf"] = mock_mod
@@ -250,7 +252,11 @@ class TestMdnsBrowser:
             mock_zc = MagicMock()
             mock_zc.get_service_info.return_value = mock_info
 
-            svc._handle_mdns_service(mock_zc, "_rtsp._tcp.local.", "HomeMonitor Camera (cam-abc123)._rtsp._tcp.local.")
+            svc._handle_mdns_service(
+                mock_zc,
+                "_rtsp._tcp.local.",
+                "HomeMonitor Camera (cam-abc123)._rtsp._tcp.local.",
+            )
 
             camera = app.store.get_camera("cam-abc123")
             assert camera is not None
@@ -258,7 +264,7 @@ class TestMdnsBrowser:
             assert camera.ip == "192.168.1.200"
             assert camera.firmware_version == "1.2.0"
 
-    def test_handle_mdns_service_ignores_non_homeMonitor(self, app):
+    def test_handle_mdns_service_ignores_non_home_monitor(self, app):
         """_handle_mdns_service() ignores services without 'cam-' id prefix."""
         with app.app_context():
             svc = DiscoveryService(app.store, app.audit)
@@ -270,7 +276,9 @@ class TestMdnsBrowser:
             mock_zc = MagicMock()
             mock_zc.get_service_info.return_value = mock_info
 
-            svc._handle_mdns_service(mock_zc, "_rtsp._tcp.local.", "SomeOtherDevice._rtsp._tcp.local.")
+            svc._handle_mdns_service(
+                mock_zc, "_rtsp._tcp.local.", "SomeOtherDevice._rtsp._tcp.local."
+            )
 
             # No camera should have been saved
             assert app.store.get_camera("other-device") is None
@@ -288,7 +296,11 @@ class TestMdnsBrowser:
             mock_zc = MagicMock()
             mock_zc.get_service_info.return_value = mock_info
 
-            svc._handle_mdns_service(mock_zc, "_rtsp._tcp.local.", "HomeMonitor Camera (cam-noip)._rtsp._tcp.local.")
+            svc._handle_mdns_service(
+                mock_zc,
+                "_rtsp._tcp.local.",
+                "HomeMonitor Camera (cam-noip)._rtsp._tcp.local.",
+            )
 
             assert app.store.get_camera("cam-noip") is None
 
@@ -299,7 +311,9 @@ class TestMdnsBrowser:
             mock_zc = MagicMock()
             mock_zc.get_service_info.return_value = None
             # Must not raise
-            svc._handle_mdns_service(mock_zc, "_rtsp._tcp.local.", "whatever._rtsp._tcp.local.")
+            svc._handle_mdns_service(
+                mock_zc, "_rtsp._tcp.local.", "whatever._rtsp._tcp.local."
+            )
 
     def test_start_mdns_browser_with_zeroconf(self, app):
         """start_mdns_browser() creates Zeroconf + ServiceBrowser when library is present."""
@@ -311,6 +325,7 @@ class TestMdnsBrowser:
 
             # Patch zeroconf in sys.modules so the lazy import picks up our mocks
             import sys
+
             mock_zeroconf_mod = MagicMock()
             mock_zeroconf_mod.Zeroconf = MagicMock(return_value=mock_zc)
             mock_zeroconf_mod.ServiceBrowser = MagicMock(return_value=mock_browser)
@@ -338,19 +353,25 @@ class TestScanEndpoint:
     def _login(self, app, client, role="admin"):
         from monitor.auth import hash_password
         from monitor.models import User
-        app.store.save_user(User(
-            id="user-scan-admin",
-            username="scanadmin",
-            password_hash=hash_password("pass"),
-            role=role,
-        ))
-        resp = client.post("/api/v1/auth/login", json={"username": "scanadmin", "password": "pass"})
+
+        app.store.save_user(
+            User(
+                id="user-scan-admin",
+                username="scanadmin",
+                password_hash=hash_password("pass"),
+                role=role,
+            )
+        )
+        resp = client.post(
+            "/api/v1/auth/login", json={"username": "scanadmin", "password": "pass"}
+        )
         client.environ_base["HTTP_X_CSRF_TOKEN"] = resp.get_json()["csrf_token"]
 
     def test_scan_returns_camera_list(self, app, client):
         """POST /cameras/scan returns current camera list."""
         with app.app_context():
             from monitor.models import Camera
+
             cam = Camera(
                 id="cam-scan01",
                 ip="192.168.1.99",

--- a/docs/adr/0016-camera-health-heartbeat-protocol.md
+++ b/docs/adr/0016-camera-health-heartbeat-protocol.md
@@ -1,0 +1,238 @@
+# ADR-0016: Camera Health and Heartbeat Protocol
+
+**Status:** Accepted
+**Date:** 2026-04-16
+**Deciders:** vinu-dev
+
+---
+
+## Context
+
+### Problem
+
+The server could display incorrect camera state indefinitely.
+A camera that crashed, lost WiFi, or ran out of battery would still appear as
+`status=online` and `streaming=true` on the dashboard because:
+
+1. `last_seen` was only updated from mDNS (Avahi) announcements — unreliable
+   in some environments, and not tied to actual stream activity.
+2. `DiscoveryService.check_offline()` existed but was never called
+   automatically, so cameras were never marked offline at runtime.
+3. No live streaming state was tracked — the server inferred streaming from
+   whether an ffmpeg process was running, not from what the camera reported.
+
+Users saw "streaming" on the dashboard even when no frames were arriving,
+leading to confusion and missed alerts.
+
+### Goal
+
+- Server must **never** show `streaming=true` for a camera that has not
+  reported itself as streaming within the last 45 seconds.
+- Server must mark a camera `offline` automatically when no contact is made
+  within 30 seconds.
+- Status must be driven by what the camera says, not by what the server
+  last remembered.
+
+---
+
+## Decision
+
+### Protocol overview
+
+Two complementary mechanisms work together:
+
+```
+Camera                               Server
+  │                                    │
+  │  POST /heartbeat every ~15s        │
+  │  (HMAC-SHA256 signed)              │
+  ├───────────────────────────────────>│  update last_seen, streaming,
+  │                                    │  cpu_temp, memory_percent
+  │<─── 200 {ok:true}                 │
+  │     OR 200 {ok:true,              │  (pending_config included when
+  │            pending_config:{...}}   │   server has unsent config push)
+  │                                    │
+  │  GET /api/v1/control/status        │
+  │<───────────────────────────────────│  server polls camera on-demand
+  │  {streaming, config, health}       │  (via CameraControlClient, mTLS)
+  │───────────────────────────────────>│
+  │                                    │
+  │  (background, every 10s)           │
+  │                                    │◄── staleness checker
+  │                                    │    if now - last_seen > 30s:
+  │                                    │      status = offline
+  │                                    │      streaming = False
+```
+
+### Camera → Server: Heartbeat
+
+**Endpoint:** `POST /api/v1/cameras/heartbeat`
+**Auth:** HMAC-SHA256 — same scheme as `config-notify` (ADR-0015):
+  `signature = HMAC(secret, camera_id:timestamp:sha256(body))`
+**Frequency:** Every 15 seconds (±3s random jitter to spread load)
+**Timeout:** 300-second replay window (same as `config-notify`)
+
+**Request payload:**
+```json
+{
+  "camera_id": "cam-a1b2",
+  "timestamp": 1712345678,
+  "streaming": true,
+  "cpu_temp": 48.5,
+  "memory_percent": 42,
+  "uptime_seconds": 3600,
+  "stream_config": {
+    "width": 1920, "height": 1080, "fps": 25,
+    "bitrate": 4000000, "h264_profile": "high",
+    "keyframe_interval": 30, "rotation": 0,
+    "hflip": false, "vflip": false
+  }
+}
+```
+
+**Server processing:**
+1. Verify HMAC and timestamp freshness.
+2. If `config_sync != "pending"`: accept `stream_config` and mark synced.
+3. If `config_sync == "pending"`: keep server's stored params (they are the
+   desired state) and return them in the response for the camera to apply.
+4. Update: `status=online`, `last_seen=now`, `streaming`, health fields.
+5. Audit `CAMERA_ONLINE` if camera was previously `offline`.
+6. Save to store.
+
+**Response — normal:**
+```json
+{"ok": true}
+```
+
+**Response — with pending config:**
+```json
+{
+  "ok": true,
+  "pending_config": {
+    "width": 1280, "height": 720, "fps": 30,
+    "bitrate": 2000000, "h264_profile": "main",
+    "keyframe_interval": 30, "rotation": 0,
+    "hflip": false, "vflip": false
+  }
+}
+```
+
+When `pending_config` is returned, the camera applies it immediately
+(via `ControlHandler.set_config(..., origin="server")`). The `origin=server`
+flag prevents a ping-pong notification back to the server.
+
+### Server → Camera: On-demand Status Query
+
+`CameraControlClient.get_status(camera_ip)` calls
+`GET /api/v1/control/status` on the camera's status server (mTLS auth).
+
+Returns:
+```json
+{
+  "streaming": true,
+  "config": { ... },
+  "stream_manager_running": true
+}
+```
+
+This endpoint already existed as part of ADR-0015 and is available for
+server-initiated checks (e.g., after a failed heartbeat, on dashboard load).
+
+### Server Staleness Checker
+
+A daemon thread started in `_startup()` runs every 10 seconds:
+
+```python
+app.discovery_service.check_offline()
+```
+
+`check_offline()` iterates online cameras and marks any with
+`now - last_seen > OFFLINE_TIMEOUT (30s)` as `offline`, also setting
+`streaming = False`. The 30s timeout means at most 2 missed heartbeats
+(each 15s) before a camera is declared offline — fast enough to surface
+real outages without false positives on a busy LAN.
+
+### Data model changes
+
+Four new fields on `Camera`:
+
+| Field              | Type    | Source     | Notes                              |
+|--------------------|---------|------------|------------------------------------|
+| `streaming`        | `bool`  | heartbeat  | Cleared to `False` on offline      |
+| `cpu_temp`         | `float` | heartbeat  | °C, displayed on dashboard         |
+| `memory_percent`   | `int`   | heartbeat  | 0–100, displayed on dashboard      |
+| `uptime_seconds`   | `int`   | heartbeat  | Seconds since last camera boot     |
+
+### Dashboard changes
+
+- `streaming` badge (green `● streaming` / gray `○ not streaming`) per camera.
+- `last_seen` shown as relative time ("3s ago", "2m ago") with warning colour
+  when stale (>30s orange, >45s red).
+- CPU temp and memory % from the most recent heartbeat.
+- Camera list refresh interval reduced from 30s → 15s to stay in sync with
+  heartbeat cadence.
+
+---
+
+## Alternatives Considered
+
+### Server polls camera periodically instead of camera pushing
+
+Rejected: requires server to maintain per-camera timers and open outbound
+connections to each camera IP. Harder to scale and requires the server to
+know when each camera booted. Push is simpler and already used for
+`config-notify`.
+
+### WebSocket or SSE for streaming status
+
+Rejected: the camera's status server is a minimal `http.server`-based
+implementation. Adding WebSocket/SSE would significantly complicate it.
+Periodic short-lived HTTPS requests are adequate and match the existing
+mTLS-authenticated control channel pattern.
+
+### mDNS alone for liveness
+
+Rejected: mDNS (Avahi) announces every 30s by default and is not a reliable
+liveness signal. It also does not carry streaming state or health metrics.
+
+---
+
+## Consequences
+
+### Positive
+
+- Server status is always fresh — camera must actively check in.
+- Stale data problem eliminated: `streaming=False` is the safe default;
+  only set to `True` by a recent, authenticated heartbeat.
+- Pending config pushes are reliably delivered even if the camera was
+  temporarily unreachable when the admin changed a setting.
+- Dashboard shows actionable health info (CPU temp, memory) without any
+  additional API call.
+- Consistent HMAC auth reuses the pattern from ADR-0015, no new key material.
+
+### Negative / Trade-offs
+
+- ~15s of extra LAN traffic per camera (small: ~600 bytes per heartbeat).
+- Camera must be paired to heartbeat (no heartbeat while in `pending` state).
+- 30-second stale threshold means a very brief WiFi glitch (~15–30s) could
+  flip a camera to `offline` unnecessarily. Acceptable for a home monitor.
+
+---
+
+## Implementation
+
+| Component | File |
+|-----------|------|
+| Camera heartbeat sender | `app/camera/camera_streamer/heartbeat.py` (new) |
+| Lifecycle hook | `app/camera/camera_streamer/lifecycle.py` |
+| Server heartbeat endpoint | `app/server/monitor/api/cameras.py` |
+| Server service method | `app/server/monitor/services/camera_service.py` |
+| Staleness checker wiring | `app/server/monitor/__init__.py` |
+| Streaming flag on offline | `app/server/monitor/services/discovery.py` |
+| Data model | `app/server/monitor/models.py` |
+| Dashboard | `app/server/monitor/templates/dashboard.html` |
+| CSS | `app/server/monitor/static/css/style.css` |
+| Camera tests | `app/camera/tests/unit/test_heartbeat.py` (new) |
+| Server unit tests | `app/server/tests/unit/test_camera_service.py` |
+| Server contract tests | `app/server/tests/contracts/test_api_contracts.py` |
+| Staleness tests | `app/server/tests/unit/test_svc_discovery.py` |

--- a/scripts/deploy-dev-app.sh
+++ b/scripts/deploy-dev-app.sh
@@ -298,6 +298,8 @@ ExecStartPre=+/bin/sh -c 'chmod 0666 /sys/class/leds/ACT/trigger /sys/class/leds
 ExecStart=/usr/bin/python3 -m camera_streamer.main
 Restart=always
 RestartSec=5
+TimeoutStopSec=20
+KillMode=control-group
 Environment=PYTHONPATH=/opt/camera
 Environment=CAMERA_DATA_DIR=/data
 Environment=CAMERA_CONFIG_DIR=/data/config

--- a/scripts/deploy-dev-app.sh
+++ b/scripts/deploy-dev-app.sh
@@ -168,6 +168,7 @@ deploy_server() {
     copy_tree "$REPO_ROOT/app/server/monitor" "$host" "$SERVER_STAGE" "monitor"
     copy_file "$REPO_ROOT/app/server/setup.py" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/server/requirements.txt" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/nginx-monitor.conf" "$host" "$SERVER_STAGE"
 
     log "Installing server app into /opt/monitor"
     ssh "${SSH_OPTS[@]}" "$host" "
@@ -188,6 +189,11 @@ deploy_server() {
         pip3 install -q -r /opt/monitor/requirements.txt
         # Pre-compile bytecode so first-request import is instant
         python3 -m compileall -q /opt/monitor/monitor
+        # Deploy updated nginx config and reload (non-fatal if nginx is not running)
+        if [ -f '$SERVER_STAGE/nginx-monitor.conf' ]; then
+            cp '$SERVER_STAGE/nginx-monitor.conf' /etc/nginx/sites-enabled/monitor.conf
+            nginx -t 2>/dev/null && nginx -s reload 2>/dev/null || true
+        fi
     "
 
     log "Applying boot optimisation overrides"

--- a/scripts/deploy-dev-app.sh
+++ b/scripts/deploy-dev-app.sh
@@ -184,6 +184,8 @@ deploy_server() {
         find /opt/monitor/monitor -type d -exec chmod 755 {} \;
         find /opt/monitor/monitor -type f -exec chmod 644 {} \;
         chmod 0644 /opt/monitor/setup.py /opt/monitor/requirements.txt
+        # Install/upgrade Python dependencies (e.g. zeroconf for mDNS browsing)
+        pip3 install -q -r /opt/monitor/requirements.txt
         # Pre-compile bytecode so first-request import is instant
         python3 -m compileall -q /opt/monitor/monitor
     "


### PR DESCRIPTION
## Summary

- **Camera pushes signed heartbeat every 15s** (`POST /cameras/heartbeat`) containing live streaming state, CPU temp, memory %, uptime, and current stream config — server never relies on stale mDNS state again
- **Server staleness checker** (daemon thread, 10s interval) marks cameras `offline` and clears `streaming=False` after 30s silence — at most 2 missed heartbeats before dashboard reflects reality
- **Pending config delivery loop closed** — when server has unsent config changes (`config_sync=pending`), heartbeat response includes `pending_config`; camera applies it immediately with `origin=server` to prevent ping-pong

## What changed

### Camera (`app/camera/`)
| File | Change |
|------|--------|
| `camera_streamer/heartbeat.py` | **New** — `HeartbeatSender`, HMAC signing, system metric helpers, pending config application |
| `camera_streamer/lifecycle.py` | Wires `HeartbeatSender` into `_do_running()` / `shutdown()` |
| `tests/unit/test_heartbeat.py` | **New** — 20 unit tests (signature, metrics, sender behaviour) |

### Server (`app/server/`)
| File | Change |
|------|--------|
| `monitor/api/cameras.py` | `POST /cameras/heartbeat` endpoint; `_verify_camera_hmac()` helper shared with config-notify |
| `monitor/services/camera_service.py` | `accept_heartbeat()` — updates status, health fields, stream config (guards pending); `list_cameras()` exposes new fields |
| `monitor/services/discovery.py` | `check_offline()` now also clears `streaming=False` |
| `monitor/__init__.py` | `_start_staleness_checker()` daemon thread wired into startup |
| `monitor/models.py` | 4 new `Camera` fields: `streaming`, `cpu_temp`, `memory_percent`, `uptime_seconds` |
| `monitor/templates/dashboard.html` | Streaming badge, relative last-seen with staleness colour, health metrics, 15s refresh |
| `monitor/static/css/style.css` | Badge + health metric styles |
| `tests/unit/test_camera_service.py` | 14 new `TestAcceptHeartbeat` tests |
| `tests/contracts/test_api_contracts.py` | 7 new `TestHeartbeatContract` tests |
| `tests/unit/test_svc_discovery.py` | 1 new staleness/streaming-clear test |

### Docs
| File | Change |
|------|--------|
| `docs/adr/0016-camera-health-heartbeat-protocol.md` | **New** — full ADR |

## Test plan

- [x] `pytest app/camera/tests/` — **464 passed** (444 before + 20 new)
- [x] `pytest app/server/tests/` — all passed (14 new service + 7 new contract + 1 new staleness)
- [x] `ruff check` — clean
- [x] `ruff format` — no diff

## Deployment notes

- No database migration needed — new `Camera` fields have safe defaults (`streaming=False`, `cpu_temp=0.0`, etc.)
- Camera devices need updated image (new `heartbeat.py` module included in `camera_streamer` package)
- Staleness checker starts automatically on server startup — no config change required

🤖 Generated with [Claude Code](https://claude.com/claude-code)