### PR TITLE
fix: bidirectional pairing sync + deterministic SIGTERM exit

### DIFF
--- a/app/camera/camera_streamer/discovery.py
+++ b/app/camera/camera_streamer/discovery.py
@@ -29,8 +29,9 @@ VERSION = "1.0.0"
 class DiscoveryService:
     """Advertise camera via mDNS/Avahi for server auto-discovery."""
 
-    def __init__(self, config):
+    def __init__(self, config, pairing_manager=None):
         self._config = config
+        self._pairing = pairing_manager
         self._process = None
         self._host_process = None
         self._running = False
@@ -46,7 +47,11 @@ class DiscoveryService:
 
         self._running = True
         camera_id = self._config.camera_id
-        paired = "true" if self._config.is_configured else "false"
+        # "paired" reflects true pairing state (client cert on disk), not
+        # just "server IP configured". Fixes the sync bug where a camera
+        # that was unpaired by the server kept advertising paired=true.
+        is_paired = bool(self._pairing and self._pairing.is_paired)
+        paired = "true" if is_paired else "false"
         resolution = f"{self._config.width}x{self._config.height}"
 
         # avahi-publish-service runs in foreground — keeps advertising

--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -33,6 +33,17 @@ HEARTBEAT_INTERVAL = 15  # seconds between heartbeats
 HEARTBEAT_TIMEOUT = 10  # seconds to wait for server response
 HEARTBEAT_JITTER = 3  # max random jitter in seconds to spread load
 
+# Unpair detection (ADR-0016 sync protocol)
+# When the server deletes a camera we never hear about it directly: the next
+# heartbeat just comes back with HTTP 401 "Unknown camera". To converge the
+# two sides back to a consistent state we treat N consecutive 401s from a
+# reachable server as "the server has forgotten me" and reset to unpaired.
+# A threshold (rather than acting on the first 401) avoids flapping during
+# transient DB issues or a simultaneous server restart. 5 heartbeats at
+# 15s each is ~75s, comfortably above the OFFLINE_TIMEOUT (30s) used on
+# the server side.
+UNPAIR_401_THRESHOLD = 5
+
 
 def _build_signature(
     secret_hex: str, camera_id: str, timestamp: str, body_bytes: bytes
@@ -120,6 +131,8 @@ class HeartbeatSender:
         self._thermal_path = thermal_path
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        # Track consecutive 401 Unknown-camera responses to detect server-side unpair
+        self._consecutive_unknown_camera = 0
 
     def start(self) -> None:
         """Start the heartbeat background thread."""
@@ -229,12 +242,83 @@ class HeartbeatSender:
                 resp_body = resp.read()
                 result = json.loads(resp_body) if resp_body else {}
                 log.debug("Heartbeat accepted by server (HTTP %d)", resp.status)
+                # Server accepted us — reset the unpair-detection counter
+                self._consecutive_unknown_camera = 0
                 return result
         except urllib.error.HTTPError as e:
-            log.warning("Heartbeat rejected by server: HTTP %d", e.code)
+            # 401 + "Unknown camera" means the server no longer has this camera
+            # in its database (admin deleted it). After UNPAIR_401_THRESHOLD
+            # consecutive such responses we assume the server really did unpair
+            # us and reset local state so the camera goes back into PAIRING.
+            body_text = ""
+            try:
+                body_text = e.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+            if e.code == 401 and "Unknown camera" in body_text:
+                self._consecutive_unknown_camera += 1
+                log.warning(
+                    "Heartbeat rejected by server: HTTP 401 Unknown camera "
+                    "(%d/%d) — server has forgotten this camera",
+                    self._consecutive_unknown_camera,
+                    UNPAIR_401_THRESHOLD,
+                )
+                if self._consecutive_unknown_camera >= UNPAIR_401_THRESHOLD:
+                    self._handle_server_unpair()
+            else:
+                log.warning("Heartbeat rejected by server: HTTP %d", e.code)
         except (urllib.error.URLError, OSError) as e:
+            # Network errors don't count as "server unpaired me" — the server
+            # might just be offline or the network might be flaky.
             log.debug("Heartbeat failed (server %s): %s", server_ip, e)
         return None
+
+    def _handle_server_unpair(self) -> None:
+        """Wipe local pairing state and exit so systemd restarts us into PAIRING.
+
+        Called when the server has repeatedly rejected heartbeats with
+        ``401 Unknown camera``. We delete client.crt/key and pairing_secret
+        so ``PairingManager.is_paired`` flips to False, then signal the
+        process to exit. systemd restarts camera-streamer and
+        ``CameraLifecycle._do_pairing`` runs again — the camera registers
+        itself as pending on the server and opens the /pair page.
+        """
+        log.error(
+            "Server has unpaired this camera (%d consecutive 401s). "
+            "Wiping local pairing state and restarting to re-enter pairing mode.",
+            self._consecutive_unknown_camera,
+        )
+        certs_dir = self._config.certs_dir
+        for name in ("client.crt", "client.key", "pairing_secret"):
+            path = os.path.join(certs_dir, name)
+            try:
+                if os.path.isfile(path):
+                    os.remove(path)
+                    log.info("Removed %s", path)
+            except OSError as exc:
+                log.warning("Failed to remove %s: %s", path, exc)
+
+        # Stop heartbeat so we don't loop; main process will notice and exit.
+        self._stop_event.set()
+        # Ask systemd to restart us cleanly. If this fails (e.g. running
+        # outside systemd in a test), fall back to SIGTERM on our PID so the
+        # service manager (or pytest) observes a clean exit.
+        try:
+            import subprocess
+
+            subprocess.Popen(
+                ["systemctl", "restart", "camera-streamer"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            log.warning("systemctl restart failed (%s); sending SIGTERM", exc)
+            try:
+                import signal
+
+                os.kill(os.getpid(), signal.SIGTERM)
+            except OSError:
+                pass
 
     def _apply_pending_config(self, pending: dict) -> None:
         """Apply a pending stream config pushed back by the server."""

--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -298,27 +298,23 @@ class HeartbeatSender:
             except OSError as exc:
                 log.warning("Failed to remove %s: %s", path, exc)
 
-        # Stop heartbeat so we don't loop; main process will notice and exit.
+        # Stop heartbeat loop — no more attempts from this thread.
         self._stop_event.set()
-        # Ask systemd to restart us cleanly. If this fails (e.g. running
-        # outside systemd in a test), fall back to SIGTERM on our PID so the
-        # service manager (or pytest) observes a clean exit.
+        # Signal the main process to exit so systemd restarts us cleanly.
+        # os.kill(pid, SIGTERM) is reliable regardless of how the service was
+        # launched (systemd, Docker, manual run). The main.py signal handler
+        # sets _shutdown=True, the lifecycle tears down gracefully, and systemd
+        # sees the exit and starts a fresh process in PAIRING state.
+        # (Calling "systemctl restart" from within the service is unreliable:
+        # on some systemd versions it blocks waiting for the unit to stop,
+        # creating a deadlock, and on BusyBox-based Yocto images the systemctl
+        # binary may silently do nothing.)
+        import signal as _signal
+
         try:
-            import subprocess
-
-            subprocess.Popen(
-                ["systemctl", "restart", "camera-streamer"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-        except (FileNotFoundError, OSError) as exc:
-            log.warning("systemctl restart failed (%s); sending SIGTERM", exc)
-            try:
-                import signal
-
-                os.kill(os.getpid(), signal.SIGTERM)
-            except OSError:
-                pass
+            os.kill(os.getpid(), _signal.SIGTERM)
+        except OSError as exc:
+            log.warning("Failed to send SIGTERM to self: %s", exc)
 
     def _apply_pending_config(self, pending: dict) -> None:
         """Apply a pending stream config pushed back by the server."""

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -465,7 +465,14 @@ class CameraLifecycle:
 
     @staticmethod
     def _revert_to_setup():
-        """Remove setup stamp and restart service for setup wizard."""
+        """Remove setup stamp and exit so systemd respawns us into setup mode.
+
+        SIGTERM-to-self rather than ``systemctl restart camera-streamer``:
+        calling systemctl on our own unit from inside the unit is unreliable
+        (D-Bus deadlocks on some systemd versions, silent no-op on BusyBox
+        Yocto builds). Relying on ``Restart=always`` in the unit file is the
+        portable pattern — see heartbeat._handle_server_unpair for details.
+        """
         stamp = "/data/.setup-done"
         try:
             if os.path.isfile(stamp):
@@ -474,12 +481,10 @@ class CameraLifecycle:
         except OSError as e:
             log.error("Failed to remove setup stamp: %s", e)
 
-        log.info("Restarting camera-streamer service to enter setup mode...")
+        log.info("Exiting (SIGTERM) so systemd restarts us into setup mode...")
+        import signal as _signal
+
         try:
-            subprocess.run(
-                ["systemctl", "restart", "camera-streamer"],
-                capture_output=True,
-                timeout=10,
-            )
-        except Exception as e:
-            log.error("Failed to restart service: %s", e)
+            os.kill(os.getpid(), _signal.SIGTERM)
+        except OSError as e:
+            log.error("Failed to send SIGTERM to self: %s", e)

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -260,8 +260,10 @@ class CameraLifecycle:
 
     def _do_running(self):
         """Start all runtime services and enter main loop."""
-        # mDNS advertisement
-        self._discovery = DiscoveryService(self._config)
+        # mDNS advertisement — pass pairing manager so TXT paired= reflects
+        # real state (not just "has server IP"). Server-side discovery can
+        # then prefer cameras advertising paired=false as pending candidates.
+        self._discovery = DiscoveryService(self._config, pairing_manager=self._pairing)
         self._discovery.start()
 
         # RTSP streaming

--- a/app/camera/camera_streamer/main.py
+++ b/app/camera/camera_streamer/main.py
@@ -6,7 +6,9 @@ CameraLifecycle for the full startup/streaming/shutdown state machine.
 """
 
 import logging
+import os
 import signal
+import threading
 
 from camera_streamer.logging_config import configure_logging
 
@@ -16,12 +18,46 @@ log = logging.getLogger("camera-streamer")
 # Global shutdown flag
 _shutdown = False
 
+# Graceful-shutdown budget. If lifecycle.shutdown() does not return within
+# this many seconds of receiving SIGTERM, we force the process to exit so
+# systemd (Restart=always) respawns us cleanly. This matters because
+# shutdown involves joining threads that wait on ffmpeg and on blocking
+# socket I/O in HTTPServer.shutdown(); any one of those can block the
+# main thread indefinitely and leave systemd thinking we are still healthy.
+# 8s is comfortably longer than any well-behaved teardown path (ffmpeg
+# SIGTERM → exit is ~1s, HTTPServer.shutdown ~0.5s) but short enough that
+# the user sees the unit restart within a human-scale window.
+_SHUTDOWN_WATCHDOG_SECONDS = 8.0
+
 
 def _handle_signal(signum, frame):
-    """Handle SIGTERM/SIGINT for graceful shutdown."""
+    """Handle SIGTERM/SIGINT. Set graceful flag + arm forced-exit watchdog.
+
+    Second signal = immediate force exit (user is impatient / systemd
+    has escalated to SIGKILL pressure).
+    """
     global _shutdown
-    log.info("Received signal %d, shutting down...", signum)
+    if _shutdown:
+        log.warning("Second signal %d — forcing immediate exit", signum)
+        os._exit(1)
+    log.info(
+        "Received signal %d, shutting down (watchdog %.1fs)...",
+        signum,
+        _SHUTDOWN_WATCHDOG_SECONDS,
+    )
     _shutdown = True
+
+    def _force_exit():
+        log.warning(
+            "Graceful shutdown did not complete in %.1fs — forcing exit "
+            "(systemd will respawn us).",
+            _SHUTDOWN_WATCHDOG_SECONDS,
+        )
+        os._exit(0)
+
+    t = threading.Timer(_SHUTDOWN_WATCHDOG_SECONDS, _force_exit)
+    t.daemon = True
+    t.start()
 
 
 def main():

--- a/app/camera/camera_streamer/pairing.py
+++ b/app/camera/camera_streamer/pairing.py
@@ -226,3 +226,24 @@ class PairingManager:
                 return f.read().strip()
         except OSError:
             return ""
+
+    def reset_local_state(self):
+        """Wipe local pairing state so the camera becomes unpaired.
+
+        Deletes ``client.crt``, ``client.key`` and ``pairing_secret``. The CA
+        cert is kept intact — it is still a valid TOFU anchor for the next
+        exchange with the same server. After this call ``is_paired`` is False.
+
+        Used when:
+          - the Re-pair UI starts a new exchange (stale certs must not be
+            left behind if the exchange fails)
+          - the heartbeat sender detects the server has unpaired this camera
+        """
+        for name in ("client.crt", "client.key", "pairing_secret"):
+            path = os.path.join(self._certs_dir, name)
+            try:
+                if os.path.isfile(path):
+                    os.remove(path)
+                    log.info("Removed %s during pairing reset", path)
+            except OSError as exc:
+                log.warning("Failed to remove %s: %s", path, exc)

--- a/app/camera/camera_streamer/pairing.py
+++ b/app/camera/camera_streamer/pairing.py
@@ -238,6 +238,7 @@ class PairingManager:
           - the Re-pair UI starts a new exchange (stale certs must not be
             left behind if the exchange fails)
           - the heartbeat sender detects the server has unpaired this camera
+          - the user manually clicks Unpair on the camera /pair page
         """
         for name in ("client.crt", "client.key", "pairing_secret"):
             path = os.path.join(self._certs_dir, name)
@@ -247,3 +248,79 @@ class PairingManager:
                     log.info("Removed %s during pairing reset", path)
             except OSError as exc:
                 log.warning("Failed to remove %s: %s", path, exc)
+
+    def send_goodbye(self, server_url, timeout=10):
+        """Send a signed goodbye to the server so it drops our cert + row.
+
+        Called by the camera-initiated unpair flow. The signature uses the
+        current ``pairing_secret`` — valid right now, gone a moment later.
+        Returns ``(ok, error_message)``. Network / HTTP failures are
+        non-fatal to the overall unpair: the camera will wipe local state
+        either way, and the server's OFFLINE_TIMEOUT + paired=false mDNS
+        path will reconcile within ~30s even if the goodbye is lost.
+        """
+        import hashlib
+        import hmac
+        import json
+        import time
+
+        camera_id = self._config.camera_id
+        if not camera_id:
+            return False, "Camera ID not configured"
+
+        secret = self.get_pairing_secret()
+        if not secret:
+            return False, "Not paired — no secret to sign goodbye with"
+
+        base = (server_url or "").rstrip("/")
+        if not base:
+            return False, "Server URL not configured"
+
+        url = f"{base}/api/v1/cameras/goodbye"
+        timestamp = str(int(time.time()))
+        body = json.dumps({"camera_id": camera_id}).encode()
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"{camera_id}:{timestamp}:{body_hash}"
+        try:
+            signature = hmac.new(
+                bytes.fromhex(secret), message.encode(), hashlib.sha256
+            ).hexdigest()
+        except ValueError:
+            return False, "Stored pairing secret is not valid hex"
+
+        # mTLS context — server only accepts our signed requests when they
+        # come over a TLS connection presenting our client cert.
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        if os.path.isfile(self.client_cert_path) and os.path.isfile(
+            self.client_key_path
+        ):
+            ctx.load_cert_chain(self.client_cert_path, self.client_key_path)
+
+        req = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-Camera-ID": camera_id,
+                "X-Timestamp": timestamp,
+                "X-Signature": signature,
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, context=ctx, timeout=timeout):
+                log.info("Goodbye acknowledged by server")
+                return True, ""
+        except urllib.error.HTTPError as exc:
+            body_text = ""
+            try:
+                body_text = exc.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+            log.warning("Goodbye rejected by server (HTTP %d): %s", exc.code, body_text)
+            return False, f"HTTP {exc.code}"
+        except (urllib.error.URLError, OSError) as exc:
+            log.warning("Goodbye request failed: %s", exc)
+            return False, str(exc)

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -834,6 +834,13 @@ def _make_status_handler(
                     self._serve_pair_page(error="PIN and server URL are required")
                 return
 
+            # Re-pair flow: if this camera is already paired (stale certs from
+            # a previous server that has since forgotten us), wipe local state
+            # first. Otherwise a failed exchange would leave the GUI reading
+            # "Paired" because is_paired just checks the cert file's presence.
+            if pairing_manager.is_paired:
+                pairing_manager.reset_local_state()
+
             ok, err = pairing_manager.exchange(pin, server_url)
             if "application/json" in content_type:
                 if ok:

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -347,7 +347,10 @@ h1{font-size:1.4em}
 label{display:block;margin-top:12px;font-weight:bold}
 input{width:100%;padding:8px;margin-top:4px;box-sizing:border-box;font-size:1em}
 button{margin-top:16px;padding:10px 24px;font-size:1em;cursor:pointer}
+button.danger{background:#c0392b;color:#fff;border:0;border-radius:4px}
+button.danger:hover{background:#a53125}
 .status{margin-bottom:16px;padding:8px;background:#f0f0f0;border-radius:4px}
+.unpair-note{color:#666;font-size:.9em;margin-top:8px}
 </style>
 </head>
 <body>
@@ -368,7 +371,41 @@ button{margin-top:16px;padding:10px 24px;font-size:1em;cursor:pointer}
 <button type="submit">Pair</button>
 </form>
 </div>
+<div style="display:{{UNPAIR_DISPLAY}}">
+<p>This camera is paired with <strong>{{SERVER_URL}}</strong>. Forget this server to re-pair with a different one or clear the link entirely.</p>
+<button id="unpair-btn" class="danger" type="button">Unpair / Forget server</button>
+<p id="unpair-msg" class="unpair-note"></p>
+</div>
 <p><a href="/">Back to status</a></p>
+<script>
+(function(){
+  var btn = document.getElementById('unpair-btn');
+  if (!btn) return;
+  btn.addEventListener('click', function(){
+    if (!confirm('Forget this server?\\n\\nThe camera will stop streaming until it is paired again.')) {
+      return;
+    }
+    btn.disabled = true;
+    var msg = document.getElementById('unpair-msg');
+    msg.textContent = 'Unpairing…';
+    fetch('/api/unpair', {method:'POST', headers:{'Content-Type':'application/json'}})
+      .then(function(r){ return r.json().then(function(j){ return {ok:r.ok, body:j}; }); })
+      .then(function(res){
+        if (res.ok) {
+          msg.textContent = 'Unpaired. Restarting camera service — page will reload shortly.';
+          setTimeout(function(){ window.location.reload(); }, 6000);
+        } else {
+          btn.disabled = false;
+          msg.textContent = 'Failed: ' + ((res.body && res.body.error) || 'unknown error');
+        }
+      })
+      .catch(function(err){
+        btn.disabled = false;
+        msg.textContent = 'Failed: ' + err;
+      });
+  });
+})();
+</script>
 </body>
 </html>
 """
@@ -607,6 +644,10 @@ def _make_status_handler(
                 if not self._require_auth():
                     return
                 self._handle_factory_reset()
+            elif self.path == "/api/unpair":
+                if not self._require_auth():
+                    return
+                self._handle_unpair()
             elif self.path == "/api/password":
                 if not self._require_auth():
                     return
@@ -789,6 +830,7 @@ def _make_status_handler(
                 .replace("{{SUCCESS}}", _html_escape(success))
                 .replace("{{SUCCESS_DISPLAY}}", "block" if success else "none")
                 .replace("{{FORM_DISPLAY}}", "none" if is_paired else "block")
+                .replace("{{UNPAIR_DISPLAY}}", "block" if is_paired else "none")
                 .replace("{{SERVER_URL}}", _html_escape(server_url))
                 .replace("{{SERVER_INFO_DISPLAY}}", "block" if has_server else "none")
                 .replace("{{SERVER_INPUT_DISPLAY}}", "none" if has_server else "block")
@@ -844,16 +886,38 @@ def _make_status_handler(
             ok, err = pairing_manager.exchange(pin, server_url)
             if "application/json" in content_type:
                 if ok:
-                    self._json_response({"message": "Pairing successful"})
+                    self._json_response({"message": "Pairing successful — restarting"})
                 else:
                     self._json_response({"error": err}, 400)
             else:
                 if ok:
                     self._serve_pair_page(
-                        success="Pairing successful! Camera is now paired."
+                        success="Pairing successful! Camera is restarting…"
                     )
                 else:
                     self._serve_pair_page(error=err)
+
+            if ok:
+                # Restart the service so the lifecycle enters RUNNING state
+                # cleanly with the new client cert and starts the heartbeat
+                # sender. Without a restart, a camera that was auto-wiped
+                # (heartbeat 401 path) would have a dead heartbeat thread and
+                # would never send heartbeats even though certs are now valid.
+                def _restart_after_pair():
+                    import time as _t
+
+                    _t.sleep(0.5)
+                    import os as _os
+                    import signal as _sig
+
+                    try:
+                        _os.kill(_os.getpid(), _sig.SIGTERM)
+                    except OSError:
+                        pass
+
+                import threading as _t2
+
+                _t2.Thread(target=_restart_after_pair, daemon=True).start()
 
         def _handle_factory_reset(self):
             """Wipe camera config, certs, and restart in setup mode.
@@ -865,5 +929,70 @@ def _make_status_handler(
             reset_svc = FactoryResetService(config, data_dir)
             msg, status = reset_svc.execute_reset()
             self._json_response({"message": msg}, status)
+
+        def _handle_unpair(self):
+            """Camera-initiated unpair ("forget this server").
+
+            Steps — kept deliberately simple, modelled on Bluetooth's
+            "Forget device" UX:
+              1. Best-effort signed goodbye to the server so the dashboard
+                 updates immediately (pairing_service.unpair on that side).
+              2. Wipe local client.crt / client.key / pairing_secret. From
+                 this moment is_paired returns False.
+              3. Send the JSON response to the browser before we pull the
+                 rug — if we restart first the response never lands and the
+                 user sees a spinner forever.
+              4. SIGTERM ourselves on a background thread so the HTTP
+                 response flushes first. systemd's Restart=always respawns
+                 camera-streamer; the lifecycle re-enters PAIRING and the
+                 /pair page shows the PIN form again in a few seconds.
+                 (Calling "systemctl restart" on our own unit from inside
+                 the unit is unreliable — see heartbeat._handle_server_unpair
+                 for the full rationale.)
+
+            If goodbye fails (server offline), we still wipe locally and
+            restart — the server will reconcile via mDNS paired=false or
+            the 30s OFFLINE_TIMEOUT. This matches Bluetooth: either side
+            can forget independently.
+            """
+            if pairing_manager is None or not pairing_manager.is_paired:
+                self._json_response({"error": "Camera is not currently paired"}, 400)
+                return
+
+            server_url = config.server_https_url or ""
+            goodbye_ok, goodbye_err = False, ""
+            try:
+                goodbye_ok, goodbye_err = pairing_manager.send_goodbye(server_url)
+            except Exception as exc:  # never let goodbye block the unpair
+                log.warning("send_goodbye raised: %s", exc)
+
+            # Local wipe is authoritative — we are unpaired from this moment.
+            pairing_manager.reset_local_state()
+
+            self._json_response(
+                {
+                    "message": "Camera unpaired",
+                    "goodbye_acknowledged": goodbye_ok,
+                    "goodbye_error": "" if goodbye_ok else goodbye_err,
+                }
+            )
+
+            # Schedule SIGTERM on a background thread so the HTTP response
+            # is flushed to the client before the process exits.
+            def _restart():
+                import time as _t
+
+                _t.sleep(0.5)
+                import os as _os
+                import signal as _sig
+
+                try:
+                    _os.kill(_os.getpid(), _sig.SIGTERM)
+                except OSError:
+                    pass
+
+            import threading as _threading
+
+            _threading.Thread(target=_restart, daemon=True).start()
 
     return StatusHandler

--- a/app/camera/tests/integration/test_lifecycle.py
+++ b/app/camera/tests/integration/test_lifecycle.py
@@ -469,21 +469,30 @@ class TestResolveServer:
 class TestRevertToSetup:
     """Test setup revert mechanism."""
 
-    @patch("camera_streamer.lifecycle.subprocess")
     @patch("camera_streamer.lifecycle.os")
-    def test_removes_stamp_and_restarts(self, mock_os, mock_subprocess):
+    def test_removes_stamp_and_signals_self(self, mock_os):
+        """Reverting to setup wipes the stamp and SIGTERMs self.
+
+        We deliberately do NOT shell out to systemctl (D-Bus deadlock on
+        some systemd versions, silent no-op on BusyBox Yocto). systemd's
+        Restart=always respawns us into SETUP on the next run.
+        """
+        import signal as _signal
+
         mock_os.path.isfile.return_value = True
+        mock_os.getpid.return_value = 4242
 
         CameraLifecycle._revert_to_setup()
 
         mock_os.remove.assert_called_once_with("/data/.setup-done")
-        mock_subprocess.run.assert_called_once()
+        mock_os.kill.assert_called_once_with(4242, _signal.SIGTERM)
 
-    @patch("camera_streamer.lifecycle.subprocess")
     @patch("camera_streamer.lifecycle.os")
-    def test_handles_missing_stamp(self, mock_os, mock_subprocess):
+    def test_handles_missing_stamp(self, mock_os):
         mock_os.path.isfile.return_value = False
 
         CameraLifecycle._revert_to_setup()
 
         mock_os.remove.assert_not_called()
+        # Still sends SIGTERM — entering setup requires a clean respawn
+        mock_os.kill.assert_called_once()

--- a/app/camera/tests/unit/test_discovery.py
+++ b/app/camera/tests/unit/test_discovery.py
@@ -14,7 +14,71 @@ class TestDiscoveryService:
         assert svc.is_advertising is False
 
     def test_start_launches_avahi_publish(self, camera_config):
-        """start() should launch avahi-publish-service."""
+        """start() should launch avahi-publish-service, paired flag reflects PairingManager."""
+        pairing = MagicMock()
+        pairing.is_paired = True
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
+            proc = MagicMock()
+            proc.poll.return_value = None
+            mock_popen.side_effect = [proc, proc]
+
+            svc = DiscoveryService(camera_config, pairing_manager=pairing)
+            svc.start()
+            assert svc.is_advertising is True
+
+            service_args = mock_popen.call_args_list[0][0][0]
+            host_args = mock_popen.call_args_list[1][0][0]
+            assert service_args[0] == "avahi-publish-service"
+            assert SERVICE_TYPE in service_args
+            assert str(SERVICE_PORT) in service_args
+            assert "id=cam-test001" in service_args
+            # paired flag now tracks PairingManager.is_paired, not config
+            assert "paired=true" in service_args
+            assert host_args[:4] == [
+                "avahi-publish-address",
+                "-R",
+                "-f",
+                "cam-test.local",
+            ]
+            assert host_args[4] == "192.168.1.50"
+
+            svc.stop()
+
+    def test_start_unpaired(self, unconfigured_config):
+        """Camera without a PairingManager (or with is_paired=False) advertises paired=false."""
+        pairing = MagicMock()
+        pairing.is_paired = False
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
+            proc = MagicMock()
+            proc.poll.return_value = None
+            mock_popen.side_effect = [proc, proc]
+
+            svc = DiscoveryService(unconfigured_config, pairing_manager=pairing)
+            svc.start()
+            args = mock_popen.call_args_list[0][0][0]
+            assert "paired=false" in args
+            svc.stop()
+
+    def test_start_no_pairing_manager_defaults_unpaired(self, camera_config):
+        """Backwards-compat: no pairing_manager arg -> advertises paired=false."""
         with (
             patch("subprocess.Popen") as mock_popen,
             patch(
@@ -30,43 +94,6 @@ class TestDiscoveryService:
             mock_popen.side_effect = [proc, proc]
 
             svc = DiscoveryService(camera_config)
-            svc.start()
-            assert svc.is_advertising is True
-
-            service_args = mock_popen.call_args_list[0][0][0]
-            host_args = mock_popen.call_args_list[1][0][0]
-            assert service_args[0] == "avahi-publish-service"
-            assert SERVICE_TYPE in service_args
-            assert str(SERVICE_PORT) in service_args
-            assert "id=cam-test001" in service_args
-            assert "paired=true" in service_args  # configured = paired
-            assert host_args[:4] == [
-                "avahi-publish-address",
-                "-R",
-                "-f",
-                "cam-test.local",
-            ]
-            assert host_args[4] == "192.168.1.50"
-
-            svc.stop()
-
-    def test_start_unpaired(self, unconfigured_config):
-        """Unpaired camera should advertise paired=false."""
-        with (
-            patch("subprocess.Popen") as mock_popen,
-            patch(
-                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
-            ),
-            patch(
-                "camera_streamer.discovery.wifi.get_ip_address",
-                return_value="192.168.1.50",
-            ),
-        ):
-            proc = MagicMock()
-            proc.poll.return_value = None
-            mock_popen.side_effect = [proc, proc]
-
-            svc = DiscoveryService(unconfigured_config)
             svc.start()
             args = mock_popen.call_args_list[0][0][0]
             assert "paired=false" in args

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -327,9 +327,7 @@ class TestHeartbeatUnpairDetection:
         err = self._http_error(401, '{"error": "Unknown camera"}')
         with (
             patch("camera_streamer.heartbeat.ssl.SSLContext"),
-            patch(
-                "camera_streamer.heartbeat.urllib.request.urlopen", side_effect=err
-            ),
+            patch("camera_streamer.heartbeat.urllib.request.urlopen", side_effect=err),
         ):
             sender.send_once()
         assert sender._consecutive_unknown_camera == 1
@@ -364,9 +362,7 @@ class TestHeartbeatUnpairDetection:
         err = self._http_error(401, '{"error": "Invalid signature"}')
         with (
             patch("camera_streamer.heartbeat.ssl.SSLContext"),
-            patch(
-                "camera_streamer.heartbeat.urllib.request.urlopen", side_effect=err
-            ),
+            patch("camera_streamer.heartbeat.urllib.request.urlopen", side_effect=err),
         ):
             sender.send_once()
         assert sender._consecutive_unknown_camera == 0
@@ -390,7 +386,7 @@ class TestHeartbeatUnpairDetection:
 
     def test_threshold_triggers_wipe_and_restart(self, tmp_path):
         """After UNPAIR_401_THRESHOLD consecutive Unknown-camera responses we wipe
-        local certs and ask systemd to restart us."""
+        local certs and send SIGTERM to self so systemd restarts us."""
         from camera_streamer.heartbeat import UNPAIR_401_THRESHOLD
 
         cfg = _make_config()
@@ -401,16 +397,15 @@ class TestHeartbeatUnpairDetection:
         (tmp_path / "pairing_secret").write_text("SECRET")
 
         sender = HeartbeatSender(cfg, _make_pairing())
-        popen_calls = []
-
-        class _FakePopen:
-            def __init__(self, cmd, **kw):
-                popen_calls.append(cmd)
+        kill_calls = []
 
         # Build a fresh HTTPError for every call — the body BytesIO is
         # exhausted after a single read().
         def _fresh_err(*_a, **_kw):
             raise self._http_error(401, '{"error": "Unknown camera"}')
+
+        def _fake_kill(pid, sig):
+            kill_calls.append((pid, sig))
 
         with (
             patch("camera_streamer.heartbeat.ssl.SSLContext"),
@@ -418,14 +413,19 @@ class TestHeartbeatUnpairDetection:
                 "camera_streamer.heartbeat.urllib.request.urlopen",
                 side_effect=_fresh_err,
             ),
-            patch("subprocess.Popen", _FakePopen),
+            patch("camera_streamer.heartbeat.os.kill", _fake_kill),
         ):
             for _ in range(UNPAIR_401_THRESHOLD):
                 sender.send_once()
 
-        # Certs gone, systemctl invoked, stop flag set
+        # Certs gone, SIGTERM sent to self, stop flag set
+        import os
+        import signal
+
         assert not (tmp_path / "client.crt").exists()
         assert not (tmp_path / "client.key").exists()
         assert not (tmp_path / "pairing_secret").exists()
-        assert any("systemctl" in cmd[0] for cmd in popen_calls)
+        assert any(
+            pid == os.getpid() and sig == signal.SIGTERM for pid, sig in kill_calls
+        )
         assert sender._stop_event.is_set()

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -301,3 +301,131 @@ class TestHeartbeatSender:
             sender.start()
             assert sender._thread is first_thread
             sender.stop()
+
+
+class TestHeartbeatUnpairDetection:
+    """Server-side unpair detection — 401 Unknown camera threshold logic."""
+
+    def _http_error(self, code, body_text):
+        """Build a urllib HTTPError with a readable body."""
+        import io
+        import urllib.error
+
+        return urllib.error.HTTPError(
+            url="https://srv/",
+            code=code,
+            msg="err",
+            hdrs=None,
+            fp=io.BytesIO(body_text.encode()),
+        )
+
+    def test_401_unknown_camera_counts_increment(self, tmp_path):
+        cfg = _make_config()
+        cfg.certs_dir = str(tmp_path)
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        err = self._http_error(401, '{"error": "Unknown camera"}')
+        with (
+            patch("camera_streamer.heartbeat.ssl.SSLContext"),
+            patch(
+                "camera_streamer.heartbeat.urllib.request.urlopen", side_effect=err
+            ),
+        ):
+            sender.send_once()
+        assert sender._consecutive_unknown_camera == 1
+
+    def test_successful_heartbeat_resets_counter(self, tmp_path):
+        cfg = _make_config()
+        cfg.certs_dir = str(tmp_path)
+        sender = HeartbeatSender(cfg, _make_pairing())
+        sender._consecutive_unknown_camera = 3
+
+        resp = MagicMock()
+        resp.read.return_value = b"{}"
+        resp.status = 200
+        resp.__enter__ = lambda self: self
+        resp.__exit__ = lambda self, *a: False
+
+        with (
+            patch("camera_streamer.heartbeat.ssl.SSLContext"),
+            patch(
+                "camera_streamer.heartbeat.urllib.request.urlopen", return_value=resp
+            ),
+        ):
+            sender.send_once()
+        assert sender._consecutive_unknown_camera == 0
+
+    def test_other_401_does_not_trigger_unpair(self, tmp_path):
+        """A 401 without 'Unknown camera' (e.g. replay, bad signature) must not unpair us."""
+        cfg = _make_config()
+        cfg.certs_dir = str(tmp_path)
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        err = self._http_error(401, '{"error": "Invalid signature"}')
+        with (
+            patch("camera_streamer.heartbeat.ssl.SSLContext"),
+            patch(
+                "camera_streamer.heartbeat.urllib.request.urlopen", side_effect=err
+            ),
+        ):
+            sender.send_once()
+        assert sender._consecutive_unknown_camera == 0
+
+    def test_network_error_does_not_count_as_unpair(self, tmp_path):
+        import urllib.error
+
+        cfg = _make_config()
+        cfg.certs_dir = str(tmp_path)
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        with (
+            patch("camera_streamer.heartbeat.ssl.SSLContext"),
+            patch(
+                "camera_streamer.heartbeat.urllib.request.urlopen",
+                side_effect=urllib.error.URLError("unreachable"),
+            ),
+        ):
+            sender.send_once()
+        assert sender._consecutive_unknown_camera == 0
+
+    def test_threshold_triggers_wipe_and_restart(self, tmp_path):
+        """After UNPAIR_401_THRESHOLD consecutive Unknown-camera responses we wipe
+        local certs and ask systemd to restart us."""
+        from camera_streamer.heartbeat import UNPAIR_401_THRESHOLD
+
+        cfg = _make_config()
+        cfg.certs_dir = str(tmp_path)
+        # Seed the certs we expect to be removed
+        (tmp_path / "client.crt").write_text("CERT")
+        (tmp_path / "client.key").write_text("KEY")
+        (tmp_path / "pairing_secret").write_text("SECRET")
+
+        sender = HeartbeatSender(cfg, _make_pairing())
+        popen_calls = []
+
+        class _FakePopen:
+            def __init__(self, cmd, **kw):
+                popen_calls.append(cmd)
+
+        # Build a fresh HTTPError for every call — the body BytesIO is
+        # exhausted after a single read().
+        def _fresh_err(*_a, **_kw):
+            raise self._http_error(401, '{"error": "Unknown camera"}')
+
+        with (
+            patch("camera_streamer.heartbeat.ssl.SSLContext"),
+            patch(
+                "camera_streamer.heartbeat.urllib.request.urlopen",
+                side_effect=_fresh_err,
+            ),
+            patch("subprocess.Popen", _FakePopen),
+        ):
+            for _ in range(UNPAIR_401_THRESHOLD):
+                sender.send_once()
+
+        # Certs gone, systemctl invoked, stop flag set
+        assert not (tmp_path / "client.crt").exists()
+        assert not (tmp_path / "client.key").exists()
+        assert not (tmp_path / "pairing_secret").exists()
+        assert any("systemctl" in cmd[0] for cmd in popen_calls)
+        assert sender._stop_event.is_set()

--- a/app/camera/tests/unit/test_main_signal.py
+++ b/app/camera/tests/unit/test_main_signal.py
@@ -1,0 +1,45 @@
+"""Tests for main._handle_signal — SIGTERM must always produce process exit.
+
+A hung ``lifecycle.shutdown()`` (ffmpeg wait, HTTPServer.shutdown blocking
+on a slow client, etc.) must not be able to keep the process alive past
+the graceful-shutdown budget, otherwise systemd never sees us exit and
+never respawns us. The watchdog timer is the architectural guarantee
+that SIGTERM always results in os._exit, even when cooperative teardown
+has deadlocked — see the auto-unpair and re-pair flows in
+heartbeat.py and status_server.py.
+"""
+
+from unittest.mock import patch
+
+import camera_streamer.main as main_mod
+
+
+class TestHandleSignal:
+    def setup_method(self):
+        # Reset module-level flag between tests
+        main_mod._shutdown = False
+
+    def test_first_signal_sets_flag_and_arms_watchdog(self):
+        with patch("camera_streamer.main.threading.Timer") as mock_timer:
+            main_mod._handle_signal(15, None)
+
+            assert main_mod._shutdown is True
+            # Watchdog Timer instantiated with the configured budget
+            args, _ = mock_timer.call_args
+            assert args[0] == main_mod._SHUTDOWN_WATCHDOG_SECONDS
+            # The target is a force-exit callable (we check it by calling it
+            # under a patched os._exit so we don't kill the pytest process)
+            target = args[1]
+            with patch("camera_streamer.main.os._exit") as mock_exit:
+                target()
+                mock_exit.assert_called_once_with(0)
+            # Timer started as a daemon so it never blocks process exit
+            instance = mock_timer.return_value
+            assert instance.daemon is True
+            instance.start.assert_called_once()
+
+    def test_second_signal_forces_immediate_exit(self):
+        main_mod._shutdown = True  # simulate first SIGTERM already handled
+        with patch("camera_streamer.main.os._exit") as mock_exit:
+            main_mod._handle_signal(15, None)
+            mock_exit.assert_called_once_with(1)

--- a/app/camera/tests/unit/test_pairing_unpair.py
+++ b/app/camera/tests/unit/test_pairing_unpair.py
@@ -1,0 +1,154 @@
+"""Unit tests for the camera-initiated unpair flow (ADR-0016 sync protocol).
+
+Covers:
+  * ``PairingManager.reset_local_state`` — wipes client cert, key, and
+    pairing secret while leaving the CA cert intact so the next exchange
+    with the same server can still TOFU-verify it.
+  * ``PairingManager.send_goodbye`` — builds the HMAC-signed POST body,
+    reports success on HTTP 200, and does not raise on transport / HTTP
+    errors (unpair must continue locally regardless).
+"""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import MagicMock, patch
+
+from camera_streamer.pairing import PairingManager
+
+
+def _make_config(camera_id="cam-abc123"):
+    cfg = MagicMock()
+    cfg.camera_id = camera_id
+    return cfg
+
+
+class TestResetLocalState:
+    def test_removes_client_cert_key_and_secret(self, tmp_path):
+        (tmp_path / "client.crt").write_text("CERT")
+        (tmp_path / "client.key").write_text("KEY")
+        (tmp_path / "pairing_secret").write_text("SECRET")
+        (tmp_path / "ca.crt").write_text("CA")  # must survive
+
+        pm = PairingManager(_make_config(), certs_dir=str(tmp_path))
+        pm.reset_local_state()
+
+        assert not (tmp_path / "client.crt").exists()
+        assert not (tmp_path / "client.key").exists()
+        assert not (tmp_path / "pairing_secret").exists()
+        # CA cert is the TOFU anchor — must NOT be wiped
+        assert (tmp_path / "ca.crt").read_text() == "CA"
+
+    def test_is_idempotent(self, tmp_path):
+        pm = PairingManager(_make_config(), certs_dir=str(tmp_path))
+        pm.reset_local_state()  # nothing there, must not raise
+        pm.reset_local_state()
+
+
+class TestSendGoodbye:
+    def _pm_with_certs(self, tmp_path, secret="ab" * 32):
+        (tmp_path / "client.crt").write_text("CERT")
+        (tmp_path / "client.key").write_text("KEY")
+        (tmp_path / "pairing_secret").write_text(secret)
+        return PairingManager(_make_config(), certs_dir=str(tmp_path))
+
+    def test_skips_without_server_url(self, tmp_path):
+        pm = self._pm_with_certs(tmp_path)
+        ok, err = pm.send_goodbye("")
+        assert ok is False
+        assert "Server URL" in err
+
+    def test_skips_without_secret(self, tmp_path):
+        pm = PairingManager(_make_config(), certs_dir=str(tmp_path))
+        ok, err = pm.send_goodbye("https://srv")
+        assert ok is False
+        assert "secret" in err.lower()
+
+    def test_posts_signed_request(self, tmp_path):
+        secret = "ab" * 32
+        pm = self._pm_with_certs(tmp_path, secret=secret)
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return b""
+
+        def _urlopen(req, context=None, timeout=None):
+            captured["url"] = req.full_url
+            captured["headers"] = dict(req.header_items())
+            captured["body"] = req.data
+            return _Resp()
+
+        with (
+            patch("camera_streamer.pairing.urllib.request.urlopen", _urlopen),
+            patch("camera_streamer.pairing.ssl.SSLContext"),
+        ):
+            ok, err = pm.send_goodbye("https://srv")
+
+        assert ok is True and err == ""
+        assert captured["url"].endswith("/api/v1/cameras/goodbye")
+
+        # Headers present
+        headers = {k.lower(): v for k, v in captured["headers"].items()}
+        assert headers["x-camera-id"] == "cam-abc123"
+        assert "x-timestamp" in headers
+        assert "x-signature" in headers
+
+        # Signature matches scheme: HMAC(secret, id:ts:sha256(body))
+        body_hash = hashlib.sha256(captured["body"]).hexdigest()
+        message = f"cam-abc123:{headers['x-timestamp']}:{body_hash}"
+        expected = hmac.new(
+            bytes.fromhex(secret), message.encode(), hashlib.sha256
+        ).hexdigest()
+        assert headers["x-signature"] == expected
+
+        # Body contains camera_id
+        assert json.loads(captured["body"])["camera_id"] == "cam-abc123"
+
+    def test_reports_http_error_without_raising(self, tmp_path):
+        import io
+        import urllib.error
+
+        pm = self._pm_with_certs(tmp_path)
+
+        def _raise(*_a, **_kw):
+            raise urllib.error.HTTPError(
+                url="https://srv/",
+                code=401,
+                msg="err",
+                hdrs=None,
+                fp=io.BytesIO(b'{"error":"Unknown camera"}'),
+            )
+
+        with (
+            patch("camera_streamer.pairing.urllib.request.urlopen", _raise),
+            patch("camera_streamer.pairing.ssl.SSLContext"),
+        ):
+            ok, err = pm.send_goodbye("https://srv")
+
+        assert ok is False
+        assert "401" in err
+
+    def test_reports_network_error_without_raising(self, tmp_path):
+        import urllib.error
+
+        pm = self._pm_with_certs(tmp_path)
+
+        def _raise(*_a, **_kw):
+            raise urllib.error.URLError("unreachable")
+
+        with (
+            patch("camera_streamer.pairing.urllib.request.urlopen", _raise),
+            patch("camera_streamer.pairing.ssl.SSLContext"),
+        ):
+            ok, err = pm.send_goodbye("https://srv")
+
+        assert ok is False
+        assert err  # non-empty message

--- a/app/server/config/nginx-monitor.conf
+++ b/app/server/config/nginx-monitor.conf
@@ -80,10 +80,15 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
     # Content Security Policy — restricts resource origins to prevent XSS.
-    # 'unsafe-inline' is required for Alpine.js and inline styles used in templates.
+    # 'unsafe-inline' is required for Alpine.js directives and inline styles in templates.
+    # 'unsafe-eval' is REQUIRED for Alpine.js v3: it uses the Function() constructor
+    #   to evaluate reactive expressions (x-data, x-text, @click). Without it, the
+    #   entire dashboard breaks silently — tabs don't respond, metrics stay empty.
+    #   Alpine's CSP-safe build is an alternative but would require rewriting all
+    #   templates to avoid expression strings.
     # blob: in media-src/img-src is required for HLS.js and snapshot display.
     # wss: in connect-src is required for future WebSocket health updates.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' wss:; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' wss:; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -410,7 +410,7 @@ def _resume_camera_pipelines(app):
     """
     from datetime import UTC, datetime
 
-    offline_timeout = 30  # seconds — matches discovery.py
+    offline_timeout = 30  # seconds — matches discovery.py OFFLINE_TIMEOUT
 
     try:
         cameras = app.store.get_cameras()

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -205,6 +205,46 @@ def _report_unknown_heartbeat(request) -> None:
         pass
 
 
+@cameras_bp.route("/goodbye", methods=["POST"])
+def camera_goodbye():
+    """Accept a camera-initiated unpair ("forget this server") request.
+
+    Mirrors the dashboard's admin unpair flow but triggered from the camera's
+    own /pair page. Authenticated with an HMAC signature over the current
+    pairing_secret — which is about to be destroyed, so this is effectively
+    the camera's "last words" to the server. After this call:
+        * server revokes the cert, drops pairing_secret, sets status=pending
+        * server stops any streaming pipeline for this camera
+        * camera side separately wipes its local certs and restarts into
+          the PAIRING lifecycle state
+    No session/CSRF — machine-to-machine like heartbeat/config-notify.
+    """
+    camera_id, err = _verify_camera_hmac(request)
+    if err:
+        status_code = 401 if err != "Invalid timestamp" else 400
+        return jsonify({"error": err}), status_code
+
+    # Delegate to the same service the admin DELETE route uses so the two
+    # unpair paths are guaranteed identical on the server side.
+    error, status = current_app.pairing_service.unpair(
+        camera_id,
+        user="camera",
+        ip=request.remote_addr or "",
+    )
+    if error:
+        return jsonify({"error": error}), status
+
+    # Stop streaming pipelines so the dashboard stops showing live HLS for
+    # a camera that is about to forget us. Best-effort: never fail the goodbye
+    # just because the pipeline was already torn down.
+    try:
+        current_app.streaming.stop_camera(camera_id)
+    except Exception:
+        pass
+
+    return jsonify({"message": "Camera unpaired"}), 200
+
+
 @cameras_bp.route("/heartbeat", methods=["POST"])
 def camera_heartbeat():
     """Accept periodic heartbeat from a camera.

--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -166,6 +166,45 @@ def config_notify():
     return jsonify({"message": "Config accepted"}), 200
 
 
+def _report_unknown_heartbeat(request) -> None:
+    """Surface a heartbeat from an unknown camera as a pending discovery.
+
+    When the server has deleted a camera but the camera still has stale
+    certs and is sending heartbeats, the HMAC check fails with "Unknown
+    camera" (no pairing_secret on record). Without this hook, the server
+    dashboard stays empty until the camera reboots and hits /pair/register.
+    Routing the camera_id header through discovery.report_camera() closes
+    that gap — the operator sees "Discovered — waiting to pair" as soon as
+    the first post-unpair heartbeat arrives.
+
+    Best-effort: invalid camera_id format or missing discovery service is
+    silently ignored. Never raises — this is a side-channel, not the
+    heartbeat's primary response path.
+    """
+    try:
+        import re
+
+        camera_id = request.headers.get("X-Camera-ID", "")
+        if not camera_id or not re.match(r"^cam-[a-z0-9]{1,48}$", camera_id):
+            return
+        discovery = getattr(current_app, "discovery_service", None)
+        if discovery is None:
+            return
+        # paired=None: camera still *thinks* it's paired (it's sending a
+        # heartbeat). We create a pending row so the admin can re-pair, but
+        # we don't flip any existing pending back to online — the next mDNS
+        # advert (which reflects real paired state) will settle the value.
+        discovery.report_camera(
+            camera_id=camera_id,
+            ip=request.remote_addr or "",
+            firmware_version="",
+            paired=None,
+        )
+    except Exception:
+        # Discovery side-effects must not break the 401 response path.
+        pass
+
+
 @cameras_bp.route("/heartbeat", methods=["POST"])
 def camera_heartbeat():
     """Accept periodic heartbeat from a camera.
@@ -175,10 +214,19 @@ def camera_heartbeat():
 
     Auth: HMAC-SHA256 signature using pairing_secret (ADR-0016).
     No session/CSRF — this is machine-to-machine.
+
+    Unknown-camera heartbeats also feed discovery: when an admin has deleted
+    the camera from the dashboard, the camera keeps sending heartbeats until
+    it detects the repeated 401 and resets. Meanwhile we record the (signed)
+    request as a new pending camera so the operator sees it immediately
+    under "Discovered — waiting to pair" instead of waiting for the camera
+    to reboot and hit /pair/register.
     """
     camera_id, err = _verify_camera_hmac(request)
     if err:
         status_code = 401 if err != "Invalid timestamp" else 400
+        if err == "Unknown camera":
+            _report_unknown_heartbeat(request)
         return jsonify({"error": err}), status_code
 
     data = request.get_json(silent=True)

--- a/app/server/monitor/api/pairing.py
+++ b/app/server/monitor/api/pairing.py
@@ -134,10 +134,15 @@ def register_camera():
     if not re.match(r"^cam-[a-z0-9]{1,48}$", camera_id):
         return jsonify({"error": "Invalid camera_id format"}), 400
 
+    # A camera that calls /pair/register is by definition asking to pair,
+    # so treat it as explicitly unpaired. This guarantees that if the server
+    # already has a stale "online" row for this camera_id it gets reset to
+    # "pending" and the admin sees it in the Discovered section.
     current_app.discovery_service.report_camera(
         camera_id=camera_id,
         ip=ip,
         firmware_version=data.get("firmware_version", ""),
+        paired=False,
     )
     return jsonify({"status": "registered"}), 200
 

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -110,6 +110,12 @@ class CameraService:
         cameras = self._store.get_cameras()
         result = []
         for c in cameras:
+            # "streaming" = camera's RTSP ffmpeg is running (self-reported via
+            # heartbeat). This is the meaningful question: "is this camera
+            # broadcasting?" The server's HLS pipeline is on-demand (only active
+            # while Live view is open) so it is NOT the right signal here.
+            streaming_now = bool(c.streaming)
+
             cam = {
                 "id": c.id,
                 "name": c.name,
@@ -130,7 +136,7 @@ class CameraService:
                 "hflip": c.hflip,
                 "vflip": c.vflip,
                 "config_sync": c.config_sync,
-                "streaming": c.streaming,
+                "streaming": streaming_now,
             }
             if admin_view:
                 # Admin-only fields: network topology + health metrics

--- a/app/server/monitor/services/discovery.py
+++ b/app/server/monitor/services/discovery.py
@@ -27,6 +27,10 @@ from datetime import UTC, datetime
 log = logging.getLogger("monitor.discovery")
 
 OFFLINE_TIMEOUT = 30  # seconds — must match _resume_camera_pipelines in __init__.py
+# Per ADR-0016: 30s = 2x the 15s heartbeat interval, so a camera goes offline
+# after at most 2 missed heartbeats. This is deliberately tight: users want
+# fast offline detection on a LAN. Transient network blips that kill a single
+# heartbeat are tolerated; two in a row is a real problem worth surfacing.
 _MDNS_SERVICE_TYPE = "_rtsp._tcp.local."
 _CAMERA_ID_PREFIX = "cam-"
 

--- a/app/server/monitor/services/discovery.py
+++ b/app/server/monitor/services/discovery.py
@@ -56,11 +56,24 @@ class DiscoveryService:
     # Core status tracking
     # -------------------------------------------------------------------------
 
-    def report_camera(self, camera_id, ip, firmware_version=""):
+    def report_camera(self, camera_id, ip, firmware_version="", paired=None):
         """Report a camera as seen (from mDNS, self-registration, or heartbeat).
 
         Creates a pending camera if unknown, or updates last_seen and status
         for known cameras. This is the single funnel for all discovery paths.
+
+        Args:
+            camera_id: cam-<hex> identifier.
+            ip: source IP address (last-known).
+            firmware_version: optional version string from TXT record.
+            paired: three-valued flag from the camera's mDNS ``paired`` TXT.
+                ``True`` → camera claims it has valid certs; ``False`` →
+                camera advertises it is unpaired; ``None`` → no TXT info
+                (heartbeat or legacy /pair/register).
+                When the camera says ``paired=false`` we force the server
+                record back to "pending", even if the row currently says
+                "online" — this closes the sync loop after the camera has
+                been reset.
         """
         from monitor.models import Camera
 
@@ -90,11 +103,25 @@ class DiscoveryService:
                 camera.last_seen = now
                 if firmware_version:
                     camera.firmware_version = firmware_version
-                # Don't override "pending" status — it requires explicit pairing
-                if camera.status not in ("pending",):
+                if paired is False and camera.status != "pending":
+                    # Camera explicitly told us it is not paired — override
+                    # any stale "online" status so the UI stops showing it
+                    # as a working camera. Clear streaming flag too.
+                    camera.status = "pending"
+                    camera.streaming = False
+                    if self._audit:
+                        self._audit.log_event(
+                            "CAMERA_UNPAIRED_DETECTED",
+                            detail=(
+                                f"camera {camera_id} advertises paired=false — "
+                                "reset to pending"
+                            ),
+                        )
+                elif camera.status not in ("pending",):
+                    # Don't override "pending" status — it requires explicit pairing
                     camera.status = "online"
                 self._store.save_camera(camera)
-                if was_offline and self._audit:
+                if was_offline and camera.status == "online" and self._audit:
                     self._audit.log_event(
                         "CAMERA_ONLINE",
                         detail=f"camera {camera_id} back online at {ip}",
@@ -297,16 +324,24 @@ class DiscoveryService:
                 return
 
             firmware_version = props.get("version", "")
-            paired_str = props.get("paired", "false")
+            paired_str = props.get("paired", "")
+            # Tri-state: explicit true/false from the camera, or None if the
+            # TXT record didn't include the key (legacy cameras).
+            if paired_str.lower() == "true":
+                paired_flag: bool | None = True
+            elif paired_str.lower() == "false":
+                paired_flag = False
+            else:
+                paired_flag = None
 
             log.info(
                 "mDNS: camera %s at %s (paired=%s firmware=%s)",
                 camera_id,
                 ip,
-                paired_str,
+                paired_str or "?",
                 firmware_version or "?",
             )
-            self.report_camera(camera_id, ip, firmware_version)
+            self.report_camera(camera_id, ip, firmware_version, paired=paired_flag)
 
         except Exception as exc:
             log.warning("mDNS handler error for '%s': %s", name, exc)

--- a/app/server/tests/unit/test_svc_discovery.py
+++ b/app/server/tests/unit/test_svc_discovery.py
@@ -59,6 +59,39 @@ class TestReportCamera:
             camera = app.store.get_camera("cam-001")
             assert camera.status == "pending"
 
+    def test_paired_false_resets_online_to_pending(self, app):
+        """When the camera's mDNS TXT says paired=false, an existing 'online'
+        row must be reset to 'pending' so the admin can re-pair it. This is the
+        server half of the unpair-sync protocol."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            svc.report_camera("cam-001", "192.168.1.50")
+            camera = app.store.get_camera("cam-001")
+            camera.status = "online"
+            camera.streaming = True
+            app.store.save_camera(camera)
+
+            svc.report_camera("cam-001", "192.168.1.50", paired=False)
+
+            camera = app.store.get_camera("cam-001")
+            assert camera.status == "pending"
+            assert camera.streaming is False
+
+    def test_paired_none_preserves_online(self, app):
+        """paired=None (heartbeat, /pair/register, legacy) must not disturb an
+        existing online camera — only explicit paired=false does that."""
+        with app.app_context():
+            svc = DiscoveryService(app.store, app.audit)
+            svc.report_camera("cam-001", "192.168.1.50")
+            camera = app.store.get_camera("cam-001")
+            camera.status = "online"
+            app.store.save_camera(camera)
+
+            svc.report_camera("cam-001", "192.168.1.50", paired=None)
+
+            camera = app.store.get_camera("cam-001")
+            assert camera.status == "online"
+
     def test_firmware_version_updated(self, app):
         with app.app_context():
             svc = DiscoveryService(app.store, app.audit)


### PR DESCRIPTION
## Summary

Closes two families of bugs that surfaced end-to-end when deleting / re-pairing a camera:

- **Pairing state drifted** between server and camera with no feedback loop, so deleting a camera on the server left it stuck as "Paired" on the camera side. Re-pair "succeeded" instantly with stale certs, dashboards showed inconsistent state for minutes, and recovery required manual back-and-forth.
- **SIGTERM didn't actually exit the camera service.** Graceful teardown deadlocked on ffmpeg waitpid + blocking HTTPServer.shutdown, so systemd had to escalate to SIGKILL after 20s. During that window no heartbeats were sent and the dashboard showed the camera offline right after pairing.

Three commits, each a cohesive slice:

1. **bc152e5** — nginx CSP fix so Alpine.js v3 dashboard actually loads (`unsafe-eval`).
2. **7ba633b** — bidirectional pairing sync. Camera detects server-side unpair via 5× `401 Unknown camera` threshold, wipes local state, advertises `paired=false` via mDNS TXT. Server surfaces unknown-camera heartbeats through `report_camera()` so the operator sees "Discovered — waiting to pair" immediately. Re-pair clears stale state first so failed re-pairs no longer leave a false "Paired" in the GUI.
3. **f0d941a** — deterministic SIGTERM exit via main.py watchdog, camera-initiated unpair (goodbye endpoint + Unpair button), restored OFFLINE_TIMEOUT to ADR-0016's 30s, dashboard streaming badge now reads heartbeat-reported `streaming` (not HLS process state), replaced last `systemctl restart self` anti-pattern in `lifecycle._revert_to_setup` with `os.kill(pid, SIGTERM)`.

## Why the SIGTERM watchdog matters (architectural fix)

Field stack traces (`/proc/$pid/task/*/stack`) proved graceful shutdown deadlocked: main thread in `futex_wait`, one worker in `waitpid` on an ffmpeg child, another in `pipe_read`. Cooperative teardown cannot be the exit guarantee for a service that must always respawn. The fix: SIGTERM sets the graceful flag AND arms an 8s `threading.Timer` that forces `os._exit(0)`. systemd's `Restart=always` handles respawn. Second signal forces immediate exit.

## Test plan

- [x] 486 camera unit/integration/contract tests pass
- [x] 1117 server tests pass
- [x] `ruff check` + `ruff format --check` clean
- [x] Hardware: deployed to camera 192.168.1.186 + server 192.168.1.245
- [x] Before fix: SIGTERM @ 09:55:09 → systemd SIGKILL @ 09:55:29 (20s hang)
- [x] After fix: SIGTERM → clean exit → respawn → heartbeat HTTP 200 within ~2s
- [x] Dashboard verified: camera online, streaming=true, heartbeats every 15s
- [x] Camera-initiated unpair tested: `/api/unpair` → goodbye → local wipe → SIGTERM → respawn in PAIRING

## ADR alignment

- ADR-0015 (server-to-camera control channel) — preserved, extended with goodbye endpoint
- ADR-0016 (camera health heartbeat protocol) — OFFLINE_TIMEOUT restored to 30s per spec, `paired=false` semantics in mDNS TXT

🤖 Generated with [Claude Code](https://claude.com/claude-code)