### PR TITLE
feat: on-demand viewer-driven streaming + recording modes (ADR-0017)

### DIFF
--- a/app/camera/camera_streamer/control.py
+++ b/app/camera/camera_streamer/control.py
@@ -17,10 +17,19 @@ OV5647 sensor modes usable for H264 streaming (libcamera on RPi Zero 2W):
 Note: 2592x1944 (full 5MP) is a valid sensor mode but the Pi Zero 2W
 cannot encode it fast enough for real-time H264 streaming — ffmpeg
 fails to detect codec parameters. Excluded from allowed resolutions.
+
+Stream start/stop control (ADR-0017):
+The handler also owns the persisted desired stream state at
+``/data/config/stream_state`` (one line: ``running`` or ``stopped``).
+The server drives start/stop via HMAC-authenticated HTTP endpoints; the
+camera writes the file atomically so a power cut cannot lose intent or
+resurrect a stopped camera on reboot.
 """
 
 import json
 import logging
+import os
+import tempfile
 import time
 
 log = logging.getLogger("camera-streamer.control")
@@ -50,6 +59,10 @@ PARAM_SCHEMA = {
 # Rate limit: minimum seconds between config changes
 RATE_LIMIT_SECONDS = 5
 
+# Default location of the persisted desired stream state file (ADR-0017).
+DEFAULT_STREAM_STATE_PATH = "/data/config/stream_state"
+VALID_STREAM_STATES = ("running", "stopped")
+
 
 class ControlHandler:
     """Handles server control API requests.
@@ -60,13 +73,104 @@ class ControlHandler:
     Args:
         config: ConfigManager instance.
         stream_manager: StreamManager instance (or None in tests).
+        stream_state_path: Path to the persisted desired stream state file
+            (ADR-0017). Default ``/data/config/stream_state``.
     """
 
-    def __init__(self, config, stream_manager=None):
+    def __init__(
+        self,
+        config,
+        stream_manager=None,
+        stream_state_path=DEFAULT_STREAM_STATE_PATH,
+    ):
         self._config = config
         self._stream = stream_manager
         self._last_request_id = 0
         self._last_change_time = 0.0
+        self._stream_state_path = stream_state_path
+        # Load the persisted desired state so a boot-time lookup is cheap
+        # and the in-memory value is always authoritative for the server.
+        self._desired_stream_state = self._load_stream_state()
+
+    @property
+    def desired_stream_state(self):
+        """Persisted desired stream state (``running`` or ``stopped``)."""
+        return self._desired_stream_state
+
+    def _load_stream_state(self):
+        """Read the persisted desired state, defaulting to ``stopped``.
+
+        Missing file or any unexpected content collapses to ``stopped`` —
+        a freshly-paired or corrupted camera must not start streaming
+        without an explicit server request (ADR-0017 §1).
+        """
+        try:
+            with open(self._stream_state_path) as f:
+                value = f.read().strip()
+        except OSError:
+            return "stopped"
+        if value in VALID_STREAM_STATES:
+            return value
+        return "stopped"
+
+    def _write_stream_state(self, desired):
+        """Atomically persist the desired state.
+
+        Tempfile in the same directory + ``os.replace`` guarantees readers
+        never see a partial write even if power is lost mid-update.
+        """
+        parent = os.path.dirname(self._stream_state_path) or "."
+        os.makedirs(parent, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".stream_state.", dir=parent, text=True)
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(desired)
+            os.chmod(tmp_path, 0o644)
+            os.replace(tmp_path, self._stream_state_path)
+        except Exception:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def get_stream_state(self):
+        """Return desired stream state and current live streaming flag."""
+        return {
+            "state": self._desired_stream_state,
+            "running": bool(self._stream and self._stream.is_streaming),
+        }
+
+    def set_stream_state(self, desired):
+        """Set the desired stream state and drive the pipeline accordingly.
+
+        Persists the value atomically before touching the stream pipeline
+        so a crash between write and start/stop leaves the on-disk intent
+        consistent with what the server asked for. Idempotent: repeated
+        ``start`` calls are safe — the underlying StreamManager reports
+        already-running and we do not respawn.
+        """
+        if desired not in VALID_STREAM_STATES:
+            return None, "desired must be 'running' or 'stopped'", 400
+
+        self._write_stream_state(desired)
+        self._desired_stream_state = desired
+
+        if self._stream is not None:
+            currently = bool(self._stream.is_streaming)
+            if desired == "running" and not currently:
+                self._stream.start()
+            elif desired == "stopped" and currently:
+                self._stream.stop()
+
+        return (
+            {
+                "state": desired,
+                "running": bool(self._stream and self._stream.is_streaming),
+            },
+            "",
+            200,
+        )
 
     def get_capabilities(self):
         """Return supported parameter ranges for this camera hardware."""
@@ -211,6 +315,7 @@ class ControlHandler:
             "config": self.get_config(),
             "camera_id": self._config.camera_id,
             "paired": self._config.has_client_cert,
+            "desired_stream_state": self._desired_stream_state,
         }
 
     def _validate_params(self, params):

--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -124,11 +124,23 @@ class HeartbeatSender:
         thermal_path: Optional path to CPU thermal zone file.
     """
 
-    def __init__(self, config, pairing_manager, stream_manager=None, thermal_path=None):
+    def __init__(
+        self,
+        config,
+        pairing_manager,
+        stream_manager=None,
+        thermal_path=None,
+        control_handler=None,
+    ):
         self._config = config
         self._pairing = pairing_manager
         self._stream = stream_manager
         self._thermal_path = thermal_path
+        # Optional ControlHandler — when provided, the heartbeat reports the
+        # *persisted desired* state (ADR-0017), which is what the server
+        # compares against to detect drift. Tests that don't care about
+        # drift pass None and we fall back to the live streaming flag.
+        self._control = control_handler
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
         # Track consecutive 401 Unknown-camera responses to detect server-side unpair
@@ -183,10 +195,19 @@ class HeartbeatSender:
         streaming = bool(self._stream and self._stream.is_streaming)
         config = self._config
 
+        # ADR-0017: report desired state when a control handler is wired
+        # (production path), falling back to the live streaming flag for
+        # tests that construct HeartbeatSender without a handler.
+        if self._control is not None:
+            stream_state = self._control.desired_stream_state
+        else:
+            stream_state = "running" if streaming else "stopped"
+
         return {
             "camera_id": config.camera_id,
             "timestamp": int(time.time()),
             "streaming": streaming,
+            "stream_state": stream_state,
             "cpu_temp": _get_cpu_temp(self._thermal_path),
             "memory_percent": _get_memory_percent(),
             "uptime_seconds": _get_uptime_seconds(),

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -42,21 +42,25 @@ log = logging.getLogger("camera-streamer.lifecycle")
 
 
 def _read_desired_stream_state(path):
-    """Return the persisted desired stream state or ``stopped``.
+    """Return the persisted desired stream state or ``running``.
+
+    Design: the camera streams to MediaMTX whenever it is paired so the
+    Live page opens with zero cold-start latency. The persisted state
+    file exists only as an explicit *override* — e.g. an operator or the
+    server asks the camera to go quiet. A missing file (fresh boot,
+    fresh pair) defaults to ``running``.
 
     Isolated as a module-level helper so the boot-time decision can be
-    unit-tested without spinning up the full lifecycle (ADR-0017 §1).
-    Missing file or garbage content collapses to ``stopped`` — we never
-    start streaming unless the server has explicitly asked for it.
+    unit-tested without spinning up the full lifecycle.
     """
     try:
         with open(path) as f:
             value = f.read().strip()
     except OSError:
-        return "stopped"
+        return "running"
     if value in VALID_STREAM_STATES:
         return value
-    return "stopped"
+    return "running"
 
 
 class State:

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -27,6 +27,7 @@ import urllib.request
 
 from camera_streamer import led
 from camera_streamer.capture import CaptureManager
+from camera_streamer.control import DEFAULT_STREAM_STATE_PATH, VALID_STREAM_STATES
 from camera_streamer.discovery import DiscoveryService
 from camera_streamer.health import HealthMonitor
 from camera_streamer.heartbeat import HeartbeatSender
@@ -38,6 +39,24 @@ from camera_streamer.stream import StreamManager
 from camera_streamer.wifi_setup import WifiSetupServer
 
 log = logging.getLogger("camera-streamer.lifecycle")
+
+
+def _read_desired_stream_state(path):
+    """Return the persisted desired stream state or ``stopped``.
+
+    Isolated as a module-level helper so the boot-time decision can be
+    unit-tested without spinning up the full lifecycle (ADR-0017 §1).
+    Missing file or garbage content collapses to ``stopped`` — we never
+    start streaming unless the server has explicitly asked for it.
+    """
+    try:
+        with open(path) as f:
+            value = f.read().strip()
+    except OSError:
+        return "stopped"
+    if value in VALID_STREAM_STATES:
+        return value
+    return "stopped"
 
 
 class State:
@@ -67,6 +86,10 @@ class CameraLifecycle:
         self._config = config
         self._platform = platform
         self._is_shutdown = shutdown_event
+        # Persisted desired stream state file (ADR-0017). Stored on the
+        # instance so tests can override and the heartbeat/control paths
+        # share a single source of truth.
+        self._stream_state_path = DEFAULT_STREAM_STATE_PATH
 
         self._state = State.INIT
 
@@ -266,15 +289,26 @@ class CameraLifecycle:
         self._discovery = DiscoveryService(self._config, pairing_manager=self._pairing)
         self._discovery.start()
 
-        # RTSP streaming
+        # RTSP streaming — on-demand per ADR-0017. The camera only starts
+        # streaming on boot if both (a) it is configured/paired AND (b) the
+        # persisted desired state is "running". A fresh camera defaults to
+        # "stopped" and waits for the server to explicitly ask for a stream.
         self._stream = StreamManager(
             self._config,
             camera_device=self._platform.camera_device,
         )
-        if self._config.is_configured:
+        desired = _read_desired_stream_state(self._stream_state_path)
+        if self._config.is_configured and desired == "running":
+            log.info("Desired stream state is 'running' — starting pipeline")
             self._stream.start()
-        else:
+        elif not self._config.is_configured:
             log.warning("Server not configured — streaming disabled")
+        else:
+            log.info(
+                "Desired stream state is '%s' — pipeline idle, awaiting "
+                "server start command",
+                desired,
+            )
 
         # Status HTTPS server (port 443)
         self._status_server = CameraStatusServer(
@@ -283,6 +317,7 @@ class CameraLifecycle:
             wifi_interface=self._platform.wifi_interface,
             thermal_path=self._platform.thermal_path,
             pairing_manager=self._pairing,
+            stream_state_path=self._stream_state_path,
         )
         self._status_server.start()
 
@@ -291,11 +326,15 @@ class CameraLifecycle:
         self._ota_agent.start()
 
         # Heartbeat sender — keeps server informed of liveness (ADR-0016)
+        # and reports the persisted desired stream state so the server can
+        # detect drift (ADR-0017 §3). The control handler is the single
+        # source of truth for desired state.
         self._heartbeat = HeartbeatSender(
             self._config,
             self._pairing,
             stream_manager=self._stream,
             thermal_path=self._platform.thermal_path,
+            control_handler=self._status_server.control_handler,
         )
         if self._config.is_configured and self._pairing.is_paired:
             self._heartbeat.start()

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -443,17 +443,28 @@ def _make_status_handler(
             """Check if the request is from the paired server.
 
             Accepts the request if:
-            - The client IP matches config.server_ip (set during pairing), OR
+            - The client IP matches config.server_ip (set during pairing,
+              either as an IP literal or as a hostname resolved to one), OR
             - The client voluntarily presented a valid TLS peer certificate.
 
             The SSL context uses CERT_NONE so browsers don't get a client-cert
             challenge (which breaks Chrome/Edge). Server IP check is the primary
             auth path; peer-cert is a fallback for future full mTLS enforcement.
             """
-            # Primary: IP-based auth — server IP is set during pairing
             server_ip = getattr(config, "server_ip", "") or ""
-            if server_ip and self.client_address[0] == server_ip:
-                return True
+            if server_ip:
+                client_ip = self.client_address[0]
+                if client_ip == server_ip:
+                    return True
+                # server_ip may be a hostname (e.g. "rpi-divinu.local").
+                # Resolve it so a fresh DNS/mDNS lookup matches the raw
+                # TCP client IP we see here.
+                try:
+                    resolved = socket.gethostbyname(server_ip)
+                except (socket.gaierror, socket.herror):
+                    resolved = ""
+                if resolved and client_ip == resolved:
+                    return True
             # Fallback: TLS peer cert (only when client voluntarily sends one)
             try:
                 peer_cert = self.request.getpeercert()

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -286,15 +286,28 @@ class CameraStatusServer:
         wifi_interface="wlan0",
         thermal_path=None,
         pairing_manager=None,
+        stream_state_path=None,
     ):
         self._config = config
         self._stream = stream_manager
         self._wifi_interface = wifi_interface
         self._thermal_path = thermal_path
         self._pairing = pairing_manager
-        self._control = ControlHandler(config, stream_manager)
+        # Let ControlHandler pick the default path when caller didn't override
+        # so tests and production share the same default (ADR-0017).
+        if stream_state_path is None:
+            self._control = ControlHandler(config, stream_manager)
+        else:
+            self._control = ControlHandler(
+                config, stream_manager, stream_state_path=stream_state_path
+            )
         self._server = None
         self._thread = None
+
+    @property
+    def control_handler(self):
+        """Return the internal ControlHandler (for lifecycle wiring)."""
+        return self._control
 
     def start(self):
         """Start the status HTTPS server on port 443."""
@@ -521,6 +534,11 @@ def _make_status_handler(
                     return
                 self._json_response(control_handler.get_status())
                 return
+            if self.path == "/api/v1/control/stream/state":
+                if not self._require_mtls():
+                    return
+                self._json_response(control_handler.get_stream_state())
+                return
 
             if self.path == "/login":
                 self._serve_login_page()
@@ -613,6 +631,26 @@ def _make_status_handler(
                     self._json_response({"restarted": ok, "status": "ok"})
                 else:
                     self._json_response({"error": "Stream manager not available"}, 503)
+                return
+
+            # Control API — on-demand stream start/stop (ADR-0017)
+            if self.path == "/api/v1/control/stream/start":
+                if not self._require_mtls():
+                    return
+                result, error, status = control_handler.set_stream_state("running")
+                if error:
+                    self._json_response({"error": error}, status)
+                else:
+                    self._json_response(result, status)
+                return
+            if self.path == "/api/v1/control/stream/stop":
+                if not self._require_mtls():
+                    return
+                result, error, status = control_handler.set_stream_state("stopped")
+                if error:
+                    self._json_response({"error": error}, status)
+                else:
+                    self._json_response(result, status)
                 return
 
             if self.path == "/login":

--- a/app/camera/tests/integration/test_lifecycle.py
+++ b/app/camera/tests/integration/test_lifecycle.py
@@ -325,14 +325,21 @@ class TestRunning:
         mock_led,
         tmp_path,
     ):
-        """ADR-0017: default desired state 'stopped' blocks boot-time stream start."""
+        """Explicit 'stopped' override in the state file blocks boot-time stream.
+
+        ADR-0017 originally defaulted this to 'stopped' (on-demand gate) but
+        the 24ac5c6 revert restored 'running' as the default so Live view is
+        instant. The persisted file still works as an explicit override —
+        that's what this test now asserts.
+        """
         config = _make_config()
         platform = _make_platform()
 
         lc = CameraLifecycle(config, platform, lambda: True)
         lc._capture = MagicMock()
-        # No file written — helper defaults to "stopped"
-        lc._stream_state_path = str(tmp_path / "missing_stream_state")
+        state_file = tmp_path / "stream_state"
+        state_file.write_text("stopped")
+        lc._stream_state_path = str(state_file)
 
         lc._do_running()
 

--- a/app/camera/tests/integration/test_lifecycle.py
+++ b/app/camera/tests/integration/test_lifecycle.py
@@ -258,7 +258,13 @@ class TestRunning:
     @patch("camera_streamer.lifecycle.StreamManager")
     @patch("camera_streamer.lifecycle.DiscoveryService")
     def test_starts_all_services(
-        self, MockDiscovery, MockStream, MockStatus, MockHealth, mock_led
+        self,
+        MockDiscovery,
+        MockStream,
+        MockStatus,
+        MockHealth,
+        mock_led,
+        tmp_path,
     ):
         config = _make_config()
         platform = _make_platform()
@@ -272,6 +278,11 @@ class TestRunning:
 
         lc = CameraLifecycle(config, platform, shutdown)
         lc._capture = MagicMock()
+        # ADR-0017: stream no longer auto-starts; desired state must be
+        # "running" for the lifecycle to spawn the pipeline on boot.
+        state_file = tmp_path / "stream_state"
+        state_file.write_text("running")
+        lc._stream_state_path = str(state_file)
 
         result = lc._do_running()
 
@@ -295,6 +306,33 @@ class TestRunning:
 
         lc = CameraLifecycle(config, platform, lambda: True)
         lc._capture = MagicMock()
+
+        lc._do_running()
+
+        MockStream.return_value.start.assert_not_called()
+
+    @patch("camera_streamer.lifecycle.led")
+    @patch("camera_streamer.lifecycle.HealthMonitor")
+    @patch("camera_streamer.lifecycle.CameraStatusServer")
+    @patch("camera_streamer.lifecycle.StreamManager")
+    @patch("camera_streamer.lifecycle.DiscoveryService")
+    def test_skips_streaming_when_desired_state_stopped(
+        self,
+        MockDiscovery,
+        MockStream,
+        MockStatus,
+        MockHealth,
+        mock_led,
+        tmp_path,
+    ):
+        """ADR-0017: default desired state 'stopped' blocks boot-time stream start."""
+        config = _make_config()
+        platform = _make_platform()
+
+        lc = CameraLifecycle(config, platform, lambda: True)
+        lc._capture = MagicMock()
+        # No file written — helper defaults to "stopped"
+        lc._stream_state_path = str(tmp_path / "missing_stream_state")
 
         lc._do_running()
 

--- a/app/camera/tests/unit/test_control.py
+++ b/app/camera/tests/unit/test_control.py
@@ -319,3 +319,139 @@ class TestCrossFieldValidation:
             {"width": 640, "height": 480, "fps": 58}
         )
         assert status == 200
+
+
+# --- stream state control (ADR-0017) ---
+
+
+class FakeStreamManager:
+    """Minimal stream manager test double — tracks start/stop invocations."""
+
+    def __init__(self, is_streaming=False):
+        self.is_streaming = is_streaming
+        self.consecutive_failures = 0
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    def start(self):
+        self.start_calls += 1
+        self.is_streaming = True
+
+    def stop(self):
+        self.stop_calls += 1
+        self.is_streaming = False
+
+    def restart(self):
+        return True
+
+
+class TestStreamStateControl:
+    def test_default_state_is_stopped_when_file_missing(self, camera_config, tmp_path):
+        path = tmp_path / "stream_state"
+        h = ControlHandler(camera_config, None, stream_state_path=str(path))
+        assert h.desired_stream_state == "stopped"
+        assert h.get_stream_state() == {"state": "stopped", "running": False}
+
+    @pytest.mark.parametrize(
+        "contents,expected",
+        [
+            ("running", "running"),
+            ("stopped", "stopped"),
+            ("garbage", "stopped"),
+            ("", "stopped"),
+            ("  running\n", "running"),
+        ],
+    )
+    def test_reads_existing_state_file(
+        self, camera_config, tmp_path, contents, expected
+    ):
+        path = tmp_path / "stream_state"
+        path.write_text(contents)
+        h = ControlHandler(camera_config, None, stream_state_path=str(path))
+        assert h.desired_stream_state == expected
+
+    def test_set_running_writes_file_and_starts_stream(self, camera_config, tmp_path):
+        path = tmp_path / "stream_state"
+        stream = FakeStreamManager(is_streaming=False)
+        h = ControlHandler(camera_config, stream, stream_state_path=str(path))
+
+        result, err, status = h.set_stream_state("running")
+
+        assert status == 200 and err == ""
+        assert result == {"state": "running", "running": True}
+        assert path.read_text() == "running"
+        assert stream.start_calls == 1
+        assert stream.stop_calls == 0
+        assert h.desired_stream_state == "running"
+
+    def test_set_stopped_writes_file_and_stops_stream(self, camera_config, tmp_path):
+        path = tmp_path / "stream_state"
+        stream = FakeStreamManager(is_streaming=True)
+        h = ControlHandler(camera_config, stream, stream_state_path=str(path))
+
+        result, err, status = h.set_stream_state("stopped")
+
+        assert status == 200 and err == ""
+        assert result == {"state": "stopped", "running": False}
+        assert path.read_text() == "stopped"
+        assert stream.stop_calls == 1
+        assert stream.start_calls == 0
+
+    def test_idempotent_start_when_already_running(self, camera_config, tmp_path):
+        path = tmp_path / "stream_state"
+        stream = FakeStreamManager(is_streaming=True)
+        h = ControlHandler(camera_config, stream, stream_state_path=str(path))
+
+        h.set_stream_state("running")
+        h.set_stream_state("running")
+
+        # Never called start — the stream already reported running on both
+        # calls — but both requests return 200 and persist the value.
+        assert stream.start_calls == 0
+        assert path.read_text() == "running"
+
+    def test_idempotent_stop_when_already_stopped(self, camera_config, tmp_path):
+        path = tmp_path / "stream_state"
+        stream = FakeStreamManager(is_streaming=False)
+        h = ControlHandler(camera_config, stream, stream_state_path=str(path))
+
+        h.set_stream_state("stopped")
+        h.set_stream_state("stopped")
+
+        assert stream.stop_calls == 0
+
+    def test_invalid_state_returns_400(self, camera_config, tmp_path):
+        path = tmp_path / "stream_state"
+        h = ControlHandler(camera_config, None, stream_state_path=str(path))
+
+        result, err, status = h.set_stream_state("paused")
+
+        assert status == 400
+        assert result is None
+        assert "running" in err and "stopped" in err
+        assert not path.exists()
+
+    def test_get_stream_state_shape(self, camera_config, tmp_path):
+        path = tmp_path / "stream_state"
+        path.write_text("running")
+        stream = FakeStreamManager(is_streaming=True)
+        h = ControlHandler(camera_config, stream, stream_state_path=str(path))
+
+        state = h.get_stream_state()
+        assert set(state.keys()) == {"state", "running"}
+        assert state["state"] == "running"
+        assert state["running"] is True
+
+    def test_get_status_includes_desired_stream_state(self, camera_config, tmp_path):
+        path = tmp_path / "stream_state"
+        path.write_text("running")
+        stream = FakeStreamManager(is_streaming=True)
+        h = ControlHandler(camera_config, stream, stream_state_path=str(path))
+
+        assert h.get_status()["desired_stream_state"] == "running"
+
+    def test_creates_parent_dir(self, camera_config, tmp_path):
+        path = tmp_path / "nested" / "dir" / "stream_state"
+        h = ControlHandler(camera_config, None, stream_state_path=str(path))
+        h.set_stream_state("running")
+        assert path.read_text() == "running"

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -190,6 +190,42 @@ class TestHeartbeatSender:
         payload = sender._build_payload()
         assert payload["streaming"] is False
 
+    def test_stream_state_fallback_without_control_handler(self):
+        """Without a handler, stream_state mirrors the streaming flag."""
+        cfg = _make_config()
+        stream = MagicMock()
+        stream.is_streaming = True
+        sender = HeartbeatSender(cfg, _make_pairing(), stream_manager=stream)
+        payload = sender._build_payload()
+        assert payload["stream_state"] == "running"
+
+        stream.is_streaming = False
+        payload = sender._build_payload()
+        assert payload["stream_state"] == "stopped"
+
+    def test_stream_state_from_control_handler(self):
+        """ADR-0017: with a handler, stream_state is the persisted desired value.
+
+        The desired state can diverge from the live streaming flag (e.g. the
+        pipeline crashed while desired=running) — the server needs the
+        *desired* value to detect drift and take corrective action.
+        """
+        cfg = _make_config()
+        stream = MagicMock()
+        stream.is_streaming = False
+        handler = MagicMock()
+        handler.desired_stream_state = "running"
+        sender = HeartbeatSender(
+            cfg,
+            _make_pairing(),
+            stream_manager=stream,
+            control_handler=handler,
+        )
+        payload = sender._build_payload()
+        assert payload["stream_state"] == "running"
+        # The legacy "streaming" field still reflects the live pipeline
+        assert payload["streaming"] is False
+
     def test_send_once_posts_with_hmac_headers(self):
         cfg = _make_config()
         sender = HeartbeatSender(cfg, _make_pairing())

--- a/app/camera/tests/unit/test_lifecycle_stream_state.py
+++ b/app/camera/tests/unit/test_lifecycle_stream_state.py
@@ -10,9 +10,10 @@ from camera_streamer.lifecycle import _read_desired_stream_state
 
 
 class TestReadDesiredStreamState:
-    def test_missing_file_defaults_to_stopped(self, tmp_path):
+    def test_missing_file_defaults_to_running(self, tmp_path):
+        """Fresh boot with no override file → stream for instant Live view."""
         path = tmp_path / "stream_state"
-        assert _read_desired_stream_state(str(path)) == "stopped"
+        assert _read_desired_stream_state(str(path)) == "running"
 
     def test_reads_running(self, tmp_path):
         path = tmp_path / "stream_state"
@@ -20,14 +21,16 @@ class TestReadDesiredStreamState:
         assert _read_desired_stream_state(str(path)) == "running"
 
     def test_reads_stopped(self, tmp_path):
+        """Explicit override to stop is honoured."""
         path = tmp_path / "stream_state"
         path.write_text("stopped")
         assert _read_desired_stream_state(str(path)) == "stopped"
 
-    def test_garbage_collapses_to_stopped(self, tmp_path):
+    def test_garbage_collapses_to_running(self, tmp_path):
+        """Unreadable content falls back to streaming (instant-live default)."""
         path = tmp_path / "stream_state"
         path.write_text("maybe")
-        assert _read_desired_stream_state(str(path)) == "stopped"
+        assert _read_desired_stream_state(str(path)) == "running"
 
     def test_trailing_whitespace_is_stripped(self, tmp_path):
         path = tmp_path / "stream_state"

--- a/app/camera/tests/unit/test_lifecycle_stream_state.py
+++ b/app/camera/tests/unit/test_lifecycle_stream_state.py
@@ -1,0 +1,70 @@
+"""Unit tests for camera lifecycle helpers.
+
+Focuses on the boot-time decision of whether to start streaming
+automatically, per ADR-0017. The full CameraLifecycle orchestrator
+touches systemd/mDNS/hardware so we isolate the one decision worth
+unit-testing into the ``_read_desired_stream_state`` helper.
+"""
+
+from camera_streamer.lifecycle import _read_desired_stream_state
+
+
+class TestReadDesiredStreamState:
+    def test_missing_file_defaults_to_stopped(self, tmp_path):
+        path = tmp_path / "stream_state"
+        assert _read_desired_stream_state(str(path)) == "stopped"
+
+    def test_reads_running(self, tmp_path):
+        path = tmp_path / "stream_state"
+        path.write_text("running")
+        assert _read_desired_stream_state(str(path)) == "running"
+
+    def test_reads_stopped(self, tmp_path):
+        path = tmp_path / "stream_state"
+        path.write_text("stopped")
+        assert _read_desired_stream_state(str(path)) == "stopped"
+
+    def test_garbage_collapses_to_stopped(self, tmp_path):
+        path = tmp_path / "stream_state"
+        path.write_text("maybe")
+        assert _read_desired_stream_state(str(path)) == "stopped"
+
+    def test_trailing_whitespace_is_stripped(self, tmp_path):
+        path = tmp_path / "stream_state"
+        path.write_text("running\n")
+        assert _read_desired_stream_state(str(path)) == "running"
+
+
+class TestDoRunningHonoursStreamState:
+    """Integration-ish: verify _do_running checks the persisted state.
+
+    We don't run the real _do_running — it spawns threads, mDNS, the
+    status server, and an OTA agent. Instead we verify the contract via
+    _read_desired_stream_state plus a direct read of the lifecycle source
+    for the decision gate. The helper is covered by the class above; here
+    we assert the gate exists on the instance attribute so future
+    refactors can't silently drop it.
+    """
+
+    def test_lifecycle_exposes_stream_state_path(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from camera_streamer.lifecycle import CameraLifecycle
+
+        # Construct with stub dependencies — we only inspect an attribute,
+        # we never call run().
+        class _Platform:
+            camera_device = "/dev/video0"
+            wifi_interface = "wlan0"
+            led_path = None
+            thermal_path = None
+            hostname_prefix = "cam"
+
+        cfg = MagicMock()
+        cfg.certs_dir = str(tmp_path)
+        lc = CameraLifecycle(
+            config=cfg,
+            platform=_Platform(),
+            shutdown_event=lambda: True,
+        )
+        assert lc._stream_state_path.endswith("stream_state")

--- a/app/server/config/nginx-monitor.conf
+++ b/app/server/config/nginx-monitor.conf
@@ -142,9 +142,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # WebRTC WHEP — proxied to Flask (auth enforced), then to MediaMTX
-    location ~ ^/webrtc/(.+)$ {
-        proxy_pass http://127.0.0.1:5000/api/v1/webrtc/$1;
+    # WebRTC WHEP — proxied straight to MediaMTX's WHEP listener on :8889.
+    # MediaMTX expects POST /<path>/whep with an SDP body and returns an
+    # SDP answer. Browser viewers connect through nginx so the TLS origin
+    # matches the app (no mixed-content warnings).
+    location ~ ^/webrtc/(?<mtx_path>[^/]+)/whep$ {
+        proxy_pass http://127.0.0.1:8889/$mtx_path/whep;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -20,9 +20,11 @@ from monitor.services.camera_service import CameraService
 from monitor.services.cert_service import CertService
 from monitor.services.discovery import DiscoveryService
 from monitor.services.factory_reset_service import FactoryResetService
+from monitor.services.loop_recorder import LoopRecorder
 from monitor.services.ota_service import OTAService
 from monitor.services.pairing_service import PairingService
 from monitor.services.provisioning_service import ProvisioningService
+from monitor.services.recording_scheduler import RecordingScheduler
 from monitor.services.recordings_service import RecordingsService
 from monitor.services.settings_service import SettingsService
 from monitor.services.storage_manager import StorageManager
@@ -266,6 +268,25 @@ def _init_services(app):
 
     app.storage_manager.set_dir_change_callback(_on_recording_dir_change)
 
+    # ADR-0017: on-demand streaming + recording-mode services
+    from monitor.api.on_demand import OnDemandCoordinator
+
+    app.on_demand_coordinator = OnDemandCoordinator(
+        store=app.store,
+        control_client=app.camera_control_client,
+        scheduler_ref=lambda: getattr(app, "recording_scheduler", None),
+    )
+    app.recording_scheduler = RecordingScheduler(
+        store=app.store,
+        streaming=app.streaming,
+        control_client=app.camera_control_client,
+        coordinator=app.on_demand_coordinator,
+    )
+    app.loop_recorder = LoopRecorder(
+        base_dir=app.config["RECORDINGS_DIR"],
+        audit=app.audit,
+    )
+
 
 def _restore_hostname(data_dir: str):
     """Restore hostname from /data on every boot.
@@ -304,6 +325,8 @@ def _startup(app):
     app.streaming.start()
     app.storage_manager.start()
     app.cert_service.start()
+    app.recording_scheduler.start()
+    app.loop_recorder.start()
 
     # mDNS browser — discovers cameras advertising _rtsp._tcp on the LAN (RFC 6762/6763)
     app.discovery_service.start_mdns_browser()
@@ -440,6 +463,7 @@ def _register_blueprints(app):
     """Register all Flask blueprints."""
     from monitor.api.cameras import cameras_bp
     from monitor.api.live import live_bp
+    from monitor.api.on_demand import on_demand_bp
     from monitor.api.ota import ota_bp
     from monitor.api.pairing import pairing_bp
     from monitor.api.recordings import recordings_bp
@@ -465,3 +489,6 @@ def _register_blueprints(app):
     app.register_blueprint(pairing_bp, url_prefix="/api/v1")
     app.register_blueprint(storage_bp, url_prefix="/api/v1/storage")
     app.register_blueprint(webrtc_bp, url_prefix="/api/v1/webrtc")
+    # ADR-0017: localhost-only on-demand coordinator for MediaMTX hooks.
+    # Mounted outside /api/v1 so the CSRF layer on /api/* can stay strict.
+    app.register_blueprint(on_demand_bp, url_prefix="/internal/on-demand")

--- a/app/server/monitor/api/on_demand.py
+++ b/app/server/monitor/api/on_demand.py
@@ -1,0 +1,148 @@
+"""
+On-demand coordinator (ADR-0017) — localhost-only Flask blueprint.
+
+MediaMTX invokes this via a shell wrapper on `runOnDemand` /
+`runOnDemandCloseAfter`. The coordinator is the single "does anyone still
+need this stream?" gate:
+
+    POST /internal/on-demand/<camera_id>/start
+        - If camera.desired_stream_state == "running" → no-op (200).
+        - Else → control_client.start_stream(ip), persist, return {"ok": true}.
+
+    POST /internal/on-demand/<camera_id>/stop
+        - If RecordingScheduler.needs_stream(cam) → no-op (200, kept_running).
+        - Else → control_client.stop_stream(ip), persist, return {"ok": true}.
+
+Auth: 127.0.0.1 / ::1 only (localhost trust). No session / CSRF.
+CSRF is not applied (blueprint is not under /api/v1).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, current_app, jsonify, request
+
+log = logging.getLogger("monitor.on_demand")
+
+on_demand_bp = Blueprint("on_demand", __name__)
+
+_ALLOWED_REMOTES = {"127.0.0.1", "::1"}
+
+
+@on_demand_bp.before_request
+def _require_localhost():
+    """Reject any request that didn't come from the loopback interface."""
+    # request.remote_addr may include IPv6-mapped IPv4 or similar; we keep
+    # the check strict because MediaMTX is local.
+    addr = request.remote_addr or ""
+    if addr not in _ALLOWED_REMOTES:
+        return jsonify({"error": "Forbidden"}), 403
+    return None
+
+
+@on_demand_bp.route("/<camera_id>/start", methods=["POST"])
+def on_demand_start(camera_id: str):
+    """Viewer arrived — make sure the camera is streaming."""
+    camera = current_app.store.get_camera(camera_id)
+    if camera is None:
+        return jsonify({"error": "Camera not found"}), 404
+
+    if camera.desired_stream_state == "running":
+        log.debug("on-demand start %s: already running", camera_id)
+        return jsonify({"ok": True, "already_running": True}), 200
+
+    if not camera.ip:
+        return jsonify({"error": "Camera IP unknown"}), 409
+
+    control = getattr(current_app, "camera_control_client", None)
+    if control is None:
+        return jsonify({"error": "Control client unavailable"}), 503
+
+    _, err = control.start_stream(camera.ip)
+    if err:
+        log.warning("on-demand start %s failed: %s", camera_id, err)
+        return jsonify({"error": err}), 502
+
+    camera.desired_stream_state = "running"
+    current_app.store.save_camera(camera)
+    return jsonify({"ok": True, "started": True}), 200
+
+
+@on_demand_bp.route("/<camera_id>/stop", methods=["POST"])
+def on_demand_stop(camera_id: str):
+    """Viewer left — stop the camera stream unless the scheduler still wants it."""
+    camera = current_app.store.get_camera(camera_id)
+    if camera is None:
+        return jsonify({"error": "Camera not found"}), 404
+
+    scheduler = getattr(current_app, "recording_scheduler", None)
+    if scheduler is not None and scheduler.needs_stream(camera_id):
+        log.debug("on-demand stop %s: scheduler still needs stream", camera_id)
+        return (
+            jsonify({"ok": True, "kept_running": True, "reason": "scheduler"}),
+            200,
+        )
+
+    control = getattr(current_app, "camera_control_client", None)
+    if control is None:
+        return jsonify({"error": "Control client unavailable"}), 503
+
+    if not camera.ip:
+        # Nothing to stop at camera level — just clear intent.
+        camera.desired_stream_state = "stopped"
+        current_app.store.save_camera(camera)
+        return jsonify({"ok": True, "stopped": True}), 200
+
+    _, err = control.stop_stream(camera.ip)
+    if err:
+        log.warning("on-demand stop %s failed: %s", camera_id, err)
+        return jsonify({"error": err}), 502
+
+    camera.desired_stream_state = "stopped"
+    current_app.store.save_camera(camera)
+    return jsonify({"ok": True, "stopped": True}), 200
+
+
+class OnDemandCoordinator:
+    """Pure-Python coordinator used by the RecordingScheduler.
+
+    This mirrors the blueprint's `stop` logic without going through Flask, so
+    the scheduler can call it directly when a schedule window closes.
+    """
+
+    def __init__(self, store, control_client, scheduler_ref):
+        self._store = store
+        self._control = control_client
+        self._scheduler_ref = scheduler_ref  # callable returning scheduler
+
+    def stop(self, camera_id: str) -> tuple[bool, str]:
+        """Stop the camera stream if no one else needs it.
+
+        Returns (acted, reason). `acted` True iff we issued a stop.
+        """
+        scheduler = None
+        if self._scheduler_ref is not None:
+            try:
+                scheduler = self._scheduler_ref()
+            except Exception:
+                scheduler = None
+        if scheduler is not None and scheduler.needs_stream(camera_id):
+            return False, "scheduler"
+
+        camera = self._store.get_camera(camera_id)
+        if camera is None:
+            return False, "not_found"
+        if camera.desired_stream_state != "running":
+            return False, "already_stopped"
+        if not camera.ip or self._control is None:
+            camera.desired_stream_state = "stopped"
+            self._store.save_camera(camera)
+            return True, "no_ip"
+
+        _, err = self._control.stop_stream(camera.ip)
+        if err:
+            return False, err
+        camera.desired_stream_state = "stopped"
+        self._store.save_camera(camera)
+        return True, "ok"

--- a/app/server/monitor/api/recordings.py
+++ b/app/server/monitor/api/recordings.py
@@ -4,11 +4,18 @@ Recordings API — thin HTTP adapter.
 Delegates all business logic to RecordingsService.
 
 Endpoints:
+  GET    /recordings/cameras                    - cameras eligible to browse
+                                                   (paired + orphaned archives)
   GET    /recordings/<cam-id>?date=YYYY-MM-DD  - list clips for a camera/date
   GET    /recordings/<cam-id>/dates             - list dates with clips
   GET    /recordings/<cam-id>/latest            - most recent clip
   GET    /recordings/<cam-id>/<date>/<filename> - serve a clip file
   DELETE /recordings/<cam-id>/<date>/<filename> - delete a clip (admin)
+  DELETE /recordings/<cam-id>/<date>            - delete all clips on a date (admin)
+  DELETE /recordings/<cam-id>                   - delete all clips for a camera (admin)
+
+Route ordering: Werkzeug prefers static segments over variable segments,
+so ``/recordings/cameras`` wins over ``/recordings/<camera_id>`` — safe.
 """
 
 from flask import Blueprint, current_app, jsonify, request, send_file, session
@@ -21,6 +28,21 @@ recordings_bp = Blueprint("recordings", __name__)
 def _svc():
     """Get the recordings service from the app."""
     return current_app.recordings_service
+
+
+@recordings_bp.route("/cameras", methods=["GET"])
+@login_required
+def list_camera_sources():
+    """List cameras that can appear in the Recordings tab.
+
+    Returns paired cameras (online/offline) and orphaned archives
+    (``status=removed``) whose Camera record was deleted but whose
+    clips remain on disk.
+    """
+    result, error, status = _svc().list_camera_sources()
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
 
 
 @recordings_bp.route("/<camera_id>", methods=["GET"])
@@ -73,6 +95,41 @@ def delete_clip(camera_id, clip_date, filename):
         camera_id,
         clip_date,
         filename,
+        requesting_user=session.get("username", ""),
+        requesting_ip=request.remote_addr or "",
+    )
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
+
+
+@recordings_bp.route("/<camera_id>/<clip_date>", methods=["DELETE"])
+@admin_required
+@csrf_protect
+def delete_date(camera_id, clip_date):
+    """Delete all clips for a camera on a given date. Admin only."""
+    result, error, status = _svc().delete_date(
+        camera_id,
+        clip_date,
+        requesting_user=session.get("username", ""),
+        requesting_ip=request.remote_addr or "",
+    )
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
+
+
+@recordings_bp.route("/<camera_id>", methods=["DELETE"])
+@admin_required
+@csrf_protect
+def delete_camera_recordings(camera_id):
+    """Delete all recordings for a camera across every date. Admin only.
+
+    The Camera record itself is not affected — remove/unpair is a
+    separate action under /api/v1/cameras.
+    """
+    result, error, status = _svc().delete_camera_recordings(
+        camera_id,
         requesting_user=session.get("username", ""),
         requesting_ip=request.remote_addr or "",
     )

--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -11,7 +11,7 @@ Files:
   /data/config/settings.json - system settings
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -24,7 +24,12 @@ class Camera:
     status: str = "pending"  # pending | online | offline
     ip: str = ""
     rtsp_url: str = ""
-    recording_mode: str = "continuous"  # continuous | off | motion (Phase 2)
+    # ADR-0017: recording mode + schedule (off default — on-demand streaming)
+    recording_mode: str = "off"  # off | continuous | schedule | motion
+    recording_schedule: list[dict] = field(default_factory=list)
+    recording_motion_enabled: bool = False  # reserved for future motion ADR
+    # Server's mirror of what it last asked the camera to do (ADR-0017)
+    desired_stream_state: str = "stopped"  # running | stopped
     resolution: str = "1080p"  # 720p | 1080p
     fps: int = 25
     paired_at: str | None = None
@@ -85,6 +90,11 @@ class Settings:
     tailscale_accept_routes: bool = False  # --accept-routes flag
     tailscale_ssh: bool = False  # --ssh flag for Tailscale SSH
     tailscale_auth_key: str = ""  # pre-auth key for headless setup
+    # Loop-recording watermarks (ADR-0017). LoopRecorder deletes oldest
+    # recording segments when free space drops below low_watermark %
+    # and stops deleting once free space reaches low + hysteresis.
+    loop_low_watermark_percent: int = 10
+    loop_hysteresis_percent: int = 5
 
 
 @dataclass

--- a/app/server/monitor/services/camera_control_client.py
+++ b/app/server/monitor/services/camera_control_client.py
@@ -97,6 +97,43 @@ class CameraControlClient:
         """
         return self._request("POST", camera_ip, "/api/v1/control/restart-stream")
 
+    def start_stream(self, camera_ip):
+        """POST /api/v1/control/stream/start on camera (ADR-0017).
+
+        Idempotent: returns success if camera reports already running.
+        Returns (result_dict, error_string).
+        """
+        result, err = self._request(
+            "POST", camera_ip, "/api/v1/control/stream/start", {}
+        )
+        if not err and isinstance(result, dict):
+            state = result.get("state")
+            if state == "running":
+                log.debug("Camera %s stream state=running (start)", camera_ip)
+        return result, err
+
+    def stop_stream(self, camera_ip):
+        """POST /api/v1/control/stream/stop on camera (ADR-0017).
+
+        Idempotent: returns success if camera reports already stopped.
+        Returns (result_dict, error_string).
+        """
+        result, err = self._request(
+            "POST", camera_ip, "/api/v1/control/stream/stop", {}
+        )
+        if not err and isinstance(result, dict):
+            state = result.get("state")
+            if state == "stopped":
+                log.debug("Camera %s stream state=stopped (stop)", camera_ip)
+        return result, err
+
+    def get_stream_state(self, camera_ip):
+        """GET /api/v1/control/stream/state from camera (ADR-0017).
+
+        Returns (state_dict, error_string). state_dict contains 'state'.
+        """
+        return self._request("GET", camera_ip, "/api/v1/control/stream/state")
+
     def _request(self, method, camera_ip, path, body=None):
         """Make an HTTPS request to the camera's control API.
 

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -17,8 +17,10 @@ from datetime import UTC, datetime
 
 log = logging.getLogger("monitor.camera_service")
 
-VALID_RECORDING_MODES = {"continuous", "off"}
+VALID_RECORDING_MODES = {"off", "continuous", "schedule", "motion"}
 VALID_RESOLUTIONS = {"720p", "1080p"}
+VALID_SCHEDULE_DAYS = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"}
+_TIME_RE = re.compile(r"^\d{2}:\d{2}$")
 
 # Camera IDs must follow cam-<hexsuffix> format: cam- prefix + 1-32 lowercase hex chars.
 # This matches the hardware serial format generated on cameras and prevents:
@@ -39,6 +41,37 @@ STREAM_PARAMS = {
     "hflip",
     "vflip",
 }
+
+
+def _validate_schedule(schedule) -> str:
+    """Validate a recording_schedule payload. Returns error string or ''."""
+    if not isinstance(schedule, list):
+        return "recording_schedule must be a list"
+    for i, item in enumerate(schedule):
+        if not isinstance(item, dict):
+            return f"recording_schedule[{i}] must be an object"
+        if set(item.keys()) != {"days", "start", "end"}:
+            return (
+                f"recording_schedule[{i}] must have exactly keys 'days', 'start', 'end'"
+            )
+        days = item["days"]
+        if not isinstance(days, list) or not days:
+            return f"recording_schedule[{i}].days must be a non-empty list"
+        for d in days:
+            if d not in VALID_SCHEDULE_DAYS:
+                return f"recording_schedule[{i}].days has invalid day: {d!r}"
+        for key in ("start", "end"):
+            val = item[key]
+            if not isinstance(val, str) or not _TIME_RE.match(val):
+                return f"recording_schedule[{i}].{key} must match HH:MM"
+            hh, mm = val.split(":")
+            try:
+                h, m = int(hh), int(mm)
+            except ValueError:
+                return f"recording_schedule[{i}].{key} must be a valid 24h time"
+            if not (0 <= h <= 23 and 0 <= m <= 59):
+                return f"recording_schedule[{i}].{key} must be a valid 24h time"
+    return ""
 
 
 class CameraService:
@@ -137,6 +170,10 @@ class CameraService:
                 "vflip": c.vflip,
                 "config_sync": c.config_sync,
                 "streaming": streaming_now,
+                # ADR-0017 recording-mode fields
+                "recording_schedule": list(c.recording_schedule),
+                "recording_motion_enabled": c.recording_motion_enabled,
+                "desired_stream_state": c.desired_stream_state,
             }
             if admin_view:
                 # Admin-only fields: network topology + health metrics
@@ -261,12 +298,9 @@ class CameraService:
 
         self._store.save_camera(camera)
 
-        # Handle recording mode transitions
-        if self._streaming and "recording_mode" in data:
-            if data["recording_mode"] == "continuous" and old_recording_mode == "off":
-                self._streaming.start_camera(camera_id)
-            elif data["recording_mode"] == "off" and old_recording_mode == "continuous":
-                self._streaming.stop_camera(camera_id)
+        # ADR-0017: recording-mode transitions are reconciled by
+        # RecordingScheduler on its next tick — no direct pipeline calls here.
+        _ = old_recording_mode  # retained for audit/logging compatibility
 
         self._log_audit(
             "CAMERA_UPDATED",
@@ -417,6 +451,8 @@ class CameraService:
             "name",
             "location",
             "recording_mode",
+            "recording_schedule",
+            "recording_motion_enabled",
             "resolution",
             "fps",
             "width",
@@ -489,6 +525,16 @@ class CameraService:
 
         if "vflip" in data and not isinstance(data["vflip"], bool):
             return "vflip must be a boolean"
+
+        if "recording_schedule" in data:
+            err = _validate_schedule(data["recording_schedule"])
+            if err:
+                return err
+
+        if "recording_motion_enabled" in data and not isinstance(
+            data["recording_motion_enabled"], bool
+        ):
+            return "recording_motion_enabled must be a boolean"
 
         return ""
 

--- a/app/server/monitor/services/loop_recorder.py
+++ b/app/server/monitor/services/loop_recorder.py
@@ -1,0 +1,195 @@
+"""
+Loop recorder (ADR-0017) — keeps the recordings volume under its watermark
+by deleting the oldest completed segments when free space runs low.
+
+Policy:
+    free_percent < low_watermark      → delete oldest until
+    free_percent >= low_watermark + hysteresis.
+
+Safeguards:
+    - Never touches the currently-writing segment. A file is "live" when its
+      mtime is within `live_age_seconds` (default 600 = 10 minutes) or it
+      appears in the `live_segments` callback from the scheduler.
+    - Only considers `.mp4` files under <base_dir>/<camera_id>/.
+    - Every deletion emits a `RECORDING_ROTATED` audit event.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+log = logging.getLogger("monitor.loop_recorder")
+
+TICK_INTERVAL_SECONDS = 60
+DEFAULT_LOW_WATERMARK = 10  # percent free
+DEFAULT_HYSTERESIS = 5  # extra percent above low watermark to reclaim
+DEFAULT_LIVE_AGE = 600  # seconds
+
+
+class LoopRecorder:
+    """Daemon that prunes oldest segments when disk is low."""
+
+    def __init__(
+        self,
+        base_dir: str | Path,
+        audit=None,
+        low_watermark: int = DEFAULT_LOW_WATERMARK,
+        hysteresis: int = DEFAULT_HYSTERESIS,
+        live_age_seconds: int = DEFAULT_LIVE_AGE,
+        live_segments_getter: Callable[[], set] | None = None,
+        tick_seconds: int = TICK_INTERVAL_SECONDS,
+    ):
+        self._base_dir = Path(base_dir)
+        self._audit = audit
+        self._low = low_watermark
+        self._hys = hysteresis
+        self._live_age = live_age_seconds
+        self._live_segments_getter = live_segments_getter
+        self._tick = tick_seconds
+        self._running = False
+        self._thread: threading.Thread | None = None
+
+    # --- Lifecycle --------------------------------------------------------
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._run, name="loop-recorder", daemon=True
+        )
+        self._thread.start()
+        log.info(
+            "LoopRecorder started (watermark=%d%%, hysteresis=%d%%)",
+            self._low,
+            self._hys,
+        )
+
+    def stop(self):
+        self._running = False
+
+    def set_watermarks(self, low: int, hysteresis: int) -> None:
+        """Update watermark thresholds at runtime.
+
+        Called by SettingsService when the admin changes the loop settings
+        so the running recorder reflects the new values without a restart.
+        """
+        self._low = int(low)
+        self._hys = int(hysteresis)
+        log.info(
+            "LoopRecorder watermarks updated (low=%d%%, hysteresis=%d%%)",
+            self._low,
+            self._hys,
+        )
+
+    # --- Public API -------------------------------------------------------
+
+    def tick(self) -> int:
+        """Run one reclamation pass. Returns the number of files deleted."""
+        try:
+            free_pct = self._free_percent()
+        except OSError as exc:
+            log.warning("LoopRecorder: statvfs failed: %s", exc)
+            return 0
+
+        if free_pct >= self._low:
+            return 0
+
+        target = self._low + self._hys
+        candidates = self._segments_oldest_first()
+        live = self._live_segments()
+        now = time.time()
+        deleted = 0
+
+        for path in candidates:
+            if self._free_percent() >= target:
+                break
+            if self._is_live(path, live, now):
+                continue
+            try:
+                size = path.stat().st_size
+            except OSError:
+                size = 0
+            try:
+                path.unlink()
+            except OSError as exc:
+                log.warning("LoopRecorder: delete %s failed: %s", path, exc)
+                continue
+            deleted += 1
+            self._audit_delete(path, size)
+        return deleted
+
+    # --- Internals --------------------------------------------------------
+
+    def _run(self):
+        while self._running:
+            try:
+                self.tick()
+            except Exception as exc:
+                log.warning("LoopRecorder tick error: %s", exc)
+            for _ in range(self._tick * 10):
+                if not self._running:
+                    return
+                time.sleep(0.1)
+
+    def _free_percent(self) -> float:
+        """Return free-space percentage for the base directory's filesystem."""
+        if not self._base_dir.exists():
+            return 100.0
+        usage = shutil.disk_usage(str(self._base_dir))
+        if usage.total == 0:
+            return 100.0
+        return 100.0 * usage.free / usage.total
+
+    def _segments_oldest_first(self) -> list[Path]:
+        """All .mp4 segments under base_dir, sorted by mtime ascending."""
+        if not self._base_dir.is_dir():
+            return []
+        files: list[Path] = []
+        for p in self._base_dir.rglob("*.mp4"):
+            if p.is_file():
+                files.append(p)
+        files.sort(key=lambda p: _safe_mtime(p))
+        return files
+
+    def _live_segments(self) -> set:
+        if self._live_segments_getter is None:
+            return set()
+        try:
+            return set(self._live_segments_getter() or ())
+        except Exception:
+            return set()
+
+    def _is_live(self, path: Path, live: set, now: float) -> bool:
+        if str(path) in live or path in live:
+            return True
+        try:
+            age = now - path.stat().st_mtime
+        except OSError:
+            return True  # safer to keep
+        return age < self._live_age
+
+    def _audit_delete(self, path: Path, size: int):
+        if self._audit is None:
+            return
+        try:
+            self._audit.log_event(
+                "RECORDING_ROTATED",
+                user="system",
+                ip="",
+                detail=f"deleted {path} ({size} bytes)",
+            )
+        except Exception as exc:
+            log.debug("LoopRecorder audit log failed: %s", exc)
+
+
+def _safe_mtime(p: Path) -> float:
+    try:
+        return p.stat().st_mtime
+    except OSError:
+        return 0.0

--- a/app/server/monitor/services/recording_scheduler.py
+++ b/app/server/monitor/services/recording_scheduler.py
@@ -186,20 +186,25 @@ class RecordingScheduler:
                 self._needed.add(cam_id)
 
             # Ask the camera to stream if we haven't already.
-            if (
-                camera.desired_stream_state != "running"
-                and camera.ip
-                and self._control is not None
-            ):
+            stream_ready = camera.desired_stream_state == "running"
+            if not stream_ready and camera.ip and self._control is not None:
                 _, err = self._control.start_stream(camera.ip)
                 if err:
                     log.warning("Scheduler: start_stream(%s) failed: %s", cam_id, err)
                 else:
                     camera.desired_stream_state = "running"
                     self._store.save_camera(camera)
+                    stream_ready = True
 
-            # Start the recorder if not already running.
-            if not is_recording and self._streaming is not None:
+            # Start the recorder only once the camera stream is actually
+            # running — otherwise ffmpeg would spin in a dead-restart loop
+            # against a source that has no publisher.
+            if (
+                stream_ready
+                and getattr(camera, "streaming", False)
+                and not is_recording
+                and self._streaming is not None
+            ):
                 rtsp_url = f"rtsp://127.0.0.1:8554/{cam_id}"
                 self._streaming.start_recorder(cam_id, rtsp_url)
         else:

--- a/app/server/monitor/services/recording_scheduler.py
+++ b/app/server/monitor/services/recording_scheduler.py
@@ -1,0 +1,222 @@
+"""
+Recording scheduler (ADR-0017) — evaluates per-camera recording mode + schedule
+once per minute and starts / stops recorder ffmpeg processes accordingly.
+
+Policy (per tick, per camera):
+    mode == "off"         → recorder stopped.
+    mode == "continuous"  → recorder running while camera is paired.
+    mode == "schedule"    → recorder running iff now-in-window(schedule, now).
+    mode == "motion"      → treated as "off" (reserved for future motion ADR).
+
+When turning a recorder on, the scheduler also asks the camera to start
+streaming (if `desired_stream_state == "stopped"`), persists the new
+desired state, and updates `cameras.json`.
+
+When turning a recorder off, the scheduler defers the camera stop to the
+on-demand coordinator (§6) which holds the single "does anything still
+need this stream?" gate — so we don't fight with an active viewer.
+"""
+
+import logging
+import threading
+import time
+from datetime import datetime
+from datetime import time as dtime
+
+log = logging.getLogger("monitor.recording_scheduler")
+
+DAY_INDEX = {
+    "mon": 0,
+    "tue": 1,
+    "wed": 2,
+    "thu": 3,
+    "fri": 4,
+    "sat": 5,
+    "sun": 6,
+}
+
+TICK_INTERVAL_SECONDS = 60
+
+
+def _parse_hhmm(s: str) -> dtime | None:
+    """Parse a HH:MM string into a datetime.time, returning None on error."""
+    try:
+        hh, mm = s.split(":")
+        return dtime(int(hh), int(mm))
+    except (ValueError, AttributeError):
+        return None
+
+
+def now_in_window(schedule: list[dict], now: datetime) -> bool:
+    """Return True if `now` falls inside any window in `schedule`.
+
+    Each window: {"days": [...], "start": "HH:MM", "end": "HH:MM"}.
+    Overnight windows (end <= start) split into two halves:
+        day D        from start to 24:00
+        day D+1      from 00:00 to end
+    """
+    if not schedule:
+        return False
+
+    today_idx = now.weekday()
+    yesterday_idx = (today_idx - 1) % 7
+    current = now.time()
+
+    for item in schedule:
+        days = item.get("days") or []
+        start = _parse_hhmm(item.get("start", ""))
+        end = _parse_hhmm(item.get("end", ""))
+        if start is None or end is None:
+            continue
+
+        day_keys = {d for d in days if d in DAY_INDEX}
+        today_match = any(DAY_INDEX[d] == today_idx for d in day_keys)
+        yest_match = any(DAY_INDEX[d] == yesterday_idx for d in day_keys)
+
+        if end > start:
+            # Same-day window [start, end).
+            if today_match and start <= current < end:
+                return True
+        else:
+            # Overnight — end <= start.
+            # Day of record: start side (D), and spillover into D+1 morning.
+            if today_match and current >= start:
+                return True
+            if yest_match and current < end:
+                return True
+    return False
+
+
+class RecordingScheduler:
+    """Background daemon that reconciles recording state once per minute."""
+
+    def __init__(
+        self,
+        store,
+        streaming,
+        control_client,
+        coordinator=None,
+        tick_seconds: int = TICK_INTERVAL_SECONDS,
+    ):
+        self._store = store
+        self._streaming = streaming
+        self._control = control_client
+        self._coordinator = coordinator  # may be None in tests
+        self._tick = tick_seconds
+        self._running = False
+        self._thread: threading.Thread | None = None
+        # Track cameras we currently think need the stream for recording.
+        self._needed: set[str] = set()
+        self._lock = threading.Lock()
+
+    # --- Lifecycle --------------------------------------------------------
+
+    def start(self):
+        """Start the daemon tick loop."""
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name="recording-scheduler",
+            daemon=True,
+        )
+        self._thread.start()
+        log.info("RecordingScheduler started (tick=%ds)", self._tick)
+
+    def stop(self):
+        """Stop the daemon."""
+        self._running = False
+
+    # --- Public API -------------------------------------------------------
+
+    def needs_stream(self, camera_id: str) -> bool:
+        """True iff the scheduler currently wants this camera streaming."""
+        with self._lock:
+            return camera_id in self._needed
+
+    def tick(self):
+        """Run one reconciliation pass. Exposed for tests."""
+        try:
+            cameras = self._store.get_cameras()
+        except Exception as exc:
+            log.warning("Scheduler: failed to load cameras: %s", exc)
+            return
+        now = datetime.now()
+        for cam in cameras:
+            try:
+                self._reconcile_camera(cam, now)
+            except Exception as exc:
+                log.warning("Scheduler reconcile failed for %s: %s", cam.id, exc)
+
+    @staticmethod
+    def evaluate(camera, now: datetime) -> bool:
+        """Pure function — is recording wanted for this camera at `now`?
+
+        Exposed for unit tests; no side-effects.
+        """
+        mode = getattr(camera, "recording_mode", "off")
+        if mode == "continuous":
+            return True
+        if mode == "schedule":
+            return now_in_window(getattr(camera, "recording_schedule", []) or [], now)
+        # "off" and "motion" both map to False for MVP.
+        return False
+
+    # --- Internals --------------------------------------------------------
+
+    def _run_loop(self):
+        while self._running:
+            self.tick()
+            for _ in range(self._tick * 10):
+                if not self._running:
+                    return
+                time.sleep(0.1)
+
+    def _reconcile_camera(self, camera, now: datetime) -> None:
+        wanted = self.evaluate(camera, now)
+        cam_id = camera.id
+
+        is_recording = False
+        if self._streaming is not None:
+            is_recording = self._streaming.is_recording(cam_id)
+
+        if wanted:
+            with self._lock:
+                self._needed.add(cam_id)
+
+            # Ask the camera to stream if we haven't already.
+            if (
+                camera.desired_stream_state != "running"
+                and camera.ip
+                and self._control is not None
+            ):
+                _, err = self._control.start_stream(camera.ip)
+                if err:
+                    log.warning("Scheduler: start_stream(%s) failed: %s", cam_id, err)
+                else:
+                    camera.desired_stream_state = "running"
+                    self._store.save_camera(camera)
+
+            # Start the recorder if not already running.
+            if not is_recording and self._streaming is not None:
+                rtsp_url = f"rtsp://127.0.0.1:8554/{cam_id}"
+                self._streaming.start_recorder(cam_id, rtsp_url)
+        else:
+            with self._lock:
+                self._needed.discard(cam_id)
+
+            if is_recording and self._streaming is not None:
+                self._streaming.stop_recorder(cam_id)
+                # After stopping, delegate the camera-stream-off decision to
+                # the coordinator so we don't yank it out from under a viewer.
+                self._maybe_request_stream_stop(cam_id)
+
+    def _maybe_request_stream_stop(self, cam_id: str) -> None:
+        """Ask the coordinator whether the camera stream can now be stopped."""
+        if self._coordinator is None:
+            return
+        try:
+            self._coordinator.stop(cam_id)
+        except Exception as exc:
+            log.debug("Coordinator stop(%s) failed: %s", cam_id, exc)

--- a/app/server/monitor/services/recordings_service.py
+++ b/app/server/monitor/services/recordings_service.py
@@ -11,12 +11,20 @@ the store or audit logger directly.
 """
 
 import logging
+import re
+import shutil
 from dataclasses import asdict
 from pathlib import Path
 
 from monitor.services.recorder_service import RecorderService
 
 log = logging.getLogger("monitor.recordings-service")
+
+# Camera IDs are derived from hardware serials (hex/alnum). Restrict here so
+# they cannot encode path traversal when used in filesystem paths.
+_CAMERA_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+# Recording date directories are always YYYY-MM-DD.
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 class RecordingsService:
@@ -52,6 +60,37 @@ class RecordingsService:
             recordings_dir = self._default_recordings_dir
         return RecorderService(recordings_dir, self._live_dir)
 
+    def _recordings_root(self) -> Path:
+        """Absolute path to the recordings root (one subdir per camera)."""
+        return Path(self._get_recorder()._recordings_dir)
+
+    def _valid_camera_id(self, camera_id: str) -> bool:
+        return bool(camera_id) and bool(_CAMERA_ID_RE.match(camera_id))
+
+    def _has_recordings_on_disk(self, camera_id: str) -> bool:
+        """True if the camera has any mp4 clips on disk."""
+        if not self._valid_camera_id(camera_id):
+            return False
+        cam_dir = self._recordings_root() / camera_id
+        if not cam_dir.is_dir():
+            return False
+        try:
+            return any(
+                d.is_dir() and any(d.glob("*.mp4"))
+                for d in cam_dir.iterdir()
+            )
+        except OSError:
+            return False
+
+    def _camera_known(self, camera_id: str) -> bool:
+        """A camera is 'known' to Recordings if it's paired OR has files.
+        The latter is the orphan case: admin deleted the Camera record but
+        we keep the clips until someone explicitly removes them.
+        """
+        if self._store.get_camera(camera_id) is not None:
+            return True
+        return self._has_recordings_on_disk(camera_id)
+
     def _log_audit(self, event, **kwargs):
         """Log an audit event (fail-silent)."""
         if not self._audit:
@@ -65,6 +104,53 @@ class RecordingsService:
     # Queries
     # ------------------------------------------------------------------
 
+    def list_camera_sources(self):
+        """Cameras the Recordings tab can browse: paired + orphans.
+
+        Paired cameras with ``status=pending`` are excluded — they've
+        never come online so there are no clips to browse. Orphans
+        (directories on disk with mp4s but no matching Camera record)
+        appear with ``status=removed`` so the UI can group them under
+        a "Removed" archive in the dropdown.
+
+        Returns:
+            (list[dict], None, 200). Each dict: {id, name, status}.
+            status ∈ {"online", "offline", "removed"}.
+        """
+        paired = {c.id: c for c in self._store.get_cameras()}
+        result = []
+        for cam in paired.values():
+            if cam.status == "pending":
+                continue
+            status = "online" if cam.status == "online" else "offline"
+            result.append({
+                "id": cam.id,
+                "name": cam.name or cam.id,
+                "status": status,
+            })
+
+        root = self._recordings_root()
+        if root.is_dir():
+            try:
+                children = sorted(root.iterdir())
+            except OSError:
+                children = []
+            for child in children:
+                if not child.is_dir():
+                    continue
+                if child.name in paired:
+                    continue
+                if not self._valid_camera_id(child.name):
+                    continue
+                if not self._has_recordings_on_disk(child.name):
+                    continue
+                result.append({
+                    "id": child.name,
+                    "name": child.name,
+                    "status": "removed",
+                })
+        return result, None, 200
+
     def list_clips(self, camera_id: str, date: str = ""):
         """List clips for a camera on a date.
 
@@ -72,8 +158,7 @@ class RecordingsService:
             (list[dict], None, 200) on success.
             (None, error_message, status_code) on failure.
         """
-        camera = self._store.get_camera(camera_id)
-        if camera is None:
+        if not self._camera_known(camera_id):
             return None, "Camera not found", 404
 
         recorder = self._get_recorder()
@@ -87,8 +172,7 @@ class RecordingsService:
             (dict, None, 200) on success.
             (None, error_message, 404) if camera not found.
         """
-        camera = self._store.get_camera(camera_id)
-        if camera is None:
+        if not self._camera_known(camera_id):
             return None, "Camera not found", 404
 
         recorder = self._get_recorder()
@@ -102,8 +186,7 @@ class RecordingsService:
             (dict, None, 200) on success.
             (None, error_message, status_code) on failure.
         """
-        camera = self._store.get_camera(camera_id)
-        if camera is None:
+        if not self._camera_known(camera_id):
             return None, "Camera not found", 404
 
         recorder = self._get_recorder()
@@ -174,3 +257,96 @@ class RecordingsService:
         )
 
         return {"message": "Clip deleted"}, None, 200
+
+    # ------------------------------------------------------------------
+    # Bulk deletion — used by the Recordings tab's danger zone and
+    # multi-select toolbar. Paths are validated + resolved + traversal-
+    # checked before any rmtree. Orphan cameras are deletable too; that
+    # is the main way to clean up a removed-camera archive.
+    # ------------------------------------------------------------------
+
+    def _safe_subpath(self, *parts: str):
+        """Resolve a path under the recordings root. Returns (path, err).
+
+        ``err`` is "" on success. Any path that escapes the root, or
+        components that fail validation, return an error + None path.
+        """
+        root = self._recordings_root().resolve()
+        try:
+            target = (root.joinpath(*parts)).resolve()
+        except (ValueError, OSError):
+            return None, "Invalid path"
+        try:
+            target.relative_to(root)
+        except ValueError:
+            return None, "Invalid path"
+        return target, ""
+
+    def delete_date(
+        self,
+        camera_id: str,
+        date: str,
+        requesting_user: str = "",
+        requesting_ip: str = "",
+    ):
+        """Delete every clip for one camera on one date.
+
+        Returns (dict, None, 200) on success with a ``count`` of deleted
+        clips, else (None, error_message, status).
+        """
+        if not self._valid_camera_id(camera_id):
+            return None, "Invalid camera id", 400
+        if not _DATE_RE.match(date or ""):
+            return None, "Invalid date", 400
+        if not self._camera_known(camera_id):
+            return None, "Camera not found", 404
+
+        target, err = self._safe_subpath(camera_id, date)
+        if err:
+            return None, err, 400
+        if not target.is_dir():
+            return None, "No recordings on that date", 404
+
+        count = sum(1 for _ in target.glob("*.mp4"))
+        shutil.rmtree(target, ignore_errors=False)
+
+        self._log_audit(
+            "CLIPS_DELETED",
+            user=requesting_user,
+            ip=requesting_ip,
+            detail=f"deleted {count} clips from {camera_id}/{date}",
+        )
+        return {"message": f"Deleted {count} clips", "count": count}, None, 200
+
+    def delete_camera_recordings(
+        self,
+        camera_id: str,
+        requesting_user: str = "",
+        requesting_ip: str = "",
+    ):
+        """Delete every clip for one camera across all dates.
+
+        The Camera record itself (if any) is left alone — unpair/remove
+        is a separate operation. Only the recordings directory is purged.
+        """
+        if not self._valid_camera_id(camera_id):
+            return None, "Invalid camera id", 400
+        if not self._camera_known(camera_id):
+            return None, "Camera not found", 404
+
+        target, err = self._safe_subpath(camera_id)
+        if err:
+            return None, err, 400
+        if not target.is_dir():
+            return None, "No recordings", 404
+
+        count = sum(1 for _ in target.rglob("*.mp4"))
+        shutil.rmtree(target, ignore_errors=False)
+
+        self._log_audit(
+            "CLIPS_DELETED",
+            user=requesting_user,
+            ip=requesting_ip,
+            detail=f"deleted all {count} clips for {camera_id}",
+        )
+        return {"message": f"Deleted {count} clips", "count": count}, None, 200

--- a/app/server/monitor/services/recordings_service.py
+++ b/app/server/monitor/services/recordings_service.py
@@ -75,10 +75,7 @@ class RecordingsService:
         if not cam_dir.is_dir():
             return False
         try:
-            return any(
-                d.is_dir() and any(d.glob("*.mp4"))
-                for d in cam_dir.iterdir()
-            )
+            return any(d.is_dir() and any(d.glob("*.mp4")) for d in cam_dir.iterdir())
         except OSError:
             return False
 
@@ -123,11 +120,13 @@ class RecordingsService:
             if cam.status == "pending":
                 continue
             status = "online" if cam.status == "online" else "offline"
-            result.append({
-                "id": cam.id,
-                "name": cam.name or cam.id,
-                "status": status,
-            })
+            result.append(
+                {
+                    "id": cam.id,
+                    "name": cam.name or cam.id,
+                    "status": status,
+                }
+            )
 
         root = self._recordings_root()
         if root.is_dir():
@@ -144,11 +143,13 @@ class RecordingsService:
                     continue
                 if not self._has_recordings_on_disk(child.name):
                     continue
-                result.append({
-                    "id": child.name,
-                    "name": child.name,
-                    "status": "removed",
-                })
+                result.append(
+                    {
+                        "id": child.name,
+                        "name": child.name,
+                        "status": "removed",
+                    }
+                )
         return result, None, 200
 
     def list_clips(self, camera_id: str, date: str = ""):

--- a/app/server/monitor/services/settings_service.py
+++ b/app/server/monitor/services/settings_service.py
@@ -29,6 +29,9 @@ UPDATABLE_FIELDS = {
     "tailscale_accept_routes",
     "tailscale_ssh",
     "tailscale_auth_key",
+    # ADR-0017: loop recording watermarks
+    "loop_low_watermark_percent",
+    "loop_hysteresis_percent",
 }
 
 
@@ -55,6 +58,8 @@ class SettingsService:
             "tailscale_accept_routes": settings.tailscale_accept_routes,
             "tailscale_ssh": settings.tailscale_ssh,
             "tailscale_has_auth_key": bool(settings.tailscale_auth_key),
+            "loop_low_watermark_percent": settings.loop_low_watermark_percent,
+            "loop_hysteresis_percent": settings.loop_hysteresis_percent,
         }
 
     def update_settings(
@@ -116,6 +121,18 @@ class SettingsService:
             if storage_manager:
                 storage_manager.set_threshold_percent(
                     settings.storage_threshold_percent
+                )
+
+        # ADR-0017: push loop-recording watermarks to the running LoopRecorder
+        if (
+            "loop_low_watermark_percent" in updated_fields
+            or "loop_hysteresis_percent" in updated_fields
+        ):
+            loop_recorder = getattr(current_app, "loop_recorder", None)
+            if loop_recorder and hasattr(loop_recorder, "set_watermarks"):
+                loop_recorder.set_watermarks(
+                    low=settings.loop_low_watermark_percent,
+                    hysteresis=settings.loop_hysteresis_percent,
                 )
 
     def get_wifi_status(self) -> dict:
@@ -286,6 +303,43 @@ class SettingsService:
                 errors.append("tailscale_auth_key must be a string")
             elif len(val) > 256:
                 errors.append("tailscale_auth_key must be at most 256 characters")
+
+        # ADR-0017: loop-recording watermarks. Low must be in [1, 50];
+        # hysteresis in [1, 50]; low + hysteresis must stay < 100 so the
+        # deletion target is reachable.
+        low = data.get("loop_low_watermark_percent")
+        hys = data.get("loop_hysteresis_percent")
+        if "loop_low_watermark_percent" in data and (
+            not isinstance(low, int) or low < 1 or low > 50
+        ):
+            errors.append(
+                "loop_low_watermark_percent must be an integer between 1 and 50"
+            )
+        if "loop_hysteresis_percent" in data and (
+            not isinstance(hys, int) or hys < 1 or hys > 50
+        ):
+            errors.append("loop_hysteresis_percent must be an integer between 1 and 50")
+        # Cross-field: if either is being updated, ensure the pair sums < 100
+        if "loop_low_watermark_percent" in data or "loop_hysteresis_percent" in data:
+            settings = self._store.get_settings()
+            new_low = (
+                low
+                if "loop_low_watermark_percent" in data
+                else (settings.loop_low_watermark_percent)
+            )
+            new_hys = (
+                hys
+                if "loop_hysteresis_percent" in data
+                else (settings.loop_hysteresis_percent)
+            )
+            if (
+                isinstance(new_low, int)
+                and isinstance(new_hys, int)
+                and new_low + new_hys >= 100
+            ):
+                errors.append(
+                    "loop_low_watermark_percent + loop_hysteresis_percent must be < 100"
+                )
 
         return errors
 

--- a/app/server/monitor/services/streaming_service.py
+++ b/app/server/monitor/services/streaming_service.py
@@ -1,17 +1,16 @@
 """
-Streaming service — manages video pipelines per camera.
+Streaming service — per-camera snapshot extraction + recorder ownership (ADR-0017).
 
-For each confirmed camera, runs ffmpeg processes that:
-1. Convert RTSP stream to HLS segments for live view
-2. Record 3-minute MP4 clips for playback
-3. Extract periodic snapshots (every 30s)
+Architecture (post-ADR-0017):
+  Camera → RTSP push → mediamtx (:8554) → consumers
+    - Live view: MediaMTX WebRTC WHEP direct to browser (no server-side HLS).
+    - Recording: owned by RecordingScheduler (started per mode/schedule).
+    - Snapshot: single long-lived ffmpeg per camera pulling every 30 s.
 
-Architecture:
-  Camera → RTSP push → mediamtx (:8554) → ffmpeg pipelines
-
-mediamtx receives RTSP pushes from cameras and republishes them
-at rtsp://localhost:8554/<stream-name>. This service pulls from
-mediamtx to create the HLS/recording/snapshot outputs.
+The old "always-on" HLS muxer and 30-second snapshot-respawn thread are gone.
+A deliberately-stopped process is NOT restarted by the watchdog — intent is
+tracked via `_snap_intent` / `_recorder_intent` dicts so we can distinguish
+"died unexpectedly" (restart) from "asked to stop" (leave alone).
 """
 
 import logging
@@ -19,98 +18,108 @@ import os
 import subprocess
 import threading
 import time
-from datetime import datetime
 from pathlib import Path
 
 log = logging.getLogger("monitor.streaming")
 
 MEDIAMTX_URL = "rtsp://127.0.0.1:8554"
-RTSP_TIMEOUT_US = "5000000"  # 5s RTSP socket timeout (microseconds)
+RTSP_TIMEOUT_US = "5000000"  # 5 s RTSP socket timeout (microseconds)
 SNAPSHOT_INTERVAL = 30  # seconds between snapshot updates
-HLS_SEGMENT_DURATION = 2  # seconds per HLS segment
-HLS_LIST_SIZE = 5  # rolling window of HLS segments
-CLIP_DURATION = 180  # 3-minute clips
+CLIP_DURATION = 180  # default segment duration if caller doesn't override
 FFMPEG_LOG_DIR = Path("/data/logs/ffmpeg")
+
+# Legacy constants kept for backwards-compat with import sites that still
+# reference them. HLS is no longer used server-side for live view.
+HLS_SEGMENT_DURATION = 2
+HLS_LIST_SIZE = 5
 
 
 class StreamingService:
-    """Manages per-camera ffmpeg video pipelines."""
+    """Per-camera snapshot + recorder process manager (ADR-0017).
+
+    Args:
+        live_dir: directory where snapshot.jpg files live (one subdir per cam).
+        recordings_dir: base directory for recorded segments.
+        clip_duration: recorder segment length (seconds).
+    """
 
     def __init__(self, live_dir, recordings_dir, clip_duration=CLIP_DURATION):
         self._live_dir = Path(live_dir)
         self._recordings_dir = Path(recordings_dir)
         self._clip_duration = clip_duration
-        self._hls_procs = {}  # cam_id -> Popen
-        self._rec_procs = {}  # cam_id -> Popen
-        self._snap_threads = {}  # cam_id -> Thread
+        self._snap_procs: dict = {}  # cam_id -> Popen (long-lived snapshot ffmpeg)
+        self._rec_procs: dict = {}  # cam_id -> Popen (recorder — owned here)
+        self._snap_intent: dict = {}  # cam_id -> "wanted" | "stopped"
+        self._recorder_intent: dict = {}  # cam_id -> "wanted" | "stopped"
         self._running = False
         self._lock = threading.Lock()
 
+    # --- Introspection ----------------------------------------------------
+
     @property
     def active_cameras(self):
-        """Return list of camera IDs with active pipelines."""
+        """Return list of camera IDs with an active snapshot pipeline."""
         with self._lock:
-            return list(self._hls_procs.keys())
+            return list(self._snap_procs.keys())
 
     @property
     def recordings_dir(self):
-        """Current recordings directory."""
+        """Current recordings directory (string)."""
         return str(self._recordings_dir)
 
-    def update_recordings_dir(self, new_dir):
-        """Change recordings directory and restart all recorder pipelines.
+    # --- Configuration updates --------------------------------------------
 
-        Called by StorageManager when switching between internal/USB storage.
-        HLS and snapshot pipelines are unaffected (they use live_dir).
-        """
+    def update_recordings_dir(self, new_dir):
+        """Change recordings directory; restart any in-flight recorder."""
         old_dir = str(self._recordings_dir)
         self._recordings_dir = Path(new_dir)
         log.info("Recordings dir changed: %s -> %s", old_dir, new_dir)
 
-        # Restart recorders for all active cameras
-        active = self.active_cameras
-        for cam_id in active:
-            self._stop_process(cam_id, self._rec_procs, "recorder")
+        with self._lock:
+            cam_ids = list(self._rec_procs.keys())
+        for cam_id in cam_ids:
             rtsp_url = f"{MEDIAMTX_URL}/{cam_id}"
-            self._start_recorder(cam_id, rtsp_url)
-            log.info("Restarted recorder for %s with new dir", cam_id)
+            self.stop_recorder(cam_id)
+            self.start_recorder(cam_id, rtsp_url)
 
     def set_clip_duration(self, new_duration):
-        """Update clip duration and restart active recorder pipelines."""
+        """Update recorder segment duration; restart active recorders."""
         if new_duration == self._clip_duration:
             return
-
-        old_duration = self._clip_duration
         self._clip_duration = new_duration
-        log.info("Clip duration changed: %ss -> %ss", old_duration, new_duration)
-
-        active = self.active_cameras
-        for cam_id in active:
-            self._stop_process(cam_id, self._rec_procs, "recorder")
+        with self._lock:
+            cam_ids = list(self._rec_procs.keys())
+        for cam_id in cam_ids:
             rtsp_url = f"{MEDIAMTX_URL}/{cam_id}"
-            self._start_recorder(cam_id, rtsp_url)
-            log.info("Restarted recorder for %s with new clip duration", cam_id)
+            self.stop_recorder(cam_id)
+            self.start_recorder(cam_id, rtsp_url)
+
+    # --- Lifecycle --------------------------------------------------------
 
     def start(self):
-        """Start the streaming service and watchdog thread."""
+        """Start the service + watchdog thread."""
         self._running = True
         self._start_watchdog()
-        log.info("Streaming service started")
+        log.info("Streaming service started (on-demand mode, ADR-0017)")
 
     def stop(self):
         """Stop all pipelines and clean up."""
         self._running = False
-        cam_ids = list(self._hls_procs.keys())
-        for cam_id in cam_ids:
-            self.stop_camera(cam_id)
+        with self._lock:
+            snap_ids = list(self._snap_procs.keys())
+            rec_ids = list(self._rec_procs.keys())
+        for cam_id in snap_ids:
+            self.stop_snapshot(cam_id)
+        for cam_id in rec_ids:
+            self.stop_recorder(cam_id)
         log.info("Streaming service stopped")
 
-    def start_camera(self, cam_id, stream_name=None):
-        """Start all pipelines for a camera.
+    # --- Per-camera convenience wrappers ----------------------------------
 
-        Args:
-            cam_id: Camera identifier
-            stream_name: RTSP stream name on mediamtx (defaults to cam_id)
+    def start_camera(self, cam_id, stream_name=None):
+        """Start the long-lived snapshot ffmpeg for a camera.
+
+        Recording is NOT started here — that is the scheduler's job.
         """
         if not self._running:
             log.warning("Streaming service not running")
@@ -119,63 +128,47 @@ class StreamingService:
         stream_name = stream_name or cam_id
         rtsp_url = f"{MEDIAMTX_URL}/{stream_name}"
 
-        # Create output directories
-        cam_live = self._live_dir / cam_id
-        cam_live.mkdir(parents=True, exist_ok=True)
+        (self._live_dir / cam_id).mkdir(parents=True, exist_ok=True)
 
-        log.info("Starting pipelines for camera %s (source: %s)", cam_id, rtsp_url)
-
-        # Start HLS pipeline
-        self._start_hls(cam_id, rtsp_url)
-
-        # Start recording pipeline
-        self._start_recorder(cam_id, rtsp_url)
-
-        # Start snapshot thread
-        self._start_snapshots(cam_id, rtsp_url)
-
+        log.info("Starting snapshot pipeline for %s", cam_id)
+        self.start_snapshot(cam_id, rtsp_url)
         return True
 
     def stop_camera(self, cam_id):
-        """Stop all pipelines for a camera."""
+        """Deliberately stop all pipelines for a camera."""
         log.info("Stopping pipelines for camera %s", cam_id)
-        self._stop_process(cam_id, self._hls_procs, "HLS")
-        self._stop_process(cam_id, self._rec_procs, "recorder")
-
-        # Stop snapshot thread
-        with self._lock:
-            if cam_id in self._snap_threads:
-                del self._snap_threads[cam_id]
-
-        # Clean up stale HLS segments
-        cam_live = self._live_dir / cam_id
-        if cam_live.is_dir():
-            for ts in cam_live.glob("segment_*.ts"):
-                try:
-                    ts.unlink()
-                except OSError:
-                    pass
+        self.stop_snapshot(cam_id)
+        self.stop_recorder(cam_id)
 
     def is_camera_active(self, cam_id):
-        """Check if a camera has active pipelines."""
+        """True iff snapshot pipeline is alive."""
         with self._lock:
-            proc = self._hls_procs.get(cam_id)
+            proc = self._snap_procs.get(cam_id)
             return proc is not None and proc.poll() is None
 
     def restart_camera(self, cam_id, stream_name=None):
-        """Restart pipelines for a camera."""
+        """Restart snapshot pipeline (kept for legacy callers)."""
         self.stop_camera(cam_id)
-        time.sleep(1)  # Brief pause between stop/start
+        time.sleep(0.5)
         return self.start_camera(cam_id, stream_name)
 
-    # --- HLS pipeline ---
+    # --- Snapshot pipeline (single long-lived ffmpeg, -update 1) ----------
 
-    def _start_hls(self, cam_id, rtsp_url):
-        """Start ffmpeg RTSP → HLS conversion."""
-        output_dir = self._live_dir / cam_id
-        playlist = output_dir / "stream.m3u8"
-        segment_pattern = str(output_dir / "segment_%03d.ts")
+    def start_snapshot(self, cam_id, rtsp_url):
+        """Start a long-lived ffmpeg that writes snapshot.jpg every 30 s."""
+        with self._lock:
+            existing = self._snap_procs.get(cam_id)
+            if existing and existing.poll() is None:
+                return  # already running
+            self._snap_intent[cam_id] = "wanted"
 
+        out_dir = self._live_dir / cam_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out = out_dir / "snapshot.jpg"
+
+        # ffmpeg's -update 1 + image2 muxer atomically rewrites snapshot.jpg.
+        # Built-in reconnect flags handle transient RTSP outages without a
+        # Python-side respawn thread.
         cmd = [
             "ffmpeg",
             "-nostdin",
@@ -183,50 +176,56 @@ class StreamingService:
             "tcp",
             "-timeout",
             RTSP_TIMEOUT_US,
+            "-reconnect",
+            "1",
+            "-reconnect_at_eof",
+            "1",
+            "-reconnect_streamed",
+            "1",
+            "-reconnect_delay_max",
+            "10",
             "-i",
             rtsp_url,
-            "-c:v",
-            "copy",
-            "-c:a",
-            "copy",
+            "-vf",
+            f"fps=1/{SNAPSHOT_INTERVAL}",
+            "-update",
+            "1",
+            "-q:v",
+            "5",
             "-f",
-            "hls",
-            "-hls_time",
-            str(HLS_SEGMENT_DURATION),
-            "-hls_list_size",
-            str(HLS_LIST_SIZE),
-            "-hls_flags",
-            "delete_segments+append_list",
-            "-hls_segment_filename",
-            segment_pattern,
-            str(playlist),
+            "image2",
+            "-y",
+            str(out),
         ]
-
-        proc = self._launch_ffmpeg(cmd, f"hls-{cam_id}")
+        proc = self._launch_ffmpeg(cmd, f"snap-{cam_id}")
         if proc:
             with self._lock:
-                self._hls_procs[cam_id] = proc
-            log.info("HLS pipeline started for %s (PID %d)", cam_id, proc.pid)
+                self._snap_procs[cam_id] = proc
+            log.info("Snapshot pipeline started for %s (PID %d)", cam_id, proc.pid)
 
-    # --- Recording pipeline ---
+    def stop_snapshot(self, cam_id):
+        """Deliberately stop the snapshot pipeline for a camera."""
+        with self._lock:
+            self._snap_intent[cam_id] = "stopped"
+        self._stop_process(cam_id, self._snap_procs, "snap")
 
-    def _start_recorder(self, cam_id, rtsp_url):
-        """Start ffmpeg RTSP → segmented MP4 recording."""
-        # Use strftime pattern for auto-dated directories
-        # ffmpeg segment_format creates: /data/recordings/<cam>/YYYY-MM-DD/HH-MM-SS.mp4
+    # --- Recorder pipeline (owned by scheduler, started on demand) --------
+
+    def start_recorder(self, cam_id, rtsp_url):
+        """Start a segmented MP4 recorder for a camera (called by scheduler).
+
+        Idempotent: if a recorder is already alive, this is a no-op.
+        Segment directory structure: <recordings_dir>/<cam_id>/YYYYMMDD_HHMMSS.mp4
+        """
+        with self._lock:
+            existing = self._rec_procs.get(cam_id)
+            if existing and existing.poll() is None:
+                return False
+            self._recorder_intent[cam_id] = "wanted"
+
         cam_rec_dir = self._recordings_dir / cam_id
         cam_rec_dir.mkdir(parents=True, exist_ok=True)
 
-        # ffmpeg segment muxer can't create subdirectories, so we
-        # pre-create today's date dir and start a thread to create
-        # tomorrow's dir at midnight.
-        today = datetime.now().strftime("%Y-%m-%d")
-        today_dir = cam_rec_dir / today
-        today_dir.mkdir(parents=True, exist_ok=True)
-
-        # Start a thread that creates the next day's dir before midnight
-        self._start_dir_creator(cam_id, cam_rec_dir)
-
         cmd = [
             "ffmpeg",
             "-nostdin",
@@ -234,13 +233,9 @@ class StreamingService:
             "tcp",
             "-timeout",
             RTSP_TIMEOUT_US,
-            "-use_wallclock_as_timestamps",
-            "1",
             "-i",
             rtsp_url,
-            "-c:v",
-            "copy",
-            "-c:a",
+            "-c",
             "copy",
             "-f",
             "segment",
@@ -248,57 +243,45 @@ class StreamingService:
             str(self._clip_duration),
             "-segment_format",
             "mp4",
-            "-segment_atclocktime",
-            "1",
-            "-segment_clocktime_wrap_duration",
-            "30",
-            "-strftime",
-            "1",
             "-reset_timestamps",
             "1",
-            str(cam_rec_dir / "%Y-%m-%d" / "%H-%M-%S.mp4"),
+            "-strftime",
+            "1",
+            str(cam_rec_dir / "%Y%m%d_%H%M%S.mp4"),
         ]
-
         proc = self._launch_ffmpeg(cmd, f"rec-{cam_id}")
         if proc:
             with self._lock:
                 self._rec_procs[cam_id] = proc
             log.info("Recorder started for %s (PID %d)", cam_id, proc.pid)
+            return True
+        return False
 
-    def _start_dir_creator(self, cam_id, rec_dir):
-        """Pre-create date directories so ffmpeg segment muxer doesn't fail at midnight."""
+    def stop_recorder(self, cam_id):
+        """Deliberately stop the recorder for a camera."""
+        with self._lock:
+            self._recorder_intent[cam_id] = "stopped"
+        self._stop_process(cam_id, self._rec_procs, "rec")
 
-        def _dir_loop():
-            while self._running and cam_id in self._rec_procs:
-                # Create today's and tomorrow's dirs
-                now = datetime.now()
-                today = now.strftime("%Y-%m-%d")
-                tomorrow = (
-                    now.replace(hour=0, minute=0, second=0)
-                    + __import__("datetime").timedelta(days=1)
-                ).strftime("%Y-%m-%d")
-                for d in [today, tomorrow]:
-                    (rec_dir / d).mkdir(parents=True, exist_ok=True)
-                # Check every 10 minutes
-                for _ in range(600):
-                    if not self._running or cam_id not in self._rec_procs:
-                        return
-                    time.sleep(1)
+    def is_recording(self, cam_id) -> bool:
+        """True iff the recorder ffmpeg for this camera is alive."""
+        with self._lock:
+            proc = self._rec_procs.get(cam_id)
+            return proc is not None and proc.poll() is None
 
-        t = threading.Thread(target=_dir_loop, daemon=True, name=f"dirs-{cam_id}")
-        t.start()
-
-    # --- Process watchdog ---
+    # --- Watchdog ---------------------------------------------------------
 
     WATCHDOG_INTERVAL = 30  # seconds between health checks
-    STALE_CLIP_FACTOR = 2  # restart if newest clip > clip_duration * factor
 
     def _start_watchdog(self):
-        """Start a watchdog thread that restarts dead ffmpeg processes."""
+        """Background thread restarting only deliberately-wanted processes."""
 
         def _watchdog_loop():
             while self._running:
-                self._check_processes()
+                try:
+                    self._check_processes()
+                except Exception as exc:
+                    log.warning("Watchdog error: %s", exc)
                 for _ in range(self.WATCHDOG_INTERVAL * 10):
                     if not self._running:
                         return
@@ -308,164 +291,44 @@ class StreamingService:
         t.start()
 
     def _check_processes(self):
-        """Check all ffmpeg processes, restart any that have died or stalled."""
-        with self._lock:
-            cam_ids = list(self._hls_procs.keys())
+        """Restart snapshot/recorder processes that died unexpectedly.
 
-        for cam_id in cam_ids:
-            rtsp_url = f"{MEDIAMTX_URL}/{cam_id}"
-
-            # Check HLS process
-            with self._lock:
-                hls_proc = self._hls_procs.get(cam_id)
-            if hls_proc and hls_proc.poll() is not None:
-                log.warning(
-                    "HLS process died for %s (PID=%d, exit=%s), restarting",
-                    cam_id,
-                    hls_proc.pid,
-                    hls_proc.returncode,
-                )
-                self._close_proc_log(hls_proc)
-                with self._lock:
-                    self._hls_procs.pop(cam_id, None)
-                self._start_hls(cam_id, rtsp_url)
-
-            # Check recorder process — dead or stalled
-            with self._lock:
-                rec_proc = self._rec_procs.get(cam_id)
-            if rec_proc and rec_proc.poll() is not None:
-                log.warning(
-                    "Recorder died for %s (PID=%d, exit=%s), restarting",
-                    cam_id,
-                    rec_proc.pid,
-                    rec_proc.returncode,
-                )
-                self._close_proc_log(rec_proc)
-                with self._lock:
-                    self._rec_procs.pop(cam_id, None)
-                self._start_recorder(cam_id, rtsp_url)
-            elif rec_proc and rec_proc.poll() is None:
-                # Process alive — check if it's actually writing clips
-                if self._is_recorder_stale(cam_id):
-                    log.warning(
-                        "Recorder stalled for %s (no new clips), force-killing PID %d",
-                        cam_id,
-                        rec_proc.pid,
-                    )
-                    self._stop_process(cam_id, self._rec_procs, "stale-rec")
-                    self._start_recorder(cam_id, rtsp_url)
-
-    def _is_recorder_stale(self, cam_id):
-        """Check if recorder is alive but not producing clips.
-
-        Returns True if the newest clip for this camera is older than
-        clip_duration * STALE_CLIP_FACTOR seconds. This catches ffmpeg
-        segment muxer hangs where the process stays alive but stops
-        writing (common on exFAT/NTFS filesystems).
+        A process whose intent is "stopped" is left alone even if its Popen
+        object is dead — the stop was deliberate.
         """
-        cam_dir = self._recordings_dir / cam_id
-        if not cam_dir.is_dir():
-            return False
-
-        # Find the newest .mp4 file across all date subdirectories
-        newest_mtime = 0
-        try:
-            for mp4 in cam_dir.rglob("*.mp4"):
-                try:
-                    mt = mp4.stat().st_mtime
-                    if mt > newest_mtime:
-                        newest_mtime = mt
-                except OSError:
-                    continue
-        except OSError:
-            return False
-
-        if newest_mtime == 0:
-            # No clips yet — recorder may still be writing the first one.
-            # Give it one full clip duration before declaring stale.
-            return False
-
-        age = time.time() - newest_mtime
-        threshold = self._clip_duration * self.STALE_CLIP_FACTOR
-        if age > threshold:
-            log.debug(
-                "Newest clip for %s is %.0fs old (threshold=%ds)",
-                cam_id,
-                age,
-                threshold,
-            )
-            return True
-        return False
-
-    # --- Snapshot extraction ---
-
-    def _start_snapshots(self, cam_id, rtsp_url):
-        """Start periodic snapshot extraction in a thread."""
-
-        def _snap_loop():
-            while self._running and cam_id in self._snap_threads:
-                self._take_snapshot(cam_id, rtsp_url)
-                # Sleep in increments for responsive shutdown
-                for _ in range(SNAPSHOT_INTERVAL * 10):
-                    if not self._running or cam_id not in self._snap_threads:
-                        return
-                    time.sleep(0.1)
-
-        t = threading.Thread(target=_snap_loop, daemon=True, name=f"snap-{cam_id}")
         with self._lock:
-            self._snap_threads[cam_id] = t
-        t.start()
+            snap_items = list(self._snap_procs.items())
+            rec_items = list(self._rec_procs.items())
 
-    def _take_snapshot(self, cam_id, rtsp_url):
-        """Extract a single JPEG frame from the RTSP stream."""
-        output = self._live_dir / cam_id / "snapshot.jpg"
-        tmp = output.with_suffix(".tmp.jpg")
+        for cam_id, proc in snap_items:
+            if proc.poll() is None:
+                continue
+            intent = self._snap_intent.get(cam_id)
+            if intent != "wanted":
+                continue
+            log.warning("Snapshot process died for %s, restarting", cam_id)
+            self._close_proc_log(proc)
+            with self._lock:
+                self._snap_procs.pop(cam_id, None)
+            self.start_snapshot(cam_id, f"{MEDIAMTX_URL}/{cam_id}")
 
-        cmd = [
-            "ffmpeg",
-            "-nostdin",
-            "-y",
-            "-rtsp_transport",
-            "tcp",
-            "-timeout",
-            RTSP_TIMEOUT_US,
-            "-i",
-            rtsp_url,
-            "-frames:v",
-            "1",
-            "-q:v",
-            "5",
-            str(tmp),
-        ]
+        for cam_id, proc in rec_items:
+            if proc.poll() is None:
+                continue
+            intent = self._recorder_intent.get(cam_id)
+            if intent != "wanted":
+                continue
+            log.warning("Recorder died for %s, restarting", cam_id)
+            self._close_proc_log(proc)
+            with self._lock:
+                self._rec_procs.pop(cam_id, None)
+            self.start_recorder(cam_id, f"{MEDIAMTX_URL}/{cam_id}")
 
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                timeout=10,
-            )
-            if result.returncode == 0 and tmp.is_file():
-                # Atomic rename so readers never see a partial file
-                tmp.rename(output)
-        except (subprocess.TimeoutExpired, OSError) as e:
-            log.debug("Snapshot failed for %s: %s", cam_id, e)
-        finally:
-            # Clean up temp file
-            try:
-                tmp.unlink(missing_ok=True)
-            except OSError:
-                pass
-
-    # --- Utility ---
+    # --- ffmpeg process plumbing ------------------------------------------
 
     def _launch_ffmpeg(self, cmd, label):
-        """Launch an ffmpeg subprocess with stderr logged to file.
-
-        Each pipeline gets its own log file under /data/logs/ffmpeg/
-        for post-mortem debugging of crashes and stalls.
-        """
+        """Launch an ffmpeg subprocess with stderr logged to a file."""
         try:
-            # Create log directory and open stderr log file
             stderr_dest = subprocess.PIPE
             log_file = None
             try:
@@ -473,9 +336,8 @@ class StreamingService:
                 log_path = FFMPEG_LOG_DIR / f"{label}.log"
                 log_file = open(log_path, "a")
                 stderr_dest = log_file
-                log.debug("ffmpeg stderr → %s", log_path)
             except OSError:
-                pass  # Fall back to PIPE if log dir isn't writable
+                pass
 
             proc = subprocess.Popen(
                 cmd,
@@ -483,7 +345,6 @@ class StreamingService:
                 stderr=stderr_dest,
                 preexec_fn=os.setsid if hasattr(os, "setsid") else None,
             )
-            # Attach log file handle so we can close it on stop
             proc._log_file = log_file  # type: ignore[attr-defined]
             return proc
         except FileNotFoundError:
@@ -494,7 +355,6 @@ class StreamingService:
 
     @staticmethod
     def _close_proc_log(proc):
-        """Close the stderr log file attached to an ffmpeg process."""
         log_file = getattr(proc, "_log_file", None)
         if log_file:
             try:
@@ -503,12 +363,11 @@ class StreamingService:
                 pass
 
     def _stop_process(self, cam_id, proc_dict, label):
-        """Stop an ffmpeg process gracefully and close its log file."""
+        """Stop an ffmpeg process gracefully."""
         with self._lock:
             proc = proc_dict.pop(cam_id, None)
         if proc is None:
             return
-
         try:
             proc.terminate()
             try:
@@ -517,7 +376,7 @@ class StreamingService:
                 proc.kill()
                 proc.wait(timeout=2)
             log.info(
-                "%s process stopped for %s (PID %d, exit=%s)",
+                "%s stopped for %s (PID %d, exit=%s)",
                 label,
                 cam_id,
                 proc.pid,
@@ -526,22 +385,11 @@ class StreamingService:
         except OSError:
             pass
         finally:
-            # Close the stderr log file handle
-            log_file = getattr(proc, "_log_file", None)
-            if log_file:
-                try:
-                    log_file.close()
-                except OSError:
-                    pass
+            self._close_proc_log(proc)
 
 
 def create_recording_dirs(recordings_dir, cam_id):
-    """Ensure recording directory exists with today's date subdirectory.
-
-    Called by the recorder's segment pattern, but ffmpeg can't create
-    nested dirs. This pre-creates today's directory.
-    """
-    today = datetime.now().strftime("%Y-%m-%d")
-    path = Path(recordings_dir) / cam_id / today
+    """Ensure <recordings_dir>/<cam_id>/ exists (flat layout under ADR-0017)."""
+    path = Path(recordings_dir) / cam_id
     path.mkdir(parents=True, exist_ok=True)
     return path

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -518,6 +518,78 @@ select.form-input {
 .camera-info__label { color: var(--color-text-muted); }
 .camera-info__value { color: var(--color-text); font-weight: 500; }
 
+/* --- Recordings Layout ---
+   Two-pane on desktop: sticky player on the left, independently scrolling
+   clip list on the right. Competitor inspiration: UniFi Protect & Frigate
+   both keep the player pinned while the timeline/list scrolls separately,
+   so pressing Play on an off-screen clip never jerks the viewer away. */
+.recordings-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+    align-items: start;
+}
+@media (min-width: 1024px) {
+    .recordings-layout {
+        grid-template-columns: minmax(0, 1.6fr) minmax(320px, 1fr);
+    }
+}
+
+.recordings-player-col {
+    min-width: 0;
+}
+@media (min-width: 1024px) {
+    .recordings-player-col {
+        position: sticky;
+        /* 60px top nav + breathing room; stays below the fixed navbar. */
+        top: calc(60px + var(--space-3));
+    }
+}
+
+.recordings-list-col {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+@media (min-width: 1024px) {
+    .recordings-list-col {
+        /* Independent scroll: viewport minus top nav (60), bottom nav (70)
+           and a little gutter on each side. */
+        max-height: calc(100vh - 60px - 70px - var(--space-4) * 2);
+        overflow-y: auto;
+        padding-right: var(--space-1);
+    }
+    .recordings-list-col::-webkit-scrollbar { width: 8px; }
+    .recordings-list-col::-webkit-scrollbar-track { background: transparent; }
+    .recordings-list-col::-webkit-scrollbar-thumb {
+        background: var(--color-border);
+        border-radius: var(--radius-sm);
+    }
+    .recordings-list-col::-webkit-scrollbar-thumb:hover {
+        background: var(--color-text-muted);
+    }
+}
+
+.recordings-list-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-2);
+    padding: 0 var(--space-1);
+}
+.recordings-list-header__title {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.recordings-list-header__count {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+
 /* --- Recordings List --- */
 .clip-list {
     display: flex;
@@ -529,9 +601,23 @@ select.form-input {
     align-items: center;
     justify-content: space-between;
     padding: var(--space-3) var(--space-4);
+    cursor: pointer;
+    transition: border-color var(--transition-base), background var(--transition-base);
+}
+.clip-card:hover {
+    border-color: var(--color-text-muted);
+}
+.clip-card.is-playing {
+    border-color: var(--color-accent);
+    background: linear-gradient(
+        90deg,
+        rgba(233, 69, 96, 0.12) 0%,
+        var(--color-surface) 60%
+    );
 }
 .clip-card__info {
     flex: 1;
+    min-width: 0;
 }
 .clip-card__time {
     font-weight: 600;
@@ -546,20 +632,157 @@ select.form-input {
     display: flex;
     gap: var(--space-2);
     align-items: center;
+    flex-shrink: 0;
+}
+.clip-card__checkbox {
+    display: flex;
+    align-items: center;
+    margin-right: var(--space-2);
+    cursor: pointer;
+}
+.clip-card__checkbox input {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--color-accent);
+    cursor: pointer;
 }
 
-/* --- Inline Player (recordings) --- */
-.inline-player {
-    margin: 12px 0;
-    display: none;
+/* --- Archive banner (removed camera) --- */
+.archive-banner {
+    background: rgba(233, 69, 96, 0.08);
+    border: 1px solid rgba(233, 69, 96, 0.35);
+    color: var(--color-text);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    font-size: var(--text-sm);
+    line-height: 1.45;
+    margin-bottom: var(--space-3);
 }
-.inline-player.visible {
+.archive-banner strong {
+    color: var(--color-accent);
+    margin-right: var(--space-1);
+}
+
+/* --- Selection bar —
+   Floats above the bottom nav only when the admin has selected one or
+   more clips. Default view never shows it, so the page doesn't nag
+   people toward deletion. */
+.selection-bar {
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(70px + var(--space-3)); /* clear the 70px bottom nav */
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    z-index: 50;
+    max-width: calc(100vw - var(--space-4) * 2);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+.selection-bar[hidden] { display: none; }
+.selection-bar__count {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    padding: 0 var(--space-2);
+    border-right: 1px solid var(--color-border);
+}
+
+/* --- "More options" — quiet opt-in toggle for bulk destructive
+   actions. Renders as a subtle muted link, not a button. */
+.more-options {
+    margin-top: var(--space-5);
+    padding-top: var(--space-3);
+    border-top: 1px dashed var(--color-border);
+}
+.more-options__toggle {
+    background: none;
+    border: none;
+    padding: var(--space-1) var(--space-2);
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: color var(--transition-base), background var(--transition-base);
+}
+.more-options__toggle:hover {
+    color: var(--color-text);
+    background: var(--color-surface-alt);
+}
+.more-options__toggle[aria-expanded="true"]::after { content: " ▲"; }
+.more-options__toggle[aria-expanded="false"]::after { content: " ▼"; }
+
+.danger-zone {
+    margin-top: var(--space-3);
+    padding: var(--space-3);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+}
+.danger-zone__title {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: var(--space-2);
+}
+.danger-zone__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+/* --- Inline Player (recordings) ---
+   Always rendered; shows a placeholder until a clip is chosen. */
+.inline-player {
     display: block;
+    margin: 0;
 }
 .inline-player video {
     width: 100%;
+    aspect-ratio: 16 / 9;
     border-radius: var(--radius-md);
     background: #000;
+    display: block;
+}
+.inline-player__placeholder {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border-radius: var(--radius-md);
+    background: #000;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: var(--space-4);
+    font-size: var(--text-sm);
+    border: 1px dashed var(--color-border);
+}
+.inline-player__placeholder.hidden { display: none; }
+.inline-player video.hidden { display: none; }
+.inline-player__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+    min-height: 28px;
+}
+.inline-player__label {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
 }
 
 /* --- Settings --- */

--- a/app/server/monitor/store.py
+++ b/app/server/monitor/store.py
@@ -12,10 +12,21 @@ corruption if the process is killed mid-write.
 
 import json
 import threading
-from dataclasses import asdict
+from dataclasses import asdict, fields
 from pathlib import Path
 
 from monitor.models import Camera, Settings, User
+
+
+def _filter_known(cls, raw: dict) -> dict:
+    """Drop keys not present in a dataclass — migration-tolerant loading.
+
+    Older JSON rows may be missing new fields (filled by dataclass defaults)
+    or carry deprecated fields (ignored). This keeps load stable across
+    schema evolution.
+    """
+    known = {f.name for f in fields(cls)}
+    return {k: v for k, v in raw.items() if k in known}
 
 
 class Store:
@@ -60,7 +71,9 @@ class Store:
         """Return all cameras."""
         with self._lock:
             raw = self._read_json("cameras.json")
-        return [Camera(**c) for c in raw] if isinstance(raw, list) else []
+        if not isinstance(raw, list):
+            return []
+        return [Camera(**_filter_known(Camera, c)) for c in raw if isinstance(c, dict)]
 
     def get_camera(self, camera_id: str) -> Camera | None:
         """Return a single camera by ID, or None."""
@@ -103,7 +116,9 @@ class Store:
         """Return all users."""
         with self._lock:
             raw = self._read_json("users.json")
-        return [User(**u) for u in raw] if isinstance(raw, list) else []
+        if not isinstance(raw, list):
+            return []
+        return [User(**_filter_known(User, u)) for u in raw if isinstance(u, dict)]
 
     def get_user(self, user_id: str) -> User | None:
         """Return a single user by ID, or None."""
@@ -153,7 +168,7 @@ class Store:
         with self._lock:
             raw = self._read_json("settings.json")
         if isinstance(raw, dict) and raw:
-            return Settings(**raw)
+            return Settings(**_filter_known(Settings, raw))
         return Settings()
 
     def save_settings(self, settings: Settings):

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -169,10 +169,16 @@
                     'badge--online': cam.status === 'online',
                     'badge--offline': cam.status === 'offline'
                 }" x-text="cam.status"></span>
+                <!-- ADR-0017: prefer `stream_state` from heartbeat; fall back
+                     to the legacy `streaming` boolean for older cameras. The
+                     pulsing dot indicates the camera is actively pushing RTSP
+                     to MediaMTX right now (either a viewer is open or the
+                     recording scheduler has asked it to stay up). -->
                 <span x-show="cam.status === 'online'" class="badge" :class="{
-                    'badge--streaming': cam.streaming,
-                    'badge--not-streaming': !cam.streaming
-                }" x-text="cam.streaming ? '\u25CF streaming' : '\u25CB not streaming'"></span>
+                    'badge--streaming': (cam.stream_state === 'running') || cam.streaming,
+                    'badge--not-streaming': !((cam.stream_state === 'running') || cam.streaming)
+                }" :aria-label="((cam.stream_state === 'running') || cam.streaming) ? 'live' : 'idle'"
+                   x-text="((cam.stream_state === 'running') || cam.streaming) ? '\u25CF live' : '\u25CB idle'"></span>
                 <div class="camera-card__btns">
                     <button class="btn btn--secondary btn--small" @click.stop="openStreamSettings(cam)">Settings</button>
                     <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>

--- a/app/server/monitor/templates/live.html
+++ b/app/server/monitor/templates/live.html
@@ -81,7 +81,9 @@
     var cameras = [];
     var currentTransport = '';  // 'webrtc' or 'hls'
 
-    // WHEP timeout — if WebRTC doesn't connect in 5s, fall back to HLS
+    // WHEP timeout — if WebRTC doesn't connect in 5s, fall back to HLS.
+    // On-demand streaming (ADR-0017) adds ~3-5 s camera warm-up on the first
+    // viewer open; the overlay text below communicates that.
     var WHEP_TIMEOUT_MS = 5000;
 
     function showOverlay(msg) {
@@ -180,7 +182,10 @@
         if (cam.status !== 'online') { showOverlay('Camera offline'); return; }
 
         statusEl.textContent = 'Connecting (WebRTC)...';
-        showOverlay('Connecting...');
+        // ADR-0017: cameras are idle by default; MediaMTX `runOnDemand` hook
+        // asks the camera to start streaming on first reader — this can take
+        // up to ~5 s for the sensor + encoder to warm up. Tell the user.
+        showOverlay('Starting stream... (camera warming up)');
 
         // Try WebRTC first, fall back to HLS on failure
         startWebRTC(cameraId).catch(function(err) {

--- a/app/server/monitor/templates/recordings.html
+++ b/app/server/monitor/templates/recordings.html
@@ -24,24 +24,86 @@
     </div>
 </div>
 
-<!-- Inline Player -->
-<div class="inline-player" id="rec-player">
-    <video id="rec-video" controls playsinline preload="metadata">
-        Your browser does not support the video tag.
-    </video>
-    <div class="flex-between mt-8">
-        <span id="rec-playing-label" class="text-small text-muted"></span>
-        <button class="btn btn--secondary btn--small" id="btn-close-player">Close</button>
+<!-- Two-pane layout: sticky player on the left, scrolling clip list on the right.
+     Competitor pattern (UniFi Protect, Frigate, Tapo): pinning the player while
+     the list scrolls independently keeps playback anchored when the user picks
+     another clip. Pressing Play must not yank the page to the top. -->
+<div class="recordings-layout">
+    <!-- Player column -->
+    <div class="recordings-player-col">
+        <!-- Banner shown only when the selected camera has been removed.
+             Its recordings are preserved but the device itself is gone. -->
+        <div class="archive-banner" id="rec-archive-banner" style="display:none;">
+            <strong>Archived recordings.</strong>
+            This camera has been removed from the system. The clips below are
+            preserved on disk — you can view them or delete them, but no new
+            recordings will arrive.
+        </div>
+        <div class="card inline-player" id="rec-player">
+            <div class="inline-player__placeholder" id="rec-placeholder">
+                Select a recording from the list to start playback.
+            </div>
+            <video id="rec-video" class="hidden" controls playsinline preload="metadata">
+                Your browser does not support the video tag.
+            </video>
+            <div class="inline-player__bar">
+                <span id="rec-playing-label" class="inline-player__label"></span>
+                <button class="btn btn--secondary btn--small" id="btn-close-player" style="display:none;">Close</button>
+            </div>
+        </div>
     </div>
-</div>
 
-<!-- Clip List -->
-<div id="rec-clip-list" class="clip-list"></div>
+    <!-- List column -->
+    <div class="recordings-list-col" id="rec-list-col">
+        <div class="recordings-list-header">
+            <span class="recordings-list-header__title">Clips</span>
+            <span class="recordings-list-header__count" id="rec-count"></span>
+        </div>
+        <div id="rec-clip-list" class="clip-list"></div>
+        <div class="empty-state" id="rec-empty" style="display:none;">
+            <div class="empty-state__title">No recordings found</div>
+            <div class="empty-state__text">Select a camera and date to browse recordings.</div>
+        </div>
 
-<!-- Empty State -->
-<div class="empty-state" id="rec-empty" style="display:none;">
-    <div class="empty-state__title">No recordings found</div>
-    <div class="empty-state__text">Select a camera and date to browse recordings.</div>
+        <!-- Quiet footer: one small "More options" toggle. Admin-only.
+             Expands into the danger zone so destructive actions are
+             deliberate, never in the foreground. -->
+        <div class="more-options" id="rec-more-options" style="display:none;">
+            <button type="button" class="more-options__toggle" id="rec-more-toggle"
+                    aria-expanded="false" aria-controls="rec-danger-zone">
+                More options
+            </button>
+            <div class="danger-zone" id="rec-danger-zone" hidden>
+                <div class="danger-zone__title">Bulk delete</div>
+                <div class="danger-zone__actions">
+                    <button class="btn btn--secondary btn--small" id="btn-delete-date"
+                            title="Delete every clip shown for this camera on this date">
+                        Delete all on this date
+                    </button>
+                    <button class="btn btn--secondary btn--small" id="btn-delete-camera"
+                            title="Delete every recording ever made by this camera (all dates)">
+                        Delete all for this camera
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Selection bar — floats in only when at least one clip is checked.
+         Admin only. Hidden the rest of the time so the Recordings tab
+         never nags the user toward destructive actions. -->
+    <div class="selection-bar" id="rec-selection-bar" hidden>
+        <span class="selection-bar__count" id="rec-bulk-count">0 selected</span>
+        <button type="button" class="btn btn--secondary btn--small" id="btn-select-all-toggle">
+            Select all
+        </button>
+        <button type="button" class="btn btn--secondary btn--small" id="btn-clear-selection">
+            Clear
+        </button>
+        <button type="button" class="btn btn--danger btn--small" id="btn-bulk-delete">
+            Delete
+        </button>
+    </div>
 </div>
 {% endblock %}
 
@@ -52,55 +114,120 @@
     var dateInput = document.getElementById('rec-date-input');
     var clipList = document.getElementById('rec-clip-list');
     var emptyState = document.getElementById('rec-empty');
-    var playerWrap = document.getElementById('rec-player');
     var videoEl = document.getElementById('rec-video');
+    var placeholderEl = document.getElementById('rec-placeholder');
     var playingLabel = document.getElementById('rec-playing-label');
     var btnClose = document.getElementById('btn-close-player');
     var datesWrap = document.getElementById('rec-available-dates');
     var datesList = document.getElementById('rec-dates-list');
-    var cameras = [];
+    var countEl = document.getElementById('rec-count');
+    var archiveBanner = document.getElementById('rec-archive-banner');
+    var selectionBar = document.getElementById('rec-selection-bar');
+    var bulkCountEl = document.getElementById('rec-bulk-count');
+    var btnSelectAllToggle = document.getElementById('btn-select-all-toggle');
+    var btnClearSelection = document.getElementById('btn-clear-selection');
+    var btnBulkDelete = document.getElementById('btn-bulk-delete');
+    var moreOptionsWrap = document.getElementById('rec-more-options');
+    var moreToggle = document.getElementById('rec-more-toggle');
+    var dangerZone = document.getElementById('rec-danger-zone');
+    var btnDeleteDate = document.getElementById('btn-delete-date');
+    var btnDeleteCamera = document.getElementById('btn-delete-camera');
+
+    var cameras = [];             // [{id, name, status}]
     var availableDates = [];
     var userRole = '';
+    var currentPlayingUrl = null;
+
+    // ------------------------------------------------------------------
+    // Init
+    // ------------------------------------------------------------------
 
     function init() {
-        var user = window.HM.auth.getUser();
-        userRole = user ? user.role : '';
-        loadCameras();
+        // auth.getUser() reads a closure var populated by auth.getMe().
+        // On a fresh page load that fetch may still be in flight when our
+        // own DOMContentLoaded handler runs, so we kick getMe() ourselves
+        // and wait for it. Without this, admin features (checkboxes,
+        // Delete button, danger zone) silently don't render.
+        window.HM.auth.getMe()
+            .catch(function() { /* 401 → app.js redirects to /login */ })
+            .then(function() {
+                var user = window.HM.auth.getUser();
+                userRole = user ? user.role : '';
+                loadCameras();
+            });
     }
 
+    function isAdmin() { return userRole === 'admin'; }
+
+    function currentCameraStatus() {
+        var id = cameraSelect.value;
+        var cam = cameras.find(function(c) { return c.id === id; });
+        return cam ? cam.status : '';
+    }
+
+    // ------------------------------------------------------------------
+    // Data loading
+    // ------------------------------------------------------------------
+
     function loadCameras() {
-        window.HM.api.get('/api/v1/cameras')
+        // /recordings/cameras returns paired + orphan archives (status=removed).
+        window.HM.api.get('/api/v1/recordings/cameras')
             .then(function(data) {
-                cameras = (data || []).filter(function(c) { return c.status !== 'pending'; });
-                cameraSelect.innerHTML = '';
+                cameras = data || [];
+                renderCameraSelect();
 
-                if (cameras.length === 0) {
-                    var opt = document.createElement('option');
-                    opt.value = '';
-                    opt.textContent = 'No cameras available';
-                    cameraSelect.appendChild(opt);
-                    return;
-                }
+                if (cameras.length === 0) return;
 
-                cameras.forEach(function(cam) {
-                    var opt = document.createElement('option');
-                    opt.value = cam.id;
-                    opt.textContent = cam.name || cam.id;
-                    cameraSelect.appendChild(opt);
-                });
-
-                // Check URL params
+                // URL param wins if still valid.
                 var params = new URLSearchParams(window.location.search);
                 var camParam = params.get('camera');
-                if (camParam) cameraSelect.value = camParam;
-
-                if (cameraSelect.value) {
-                    loadDates(cameraSelect.value);
+                if (camParam && cameras.some(function(c) { return c.id === camParam; })) {
+                    cameraSelect.value = camParam;
                 }
+                onCameraChanged();
             })
             .catch(function() {
                 window.HM.toast('Failed to load cameras', 'error');
             });
+    }
+
+    function renderCameraSelect() {
+        cameraSelect.innerHTML = '';
+
+        if (cameras.length === 0) {
+            var opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = 'No cameras with recordings';
+            cameraSelect.appendChild(opt);
+            return;
+        }
+
+        // Split into paired vs removed so we can show an <optgroup> archive.
+        var paired = cameras.filter(function(c) { return c.status !== 'removed'; });
+        var removed = cameras.filter(function(c) { return c.status === 'removed'; });
+
+        function makeOption(cam) {
+            var opt = document.createElement('option');
+            opt.value = cam.id;
+            var label = cam.name || cam.id;
+            if (cam.status === 'offline') label += ' (offline)';
+            else if (cam.status === 'removed') label += ' (removed)';
+            opt.textContent = label;
+            return opt;
+        }
+
+        if (paired.length > 0) {
+            var g1 = document.createElement('optgroup');
+            g1.label = 'Cameras';
+            paired.forEach(function(c) { g1.appendChild(makeOption(c)); });
+            cameraSelect.appendChild(g1);
+        }
+        if (removed.length > 0) {
+            var g2 = document.createElement('optgroup');
+            g2.label = 'Removed';
+            removed.forEach(function(c) { g2.appendChild(makeOption(c)); });
+            cameraSelect.appendChild(g2);
+        }
     }
 
     function loadDates(cameraId) {
@@ -112,7 +239,6 @@
                     datesWrap.style.display = '';
                     datesList.textContent = availableDates.slice(-10).join(', ');
 
-                    // Set date to URL param or latest available
                     var params = new URLSearchParams(window.location.search);
                     var dateParam = params.get('date');
                     if (dateParam && availableDates.indexOf(dateParam) >= 0) {
@@ -141,62 +267,11 @@
 
         clipList.innerHTML = '';
         emptyState.style.display = 'none';
+        countEl.textContent = '';
 
         window.HM.api.get('/api/v1/recordings/' + encodeURIComponent(cameraId) + '?date=' + encodeURIComponent(date))
             .then(function(clips) {
-                if (!clips || clips.length === 0) {
-                    showEmpty();
-                    return;
-                }
-
-                clips.forEach(function(clip) {
-                    var card = document.createElement('div');
-                    card.className = 'card clip-card';
-
-                    var actionsHtml =
-                        '<button class="btn btn--primary btn--small btn-play-clip" ' +
-                        'data-url="/api/v1/recordings/' + encodeURIComponent(clip.camera_id) + '/' +
-                        encodeURIComponent(clip.date) + '/' + encodeURIComponent(clip.filename) + '" ' +
-                        'data-label="' + window.HM.escapeHtml(clip.start_time) + '">Play</button>';
-
-                    if (userRole === 'admin') {
-                        actionsHtml +=
-                            '<button class="btn btn--danger btn--small btn-delete-clip" ' +
-                            'data-camera="' + window.HM.escapeHtml(clip.camera_id) + '" ' +
-                            'data-date="' + window.HM.escapeHtml(clip.date) + '" ' +
-                            'data-filename="' + window.HM.escapeHtml(clip.filename) + '">Delete</button>';
-                    }
-
-                    card.innerHTML =
-                        '<div class="clip-card__info">' +
-                            '<div class="clip-card__time">' + window.HM.escapeHtml(clip.start_time) + '</div>' +
-                            '<div class="clip-card__meta">' +
-                                window.HM.formatDuration(clip.duration_seconds) + ' / ' +
-                                window.HM.formatBytes(clip.size_bytes) +
-                            '</div>' +
-                        '</div>' +
-                        '<div class="clip-card__actions">' + actionsHtml + '</div>';
-
-                    clipList.appendChild(card);
-                });
-
-                // Bind play buttons
-                clipList.querySelectorAll('.btn-play-clip').forEach(function(btn) {
-                    btn.addEventListener('click', function() {
-                        playClip(btn.getAttribute('data-url'), btn.getAttribute('data-label'));
-                    });
-                });
-
-                // Bind delete buttons
-                clipList.querySelectorAll('.btn-delete-clip').forEach(function(btn) {
-                    btn.addEventListener('click', function() {
-                        deleteClip(
-                            btn.getAttribute('data-camera'),
-                            btn.getAttribute('data-date'),
-                            btn.getAttribute('data-filename')
-                        );
-                    });
-                });
+                renderClips(clips || []);
             })
             .catch(function() {
                 showEmpty();
@@ -204,52 +279,290 @@
             });
     }
 
-    function showEmpty() {
-        clipList.innerHTML = '';
-        emptyState.style.display = '';
-    }
-
-    function playClip(url, label) {
-        videoEl.src = url;
-        videoEl.load();
-        videoEl.play().catch(function() {});
-        playingLabel.textContent = 'Playing: ' + label;
-        playerWrap.classList.add('visible');
-        playerWrap.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-
-    function deleteClip(cameraId, date, filename) {
-        if (!confirm('Delete recording ' + filename + '? This cannot be undone.')) {
+    function renderClips(clips) {
+        if (clips.length === 0) {
+            showEmpty();
             return;
         }
-        window.HM.api.del(
-            '/api/v1/recordings/' + encodeURIComponent(cameraId) + '/' +
-            encodeURIComponent(date) + '/' + encodeURIComponent(filename)
-        )
-        .then(function() {
-            window.HM.toast('Recording deleted', 'success');
-            loadClips(cameraSelect.value, dateInput.value);
-        })
-        .catch(function(err) {
-            window.HM.toast(err.message || 'Failed to delete recording', 'error');
+
+        countEl.textContent = clips.length + (clips.length === 1 ? ' clip' : ' clips');
+
+        clips.forEach(function(clip) {
+            clipList.appendChild(buildClipCard(clip));
+        });
+
+        clipList.querySelectorAll('.clip-card').forEach(function(card) {
+            card.addEventListener('click', function(e) {
+                // Don't steal focus from the checkbox.
+                if (e.target.closest('.clip-card__checkbox')) return;
+                if (e.target.closest('.btn-play-clip')) {
+                    // Play button clicked — handled via normal bubbling.
+                }
+                playClip(card.getAttribute('data-url'), card.getAttribute('data-label'));
+            });
+        });
+
+        clipList.querySelectorAll('.clip-card__checkbox input').forEach(function(cb) {
+            cb.addEventListener('click', function(e) { e.stopPropagation(); });
+            cb.addEventListener('change', updateBulkState);
+        });
+
+        refreshPlayingHighlight();
+        updateBulkState();
+    }
+
+    function buildClipCard(clip) {
+        var clipUrl = '/api/v1/recordings/' + encodeURIComponent(clip.camera_id) + '/' +
+            encodeURIComponent(clip.date) + '/' + encodeURIComponent(clip.filename);
+
+        var card = document.createElement('div');
+        card.className = 'card clip-card';
+        card.setAttribute('data-url', clipUrl);
+        card.setAttribute('data-label', clip.start_time);
+        card.setAttribute('data-camera', clip.camera_id);
+        card.setAttribute('data-date', clip.date);
+        card.setAttribute('data-filename', clip.filename);
+
+        // Admin gets a subtle checkbox for selection. Delete itself is
+        // never on the card — it only appears in the floating selection
+        // bar once something is picked. This keeps the default view calm
+        // and makes destructive actions deliberate.
+        var checkHtml = '';
+        if (isAdmin()) {
+            checkHtml =
+                '<label class="clip-card__checkbox" title="Select">' +
+                    '<input type="checkbox">' +
+                '</label>';
+        }
+
+        var actionsHtml =
+            '<button class="btn btn--primary btn--small btn-play-clip">Play</button>';
+
+        card.innerHTML =
+            checkHtml +
+            '<div class="clip-card__info">' +
+                '<div class="clip-card__time">' + window.HM.escapeHtml(clip.start_time) + '</div>' +
+                '<div class="clip-card__meta">' +
+                    window.HM.formatDuration(clip.duration_seconds) + ' / ' +
+                    window.HM.formatBytes(clip.size_bytes) +
+                '</div>' +
+            '</div>' +
+            '<div class="clip-card__actions">' + actionsHtml + '</div>';
+
+        return card;
+    }
+
+    function showEmpty() {
+        clipList.innerHTML = '';
+        countEl.textContent = '';
+        emptyState.style.display = '';
+        updateBulkState();
+    }
+
+    // ------------------------------------------------------------------
+    // Player
+    // ------------------------------------------------------------------
+
+    function refreshPlayingHighlight() {
+        clipList.querySelectorAll('.clip-card').forEach(function(card) {
+            if (currentPlayingUrl && card.getAttribute('data-url') === currentPlayingUrl) {
+                card.classList.add('is-playing');
+            } else {
+                card.classList.remove('is-playing');
+            }
         });
     }
 
-    btnClose.addEventListener('click', function() {
+    function playClip(url, label) {
+        // Intentionally no scrollIntoView: the player is sticky (desktop) or
+        // above the list (mobile), so playback starts in place.
+        currentPlayingUrl = url;
+        videoEl.src = url;
+        videoEl.classList.remove('hidden');
+        placeholderEl.classList.add('hidden');
+        videoEl.load();
+        videoEl.play().catch(function() {});
+        playingLabel.textContent = 'Playing: ' + label;
+        btnClose.style.display = '';
+        refreshPlayingHighlight();
+    }
+
+    function closePlayer() {
         videoEl.pause();
         videoEl.removeAttribute('src');
         videoEl.load();
-        playerWrap.classList.remove('visible');
+        videoEl.classList.add('hidden');
+        placeholderEl.classList.remove('hidden');
         playingLabel.textContent = '';
-    });
+        btnClose.style.display = 'none';
+        currentPlayingUrl = null;
+        refreshPlayingHighlight();
+    }
 
-    cameraSelect.addEventListener('change', function() {
-        closePlayer();
-        if (cameraSelect.value) {
-            loadDates(cameraSelect.value);
-            updateUrl();
+    // ------------------------------------------------------------------
+    // Selection + bulk delete
+    //
+    // Design rule: the UI does not advertise destructive actions. The
+    // selection bar only appears once the admin checks at least one
+    // clip. Individual clip cards have no Delete button — selection is
+    // the only path, and selection is explicit.
+    // ------------------------------------------------------------------
+
+    function getSelectedCards() {
+        return Array.prototype.slice.call(
+            clipList.querySelectorAll('.clip-card')
+        ).filter(function(card) {
+            var cb = card.querySelector('.clip-card__checkbox input');
+            return cb && cb.checked;
+        });
+    }
+
+    function clearSelection() {
+        clipList.querySelectorAll('.clip-card__checkbox input').forEach(function(cb) {
+            cb.checked = false;
+        });
+        updateBulkState();
+    }
+
+    function updateBulkState() {
+        if (!isAdmin()) {
+            selectionBar.hidden = true;
+            return;
         }
-    });
+        var total = clipList.querySelectorAll('.clip-card').length;
+        var selected = getSelectedCards();
+
+        if (selected.length === 0) {
+            selectionBar.hidden = true;
+            return;
+        }
+        selectionBar.hidden = false;
+        bulkCountEl.textContent = selected.length + ' of ' + total + ' selected';
+
+        // Toggle label reflects the next action.
+        btnSelectAllToggle.textContent = selected.length === total ? 'Unselect all' : 'Select all';
+    }
+
+    function bulkDelete() {
+        var cards = getSelectedCards();
+        if (cards.length === 0) return;
+        if (!confirm('Delete ' + cards.length + ' recordings? This cannot be undone.')) return;
+
+        btnBulkDelete.disabled = true;
+        var promises = cards.map(function(card) {
+            return window.HM.api.del(
+                '/api/v1/recordings/' +
+                encodeURIComponent(card.getAttribute('data-camera')) + '/' +
+                encodeURIComponent(card.getAttribute('data-date')) + '/' +
+                encodeURIComponent(card.getAttribute('data-filename'))
+            ).then(function() { return { ok: true }; })
+             .catch(function() { return { ok: false }; });
+        });
+
+        Promise.all(promises).then(function(results) {
+            var ok = results.filter(function(r) { return r.ok; }).length;
+            var failed = results.length - ok;
+            if (failed === 0) {
+                window.HM.toast('Deleted ' + ok + ' recordings', 'success');
+            } else {
+                window.HM.toast('Deleted ' + ok + ', failed ' + failed, 'error');
+            }
+            // If the currently playing clip was among them, close the player.
+            if (currentPlayingUrl) {
+                var stillExists = false;
+                getSelectedCards(); // no-op; just for symmetry
+                var playingCard = Array.prototype.slice.call(
+                    clipList.querySelectorAll('.clip-card')
+                ).find(function(c) { return c.getAttribute('data-url') === currentPlayingUrl; });
+                stillExists = !!playingCard;
+                if (!stillExists) closePlayer();
+            }
+            loadClips(cameraSelect.value, dateInput.value);
+        });
+    }
+
+    function deleteAllOnDate() {
+        var camId = cameraSelect.value;
+        var date = dateInput.value;
+        if (!camId || !date) return;
+        if (!confirm('Delete ALL recordings for this camera on ' + date + '?\n\nThis cannot be undone.')) return;
+
+        window.HM.api.del(
+            '/api/v1/recordings/' + encodeURIComponent(camId) + '/' + encodeURIComponent(date)
+        )
+        .then(function(res) {
+            window.HM.toast('Deleted ' + (res.count || 0) + ' clips', 'success');
+            closePlayer();
+            // Date probably no longer has content — reload dates then clips.
+            loadDates(camId);
+        })
+        .catch(function(err) {
+            window.HM.toast(err.message || 'Failed to delete', 'error');
+        });
+    }
+
+    function deleteAllForCamera() {
+        var camId = cameraSelect.value;
+        if (!camId) return;
+        var camLabel = (cameras.find(function(c) { return c.id === camId; }) || {}).name || camId;
+        if (!confirm(
+            'Delete EVERY recording for "' + camLabel + '" across all dates?\n\n' +
+            'This cannot be undone.'
+        )) return;
+
+        window.HM.api.del('/api/v1/recordings/' + encodeURIComponent(camId))
+            .then(function(res) {
+                window.HM.toast('Deleted ' + (res.count || 0) + ' clips', 'success');
+                closePlayer();
+                // Camera may now be empty; reload the whole dropdown so a
+                // removed camera disappears from the Archive section.
+                loadCameras();
+                availableDates = [];
+                datesWrap.style.display = 'none';
+                dateInput.value = '';
+                showEmpty();
+                dangerZone.style.display = 'none';
+            })
+            .catch(function(err) {
+                window.HM.toast(err.message || 'Failed to delete', 'error');
+            });
+    }
+
+    // ------------------------------------------------------------------
+    // Selection changes
+    // ------------------------------------------------------------------
+
+    function onCameraChanged() {
+        closePlayer();
+        var camId = cameraSelect.value;
+        var status = currentCameraStatus();
+
+        archiveBanner.style.display = status === 'removed' ? '' : 'none';
+        // Show the quiet "More options" toggle only when admin + camera
+        // picked. Collapse the danger zone on every camera switch so it
+        // never leaks state across selections.
+        moreOptionsWrap.style.display = (isAdmin() && camId) ? '' : 'none';
+        dangerZone.hidden = true;
+        moreToggle.setAttribute('aria-expanded', 'false');
+
+        if (camId) {
+            loadDates(camId);
+            updateUrl();
+        } else {
+            availableDates = [];
+            datesWrap.style.display = 'none';
+            dateInput.value = '';
+            showEmpty();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Events
+    // ------------------------------------------------------------------
+
+    btnClose.addEventListener('click', closePlayer);
+
+    cameraSelect.addEventListener('change', onCameraChanged);
 
     dateInput.addEventListener('change', function() {
         closePlayer();
@@ -259,13 +572,26 @@
         }
     });
 
-    function closePlayer() {
-        videoEl.pause();
-        videoEl.removeAttribute('src');
-        videoEl.load();
-        playerWrap.classList.remove('visible');
-        playingLabel.textContent = '';
-    }
+    btnSelectAllToggle.addEventListener('click', function() {
+        var cards = clipList.querySelectorAll('.clip-card__checkbox input');
+        var allChecked = Array.prototype.every.call(cards, function(cb) { return cb.checked; });
+        // If every clip is already selected, this toggle unselects all.
+        var target = !allChecked;
+        cards.forEach(function(cb) { cb.checked = target; });
+        updateBulkState();
+    });
+
+    btnClearSelection.addEventListener('click', clearSelection);
+    btnBulkDelete.addEventListener('click', bulkDelete);
+
+    moreToggle.addEventListener('click', function() {
+        var open = !dangerZone.hidden;
+        dangerZone.hidden = open;
+        moreToggle.setAttribute('aria-expanded', String(!open));
+    });
+
+    btnDeleteDate.addEventListener('click', deleteAllOnDate);
+    btnDeleteCamera.addEventListener('click', deleteAllForCamera);
 
     function updateUrl() {
         var url = new URL(window.location);

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -12,6 +12,7 @@
     <button class="settings-tab" :class="{ active: tab === 'network' }" @click="tab = 'network'">Network</button>
     <button class="settings-tab" :class="{ active: tab === 'tailscale' }" @click="tab = 'tailscale'">Tailscale</button>
     <button class="settings-tab" :class="{ active: tab === 'users' }" @click="tab = 'users'">Users</button>
+    <button class="settings-tab" :class="{ active: tab === 'recording' }" @click="tab = 'recording'">Recording</button>
     <button class="settings-tab" :class="{ active: tab === 'storage' }" @click="tab = 'storage'">Storage</button>
 </div>
 
@@ -470,9 +471,130 @@
     </div>
 </div>
 
-<!-- ���══════════════════════════════════════════════════════════
+<!-- ═══════════════════════════════════════════════════════════
+     RECORDING TAB (admin only) — ADR-0017
+     Per-camera recording mode + schedule editor.
+     ═══════════════════════════════════════════════════════════ -->
+<div x-show="isAdmin && tab === 'recording'" x-cloak>
+    <div class="settings-section">
+        <div class="settings-section__title">Recording Modes</div>
+        <div class="card">
+            <div class="info-row" style="border-bottom:none;">
+                <span class="info-row__label">Server Timezone</span>
+                <span class="info-row__value" x-text="recording.timezone || settings.timezone || '--'"></span>
+            </div>
+            <div class="text-small text-muted" style="margin-top:6px;">
+                Schedule windows are evaluated in the server's system timezone.
+                Per-camera timezone is not supported (ADR-0017).
+            </div>
+        </div>
+
+        <template x-if="recording.cameras.length === 0">
+            <div class="card mt-16 text-muted">No cameras paired yet.</div>
+        </template>
+
+        <template x-for="cam in recording.cameras" :key="cam.id">
+            <div class="card mt-16" :data-rec-cam-id="cam.id">
+                <div class="flex-between" style="margin-bottom:8px;">
+                    <span style="font-weight:600;" x-text="cam.name || cam.id"></span>
+                    <span class="text-small text-muted" x-text="cam.location || ''"></span>
+                </div>
+
+                <!-- Mode radios -->
+                <fieldset class="form-group" style="border:none; padding:0; margin:0;">
+                    <legend class="info-row__label" style="margin-bottom:6px;">Recording mode</legend>
+                    <label style="display:flex; align-items:center; gap:6px; cursor:pointer;">
+                        <input type="radio" :name="'rec-mode-' + cam.id" value="off"
+                               x-model="cam.recording_mode">
+                        <span>Off</span>
+                    </label>
+                    <label style="display:flex; align-items:center; gap:6px; cursor:pointer;">
+                        <input type="radio" :name="'rec-mode-' + cam.id" value="continuous"
+                               x-model="cam.recording_mode">
+                        <span>Continuous</span>
+                    </label>
+                    <label style="display:flex; align-items:center; gap:6px; cursor:pointer;">
+                        <input type="radio" :name="'rec-mode-' + cam.id" value="schedule"
+                               x-model="cam.recording_mode">
+                        <span>Schedule</span>
+                    </label>
+                    <label style="display:flex; align-items:center; gap:6px; cursor:not-allowed; opacity:0.6;">
+                        <input type="radio" :name="'rec-mode-' + cam.id" value="motion" disabled>
+                        <span>Motion <span class="text-small text-muted">(coming soon)</span></span>
+                    </label>
+                </fieldset>
+
+                <!-- Schedule editor -->
+                <div x-show="cam.recording_mode === 'schedule'" style="margin-top:12px;">
+                    <div class="info-row__label" style="margin-bottom:6px;">Windows</div>
+                    <template x-for="(day, dayIdx) in recording.DAY_ORDER" :key="day">
+                        <div class="rec-day-row" style="display:flex; flex-direction:column; gap:4px; padding:6px 0; border-bottom:1px solid var(--border);">
+                            <div style="display:flex; align-items:center; gap:8px;">
+                                <label style="display:flex; align-items:center; gap:4px; min-width:70px; cursor:pointer;">
+                                    <input type="checkbox"
+                                           :checked="recordingDayEnabled(cam, day)"
+                                           @change="toggleRecordingDay(cam, day, $event.target.checked)">
+                                    <span x-text="day.toUpperCase()"></span>
+                                </label>
+                                <button type="button" class="btn btn--secondary btn--small"
+                                        @click="addRecordingWindow(cam, day)"
+                                        :aria-label="'Add window for ' + day">+ Window</button>
+                            </div>
+                            <template x-for="(win, winIdx) in recordingWindowsForDay(cam, day)" :key="day + '-' + winIdx">
+                                <div style="display:flex; align-items:center; gap:8px; padding-left:78px;">
+                                    <input type="time" class="form-input" style="max-width:110px;"
+                                           :value="win.start"
+                                           @change="updateRecordingWindow(cam, day, winIdx, 'start', $event.target.value)"
+                                           :aria-label="'Start time for window ' + (winIdx + 1) + ' on ' + day">
+                                    <span class="text-muted">to</span>
+                                    <input type="time" class="form-input" style="max-width:110px;"
+                                           :value="win.end"
+                                           @change="updateRecordingWindow(cam, day, winIdx, 'end', $event.target.value)"
+                                           :aria-label="'End time for window ' + (winIdx + 1) + ' on ' + day">
+                                    <button type="button" class="btn btn--danger btn--small btn--icon"
+                                            @click="removeRecordingWindow(cam, day, winIdx)"
+                                            :aria-label="'Remove window'">&#x2715;</button>
+                                </div>
+                            </template>
+                        </div>
+                    </template>
+
+                    <!-- 24x7 grid preview -->
+                    <div class="info-row__label" style="margin-top:12px;">Preview (24 &times; 7)</div>
+                    <div class="rec-grid" style="display:grid; grid-template-columns:40px repeat(24, 1fr); gap:1px; margin-top:4px; font-size:0.65em;">
+                        <div></div>
+                        <template x-for="h in 24" :key="'h-' + h">
+                            <div class="text-muted text-center" x-text="(h - 1).toString().padStart(2,'0')"></div>
+                        </template>
+                        <template x-for="day in recording.DAY_ORDER" :key="'grid-' + day">
+                            <template x-for="h in 25" :key="day + '-' + h">
+                                <template x-if="h === 1">
+                                    <div class="text-muted" x-text="day"></div>
+                                </template>
+                                <template x-if="h > 1">
+                                    <div :title="day + ' ' + (h - 2).toString().padStart(2,'0') + ':00'"
+                                         :style="'height:14px;background:' + (recordingGridActive(cam, day, h - 2) ? 'var(--color-success, #4ade80)' : 'var(--bg-card, #1f2937)') + ';border:1px solid var(--border, #374151);'"></div>
+                                </template>
+                            </template>
+                        </template>
+                    </div>
+                </div>
+
+                <div style="margin-top:12px; display:flex; gap:8px;">
+                    <button class="btn btn--primary btn--small" @click="saveRecording(cam)" :disabled="cam._saving">
+                        <span x-text="cam._saving ? 'Saving...' : 'Save'"></span>
+                    </button>
+                    <span x-show="cam._savedAt" class="text-small text-muted" style="align-self:center;"
+                          x-text="'Saved ' + cam._savedAt"></span>
+                </div>
+            </div>
+        </template>
+    </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════
      STORAGE TAB (admin only)
-     ═══════════════════════════��═══════════════════════════════ -->
+     ═══════════════════════════════════════════════════════════ -->
 <div x-show="isAdmin && tab === 'storage'" x-cloak>
     <div class="settings-section">
         <div class="settings-section__title">Recording Storage</div>
@@ -554,6 +676,53 @@
         <div x-show="storage.isUsb" style="margin-top:12px;">
             <button class="btn btn--secondary btn--small" @click="ejectUsb()">Eject USB &amp; Use Internal Storage</button>
         </div>
+
+        <!-- ADR-0017: loop recording + segment range -->
+        <div class="settings-section" style="margin-top:var(--space-3);">
+            <div class="settings-section__title">Loop Recording</div>
+            <div class="card">
+                <div class="info-row">
+                    <span class="info-row__label">Mount Path</span>
+                    <span class="info-row__value" x-text="storage.mountPath || '/data/recordings'"></span>
+                </div>
+                <div class="info-row">
+                    <span class="info-row__label">Total / Used / Free</span>
+                    <span class="info-row__value" x-text="storage.spaceDetail || '--'"></span>
+                </div>
+                <div class="info-row">
+                    <span class="info-row__label">Oldest Segment</span>
+                    <span class="info-row__value" x-text="storage.oldestSegment || '--'"></span>
+                </div>
+                <div class="info-row" style="border-bottom:none;">
+                    <span class="info-row__label">Newest Segment</span>
+                    <span class="info-row__value" x-text="storage.newestSegment || '--'"></span>
+                </div>
+
+                <form @submit.prevent="saveLoopSettings()" style="margin-top:12px;">
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="loop-low-watermark">Low watermark (% free)</label>
+                            <input type="number" id="loop-low-watermark" class="form-input"
+                                   min="1" max="50" step="1"
+                                   x-model.number="storage.lowWatermark"
+                                   aria-describedby="loop-low-watermark-hint">
+                            <span id="loop-low-watermark-hint" class="form-hint">Start deleting when free space drops below this.</span>
+                        </div>
+                        <div class="form-group">
+                            <label for="loop-hysteresis">Hysteresis (%)</label>
+                            <input type="number" id="loop-hysteresis" class="form-input"
+                                   min="1" max="30" step="1"
+                                   x-model.number="storage.hysteresis"
+                                   aria-describedby="loop-hysteresis-hint">
+                            <span id="loop-hysteresis-hint" class="form-hint">Stop deleting once free space reaches low + hysteresis.</span>
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn--primary btn--small" :disabled="storage.loopSaving">
+                        <span x-text="storage.loopSaving ? 'Saving...' : 'Save'"></span>
+                    </button>
+                </form>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -617,7 +786,9 @@ function settingsPage() {
 
         tailscale: { installed: false, running: false, state: 'unavailable', hostname: '', ip: '', peers: [], authUrl: '', loading: false, daemon_enabled: false, authenticated: false, config: { enabled: false, auto_connect: false, accept_routes: false, ssh: false, has_auth_key: false }, authKey: '', pollTimer: null },
 
-        storage: { location: '', recSize: '', space: '', clips: '', isUsb: false, devices: [], scanned: false, scanning: false, showFormat: false, formatDevice: {}, formatting: false },
+        storage: { location: '', recSize: '', space: '', clips: '', isUsb: false, devices: [], scanned: false, scanning: false, showFormat: false, formatDevice: {}, formatting: false, mountPath: '', spaceDetail: '', oldestSegment: '', newestSegment: '', lowWatermark: 10, hysteresis: 5, loopSaving: false },
+
+        recording: { cameras: [], timezone: '', DAY_ORDER: ['mon','tue','wed','thu','fri','sat','sun'] },
 
         resetConfirm: false,
         resetKeepRecordings: false,
@@ -639,6 +810,126 @@ function settingsPage() {
                 this.scanUsb();
                 this.loadNetworkInterfaces();
                 this.loadTailscale();
+                this.loadRecordingCameras();
+            }
+        },
+
+        /* --- Recording (ADR-0017) --- */
+        async loadRecordingCameras() {
+            try {
+                var list = await window.HM.api.get('/api/v1/cameras');
+                this.recording.cameras = (list || []).map(c => ({
+                    id: c.id,
+                    name: c.name || c.id,
+                    location: c.location || '',
+                    recording_mode: c.recording_mode || 'off',
+                    recording_schedule: Array.isArray(c.recording_schedule) ? JSON.parse(JSON.stringify(c.recording_schedule)) : [],
+                    _saving: false,
+                    _savedAt: '',
+                }));
+            } catch(e) {}
+            try {
+                var s = await window.HM.api.get('/api/v1/settings');
+                this.recording.timezone = s.timezone || '';
+            } catch(e) {}
+        },
+
+        recordingWindowsForDay(cam, day) {
+            if (!Array.isArray(cam.recording_schedule)) return [];
+            return cam.recording_schedule
+                .map((w, idx) => ({ w: w, idx: idx }))
+                .filter(x => Array.isArray(x.w.days) && x.w.days.indexOf(day) !== -1)
+                .map(x => ({ start: x.w.start, end: x.w.end, _idx: x.idx }));
+        },
+
+        recordingDayEnabled(cam, day) {
+            return this.recordingWindowsForDay(cam, day).length > 0;
+        },
+
+        addRecordingWindow(cam, day) {
+            if (!Array.isArray(cam.recording_schedule)) cam.recording_schedule = [];
+            cam.recording_schedule.push({ days: [day], start: '09:00', end: '17:00' });
+        },
+
+        toggleRecordingDay(cam, day, enabled) {
+            if (enabled) {
+                if (!this.recordingDayEnabled(cam, day)) {
+                    this.addRecordingWindow(cam, day);
+                }
+            } else {
+                cam.recording_schedule = (cam.recording_schedule || [])
+                    .filter(w => !(Array.isArray(w.days) && w.days.length === 1 && w.days[0] === day));
+            }
+        },
+
+        updateRecordingWindow(cam, day, visibleIdx, field, value) {
+            var windows = this.recordingWindowsForDay(cam, day);
+            var target = windows[visibleIdx];
+            if (!target) return;
+            var real = cam.recording_schedule[target._idx];
+            if (!real) return;
+            // Enforce HH:MM
+            if (!/^\d{2}:\d{2}$/.test(value)) return;
+            real[field] = value;
+        },
+
+        removeRecordingWindow(cam, day, visibleIdx) {
+            var windows = this.recordingWindowsForDay(cam, day);
+            var target = windows[visibleIdx];
+            if (!target) return;
+            cam.recording_schedule.splice(target._idx, 1);
+        },
+
+        recordingGridActive(cam, day, hour) {
+            if (cam.recording_mode !== 'schedule') {
+                return cam.recording_mode === 'continuous';
+            }
+            var windows = (cam.recording_schedule || []).filter(w =>
+                Array.isArray(w.days) && w.days.indexOf(day) !== -1);
+            for (var i = 0; i < windows.length; i++) {
+                var w = windows[i];
+                if (!/^\d{2}:\d{2}$/.test(w.start) || !/^\d{2}:\d{2}$/.test(w.end)) continue;
+                var sh = parseInt(w.start.slice(0,2), 10);
+                var eh = parseInt(w.end.slice(0,2), 10);
+                // For grid preview, treat overnight windows as two halves.
+                if (eh > sh) {
+                    if (hour >= sh && hour < eh) return true;
+                } else if (eh < sh) {
+                    if (hour >= sh || hour < eh) return true;
+                }
+            }
+            return false;
+        },
+
+        async saveRecording(cam) {
+            cam._saving = true;
+            try {
+                var payload = {
+                    recording_mode: cam.recording_mode,
+                    recording_schedule: cam.recording_schedule || [],
+                };
+                await window.HM.api.put('/api/v1/cameras/' + encodeURIComponent(cam.id), payload);
+                cam._savedAt = new Date().toLocaleTimeString();
+                window.HM.toast('Recording settings saved for ' + (cam.name || cam.id), 'success');
+            } catch(e) {
+                window.HM.toast(e.message || 'Failed to save recording settings', 'error');
+            } finally {
+                cam._saving = false;
+            }
+        },
+
+        async saveLoopSettings() {
+            this.storage.loopSaving = true;
+            try {
+                await window.HM.api.put('/api/v1/settings', {
+                    loop_low_watermark_percent: this.storage.lowWatermark,
+                    loop_hysteresis_percent: this.storage.hysteresis,
+                });
+                window.HM.toast('Loop recording settings saved', 'success');
+            } catch(e) {
+                window.HM.toast(e.message || 'Failed to save loop settings', 'error');
+            } finally {
+                this.storage.loopSaving = false;
             }
         },
 
@@ -890,6 +1181,23 @@ function settingsPage() {
                 this.storage.space = (data.total_gb || 0) + ' GB / ' + (data.free_gb || 0) + ' GB free';
                 this.storage.clips = (data.clip_count || 0) + ' clips across ' + (data.camera_count || 0) + ' cameras';
                 this.storage.isUsb = data.is_usb;
+                // ADR-0017 fields — tolerate older servers that don't send them.
+                this.storage.mountPath = data.mount_path || data.recordings_path || '';
+                var used = (data.used_gb !== undefined) ? data.used_gb : ((data.total_gb || 0) - (data.free_gb || 0));
+                this.storage.spaceDetail = (data.total_gb || 0) + ' GB total / '
+                    + used + ' GB used / '
+                    + (data.free_gb || 0) + ' GB free';
+                this.storage.oldestSegment = data.oldest_segment || data.oldest_clip || '';
+                this.storage.newestSegment = data.newest_segment || data.newest_clip || '';
+            } catch(e) {}
+            try {
+                var s = await window.HM.api.get('/api/v1/settings');
+                if (typeof s.loop_low_watermark_percent === 'number') {
+                    this.storage.lowWatermark = s.loop_low_watermark_percent;
+                }
+                if (typeof s.loop_hysteresis_percent === 'number') {
+                    this.storage.hysteresis = s.loop_hysteresis_percent;
+                }
             } catch(e) {}
         },
 

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -660,6 +660,78 @@ class TestRecordingsDeleteContract:
         _assert_fields(data, {"error"})
 
 
+class TestRecordingsCamerasContract:
+    """GET /api/v1/recordings/cameras — paired + orphan archive list."""
+
+    def test_paired_camera_fields(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        resp = client.get("/api/v1/recordings/cameras")
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        _assert_fields(data[0], {"id", "name", "status"})
+        assert data[0]["status"] in {"online", "offline", "removed"}
+
+    def test_orphan_surfaces_as_removed(self, app, client):
+        _login(app, client)
+        # No Camera record — just a clip on disk.
+        rec_dir = app.config["RECORDINGS_DIR"]
+        clip_dir = os.path.join(rec_dir, "cam-orphan", "2026-04-11")
+        os.makedirs(clip_dir, exist_ok=True)
+        with open(os.path.join(clip_dir, "14-30-00.mp4"), "wb") as f:
+            f.write(b"\x00" * 64)
+
+        data = client.get("/api/v1/recordings/cameras").get_json()
+        entry = next((c for c in data if c["id"] == "cam-orphan"), None)
+        assert entry is not None
+        assert entry["status"] == "removed"
+
+
+class TestRecordingsBulkDeleteContract:
+    """DELETE bulk endpoints — by date and by camera."""
+
+    def _seed(self, app, cam="cam-001", date="2026-04-11"):
+        rec_dir = app.config["RECORDINGS_DIR"]
+        clip_dir = os.path.join(rec_dir, cam, date)
+        os.makedirs(clip_dir, exist_ok=True)
+        for t in ("14-30-00", "15-00-00"):
+            with open(os.path.join(clip_dir, f"{t}.mp4"), "wb") as f:
+                f.write(b"\x00" * 128)
+
+    def test_delete_date_success_fields(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        self._seed(app)
+        resp = client.delete("/api/v1/recordings/cam-001/2026-04-11")
+        data = resp.get_json()
+        _assert_fields(data, {"message", "count"})
+        assert data["count"] == 2
+
+    def test_delete_date_bad_date(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        resp = client.delete("/api/v1/recordings/cam-001/not-a-date")
+        data = resp.get_json()
+        _assert_fields(data, {"error"})
+
+    def test_delete_camera_success_fields(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        self._seed(app, date="2026-04-11")
+        self._seed(app, date="2026-04-12")
+        resp = client.delete("/api/v1/recordings/cam-001")
+        data = resp.get_json()
+        _assert_fields(data, {"message", "count"})
+        assert data["count"] == 4
+
+    def test_delete_camera_not_found(self, app, client):
+        _login(app, client)
+        resp = client.delete("/api/v1/recordings/nope")
+        data = resp.get_json()
+        _assert_fields(data, {"error"})
+
+
 # ===========================================================================
 # Storage contracts (/api/v1/storage/*)
 # ===========================================================================

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -157,6 +157,10 @@ CAMERA_LIST_FIELDS_ADMIN = {
     "cpu_temp",
     "memory_percent",
     "uptime_seconds",
+    # ADR-0017: recording-mode + on-demand streaming fields
+    "recording_schedule",
+    "recording_motion_enabled",
+    "desired_stream_state",
 }
 
 # Viewers see a subset — no IP (network topology) or health metrics (occupancy risk)
@@ -1137,3 +1141,89 @@ class TestHeartbeatContract:
             },
         )
         assert resp.status_code == 401
+
+
+# ===========================================================================
+# ADR-0017: recording-mode fields + on-demand endpoints
+# ===========================================================================
+
+
+class TestCameraUpdateRecordingModeContract:
+    """PUT /api/v1/cameras/<id> accepts new recording_* fields."""
+
+    def test_put_accepts_schedule_mode(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        resp = client.put(
+            "/api/v1/cameras/cam-001",
+            json={
+                "recording_mode": "schedule",
+                "recording_schedule": [
+                    {"days": ["mon", "tue"], "start": "09:00", "end": "17:00"}
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        cam = app.store.get_camera("cam-001")
+        assert cam.recording_mode == "schedule"
+        assert cam.recording_schedule[0]["start"] == "09:00"
+
+    def test_put_rejects_invalid_mode(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        resp = client.put("/api/v1/cameras/cam-001", json={"recording_mode": "nope"})
+        assert resp.status_code == 400
+
+    def test_put_rejects_bad_schedule_day(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        resp = client.put(
+            "/api/v1/cameras/cam-001",
+            json={
+                "recording_mode": "schedule",
+                "recording_schedule": [
+                    {"days": ["funday"], "start": "09:00", "end": "17:00"}
+                ],
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_put_rejects_bad_time_format(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        resp = client.put(
+            "/api/v1/cameras/cam-001",
+            json={
+                "recording_mode": "schedule",
+                "recording_schedule": [{"days": ["mon"], "start": "9am", "end": "5pm"}],
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_put_motion_accepted_as_forward_compat(self, app, client):
+        _login(app, client)
+        _add_camera(app)
+        resp = client.put("/api/v1/cameras/cam-001", json={"recording_mode": "motion"})
+        assert resp.status_code == 200
+
+
+class TestOnDemandEndpointContract:
+    """Internal-only coordinator shape (marked x-internal in OpenAPI)."""
+
+    def test_start_shape(self, app, client):
+        from unittest.mock import MagicMock
+
+        _add_camera(app)
+        app.camera_control_client = MagicMock()
+        app.camera_control_client.start_stream.return_value = ({"state": "running"}, "")
+
+        resp = client.post("/internal/on-demand/cam-001/start")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        _assert_has_fields(data, {"ok"})
+
+    def test_non_localhost_forbidden(self, app, client):
+        _add_camera(app)
+        client.environ_base["REMOTE_ADDR"] = "10.0.0.5"
+        resp = client.post("/internal/on-demand/cam-001/start")
+        assert resp.status_code == 403

--- a/app/server/tests/integration/test_on_demand_flow.py
+++ b/app/server/tests/integration/test_on_demand_flow.py
@@ -1,0 +1,95 @@
+"""End-to-end on-demand streaming flow (ADR-0017).
+
+Simulates: MediaMTX → coordinator → camera start → viewer leaves →
+coordinator stop → camera stop. Uses a fake CameraControlClient that
+records calls instead of actually reaching out over mTLS.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from monitor.models import Camera
+
+
+class FakeControlClient:
+    """Records every call so we can assert on them."""
+
+    def __init__(self):
+        self.calls: list = []
+
+    def start_stream(self, ip):
+        self.calls.append(("start", ip))
+        return {"state": "running"}, ""
+
+    def stop_stream(self, ip):
+        self.calls.append(("stop", ip))
+        return {"state": "stopped"}, ""
+
+
+@pytest.fixture
+def staged(app):
+    cam = Camera(
+        id="cam-a",
+        name="Front",
+        status="online",
+        ip="10.0.0.7",
+        recording_mode="off",
+        desired_stream_state="stopped",
+    )
+    app.store.save_camera(cam)
+
+    fake = FakeControlClient()
+    app.camera_control_client = fake
+    # Plug a no-op scheduler by default.
+    app.recording_scheduler = MagicMock()
+    app.recording_scheduler.needs_stream.return_value = False
+    return app, fake
+
+
+class TestOnDemandFlow:
+    def test_viewer_open_then_close(self, staged):
+        app, fake = staged
+        client = app.test_client()
+
+        # Viewer arrives → MediaMTX calls start.
+        r = client.post("/internal/on-demand/cam-a/start")
+        assert r.status_code == 200
+        assert fake.calls == [("start", "10.0.0.7")]
+        assert app.store.get_camera("cam-a").desired_stream_state == "running"
+
+        # Viewer leaves → MediaMTX calls stop.
+        r = client.post("/internal/on-demand/cam-a/stop")
+        assert r.status_code == 200
+        assert ("stop", "10.0.0.7") in fake.calls
+        assert app.store.get_camera("cam-a").desired_stream_state == "stopped"
+
+    def test_stop_respects_scheduler_need(self, staged):
+        app, fake = staged
+        client = app.test_client()
+
+        # Get the camera to running state first.
+        client.post("/internal/on-demand/cam-a/start")
+        fake.calls.clear()
+
+        # Now scheduler insists on keeping it alive.
+        app.recording_scheduler.needs_stream.return_value = True
+        r = client.post("/internal/on-demand/cam-a/stop")
+        assert r.status_code == 200
+        assert r.get_json().get("kept_running") is True
+        assert fake.calls == []  # no stop sent
+        # desired state remains running
+        assert app.store.get_camera("cam-a").desired_stream_state == "running"
+
+    def test_start_is_idempotent(self, staged):
+        app, fake = staged
+        client = app.test_client()
+
+        client.post("/internal/on-demand/cam-a/start")
+        fake.calls.clear()
+
+        # Second start call should be a no-op.
+        r = client.post("/internal/on-demand/cam-a/start")
+        assert r.status_code == 200
+        assert fake.calls == []
+        assert r.get_json().get("already_running") is True

--- a/app/server/tests/unit/test_app.py
+++ b/app/server/tests/unit/test_app.py
@@ -76,8 +76,15 @@ class TestBlueprintRegistration:
         assert "provisioning" in app.blueprints
 
     def test_all_blueprints_count(self, app):
-        """We expect exactly 13 blueprints (11 API + views + setup)."""
-        assert len(app.blueprints) == 13
+        """We expect exactly 14 blueprints (12 API + views + setup).
+
+        Count bumped to 14 when ADR-0017 added the on-demand coordinator
+        blueprint (`on_demand`) for MediaMTX `runOnDemand` hooks.
+        """
+        assert len(app.blueprints) == 14
+
+    def test_on_demand_blueprint_registered(self, app):
+        assert "on_demand" in app.blueprints
 
     def test_webrtc_blueprint_registered(self, app):
         assert "webrtc" in app.blueprints

--- a/app/server/tests/unit/test_camera_control_client.py
+++ b/app/server/tests/unit/test_camera_control_client.py
@@ -46,6 +46,70 @@ class TestCameraControlClientUnit:
         result, err = client.restart_stream("192.168.99.99")
         assert result is None
 
+    def test_start_stream_unreachable(self, client):
+        """ADR-0017: stream/start returns error on unreachable camera."""
+        result, err = client.start_stream("192.168.99.99")
+        assert result is None
+        assert err
+
+    def test_stop_stream_unreachable(self, client):
+        result, err = client.stop_stream("192.168.99.99")
+        assert result is None
+        assert err
+
+    def test_get_stream_state_unreachable(self, client):
+        result, err = client.get_stream_state("192.168.99.99")
+        assert result is None
+        assert err
+
+
+class TestStreamControlEndpoints:
+    """ADR-0017: start/stop/state use the correct camera paths."""
+
+    def test_start_stream_uses_correct_path(self, client):
+        from unittest.mock import patch
+
+        with patch.object(
+            client, "_request", return_value=({"state": "running"}, "")
+        ) as m:
+            result, err = client.start_stream("10.0.0.1")
+        assert err == ""
+        assert result == {"state": "running"}
+        m.assert_called_once_with(
+            "POST", "10.0.0.1", "/api/v1/control/stream/start", {}
+        )
+
+    def test_stop_stream_uses_correct_path(self, client):
+        from unittest.mock import patch
+
+        with patch.object(
+            client, "_request", return_value=({"state": "stopped"}, "")
+        ) as m:
+            result, err = client.stop_stream("10.0.0.1")
+        assert err == ""
+        assert result == {"state": "stopped"}
+        m.assert_called_once_with("POST", "10.0.0.1", "/api/v1/control/stream/stop", {})
+
+    def test_get_stream_state_uses_correct_path(self, client):
+        from unittest.mock import patch
+
+        with patch.object(
+            client, "_request", return_value=({"state": "running"}, "")
+        ) as m:
+            result, err = client.get_stream_state("10.0.0.1")
+        assert err == ""
+        assert result == {"state": "running"}
+        m.assert_called_once_with("GET", "10.0.0.1", "/api/v1/control/stream/state")
+
+    def test_start_stream_idempotent_already_running(self, client):
+        """Camera reports already running → we surface success."""
+        from unittest.mock import patch
+
+        with patch.object(client, "_request", return_value=({"state": "running"}, "")):
+            result, err = client.start_stream("10.0.0.1")
+        assert err == ""
+        assert result["state"] == "running"
+
 
 class TestCameraServiceWithControl:
     """Test CameraService integration with control client."""

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -36,6 +36,10 @@ def _make_camera(**overrides):
         "memory_percent": 0,
         "uptime_seconds": 0,
         "pairing_secret": "",
+        # ADR-0017 recording-mode + on-demand streaming fields
+        "recording_schedule": [],
+        "recording_motion_enabled": False,
+        "desired_stream_state": "stopped",
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -320,7 +324,9 @@ class TestUpdate:
         store = MagicMock()
         store.get_camera.return_value = cam
         svc = CameraService(store)
-        error, status = svc.update("cam-001", {"recording_mode": "motion"})
+        # ADR-0017: 'motion' is now an accepted (forward-compat) mode.
+        # An unknown string must still be rejected.
+        error, status = svc.update("cam-001", {"recording_mode": "bogus"})
         assert status == 400
         assert "recording_mode" in error
 
@@ -378,23 +384,26 @@ class TestUpdate:
         assert status == 400
         assert "name" in error
 
-    def test_starts_streaming_on_off_to_continuous_transition(self):
+    def test_mode_change_off_to_continuous_no_direct_streaming_call(self):
+        """ADR-0017: pipeline changes are driven by RecordingScheduler, not here."""
         cam = _make_camera(recording_mode="off")
         store = MagicMock()
         store.get_camera.return_value = cam
         streaming = MagicMock()
         svc = CameraService(store, streaming=streaming)
         svc.update("cam-001", {"recording_mode": "continuous"})
-        streaming.start_camera.assert_called_once_with("cam-001")
+        streaming.start_camera.assert_not_called()
+        streaming.stop_camera.assert_not_called()
 
-    def test_stops_streaming_on_continuous_to_off_transition(self):
+    def test_mode_change_continuous_to_off_no_direct_streaming_call(self):
         cam = _make_camera(recording_mode="continuous")
         store = MagicMock()
         store.get_camera.return_value = cam
         streaming = MagicMock()
         svc = CameraService(store, streaming=streaming)
         svc.update("cam-001", {"recording_mode": "off"})
-        streaming.stop_camera.assert_called_once_with("cam-001")
+        streaming.start_camera.assert_not_called()
+        streaming.stop_camera.assert_not_called()
 
     def test_no_streaming_change_when_mode_unchanged(self):
         cam = _make_camera(recording_mode="continuous")

--- a/app/server/tests/unit/test_loop_recorder.py
+++ b/app/server/tests/unit/test_loop_recorder.py
@@ -1,0 +1,115 @@
+"""Unit tests for LoopRecorder (ADR-0017)."""
+
+import os
+import time
+from unittest.mock import MagicMock
+
+from monitor.services.loop_recorder import LoopRecorder
+
+
+def _mkseg(base, cam, name, age_seconds):
+    """Create a fake .mp4 segment with a specific mtime."""
+    d = base / cam
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    p.write_bytes(b"\x00" * 100)
+    t = time.time() - age_seconds
+    os.utime(p, (t, t))
+    return p
+
+
+class TestLoopRecorderWatermark:
+    def test_no_deletion_above_watermark(self, tmp_path, monkeypatch):
+        _mkseg(tmp_path, "cam1", "old.mp4", 4000)
+        _mkseg(tmp_path, "cam1", "new.mp4", 3000)
+
+        lr = LoopRecorder(tmp_path, audit=MagicMock(), low_watermark=10)
+        # Simulate 50% free (above watermark).
+        monkeypatch.setattr(lr, "_free_percent", lambda: 50.0)
+
+        assert lr.tick() == 0
+        assert (tmp_path / "cam1" / "old.mp4").exists()
+        assert (tmp_path / "cam1" / "new.mp4").exists()
+
+    def test_deletes_oldest_when_below_watermark(self, tmp_path):
+        old = _mkseg(tmp_path, "cam1", "old.mp4", 5000)
+        new = _mkseg(tmp_path, "cam1", "new.mp4", 4000)
+
+        lr = LoopRecorder(tmp_path, audit=MagicMock(), low_watermark=10, hysteresis=5)
+
+        # Stay below watermark for the first two checks (entry + one loop
+        # iter to delete the oldest), then jump above target.
+        seq = iter([5.0, 5.0, 20.0, 20.0, 20.0])
+        lr._free_percent = lambda: next(seq)
+
+        deleted = lr.tick()
+        assert deleted == 1
+        assert not old.exists()
+        assert new.exists()
+
+    def test_hysteresis_prevents_flap(self, tmp_path):
+        """Once free_percent >= low + hysteresis we stop deleting."""
+        for i in range(5):
+            _mkseg(tmp_path, "cam1", f"s{i}.mp4", 10000 - i)
+
+        lr = LoopRecorder(tmp_path, audit=MagicMock(), low_watermark=10, hysteresis=5)
+
+        # Free: entry below, first loop-iter below, then above target.
+        seq = iter([5.0, 5.0, 16.0, 16.0, 16.0, 16.0])
+        lr._free_percent = lambda: next(seq)
+
+        deleted = lr.tick()
+        assert deleted == 1  # hysteresis stopped further deletion
+
+    def test_live_segments_never_deleted(self, tmp_path):
+        old_live = _mkseg(tmp_path, "cam1", "live.mp4", 0)  # brand new
+        truly_old = _mkseg(tmp_path, "cam1", "stale.mp4", 10000)
+
+        lr = LoopRecorder(tmp_path, audit=MagicMock(), low_watermark=10, hysteresis=5)
+        # Keep free low the entire run so we would normally keep deleting.
+        lr._free_percent = lambda: 1.0
+
+        deleted = lr.tick()
+        # Live file protected by mtime (<10 min old); old one gone.
+        assert old_live.exists()
+        assert not truly_old.exists()
+        assert deleted == 1
+
+    def test_live_segments_callback_protects(self, tmp_path):
+        """Scheduler-provided live set protects a file even if mtime is old."""
+        _mkseg(tmp_path, "cam1", "a.mp4", 10000)
+        live = _mkseg(tmp_path, "cam1", "b.mp4", 10000)
+
+        lr = LoopRecorder(
+            tmp_path,
+            audit=MagicMock(),
+            low_watermark=10,
+            hysteresis=5,
+            live_segments_getter=lambda: {str(live)},
+        )
+        lr._free_percent = lambda: 1.0
+        lr.tick()
+        assert live.exists()
+
+    def test_audit_event_emitted(self, tmp_path):
+        _mkseg(tmp_path, "cam1", "old.mp4", 5000)
+        audit = MagicMock()
+        lr = LoopRecorder(tmp_path, audit=audit, low_watermark=10, hysteresis=5)
+        seq = iter([5.0, 5.0, 20.0, 20.0])
+        lr._free_percent = lambda: next(seq)
+        lr.tick()
+        audit.log_event.assert_called_once()
+        args, kwargs = audit.log_event.call_args
+        assert args[0] == "RECORDING_ROTATED"
+
+
+class TestLoopRecorderEdgeCases:
+    def test_missing_base_dir_does_not_raise(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        lr = LoopRecorder(missing, audit=MagicMock())
+        assert lr.tick() == 0
+
+    def test_no_segments_returns_zero(self, tmp_path):
+        lr = LoopRecorder(tmp_path, audit=MagicMock())
+        lr._free_percent = lambda: 1.0
+        assert lr.tick() == 0

--- a/app/server/tests/unit/test_models.py
+++ b/app/server/tests/unit/test_models.py
@@ -13,9 +13,13 @@ class TestCamera:
         assert cam.id == "cam-001"
         assert cam.name == ""
         assert cam.status == "pending"
-        assert cam.recording_mode == "continuous"
+        # ADR-0017: default recording mode is now "off" (on-demand streaming)
+        assert cam.recording_mode == "off"
         assert cam.resolution == "1080p"
         assert cam.fps == 25
+        assert cam.recording_schedule == []
+        assert cam.recording_motion_enabled is False
+        assert cam.desired_stream_state == "stopped"
 
     def test_create_camera_full(self, sample_camera):
         assert sample_camera.id == "cam-abc123"
@@ -84,7 +88,10 @@ class TestSettings:
         d = asdict(Settings())
         assert d["timezone"] == "Europe/Dublin"
         assert isinstance(d, dict)
-        assert len(d) == 14  # 9 base + 5 tailscale fields
+        # 9 base + 5 tailscale + 2 ADR-0017 loop-recording watermarks
+        assert len(d) == 16
+        assert d["loop_low_watermark_percent"] == 10
+        assert d["loop_hysteresis_percent"] == 5
 
 
 class TestClip:

--- a/app/server/tests/unit/test_on_demand_coordinator.py
+++ b/app/server/tests/unit/test_on_demand_coordinator.py
@@ -1,0 +1,148 @@
+"""Unit tests for the on-demand coordinator blueprint (ADR-0017)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from monitor.models import Camera
+
+
+@pytest.fixture
+def app_with_cam(app):
+    """App with one registered camera + mocked control client."""
+    cam = Camera(
+        id="cam-x",
+        name="X",
+        status="online",
+        ip="192.0.2.50",
+        desired_stream_state="stopped",
+    )
+    app.store.save_camera(cam)
+    app.camera_control_client = MagicMock()
+    app.camera_control_client.start_stream.return_value = ({"state": "running"}, "")
+    app.camera_control_client.stop_stream.return_value = ({"state": "stopped"}, "")
+    return app
+
+
+class TestOnDemandStart:
+    def test_start_calls_control_when_stopped(self, app_with_cam):
+        app = app_with_cam
+        client = app.test_client()
+        resp = client.post("/internal/on-demand/cam-x/start")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body.get("started") is True
+        app.camera_control_client.start_stream.assert_called_once_with("192.0.2.50")
+        cam = app.store.get_camera("cam-x")
+        assert cam.desired_stream_state == "running"
+
+    def test_start_noop_when_already_running(self, app_with_cam):
+        app = app_with_cam
+        cam = app.store.get_camera("cam-x")
+        cam.desired_stream_state = "running"
+        app.store.save_camera(cam)
+
+        client = app.test_client()
+        resp = client.post("/internal/on-demand/cam-x/start")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body.get("already_running") is True
+        app.camera_control_client.start_stream.assert_not_called()
+
+    def test_start_404_unknown_camera(self, app_with_cam):
+        client = app_with_cam.test_client()
+        resp = client.post("/internal/on-demand/cam-nope/start")
+        assert resp.status_code == 404
+
+
+class TestOnDemandStop:
+    def test_stop_calls_control_when_no_one_needs_it(self, app_with_cam):
+        app = app_with_cam
+        cam = app.store.get_camera("cam-x")
+        cam.desired_stream_state = "running"
+        app.store.save_camera(cam)
+
+        # Scheduler says: nope, don't need it.
+        app.recording_scheduler = MagicMock()
+        app.recording_scheduler.needs_stream.return_value = False
+
+        client = app.test_client()
+        resp = client.post("/internal/on-demand/cam-x/stop")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body.get("stopped") is True
+        app.camera_control_client.stop_stream.assert_called_once_with("192.0.2.50")
+        cam = app.store.get_camera("cam-x")
+        assert cam.desired_stream_state == "stopped"
+
+    def test_stop_kept_running_when_scheduler_needs_it(self, app_with_cam):
+        app = app_with_cam
+        cam = app.store.get_camera("cam-x")
+        cam.desired_stream_state = "running"
+        app.store.save_camera(cam)
+
+        app.recording_scheduler = MagicMock()
+        app.recording_scheduler.needs_stream.return_value = True
+
+        client = app.test_client()
+        resp = client.post("/internal/on-demand/cam-x/stop")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body.get("kept_running") is True
+        assert body.get("reason") == "scheduler"
+        app.camera_control_client.stop_stream.assert_not_called()
+
+
+class TestOnDemandAuth:
+    def test_non_localhost_rejected_403(self, app_with_cam):
+        """Only 127.0.0.1 / ::1 are allowed."""
+        client = app_with_cam.test_client()
+        # Simulate a non-localhost remote by overriding environ_base.
+        client.environ_base["REMOTE_ADDR"] = "192.168.1.50"
+        resp = client.post("/internal/on-demand/cam-x/start")
+        assert resp.status_code == 403
+
+
+class TestCoordinatorDirect:
+    """The pure-Python coordinator used by the scheduler."""
+
+    def test_stop_keeps_running_when_scheduler_needs(self, tmp_path):
+        from monitor.api.on_demand import OnDemandCoordinator
+        from monitor.store import Store
+
+        store = Store(str(tmp_path))
+        cam = Camera(id="cam-x", ip="10.0.0.5", desired_stream_state="running")
+        store.save_camera(cam)
+
+        scheduler = MagicMock()
+        scheduler.needs_stream.return_value = True
+        control = MagicMock()
+
+        coord = OnDemandCoordinator(store, control, lambda: scheduler)
+        acted, reason = coord.stop("cam-x")
+        assert acted is False
+        assert reason == "scheduler"
+        control.stop_stream.assert_not_called()
+
+    def test_stop_acts_when_no_one_needs(self, tmp_path):
+        from monitor.api.on_demand import OnDemandCoordinator
+        from monitor.store import Store
+
+        store = Store(str(tmp_path))
+        cam = Camera(id="cam-x", ip="10.0.0.5", desired_stream_state="running")
+        store.save_camera(cam)
+
+        scheduler = MagicMock()
+        scheduler.needs_stream.return_value = False
+        control = MagicMock()
+        control.stop_stream.return_value = ({"state": "stopped"}, "")
+
+        coord = OnDemandCoordinator(store, control, lambda: scheduler)
+        acted, reason = coord.stop("cam-x")
+        assert acted is True
+        assert reason == "ok"
+        control.stop_stream.assert_called_once_with("10.0.0.5")
+        assert store.get_camera("cam-x").desired_stream_state == "stopped"

--- a/app/server/tests/unit/test_recording_scheduler.py
+++ b/app/server/tests/unit/test_recording_scheduler.py
@@ -1,0 +1,172 @@
+"""Unit tests for RecordingScheduler (ADR-0017)."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from monitor.models import Camera
+from monitor.services.recording_scheduler import (
+    RecordingScheduler,
+    now_in_window,
+)
+
+
+def _cam(mode="off", schedule=None, ip="192.0.2.5", desired="stopped"):
+    return Camera(
+        id="cam-x",
+        name="X",
+        status="online",
+        ip=ip,
+        recording_mode=mode,
+        recording_schedule=schedule or [],
+        desired_stream_state=desired,
+    )
+
+
+class TestEvaluatePure:
+    def test_off_never_records(self):
+        cam = _cam("off")
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 17, 10, 0)) is False
+
+    def test_continuous_always_records(self):
+        cam = _cam("continuous")
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 17, 3, 0)) is True
+
+    def test_motion_treated_as_off(self):
+        cam = _cam("motion")
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 17, 10, 0)) is False
+
+    def test_schedule_in_window(self):
+        # 2026-04-17 is a Friday.
+        cam = _cam("schedule", [{"days": ["fri"], "start": "09:00", "end": "17:00"}])
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 17, 10, 30)) is True
+
+    def test_schedule_out_of_window_time(self):
+        cam = _cam("schedule", [{"days": ["fri"], "start": "09:00", "end": "17:00"}])
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 17, 8, 59)) is False
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 17, 17, 0)) is False
+
+    def test_schedule_out_of_window_day(self):
+        # Saturday is the 18th.
+        cam = _cam("schedule", [{"days": ["fri"], "start": "09:00", "end": "17:00"}])
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 18, 10, 0)) is False
+
+    def test_overnight_window_evaluates_correctly(self):
+        # 22:00 Thursday → 06:00 Friday.
+        cam = _cam("schedule", [{"days": ["thu"], "start": "22:00", "end": "06:00"}])
+        # Thursday 23:00 (day record matches, post-start) → True
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 16, 23, 0)) is True
+        # Friday 05:30 (day of record = Thursday, pre-end on spillover) → True
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 17, 5, 30)) is True
+        # Friday 10:00 outside any recorded window → False
+        assert RecordingScheduler.evaluate(cam, datetime(2026, 4, 17, 10, 0)) is False
+
+    def test_now_in_window_empty_list(self):
+        assert now_in_window([], datetime(2026, 4, 17, 10, 0)) is False
+
+
+class TestReconcileSideEffects:
+    """Per-tick reconciliation drives streaming + control + store."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        from monitor.store import Store
+
+        return Store(str(tmp_path))
+
+    def test_continuous_starts_recorder_and_stream(self, store):
+        cam = _cam("continuous", desired="stopped")
+        store.save_camera(cam)
+
+        streaming = MagicMock()
+        streaming.is_recording.return_value = False
+        control = MagicMock()
+        control.start_stream.return_value = ({"state": "running"}, "")
+
+        sched = RecordingScheduler(store, streaming, control)
+        sched.tick()
+
+        control.start_stream.assert_called_once_with("192.0.2.5")
+        streaming.start_recorder.assert_called_once()
+        reloaded = store.get_camera("cam-x")
+        assert reloaded.desired_stream_state == "running"
+        assert sched.needs_stream("cam-x") is True
+
+    def test_off_stops_recorder_and_asks_coordinator(self, store):
+        cam = _cam("off", desired="running")
+        store.save_camera(cam)
+
+        streaming = MagicMock()
+        streaming.is_recording.return_value = True
+        control = MagicMock()
+        coordinator = MagicMock()
+
+        sched = RecordingScheduler(store, streaming, control, coordinator=coordinator)
+        sched.tick()
+
+        streaming.stop_recorder.assert_called_once_with("cam-x")
+        coordinator.stop.assert_called_once_with("cam-x")
+        assert sched.needs_stream("cam-x") is False
+
+    def test_schedule_active_window_behaves_like_continuous(self, store, monkeypatch):
+        # Force `now` to a Friday inside the window.
+        cam = _cam(
+            "schedule",
+            schedule=[{"days": ["fri"], "start": "08:00", "end": "18:00"}],
+            desired="stopped",
+        )
+        store.save_camera(cam)
+
+        streaming = MagicMock()
+        streaming.is_recording.return_value = False
+        control = MagicMock()
+        control.start_stream.return_value = ({"state": "running"}, "")
+
+        sched = RecordingScheduler(store, streaming, control)
+
+        class _FakeDT:
+            @classmethod
+            def now(cls):
+                return datetime(2026, 4, 17, 12, 0)
+
+        monkeypatch.setattr("monitor.services.recording_scheduler.datetime", _FakeDT)
+        sched.tick()
+        streaming.start_recorder.assert_called_once()
+
+    def test_mode_change_mid_tick_flips(self, store):
+        """Flipping recording_mode between ticks stops/starts the recorder."""
+        cam = _cam("continuous", desired="stopped")
+        store.save_camera(cam)
+
+        streaming = MagicMock()
+        streaming.is_recording.return_value = False
+        control = MagicMock()
+        control.start_stream.return_value = ({}, "")
+
+        sched = RecordingScheduler(store, streaming, control)
+        sched.tick()  # start
+        streaming.start_recorder.assert_called_once()
+
+        # Flip to off, pretend recorder is now running.
+        cam = store.get_camera("cam-x")
+        cam.recording_mode = "off"
+        store.save_camera(cam)
+        streaming.is_recording.return_value = True
+        sched.tick()
+        streaming.stop_recorder.assert_called_once()
+
+    def test_no_control_call_when_already_running(self, store):
+        cam = _cam("continuous", desired="running")
+        store.save_camera(cam)
+
+        streaming = MagicMock()
+        streaming.is_recording.return_value = True
+        control = MagicMock()
+
+        sched = RecordingScheduler(store, streaming, control)
+        sched.tick()
+
+        control.start_stream.assert_not_called()
+        # Recorder already running → no new start_recorder call either.
+        streaming.start_recorder.assert_not_called()

--- a/app/server/tests/unit/test_recording_scheduler.py
+++ b/app/server/tests/unit/test_recording_scheduler.py
@@ -12,7 +12,7 @@ from monitor.services.recording_scheduler import (
 )
 
 
-def _cam(mode="off", schedule=None, ip="192.0.2.5", desired="stopped"):
+def _cam(mode="off", schedule=None, ip="192.0.2.5", desired="stopped", streaming=True):
     return Camera(
         id="cam-x",
         name="X",
@@ -21,6 +21,7 @@ def _cam(mode="off", schedule=None, ip="192.0.2.5", desired="stopped"):
         recording_mode=mode,
         recording_schedule=schedule or [],
         desired_stream_state=desired,
+        streaming=streaming,
     )
 
 
@@ -155,6 +156,30 @@ class TestReconcileSideEffects:
         streaming.is_recording.return_value = True
         sched.tick()
         streaming.stop_recorder.assert_called_once()
+
+    def test_recorder_not_started_until_camera_confirms_streaming(self, store):
+        """Scheduler requests stream but defers recorder until heartbeat confirms."""
+        cam = _cam("continuous", desired="stopped", streaming=False)
+        store.save_camera(cam)
+
+        streaming = MagicMock()
+        streaming.is_recording.return_value = False
+        control = MagicMock()
+        control.start_stream.return_value = ({"state": "running"}, "")
+
+        sched = RecordingScheduler(store, streaming, control)
+        sched.tick()
+
+        # Stream requested, but no recorder yet — camera hasn't confirmed.
+        control.start_stream.assert_called_once()
+        streaming.start_recorder.assert_not_called()
+
+        # Next tick after heartbeat reports streaming=True → recorder starts.
+        cam2 = store.get_camera("cam-x")
+        cam2.streaming = True
+        store.save_camera(cam2)
+        sched.tick()
+        streaming.start_recorder.assert_called_once()
 
     def test_no_control_call_when_already_running(self, store):
         cam = _cam("continuous", desired="running")

--- a/app/server/tests/unit/test_settings_service.py
+++ b/app/server/tests/unit/test_settings_service.py
@@ -21,6 +21,9 @@ def _make_settings(**overrides):
         "tailscale_accept_routes": False,
         "tailscale_ssh": False,
         "tailscale_auth_key": "",
+        # ADR-0017 loop-recording watermarks
+        "loop_low_watermark_percent": 10,
+        "loop_hysteresis_percent": 5,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -49,12 +52,16 @@ class TestGetSettings:
         assert result["hostname"] == "homemonitor"
         assert result["setup_completed"] is False
         assert result["firmware_version"] == "1.0.0"
+        # ADR-0017 loop-recording watermarks
+        assert result["loop_low_watermark_percent"] == 10
+        assert result["loop_hysteresis_percent"] == 5
 
     def test_returns_dict(self):
         svc, _ = _make_service()
         result = svc.get_settings()
         assert isinstance(result, dict)
-        assert len(result) == 12
+        # 12 original + 2 ADR-0017 loop-recording fields
+        assert len(result) == 14
 
     def test_reflects_custom_values(self):
         settings = _make_settings(timezone="US/Pacific", hostname="mybox")
@@ -611,6 +618,9 @@ class TestUpdatableFields:
             "tailscale_accept_routes",
             "tailscale_ssh",
             "tailscale_auth_key",
+            # ADR-0017 loop-recording watermarks
+            "loop_low_watermark_percent",
+            "loop_hysteresis_percent",
         }
         assert expected == UPDATABLE_FIELDS
 

--- a/app/server/tests/unit/test_streaming.py
+++ b/app/server/tests/unit/test_streaming.py
@@ -1,13 +1,8 @@
-"""Tests for monitor.services.streaming_service module."""
+"""Tests for monitor.services.streaming_service (post ADR-0017 rewrite)."""
 
-import os
-import time
 from unittest.mock import MagicMock, patch
 
 from monitor.services.streaming_service import (
-    CLIP_DURATION,
-    HLS_LIST_SIZE,
-    HLS_SEGMENT_DURATION,
     MEDIAMTX_URL,
     SNAPSHOT_INTERVAL,
     StreamingService,
@@ -15,446 +10,215 @@ from monitor.services.streaming_service import (
 )
 
 
-class TestStreamingService:
-    """Test the video pipeline manager."""
-
-    def test_init(self, tmp_path):
-        """Should initialize with empty state."""
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
+class TestStreamingServiceLifecycle:
+    def test_init_has_empty_state(self, tmp_path):
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
         assert svc.active_cameras == []
+        assert svc.recordings_dir.endswith("rec")
 
-    def test_start_stop(self, tmp_path):
-        """Should start and stop cleanly."""
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
+    def test_start_stop_clean(self, tmp_path):
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
         svc.start()
         svc.stop()
 
-    @patch("monitor.services.streaming_service.StreamingService._take_snapshot")
+
+class TestSnapshotPipeline:
+    """The rewrite keeps a single long-lived snapshot ffmpeg per camera."""
+
     @patch("subprocess.Popen")
-    def test_start_camera(self, mock_popen, mock_snap, tmp_path):
-        """start_camera should launch HLS and recorder ffmpeg processes."""
+    def test_start_camera_launches_one_snapshot_ffmpeg(self, mock_popen, tmp_path):
         proc = MagicMock()
         proc.pid = 1234
         proc.poll.return_value = None
         mock_popen.return_value = proc
 
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
         svc.start()
-        result = svc.start_camera("cam-abc123")
-
-        assert result is True
-        assert "cam-abc123" in svc.active_cameras
-        # Should have launched 2 ffmpeg processes (HLS + recorder)
-        assert mock_popen.call_count == 2
+        assert svc.start_camera("cam-abc") is True
+        # Exactly one ffmpeg (snapshot) — no HLS muxer, no recorder.
+        assert mock_popen.call_count == 1
+        assert "cam-abc" in svc.active_cameras
         svc.stop()
 
     @patch("subprocess.Popen")
-    def test_start_camera_creates_dirs(self, mock_popen, tmp_path):
-        """start_camera should create live and recording directories."""
+    def test_snapshot_command_uses_update_and_fps(self, mock_popen, tmp_path):
         proc = MagicMock()
-        proc.pid = 1234
+        proc.pid = 1
         proc.poll.return_value = None
         mock_popen.return_value = proc
 
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
         svc.start()
-        svc.start_camera("cam-abc123")
-
-        assert (tmp_path / "live" / "cam-abc123").is_dir()
-        assert (tmp_path / "recordings" / "cam-abc123").is_dir()
-        svc.stop()
-
-    def test_start_camera_when_not_running(self, tmp_path):
-        """Should refuse to start camera when service not running."""
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        result = svc.start_camera("cam-abc123")
-        assert result is False
-
-    @patch("subprocess.Popen")
-    def test_stop_camera(self, mock_popen, tmp_path):
-        """stop_camera should terminate ffmpeg processes."""
-        proc = MagicMock()
-        proc.pid = 1234
-        proc.poll.return_value = None
-        proc.wait.return_value = None
-        mock_popen.return_value = proc
-
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        svc.start()
-        svc.start_camera("cam-abc123")
-        svc.stop_camera("cam-abc123")
-
-        assert "cam-abc123" not in svc.active_cameras
-        proc.terminate.assert_called()
-        svc.stop()
-
-    @patch("subprocess.Popen")
-    def test_is_camera_active(self, mock_popen, tmp_path):
-        """is_camera_active should reflect HLS process state."""
-        proc = MagicMock()
-        proc.pid = 1234
-        proc.poll.return_value = None
-        mock_popen.return_value = proc
-
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        svc.start()
-        assert svc.is_camera_active("cam-abc123") is False
-
-        svc.start_camera("cam-abc123")
-        assert svc.is_camera_active("cam-abc123") is True
-        svc.stop()
-
-    def test_stop_nonexistent_camera(self, tmp_path):
-        """stop_camera should not raise for unknown camera."""
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        svc.stop_camera("nonexistent")  # Should not raise
-
-    @patch("subprocess.Popen")
-    def test_stop_cleans_hls_segments(self, mock_popen, tmp_path):
-        """stop_camera should remove stale HLS segment files."""
-        proc = MagicMock()
-        proc.pid = 1234
-        proc.poll.return_value = None
-        proc.wait.return_value = None
-        mock_popen.return_value = proc
-
-        live_dir = tmp_path / "live"
-        cam_dir = live_dir / "cam-abc123"
-        cam_dir.mkdir(parents=True)
-        (cam_dir / "segment_001.ts").write_text("fake")
-        (cam_dir / "segment_002.ts").write_text("fake")
-
-        svc = StreamingService(
-            live_dir=str(live_dir),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        svc.start()
-        svc.start_camera("cam-abc123")
-        svc.stop_camera("cam-abc123")
-
-        # HLS segments should be cleaned up
-        assert not list(cam_dir.glob("segment_*.ts"))
-        svc.stop()
-
-
-class TestHLSPipeline:
-    """Test HLS ffmpeg command construction."""
-
-    @patch("subprocess.Popen")
-    def test_hls_command(self, mock_popen, tmp_path):
-        """HLS command should have correct flags."""
-        proc = MagicMock()
-        proc.pid = 1234
-        mock_popen.return_value = proc
-
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        svc.start()
-        svc._start_hls("cam-test", "rtsp://127.0.0.1:8554/cam-test")
-
+        svc.start_camera("cam-x")
         cmd = mock_popen.call_args[0][0]
         assert cmd[0] == "ffmpeg"
-        assert "-nostdin" in cmd
-        assert "-rtsp_transport" in cmd
-        assert "tcp" in cmd
-        assert "rtsp://127.0.0.1:8554/cam-test" in cmd
-        assert "-f" in cmd
-        assert "hls" in cmd
-        assert "-hls_time" in cmd
-        assert str(HLS_SEGMENT_DURATION) in cmd
-        assert "-hls_list_size" in cmd
-        assert str(HLS_LIST_SIZE) in cmd
+        assert "-update" in cmd
+        assert "1" in cmd
+        # fps=1/30 string appears somewhere
+        assert any(f"fps=1/{SNAPSHOT_INTERVAL}" in c for c in cmd)
+        svc.stop()
+
+    @patch("subprocess.Popen")
+    def test_start_camera_creates_live_dir(self, mock_popen, tmp_path):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.poll.return_value = None
+        mock_popen.return_value = proc
+
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        svc.start()
+        svc.start_camera("cam-abc")
+        assert (tmp_path / "live" / "cam-abc").is_dir()
+        svc.stop()
+
+    def test_start_camera_refused_when_not_running(self, tmp_path):
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        assert svc.start_camera("cam-abc") is False
+
+    @patch("subprocess.Popen")
+    def test_stop_camera_marks_intent_stopped(self, mock_popen, tmp_path):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.poll.return_value = None
+        proc.wait.return_value = None
+        mock_popen.return_value = proc
+
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        svc.start()
+        svc.start_camera("cam-abc")
+        svc.stop_camera("cam-abc")
+        assert svc._snap_intent["cam-abc"] == "stopped"
+        assert "cam-abc" not in svc.active_cameras
         svc.stop()
 
 
 class TestRecorderPipeline:
-    """Test recording ffmpeg command construction."""
+    """The recorder is now owned by StreamingService but driven by scheduler."""
 
     @patch("subprocess.Popen")
-    def test_recorder_command(self, mock_popen, tmp_path):
-        """Recorder command should use segment muxer with 3-min duration."""
+    def test_start_recorder_uses_c_copy_and_segment(self, mock_popen, tmp_path):
         proc = MagicMock()
-        proc.pid = 1234
+        proc.pid = 1
+        proc.poll.return_value = None
         mock_popen.return_value = proc
 
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
         svc.start()
-        svc._start_recorder("cam-test", "rtsp://127.0.0.1:8554/cam-test")
-
+        started = svc.start_recorder("cam-x", f"{MEDIAMTX_URL}/cam-x")
+        assert started is True
         cmd = mock_popen.call_args[0][0]
-        assert cmd[0] == "ffmpeg"
-        assert "-segment_time" in cmd
-        idx = cmd.index("-segment_time")
-        assert cmd[idx + 1] == str(CLIP_DURATION)
-        assert "-segment_format" in cmd
-        assert "mp4" in cmd
-        assert "-strftime" in cmd
+        assert "-c" in cmd and "copy" in cmd
+        assert "-f" in cmd and "segment" in cmd
+        assert any(arg.endswith(".mp4") for arg in cmd)
+        svc.stop()
+
+    @patch("subprocess.Popen")
+    def test_start_recorder_is_idempotent(self, mock_popen, tmp_path):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.poll.return_value = None
+        mock_popen.return_value = proc
+
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        svc.start()
+        svc.start_recorder("cam-x", f"{MEDIAMTX_URL}/cam-x")
+        assert svc.start_recorder("cam-x", f"{MEDIAMTX_URL}/cam-x") is False
+        assert mock_popen.call_count == 1
+        svc.stop()
+
+    @patch("subprocess.Popen")
+    def test_is_recording_reflects_process_state(self, mock_popen, tmp_path):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.poll.return_value = None
+        mock_popen.return_value = proc
+
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        svc.start()
+        assert svc.is_recording("cam-x") is False
+        svc.start_recorder("cam-x", f"{MEDIAMTX_URL}/cam-x")
+        assert svc.is_recording("cam-x") is True
         svc.stop()
 
 
-class TestSnapshot:
-    """Test snapshot extraction."""
+class TestWatchdogIntent:
+    """Deliberately-stopped processes are NOT restarted by the watchdog."""
 
-    @patch("subprocess.run")
-    def test_take_snapshot(self, mock_run, tmp_path):
-        """Should extract JPEG frame via ffmpeg."""
-        mock_run.return_value = MagicMock(returncode=0)
-        cam_live = tmp_path / "live" / "cam-test"
-        cam_live.mkdir(parents=True)
-        # Create the tmp file that ffmpeg would produce
-        tmp_jpg = cam_live / "snapshot.tmp.jpg"
-        tmp_jpg.write_bytes(b"\xff\xd8fake-jpeg")
+    @patch("subprocess.Popen")
+    def test_dead_and_stopped_is_not_restarted(self, mock_popen, tmp_path):
+        dead = MagicMock()
+        dead.poll.return_value = 0  # exited
+        dead.pid = 99
+        mock_popen.return_value = dead
 
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        svc._take_snapshot("cam-test", "rtsp://127.0.0.1:8554/cam-test")
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        svc.start()
+        svc.start_camera("cam-x")
+        # Mark intent as stopped, then let watchdog see a dead proc.
+        svc._snap_intent["cam-x"] = "stopped"
 
-        mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
-        assert "ffmpeg" in cmd[0]
-        assert "-frames:v" in cmd
-        assert "1" in cmd
+        calls_before = mock_popen.call_count
+        svc._check_processes()
+        assert mock_popen.call_count == calls_before  # no restart
+        svc.stop()
 
-    @patch("subprocess.run")
-    def test_snapshot_timeout(self, mock_run, tmp_path):
-        """Should handle ffmpeg timeout gracefully."""
-        import subprocess
+    @patch("subprocess.Popen")
+    def test_dead_but_wanted_is_restarted(self, mock_popen, tmp_path):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.poll.return_value = 1  # exited unexpectedly
+        mock_popen.return_value = proc
 
-        mock_run.side_effect = subprocess.TimeoutExpired("cmd", 10)
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        svc.start()
+        svc.start_camera("cam-x")
+        calls_before = mock_popen.call_count
 
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        (tmp_path / "live" / "cam-test").mkdir(parents=True)
-        svc._take_snapshot("cam-test", "rtsp://127.0.0.1:8554/cam-test")
-        # Should not raise
-
-
-class TestLaunchFFmpeg:
-    """Test ffmpeg process launching."""
-
-    @patch("subprocess.Popen", side_effect=FileNotFoundError)
-    def test_ffmpeg_not_found(self, mock_popen, tmp_path):
-        """Should return None when ffmpeg not installed."""
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        result = svc._launch_ffmpeg(["ffmpeg"], "test")
-        assert result is None
-
-    @patch("subprocess.Popen", side_effect=OSError("some error"))
-    def test_oserror(self, mock_popen, tmp_path):
-        """Should return None on OS error."""
-        svc = StreamingService(
-            live_dir=str(tmp_path / "live"),
-            recordings_dir=str(tmp_path / "recordings"),
-        )
-        result = svc._launch_ffmpeg(["ffmpeg"], "test")
-        assert result is None
+        svc._check_processes()
+        assert mock_popen.call_count > calls_before
+        svc.stop()
 
 
 class TestCreateRecordingDirs:
-    """Test recording directory creation."""
-
-    def test_creates_date_dir(self, tmp_path):
-        """Should create cam/<date> directory."""
-        path = create_recording_dirs(str(tmp_path), "cam-test")
-        assert path.is_dir()
-        assert "cam-test" in str(path)
+    def test_creates_flat_per_camera_dir(self, tmp_path):
+        p = create_recording_dirs(str(tmp_path), "cam-x")
+        assert p.is_dir()
+        assert p.name == "cam-x"
 
     def test_idempotent(self, tmp_path):
-        """Should not fail if directory exists."""
-        create_recording_dirs(str(tmp_path), "cam-test")
-        create_recording_dirs(str(tmp_path), "cam-test")
+        create_recording_dirs(str(tmp_path), "cam-x")
+        create_recording_dirs(str(tmp_path), "cam-x")
 
 
-class TestStaleClipDetection:
-    """Test _is_recorder_stale — detects hung ffmpeg segment muxer."""
-
-    def test_no_cam_dir_not_stale(self, tmp_path):
-        """Missing camera directory is not stale (hasn't started yet)."""
+class TestLaunchFFmpegErrorPaths:
+    @patch("subprocess.Popen", side_effect=FileNotFoundError)
+    def test_ffmpeg_not_found(self, _mock, tmp_path):
         svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
-        assert svc._is_recorder_stale("cam-nonexistent") is False
+        assert svc._launch_ffmpeg(["ffmpeg"], "test") is None
 
-    def test_no_clips_not_stale(self, tmp_path):
-        """Camera dir exists but no clips — first clip still recording."""
-        rec = tmp_path / "rec"
-        (rec / "cam1" / "2026-04-11").mkdir(parents=True)
-        svc = StreamingService(str(tmp_path / "live"), str(rec))
-        assert svc._is_recorder_stale("cam1") is False
-
-    def test_recent_clip_not_stale(self, tmp_path):
-        """Clip written within threshold is fine."""
-        rec = tmp_path / "rec"
-        cam_dir = rec / "cam1" / "2026-04-11"
-        cam_dir.mkdir(parents=True)
-        clip = cam_dir / "08-30-00.mp4"
-        clip.write_bytes(b"\x00" * 100)
-        # Touch it to now
-        clip.touch()
-
-        svc = StreamingService(str(tmp_path / "live"), str(rec))
-        assert svc._is_recorder_stale("cam1") is False
-
-    def test_old_clip_is_stale(self, tmp_path):
-        """Clip older than 2 * clip_duration triggers stale detection."""
-        rec = tmp_path / "rec"
-        cam_dir = rec / "cam1" / "2026-04-11"
-        cam_dir.mkdir(parents=True)
-        clip = cam_dir / "06-00-00.mp4"
-        clip.write_bytes(b"\x00" * 100)
-        # Set mtime to 10 minutes ago (threshold = 2 * 180 = 360s)
-        old_time = time.time() - 600
-        os.utime(str(clip), (old_time, old_time))
-
-        svc = StreamingService(str(tmp_path / "live"), str(rec))
-        assert svc._is_recorder_stale("cam1") is True
-
-    def test_stale_threshold_uses_clip_duration(self, tmp_path):
-        """Custom clip_duration changes stale threshold."""
-        rec = tmp_path / "rec"
-        cam_dir = rec / "cam1" / "2026-04-11"
-        cam_dir.mkdir(parents=True)
-        clip = cam_dir / "08-00-00.mp4"
-        clip.write_bytes(b"\x00" * 100)
-        # Set mtime to 70 seconds ago
-        os.utime(str(clip), (time.time() - 70, time.time() - 70))
-
-        # With clip_duration=30, threshold = 2*30 = 60s → 70s is stale
-        svc = StreamingService(str(tmp_path / "live"), str(rec), clip_duration=30)
-        assert svc._is_recorder_stale("cam1") is True
-
-        # With clip_duration=60, threshold = 2*60 = 120s → 70s is NOT stale
-        svc2 = StreamingService(str(tmp_path / "live"), str(rec), clip_duration=60)
-        assert svc2._is_recorder_stale("cam1") is False
-
-    def test_multiple_clips_uses_newest(self, tmp_path):
-        """Stale check uses the newest clip, not oldest."""
-        rec = tmp_path / "rec"
-        cam_dir = rec / "cam1" / "2026-04-11"
-        cam_dir.mkdir(parents=True)
-
-        old_clip = cam_dir / "06-00-00.mp4"
-        old_clip.write_bytes(b"\x00" * 100)
-        os.utime(str(old_clip), (time.time() - 600, time.time() - 600))
-
-        new_clip = cam_dir / "08-30-00.mp4"
-        new_clip.write_bytes(b"\x00" * 100)
-        new_clip.touch()  # now
-
-        svc = StreamingService(str(tmp_path / "live"), str(rec))
-        assert svc._is_recorder_stale("cam1") is False
+    @patch("subprocess.Popen", side_effect=OSError("boom"))
+    def test_oserror(self, _mock, tmp_path):
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        assert svc._launch_ffmpeg(["ffmpeg"], "test") is None
 
 
-class TestWatchdogStaleRestart:
-    """Test that _check_processes force-restarts stalled recorders."""
+class TestUpdateRecordingsDir:
+    @patch("subprocess.Popen")
+    def test_restarts_active_recorders(self, mock_popen, tmp_path):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.poll.return_value = None
+        proc.wait.return_value = None
+        mock_popen.return_value = proc
 
-    @patch.object(StreamingService, "_start_recorder")
-    @patch.object(StreamingService, "_start_hls")
-    def test_stale_recorder_is_killed_and_restarted(self, mock_hls, mock_rec, tmp_path):
-        """A live but stale recorder should be force-killed and restarted."""
-        rec = tmp_path / "rec"
-        cam_dir = rec / "cam1" / "2026-04-11"
-        cam_dir.mkdir(parents=True)
-        clip = cam_dir / "06-00-00.mp4"
-        clip.write_bytes(b"\x00" * 100)
-        os.utime(str(clip), (time.time() - 600, time.time() - 600))
-
-        svc = StreamingService(str(tmp_path / "live"), str(rec))
-
-        # Simulate live HLS and recorder processes
-        fake_hls = MagicMock()
-        fake_hls.poll.return_value = None  # alive
-        fake_rec = MagicMock()
-        fake_rec.poll.return_value = None  # alive but stale
-        fake_rec.pid = 12345
-
-        svc._hls_procs["cam1"] = fake_hls
-        svc._rec_procs["cam1"] = fake_rec
-
-        svc._check_processes()
-
-        # Recorder should have been terminated and restarted
-        fake_rec.terminate.assert_called_once()
-        mock_rec.assert_called_once_with("cam1", f"{MEDIAMTX_URL}/cam1")
-        # HLS should NOT have been restarted (it's alive)
-        mock_hls.assert_not_called()
-
-    @patch.object(StreamingService, "_start_recorder")
-    @patch.object(StreamingService, "_start_hls")
-    def test_healthy_recorder_not_restarted(self, mock_hls, mock_rec, tmp_path):
-        """A live recorder with recent clips should not be restarted."""
-        rec = tmp_path / "rec"
-        cam_dir = rec / "cam1" / "2026-04-11"
-        cam_dir.mkdir(parents=True)
-        clip = cam_dir / "08-30-00.mp4"
-        clip.write_bytes(b"\x00" * 100)
-        clip.touch()  # recent
-
-        svc = StreamingService(str(tmp_path / "live"), str(rec))
-
-        fake_hls = MagicMock()
-        fake_hls.poll.return_value = None
-        fake_rec = MagicMock()
-        fake_rec.poll.return_value = None
-
-        svc._hls_procs["cam1"] = fake_hls
-        svc._rec_procs["cam1"] = fake_rec
-
-        svc._check_processes()
-
-        # Neither should be restarted
-        mock_rec.assert_not_called()
-        mock_hls.assert_not_called()
-
-
-class TestConstants:
-    """Test module constants."""
-
-    def test_mediamtx_url(self):
-        assert MEDIAMTX_URL == "rtsp://127.0.0.1:8554"
-
-    def test_hls_segment_duration(self):
-        assert HLS_SEGMENT_DURATION == 2
-
-    def test_hls_list_size(self):
-        assert HLS_LIST_SIZE == 5
-
-    def test_clip_duration(self):
-        assert CLIP_DURATION == 180
-
-    def test_snapshot_interval(self):
-        assert SNAPSHOT_INTERVAL == 30
+        svc = StreamingService(str(tmp_path / "live"), str(tmp_path / "rec"))
+        svc.start()
+        svc.start_recorder("cam-x", f"{MEDIAMTX_URL}/cam-x")
+        calls_before = mock_popen.call_count
+        new_dir = tmp_path / "rec2"
+        new_dir.mkdir()
+        svc.update_recordings_dir(str(new_dir))
+        # Recorder should have been stopped & restarted.
+        assert mock_popen.call_count > calls_before
+        assert svc.recordings_dir == str(new_dir)
+        svc.stop()

--- a/app/server/tests/unit/test_svc_recordings.py
+++ b/app/server/tests/unit/test_svc_recordings.py
@@ -209,7 +209,7 @@ class TestListCameraSources:
     def test_paired_online_and_offline(self, svc, store):
         store.get_cameras.return_value = [
             Camera(id="cam-a", name="Front", status="online"),
-            Camera(id="cam-b", name="Back",  status="offline"),
+            Camera(id="cam-b", name="Back", status="offline"),
         ]
         result, error, status = svc.list_camera_sources()
         assert status == 200 and error is None
@@ -239,6 +239,7 @@ class TestListCameraSources:
 
     def test_orphan_dir_without_mp4s_is_ignored(self, svc, store, storage_manager):
         from pathlib import Path
+
         store.get_cameras.return_value = []
         # Empty camera dir (no clips yet) — not an archive, skip.
         (Path(storage_manager.recordings_dir) / "cam-empty").mkdir()
@@ -247,6 +248,7 @@ class TestListCameraSources:
 
     def test_orphan_with_invalid_id_is_ignored(self, svc, store, storage_manager):
         from pathlib import Path
+
         store.get_cameras.return_value = []
         # Path-traversal-ish names must not be surfaced.
         bad = Path(storage_manager.recordings_dir) / "..weird"
@@ -314,15 +316,20 @@ class TestDeleteDate:
         _create_clip_file(storage_manager, "cam-001", "2026-04-09", "15-00-00")
         _create_clip_file(storage_manager, "cam-001", "2026-04-10", "09-00-00")
         result, error, status = svc.delete_date(
-            "cam-001", "2026-04-09",
-            requesting_user="admin", requesting_ip="127.0.0.1",
+            "cam-001",
+            "2026-04-09",
+            requesting_user="admin",
+            requesting_ip="127.0.0.1",
         )
         assert error is None and status == 200
         assert result["count"] == 2
         # The other date survives untouched.
         from pathlib import Path
+
         remaining = list(
-            (Path(storage_manager.recordings_dir) / "cam-001" / "2026-04-10").glob("*.mp4")
+            (Path(storage_manager.recordings_dir) / "cam-001" / "2026-04-10").glob(
+                "*.mp4"
+            )
         )
         assert len(remaining) == 1
         audit.log_event.assert_called_once()
@@ -346,11 +353,13 @@ class TestDeleteCameraRecordings:
         _create_clip_file(storage_manager, "cam-001", "2026-04-10", "09-00-00")
         result, error, status = svc.delete_camera_recordings(
             "cam-001",
-            requesting_user="admin", requesting_ip="127.0.0.1",
+            requesting_user="admin",
+            requesting_ip="127.0.0.1",
         )
         assert error is None and status == 200
         assert result["count"] == 2
         from pathlib import Path
+
         cam_root = Path(storage_manager.recordings_dir) / "cam-001"
         assert not cam_root.exists()
         audit.log_event.assert_called_once()

--- a/app/server/tests/unit/test_svc_recordings.py
+++ b/app/server/tests/unit/test_svc_recordings.py
@@ -203,6 +203,166 @@ class TestDeleteClip:
         assert status == 200
 
 
+class TestListCameraSources:
+    """Test the /recordings/cameras aggregator (paired + orphans)."""
+
+    def test_paired_online_and_offline(self, svc, store):
+        store.get_cameras.return_value = [
+            Camera(id="cam-a", name="Front", status="online"),
+            Camera(id="cam-b", name="Back",  status="offline"),
+        ]
+        result, error, status = svc.list_camera_sources()
+        assert status == 200 and error is None
+        ids = [c["id"] for c in result]
+        assert ids == ["cam-a", "cam-b"]
+        assert [c["status"] for c in result] == ["online", "offline"]
+
+    def test_pending_cameras_are_excluded(self, svc, store):
+        store.get_cameras.return_value = [
+            Camera(id="cam-a", name="Front", status="online"),
+            Camera(id="cam-p", name="NewOne", status="pending"),
+        ]
+        result, _, _ = svc.list_camera_sources()
+        assert [c["id"] for c in result] == ["cam-a"]
+
+    def test_orphan_cameras_appear_as_removed(self, svc, store, storage_manager):
+        # Paired list is empty, but a cam dir with a clip exists on disk.
+        store.get_cameras.return_value = []
+        _create_clip_file(storage_manager, "cam-orphan", "2026-04-09", "14-00-00")
+        result, _, _ = svc.list_camera_sources()
+        assert len(result) == 1
+        assert result[0] == {
+            "id": "cam-orphan",
+            "name": "cam-orphan",
+            "status": "removed",
+        }
+
+    def test_orphan_dir_without_mp4s_is_ignored(self, svc, store, storage_manager):
+        from pathlib import Path
+        store.get_cameras.return_value = []
+        # Empty camera dir (no clips yet) — not an archive, skip.
+        (Path(storage_manager.recordings_dir) / "cam-empty").mkdir()
+        result, _, _ = svc.list_camera_sources()
+        assert result == []
+
+    def test_orphan_with_invalid_id_is_ignored(self, svc, store, storage_manager):
+        from pathlib import Path
+        store.get_cameras.return_value = []
+        # Path-traversal-ish names must not be surfaced.
+        bad = Path(storage_manager.recordings_dir) / "..weird"
+        bad.mkdir()
+        (bad / "2026-04-09").mkdir()
+        (bad / "2026-04-09" / "14.mp4").write_bytes(b"x")
+        result, _, _ = svc.list_camera_sources()
+        assert result == []
+
+    def test_paired_camera_does_not_double_as_orphan(self, svc, store, storage_manager):
+        store.get_cameras.return_value = [
+            Camera(id="cam-a", name="Front", status="online"),
+        ]
+        _create_clip_file(storage_manager, "cam-a", "2026-04-09", "14-00-00")
+        result, _, _ = svc.list_camera_sources()
+        assert [c["id"] for c in result] == ["cam-a"]
+        assert result[0]["status"] == "online"
+
+
+class TestOrphanBrowsing:
+    """Orphan cameras (store returns None, files exist) must stay browseable."""
+
+    def test_list_clips_works_for_orphan(self, svc, store, storage_manager):
+        store.get_camera.return_value = None  # Camera record deleted
+        _create_clip_file(storage_manager, "cam-orphan", "2026-04-09", "14-00-00")
+        result, error, status = svc.list_clips("cam-orphan", "2026-04-09")
+        assert error is None and status == 200
+        assert len(result) == 1
+
+    def test_list_dates_works_for_orphan(self, svc, store, storage_manager):
+        store.get_camera.return_value = None
+        _create_clip_file(storage_manager, "cam-orphan", "2026-04-09", "14-00-00")
+        result, error, status = svc.list_dates("cam-orphan")
+        assert status == 200
+        assert result["dates"] == ["2026-04-09"]
+
+    def test_unknown_cam_still_404s(self, svc, store):
+        store.get_camera.return_value = None  # and no files on disk
+        _, error, status = svc.list_clips("nope", "2026-04-09")
+        assert status == 404 and error == "Camera not found"
+
+
+class TestDeleteDate:
+    """Bulk delete all clips for one camera on one date."""
+
+    def test_invalid_camera_id(self, svc):
+        _, error, status = svc.delete_date("../etc", "2026-04-09")
+        assert status == 400 and error == "Invalid camera id"
+
+    def test_invalid_date(self, svc):
+        _, error, status = svc.delete_date("cam-001", "not-a-date")
+        assert status == 400 and error == "Invalid date"
+
+    def test_camera_not_found(self, svc, store):
+        store.get_camera.return_value = None
+        _, error, status = svc.delete_date("cam-001", "2026-04-09")
+        assert status == 404
+
+    def test_no_recordings_on_date(self, svc):
+        _, error, status = svc.delete_date("cam-001", "2026-04-09")
+        assert status == 404
+
+    def test_deletes_all_clips_on_date(self, svc, storage_manager, audit):
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-00-00")
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "15-00-00")
+        _create_clip_file(storage_manager, "cam-001", "2026-04-10", "09-00-00")
+        result, error, status = svc.delete_date(
+            "cam-001", "2026-04-09",
+            requesting_user="admin", requesting_ip="127.0.0.1",
+        )
+        assert error is None and status == 200
+        assert result["count"] == 2
+        # The other date survives untouched.
+        from pathlib import Path
+        remaining = list(
+            (Path(storage_manager.recordings_dir) / "cam-001" / "2026-04-10").glob("*.mp4")
+        )
+        assert len(remaining) == 1
+        audit.log_event.assert_called_once()
+        assert audit.log_event.call_args[0][0] == "CLIPS_DELETED"
+
+
+class TestDeleteCameraRecordings:
+    """Bulk delete all clips for a camera across every date."""
+
+    def test_invalid_camera_id(self, svc):
+        _, error, status = svc.delete_camera_recordings("../escape")
+        assert status == 400
+
+    def test_camera_not_found(self, svc, store):
+        store.get_camera.return_value = None
+        _, error, status = svc.delete_camera_recordings("nope")
+        assert status == 404
+
+    def test_deletes_entire_tree(self, svc, storage_manager, audit):
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-00-00")
+        _create_clip_file(storage_manager, "cam-001", "2026-04-10", "09-00-00")
+        result, error, status = svc.delete_camera_recordings(
+            "cam-001",
+            requesting_user="admin", requesting_ip="127.0.0.1",
+        )
+        assert error is None and status == 200
+        assert result["count"] == 2
+        from pathlib import Path
+        cam_root = Path(storage_manager.recordings_dir) / "cam-001"
+        assert not cam_root.exists()
+        audit.log_event.assert_called_once()
+
+    def test_orphan_cameras_are_deletable(self, svc, store, storage_manager):
+        store.get_camera.return_value = None
+        _create_clip_file(storage_manager, "cam-orphan", "2026-04-09", "14-00-00")
+        result, error, status = svc.delete_camera_recordings("cam-orphan")
+        assert error is None and status == 200
+        assert result["count"] == 1
+
+
 class TestFallbackRecordingsDir:
     """Test fallback when storage_manager is None."""
 

--- a/docs/adr/0015-server-camera-control-channel.md
+++ b/docs/adr/0015-server-camera-control-channel.md
@@ -405,3 +405,9 @@ the camera notifies the server using HMAC-SHA256 authentication:
 Camera is always source of truth. If both sides change simultaneously,
 the camera's rate limiter (5s cooldown) rejects the server push. The camera's
 local change succeeds and its notification overwrites the server's stored copy.
+
+## See also
+
+- [ADR-0017](0017-on-demand-viewer-driven-streaming.md) — extends this
+  control channel with `POST /api/v1/control/stream/{start,stop}` for
+  on-demand streaming.

--- a/docs/adr/0016-camera-health-heartbeat-protocol.md
+++ b/docs/adr/0016-camera-health-heartbeat-protocol.md
@@ -236,3 +236,9 @@ liveness signal. It also does not carry streaming state or health metrics.
 | Server unit tests | `app/server/tests/unit/test_camera_service.py` |
 | Server contract tests | `app/server/tests/contracts/test_api_contracts.py` |
 | Staleness tests | `app/server/tests/unit/test_svc_discovery.py` |
+
+## See also
+
+- [ADR-0017](0017-on-demand-viewer-driven-streaming.md) — extends the
+  heartbeat payload with `stream_state` and `recording_state` fields so
+  the server can detect drift between desired and actual stream state.

--- a/docs/adr/0017-on-demand-viewer-driven-streaming.md
+++ b/docs/adr/0017-on-demand-viewer-driven-streaming.md
@@ -1,0 +1,318 @@
+# ADR-0017: On-Demand, Viewer-Driven Streaming + Recording Modes
+
+**Status:** Proposed
+**Date:** 2026-04-17
+**Deciders:** vinu-dev
+
+---
+
+## Context
+
+### Problem
+
+Today every paired camera pushes RTSP to the server 24 × 7, whether or not
+anyone is watching and whether or not recording is required:
+
+1. `lifecycle._do_running()` (camera) starts `libcamera-vid | ffmpeg` on
+   boot and keeps it alive unconditionally.
+2. `StreamingService` (server) spawns a per-camera HLS muxer ffmpeg and a
+   30-second snapshot-respawn thread the moment a camera pairs, and keeps
+   them running forever.
+3. MediaMTX relays the RTSP push whether anyone consumes the WebRTC /
+   HLS output or not.
+
+At a nominal 4 Mbps this is ~43 GB/day/camera of Wi-Fi + disk + CPU — all
+wasted when nobody is looking at the dashboard and the user has not opted
+in to recording. With a 10-camera home target (see mission), 24 × 7
+streaming saturates home Wi-Fi and burns SD-card write endurance for no
+user benefit.
+
+There is also no user-facing control over *when* to record. Tapo and
+UniFi cameras let the owner choose Off / Continuous / Schedule / Motion;
+this system has no equivalent — it effectively records continuously if
+any recorder is hooked up, with no schedule.
+
+### Goal
+
+- Idle Wi-Fi traffic from a camera → server drops to ~0 when no dashboard
+  is open AND `recording_mode = off` (or outside a schedule window).
+- Live view starts within ~3–5 s of a user opening a tile (bounded by
+  libcamera sensor + ffmpeg keyframe warm-up).
+- User chooses per camera: `Off` / `Continuous` / `Schedule`
+  (Motion slot reserved in the data model, disabled in the UI).
+- Loop recording on the inserted media: oldest segments auto-deleted when
+  free space falls below a low-watermark.
+- No hardware changes; no new protocols; no new auth surface.
+
+### Non-Goals
+
+- Dual-encoder sub-stream / main-stream split on the camera. Keeping a
+  single H.264 encoder keeps us on known-good libcamera territory; the
+  on-demand win already addresses the bandwidth problem without it.
+- Motion detection logic. The UI exposes a disabled Motion option so the
+  data model is future-proof, but no detector ships in this change.
+- Remote (off-LAN) viewing — requires TURN and belongs in a separate ADR.
+- Per-camera timezone. Schedule windows evaluate in the server's system
+  timezone; surfaced read-only in the UI.
+
+---
+
+## Decision
+
+### Overall shape
+
+```
+Viewer (browser)        Server                    MediaMTX           Camera
+     │                    │                         │                  │
+     │ open /live/<id>    │                         │                  │
+     │───────────────────>│  (WebRTC page)          │                  │
+     │<─── html + JS ─────│                         │                  │
+     │                    │                         │                  │
+     │ WHEP POST ──────────────────────────────────>│                  │
+     │                    │                         │ runOnDemand hook │
+     │                    │  /internal/on-demand/<id>/start            │
+     │                    │<──────── curl ──────────│                  │
+     │                    │                         │                  │
+     │                    │ POST /control/stream/start (HMAC, mTLS)    │
+     │                    │───────────────────────────────────────────>│
+     │                    │                         │                  │ libcamera+ffmpeg
+     │                    │                         │<── RTSP push ────│ starts
+     │<──── WebRTC frames ─────────────────────────│                  │
+     │                    │                         │                  │
+     │ close tab          │                         │ (no readers)     │
+     │                    │                         │ runOnDemandClose │
+     │                    │  /internal/on-demand/<id>/stop             │
+     │                    │<──────── curl ──────────│                  │
+     │                    │                         │                  │
+     │                    │  coordinator asks:                         │
+     │                    │   does scheduler still need the stream?    │
+     │                    │    - yes → no-op                           │
+     │                    │    - no  → POST /control/stream/stop ────>│ ffmpeg stops
+```
+
+Recording continues to ride on the same camera-push stream; when a
+schedule is active, the scheduler is the thing that "needs" the stream
+and the coordinator keeps the camera streaming even with no viewer.
+
+### 1. Persisted desired stream state on the camera
+
+- New file: `/data/config/stream_state` — one line, either `running` or
+  `stopped`.
+- Default on first boot: `stopped`. A freshly paired camera does not
+  start streaming until something (viewer or scheduler) asks it to.
+- `lifecycle._do_running()` reads the file on entry and either spawns
+  the stream pipeline or parks in an idle wait loop.
+- Every explicit start/stop command from the server rewrites the file
+  atomically (tempfile + `os.replace`) so a power cut can't lose intent
+  nor resurrect a stopped camera on reboot.
+
+### 2. Camera control endpoints
+
+Two new HMAC-authenticated endpoints on `status_server.py`, same scheme
+as ADR-0015 `config-notify`:
+
+| Method | Path                                 | Body        | Response                      |
+|--------|--------------------------------------|-------------|-------------------------------|
+| POST   | `/api/v1/control/stream/start`       | `{}`        | `{"state": "running"}`        |
+| POST   | `/api/v1/control/stream/stop`        | `{}`        | `{"state": "stopped"}`        |
+
+Both are idempotent: calling `start` on an already-running camera is a
+no-op that returns the current state. `ControlHandler.set_stream_state`
+is the single code path, persists the file in §1, and signals
+`lifecycle`.
+
+### 3. Heartbeat payload additions
+
+ADR-0016 heartbeat gains two fields (server-tolerant of missing values
+for legacy cameras):
+
+```json
+{
+  "stream_state": "running",
+  "recording_state": {
+    "mode": "schedule",
+    "recording_now": true
+  }
+}
+```
+
+The camera does not itself schedule recordings — `recording_state` is
+the mirror the server last told the camera to expect, echoed back so the
+server can detect drift (same pattern as `config_sync`).
+
+### 4. Server control client
+
+`CameraControlClient` gains `start_stream(ip)` / `stop_stream(ip)` —
+thin wrappers over the existing HMAC POST helper.
+
+### 5. On-demand coordinator
+
+- New blueprint bound to **127.0.0.1 only**, no auth (localhost trust):
+  - `POST /internal/on-demand/<camera_id>/start`
+  - `POST /internal/on-demand/<camera_id>/stop`
+- MediaMTX invokes these via a shell wrapper
+  `/opt/monitor/bin/mediamtx-on-demand.sh <id> <start|stop>` hooked as
+  `runOnDemand` / `runOnDemandCloseAfter` (15 s grace).
+- `start` handler: idempotent; if camera already `running`, no-op;
+  otherwise calls `CameraControlClient.start_stream`.
+- `stop` handler: consults `RecordingScheduler.needs_stream(camera_id)`.
+  If the scheduler still wants the stream (continuous or in-window
+  schedule), no-op. Otherwise calls `stop_stream`.
+- The coordinator is the single "anyone still need this?" gate — no
+  race between scheduler and viewer-close.
+
+If MediaMTX version actually only exposes `runOnConnect` / `runOnReady`,
+we hook those equivalently; the coordinator API is the stable surface.
+
+### 6. Recording mode policy
+
+New fields on the `Camera` model (stored in `cameras.json`, ADR-0002):
+
+| Field                         | Type     | Values / shape                                              |
+|-------------------------------|----------|-------------------------------------------------------------|
+| `recording_mode`              | `str`    | `"off"` \| `"continuous"` \| `"schedule"` \| `"motion"`     |
+| `recording_schedule`          | `list`   | `[{"days": ["mon","tue",...], "start": "HH:MM", "end": "HH:MM"}, ...]` |
+| `recording_motion_enabled`    | `bool`   | reserved for future motion ADR; default `false`             |
+
+`recording_mode = "motion"` is accepted by the API for forward compat
+but treated as "off" by the scheduler until the motion ADR lands.
+
+### 7. RecordingScheduler service
+
+- Daemon thread, 60 s tick (overlaps with heartbeat cadence; good
+  enough for minute-precision schedule windows).
+- For each camera:
+  - Compute `wanted = mode is continuous, OR (mode is schedule AND
+    now-in-window)`. Overnight windows (`end < start`) handled by
+    splitting into `[start, 24:00) ∪ [00:00, end)`.
+  - If `wanted` and no recorder ffmpeg running → start one, AND if the
+    camera's `stream_state == stopped` call `start_stream(ip)`.
+  - If not `wanted` and a recorder is running → stop it; then call
+    the coordinator's stop path (which will no-op if a viewer is
+    active).
+- Recorder ffmpeg command: `-c copy` RTSP → segmented MP4 in
+  `/media/recordings/<cam-id>/` — no re-encoding, bit-for-bit copy.
+- Persists no extra state; recomputes from `cameras.json` every tick so
+  mode changes propagate within one minute.
+
+### 8. LoopRecorder service
+
+- Daemon thread, 60 s tick.
+- Scans `/media/recordings/`; if `free_percent < low_watermark`
+  (default 10 %, configurable), deletes oldest segment files until
+  `free_percent >= low_watermark + hysteresis` (default 5 %).
+- Emits `RECORDING_ROTATED` audit events per deletion.
+- Never deletes the currently-writing segment.
+
+### 9. Live transport
+
+Live view is served via **WebRTC WHEP** (ADR-0005 primary) from
+MediaMTX. The server's old per-camera HLS muxer and 30-s snapshot
+respawn are deleted. A single long-lived ffmpeg per camera pulls one
+snapshot every 30 s while the RTSP stream is available (`-update 1`);
+when the camera is idle, the last snapshot persists on disk and the
+dashboard tile shows a "last seen Xs ago" label over the stale frame.
+
+LL-HLS remains the documented fallback (ADR-0005) for browsers that
+fail WHEP negotiation; the client-side player tries WHEP first, then
+falls back.
+
+---
+
+## Alternatives Considered
+
+### Keep always-on streaming, add "pause when idle" later
+
+Rejected: the costs compound as cameras are added. With 10 cameras at
+4 Mbps each the LAN saturates a typical 2.4 GHz AP; SD-card writes on
+the server bound monthly write volume even with no viewers. The
+symmetric fix ("idle = off") is cleaner than layering throttles.
+
+### Camera-side schedule evaluation
+
+Rejected: introduces clock-skew bugs, requires NTP discipline per
+camera, and needs the camera to know the user-configured schedule
+(either via push config or polling). The server already knows the
+schedule, already has reliable time, and already has the control
+channel. Server-side evaluation is strictly simpler.
+
+### Separate sub-stream for live, main-stream for record
+
+Rejected for MVP: libcamera multi-stream + dual ffmpeg pipelines is a
+real hardware-risk area. Single-encoder + on-demand already solves the
+bandwidth problem for the 10-camera home target. Re-visit when motion
+detection (ADR-TBD) needs a continuous low-res analysis stream.
+
+### MQTT control bus instead of per-camera HTTPS
+
+Rejected: ADR-0015 already standardises HTTP + HMAC for the control
+channel; adding a broker is additional infrastructure with no win at
+10-camera scale. The new endpoints reuse the existing HMAC scheme and
+mTLS socket.
+
+### Recording on the camera, pulled on demand
+
+Rejected: SD cards on the camera are smaller and harder to service;
+users expect the "server collects footage" shape. Also defeats loop
+recording on a user-inserted storage medium (USB / external SD on the
+server) which is the shipping design.
+
+---
+
+## Consequences
+
+### Positive
+
+- Idle bandwidth from a camera drops from ~4 Mbps to ~600 bytes every
+  15 s (just the heartbeat).
+- Recorder policy is user-visible and matches consumer camera UX.
+- Loop recording guarantees the disk never fills; user does not have
+  to manually prune.
+- Single-encoder hardware path unchanged — lowest-risk route to the
+  user-visible behaviour change.
+- Schedule evaluation lives entirely on the server — no camera-clock
+  bugs to chase.
+
+### Negative / Trade-offs
+
+- Live-view first-frame is ~3–5 s instead of sub-second, because the
+  encoder has to warm up on each viewer arrival. Acceptable for a home
+  monitor; documented in the settings UI.
+- MediaMTX `runOnDemand` hook semantics depend on version — plan
+  validates at implementation time and falls back to `runOnReady` or a
+  server-owned WHEP proxy shim if needed.
+- Recording continuously still writes ~43 GB/day/camera at 4 Mbps. Loop
+  policy bounds total bytes, but SD endurance is still the user's
+  concern — recommend high-endurance cards in docs.
+- One more background thread on the server (`RecordingScheduler`) plus
+  one (`LoopRecorder`). Within the "small number of service threads"
+  budget set by ADR-0003.
+
+---
+
+## Implementation
+
+| Component                           | File                                                                       |
+|-------------------------------------|----------------------------------------------------------------------------|
+| Camera stream control               | `app/camera/camera_streamer/control.py`                                    |
+| Camera control HTTP surface         | `app/camera/camera_streamer/status_server.py`                              |
+| Camera lifecycle honours state file | `app/camera/camera_streamer/lifecycle.py`                                  |
+| Persisted stream state              | `/data/config/stream_state` (atomic write)                                 |
+| Camera heartbeat extension          | `app/camera/camera_streamer/heartbeat.py`                                  |
+| Server control client               | `app/server/monitor/services/camera_control_client.py`                     |
+| Server streaming rewrite            | `app/server/monitor/services/streaming_service.py`                         |
+| Recording scheduler (new)           | `app/server/monitor/services/recording_scheduler.py`                       |
+| Loop recorder (new)                 | `app/server/monitor/services/loop_recorder.py`                             |
+| On-demand coordinator (new)         | `app/server/monitor/api/on_demand.py`                                      |
+| MediaMTX hook script                | `meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx-on-demand.sh`|
+| MediaMTX config                     | `meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx.yml`         |
+| Camera model fields                 | `app/server/monitor/models.py`                                             |
+| REST validation                     | `app/server/monitor/api/cameras.py`                                        |
+| Live page (WebRTC WHEP)             | `app/server/monitor/templates/live.html`                                   |
+| Settings: Recording tab             | `app/server/monitor/templates/camera_settings.html`                        |
+| Settings: Storage tab               | `app/server/monitor/templates/settings.html`                               |
+| OpenAPI updates                     | `app/server/monitor/openapi/*.yaml`, `app/camera/.../openapi.yaml`         |
+| Camera tests                        | `app/camera/tests/unit/test_control.py`, `test_stream.py`, `test_heartbeat.py` |
+| Server tests (new + updated)        | `app/server/tests/unit/test_streaming.py`, `test_recording_scheduler.py`, `test_loop_recorder.py`, `test_on_demand_coordinator.py` |
+| Integration tests                   | `app/server/tests/integration/test_on_demand_flow.py` (new)                |
+| Docs                                | `docs/architecture.md`, `docs/requirements.md`, `docs/exec-plans/on-demand-streaming.md` |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,55 @@
+# Architecture Decision Records
+
+This directory collects the Architecture Decision Records (ADRs) for
+`rpi-home-monitor`. Each ADR captures **one** decision: the context that
+forced it, the option chosen, the alternatives considered, and the
+consequences the project now has to live with.
+
+Format: lightly adapted Michael Nygard style (`Status / Date / Deciders`
+header, then `Context → Decision → Alternatives → Consequences →
+Implementation`). Numbering is sequential and gap-free; a superseded ADR
+is marked `Status: Superseded by ADR-XXXX` rather than deleted.
+
+## Index
+
+| #    | Title                                                                                           | Status     |
+|------|-------------------------------------------------------------------------------------------------|------------|
+| 0001 | [Custom Yocto distro](0001-custom-yocto-distro.md)                                              | Accepted   |
+| 0002 | [JSON file storage (no database)](0002-json-file-storage.md)                                    | Accepted   |
+| 0003 | [Service layer pattern](0003-service-layer-pattern.md)                                          | Accepted   |
+| 0004 | [Camera lifecycle state machine](0004-camera-lifecycle-state-machine.md)                        | Accepted   |
+| 0005 | [WebRTC primary, HLS fallback for live view](0005-webrtc-primary-hls-fallback.md)               | Accepted   |
+| 0006 | [Modular monolith architecture](0006-modular-monolith-architecture.md)                          | Accepted   |
+| 0007 | [Dev-build default credentials](0007-dev-build-default-credentials.md)                          | Accepted   |
+| 0008 | [SWUpdate A/B rollback](0008-swupdate-ab-rollback.md)                                           | Accepted   |
+| 0009 | [Camera pairing via mTLS + TOFU](0009-camera-pairing-mtls.md)                                   | Accepted   |
+| 0010 | [LUKS data encryption](0010-luks-data-encryption.md)                                            | Accepted   |
+| 0011 | [Auth hardening (password + rate limit + TOTP)](0011-auth-hardening.md)                         | Accepted   |
+| 0012 | [UI architecture (HTMX + Alpine)](0012-ui-architecture.md)                                      | Accepted   |
+| 0013 | [Unified provisioning + GPIO triggers](0013-unified-provisioning-gpio-triggers.md)              | Accepted   |
+| 0014 | [SWUpdate signing (dev / prod split)](0014-swupdate-signing-dev-prod.md)                        | Accepted   |
+| 0015 | [Server → camera control channel](0015-server-camera-control-channel.md)                        | Accepted   |
+| 0016 | [Camera health heartbeat protocol](0016-camera-health-heartbeat-protocol.md)                    | Accepted   |
+| 0017 | [On-demand, viewer-driven streaming + recording modes](0017-on-demand-viewer-driven-streaming.md) | Proposed |
+
+## Writing a new ADR
+
+1. Copy the most recent accepted ADR as a template (0016 is the current
+   reference for formatting).
+2. Number it `NNNN-short-slug.md` — the next unused integer, four digits.
+3. Keep the scope tight: one ADR per decision. Cross-link rather than
+   bundle.
+4. Start in `Status: Proposed`. Flip to `Accepted` when merged, or
+   `Rejected` / `Superseded by ADR-XXXX` if the decision is reversed
+   later.
+5. Update the index table above in the same commit.
+6. Link the ADR from the relevant code or doc (`docs/architecture.md`,
+   module docstrings, etc.) so readers can find it from the surface
+   they're reading.
+
+## See also
+
+- [`docs/ai/index.md`](../ai/index.md) — AI-assistant entrypoint
+- [`docs/architecture.md`](../architecture.md) — current system picture
+- [`docs/exec-plans/`](../exec-plans/) — multi-session execution plans
+  that implement ADRs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -859,6 +859,68 @@ Application code lives in `app/` and can be developed, tested, and deployed inde
 
 ## 8. Video Recording Design
 
+### 8.0 On-Demand Streaming (ADR-0017)
+
+Cameras are **idle by default** — a freshly paired camera does not push
+RTSP until something asks it to. Two things can ask:
+
+1. **A viewer** — opening `/live/<id>` triggers a WebRTC WHEP request to
+   MediaMTX. MediaMTX invokes its `runOnDemand` hook, which calls the
+   localhost-only coordinator blueprint
+   (`POST /internal/on-demand/<id>/start`), which in turn POSTs to the
+   camera's HMAC-gated `/api/v1/control/stream/start` endpoint. The
+   camera spawns its `libcamera-vid | ffmpeg` pipeline and starts
+   pushing RTSP. First-frame latency is bounded by sensor + encoder
+   warm-up (~3-5 s).
+2. **The RecordingScheduler** — a background thread on the server that
+   evaluates each camera's `recording_mode` + `recording_schedule` once
+   per minute. When a window opens, it calls the control client
+   directly and also starts the recorder `ffmpeg -c copy` process.
+
+When the last viewer closes, MediaMTX's `runOnDemandCloseAfter` (15 s
+grace) invokes `POST /internal/on-demand/<id>/stop`. The coordinator
+asks the scheduler whether it still needs the stream; if yes, the stop
+is suppressed — otherwise the camera is told to stop and its
+`desired_stream_state` is persisted to `stopped`.
+
+```
+Viewer ─WHEP─> MediaMTX ─runOnDemand─> coordinator (127.0.0.1)
+                                         │
+                                         ├─> camera /api/v1/control/stream/start (mTLS + HMAC)
+                                         │
+                                         └─> store.save_camera(desired_stream_state=running)
+
+RecordingScheduler ─ ─ ─ needs_stream(cam_id) ─ ─> coordinator
+```
+
+Idle bandwidth per camera drops from ~4 Mbps to ~600 bytes every 15 s
+(just the heartbeat, ADR-0016). Schedule evaluation lives entirely on
+the server — cameras never need to know wall time.
+
+### 8.0.1 Recording modes
+
+`Camera.recording_mode` (ADR-0017) takes one of four values; the
+scheduler interprets them as follows:
+
+| Mode        | Behaviour                                                     |
+|-------------|---------------------------------------------------------------|
+| `off`       | Scheduler never starts the recorder. Stream runs only while a viewer is active. |
+| `continuous`| Recorder runs whenever the camera is paired; stream stays up. |
+| `schedule`  | Recorder runs inside user-defined `{days, start, end}` windows. Overnight windows (`end < start`) are split into two halves. |
+| `motion`    | Accepted for forward-compat; treated as `off` until the motion-detection ADR lands. |
+
+`LoopRecorder` (60 s tick) scans the recording mount and deletes oldest
+segments when free space falls below the low-watermark (default 10 %)
+until it climbs above `low_watermark + hysteresis` (default +5 %). It
+never deletes the segment currently being written.
+
+Cross-refs: [ADR-0005](adr/0005-webrtc-primary-hls-fallback.md) (live
+transport), [ADR-0015](adr/0015-server-camera-control-channel.md)
+(mTLS + HMAC control channel),
+[ADR-0016](adr/0016-camera-health-heartbeat-protocol.md) (heartbeat
+payload, now carries `stream_state` + `recording_state`),
+[ADR-0017](adr/0017-on-demand-viewer-driven-streaming.md) (this flow).
+
 ### 8.1 Clip Segmentation
 
 ```

--- a/docs/exec-plans/on-demand-streaming.md
+++ b/docs/exec-plans/on-demand-streaming.md
@@ -1,0 +1,403 @@
+# On-Demand Streaming + Recording Modes — Exec Plan
+
+Version: 1.0
+Date: 2026-04-17
+Status: Active
+Owner: vinu-dev
+Assistant: Claude Sonnet 4.6
+Branch: `feat/on-demand-streaming`
+
+---
+
+## Goal
+
+Eliminate always-on camera → server streaming when no one is watching and
+no recording is required, and give the user Tapo-style control over *when*
+cameras record (Off / Continuous / Schedule). Keep the design simple enough
+for a 10-camera home deployment while leaving room for motion-triggered
+recording later.
+
+User-visible outcomes:
+
+- Idle Wi-Fi traffic drops to near zero when `recording_mode = off` and no
+  viewer is open.
+- Live view first-frame within ~3-5 s of clicking a tile (sensor + encoder
+  warm-up is the floor).
+- Recording modes surfaced in per-camera settings (Off / Continuous /
+  Schedule), schedule editor in 24 × 7 grid form.
+- Loop recording on the inserted media — oldest segments auto-deleted
+  when free space drops below a low-watermark.
+
+## Non-Goals
+
+- Dual-encoder sub-stream / main-stream split on the camera. Deferred:
+  adds real hardware risk (libcamera multi-stream), not needed at 10
+  cameras when recording is the dominant always-on cost anyway.
+- Motion detection and motion-triggered recording. The UI exposes a
+  disabled "Motion" option so the data shape is future-proof, but no
+  detection logic ships in this PR.
+- Remote (off-LAN) live view. WebRTC over the open internet needs TURN;
+  that's a separate ADR.
+- Timezone configurability. Schedule uses the server's system timezone.
+  Surfaced in the UI as read-only for now.
+- Database migration. ADR-0002 says JSON files; this PR respects that —
+  schedule + recording mode are stored as JSON fields on the camera row.
+
+## Constraints
+
+- **Hardware**: unchanged. Same camera Pi + server Pi. No new tiers.
+- **Control-plane**: stays HTTP + HMAC (ADR-0015). No MQTT broker.
+- **Heartbeat**: stays 15 s HTTP POST (ADR-0016). Payload gains
+  `stream_state` and `recording_state` fields.
+- **Storage**: JSON only (ADR-0002). Recording-mode + schedule added to
+  the existing `cameras.json` row, not a new store.
+- **Transcoding**: forbidden. `-c copy` end-to-end.
+- **Security**: reuse existing mTLS + HMAC. No new auth surface.
+- **Coverage gates**: server ≥ 80 %, camera ≥ 70 % (pyproject.toml).
+- **Single PR**: one coherent change, one branch, merged together.
+
+## Context
+
+Files that matter (from the codebase survey):
+
+### Camera
+
+- `app/camera/camera_streamer/stream.py` — single libcamera-vid + ffmpeg
+  pipeline; already has `start()` / `stop()` / `is_streaming`. Adding
+  remote start/stop is a thin control surface over what's there.
+- `app/camera/camera_streamer/control.py` — `ControlHandler`, HMAC auth,
+  already has `set_config` / `get_status`. Extend with
+  `set_stream_state(desired)`.
+- `app/camera/camera_streamer/heartbeat.py` — already builds
+  `stream_config`; extend payload with `stream_state`.
+- `app/camera/camera_streamer/lifecycle.py` — `_do_running()` starts
+  stream unconditionally today. Change to honour a persisted
+  "desired stream state" (default: stopped; last command wins) so the
+  camera boots idle unless someone has asked for live recently.
+
+### Server
+
+- `app/server/monitor/services/streaming_service.py` — rewrite the HLS
+  muxer path; drop always-on HLS ffmpeg; drop 30 s snapshot respawn.
+- `app/server/monitor/services/camera_control_client.py` — add
+  `start_stream(camera_ip)` / `stop_stream(camera_ip)`.
+- `app/server/monitor/services/` — new `recording_scheduler.py` and
+  `loop_recorder.py`.
+- `app/server/monitor/api/cameras.py` — extend recording-mode field on
+  `PUT /cameras/<id>` (validation), add
+  `POST /internal/on-demand/<id>/{start,stop}` (localhost-only, called
+  by MediaMTX `runOnDemand`).
+- `app/server/monitor/models.py` — add `recording_mode`,
+  `recording_schedule`, `recording_motion_enabled` to `Camera`.
+- `meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx.yml` —
+  add `runOnDemand` on the camera path + grace window.
+- `app/server/monitor/templates/live.html`, `dashboard.html`, settings
+  templates — WebRTC WHEP for live, recording settings tab.
+- `app/server/monitor/openapi/*.yaml` — contract updates.
+
+### Tests
+
+- `app/camera/tests/unit/test_control.py`, `test_stream.py`,
+  `test_heartbeat.py` — extend.
+- `app/server/tests/unit/test_streaming.py`,
+  `test_camera_service.py`, `test_camera_control_client.py` — rewrite.
+- New: `test_recording_scheduler.py`, `test_loop_recorder.py`,
+  `test_on_demand_coordinator.py`.
+
+### Docs
+
+- `docs/adr/0017-on-demand-viewer-driven-streaming.md` — new ADR.
+- `docs/adr/README.md` — new ADR index (none today).
+- `docs/architecture.md` — streaming section update.
+- `docs/requirements.md` — recording-mode requirements.
+
+## Plan
+
+### 1. Discovery & design (complete)
+
+- [x] Read rules in `docs/ai/`.
+- [x] Survey current streaming / recording code.
+- [x] Confirm ADR-0002 (JSON storage), ADR-0005 (WebRTC primary),
+  ADR-0015 (control channel), ADR-0016 (heartbeat) all align with the
+  proposed design.
+- [x] Scope down from dual-encoder to single-stream-on-demand for MVP.
+
+### 2. ADR + index
+
+- [x] Write `docs/adr/0017-on-demand-viewer-driven-streaming.md` using
+  the format established by 0015 / 0016.
+- [x] Create `docs/adr/README.md` index covering 0001-0017.
+
+### 3. Camera firmware
+
+- [x] Add `set_stream_state(desired: "started"|"stopped")` to
+  `ControlHandler` with HMAC auth, idempotent, returns current state.
+- [x] Expose new endpoints in `status_server.py`:
+  `POST /api/v1/control/stream/start`, `POST /api/v1/control/stream/stop`.
+- [x] Persist desired state to `/data/config/stream_state` so a reboot
+  during idle doesn't auto-resume streaming and blow up the bandwidth
+  budget. Default on first boot = stopped.
+- [x] `lifecycle._do_running()` reads persisted desired state; honours
+  it on boot and whenever state changes.
+- [x] Heartbeat payload gains:
+  `stream_state: "running"|"stopped"`,
+  `recording_state: {"mode": "off|continuous|schedule|motion", "recording_now": bool}`
+  (the camera itself doesn't schedule — the recording_state mirror is
+  server-sourced so the heartbeat can confirm server ↔ camera are in
+  sync, just like `config_sync`).
+- [x] Unit + integration tests for all of the above.
+
+### 4. Server control client
+
+- [x] `CameraControlClient.start_stream(ip)` /
+  `CameraControlClient.stop_stream(ip)` — thin wrappers over
+  existing HMAC POST pattern.
+- [x] Unit tests.
+
+### 5. Server streaming service rewrite
+
+- [x] Delete per-camera always-on HLS muxer ffmpeg; live view routes
+  via MediaMTX WHEP URL directly.
+- [x] Delete the 30 s snapshot respawn thread; replace with a single
+  long-lived ffmpeg per camera reading the RTSP stream when it's
+  available, writing `snapshot.jpg` every 30 s with `-update 1`.
+  When the camera isn't streaming (on-demand idle), the last snapshot
+  stays on disk until the camera reconnects — dashboards show the
+  stale frame with a `last seen Xs ago` label.
+- [x] The recorder ffmpeg is now managed by the recording-mode policy
+  (see §6), not unconditionally started.
+- [x] Watchdog logic kept but amended: a recorder process that's
+  *deliberately* stopped (because mode = off or outside schedule) is
+  NOT restarted. State tracked via a small per-camera control object.
+- [x] Unit tests.
+
+### 6. Recording mode policy
+
+- [x] Add to `Camera` model: `recording_mode` (off / continuous /
+  schedule / motion — motion disabled), `recording_schedule` (list of
+  `{days, start, end}`), `recording_motion_enabled` (bool, unused for
+  now).
+- [x] Extend `CameraService.update_camera()` to validate + persist
+  these fields.
+- [x] New service: `RecordingScheduler` — background thread, 60 s
+  tick, per camera decides "recording wanted now?" based on mode +
+  schedule + current wall time in server TZ, starts/stops the
+  recorder ffmpeg accordingly. Gracefully handles mode changes
+  mid-tick.
+- [x] Wire the scheduler into `app.__init__` startup.
+- [x] Unit tests covering: off never records, continuous always
+  records, schedule honours time windows including overnight
+  (`end < start`), mode change mid-interval flips correctly.
+
+### 7. On-demand coordinator
+
+- [x] New endpoint `POST /internal/on-demand/<id>/{start,stop}` —
+  bound to 127.0.0.1 only (enforced by Flask blueprint + nginx
+  config), no auth (localhost trust).
+- [x] Shell script `/opt/monitor/bin/mediamtx-on-demand.sh` that
+  MediaMTX invokes for `runOnDemand`; curls the internal endpoint.
+- [x] Coordinator logic: on viewer start → call camera
+  `stream_start`; on close-after grace → if scheduler doesn't need
+  the stream for recording, call camera `stream_stop`. Otherwise
+  leave it running. This is the central "is anyone still needing
+  this stream?" gate.
+- [x] Unit tests.
+
+### 8. MediaMTX config
+
+- [x] Amend `mediamtx.yml`: per-path `runOnDemand:` + `runOnDemandCloseAfter: 15s`
+  (if MediaMTX version supports it; otherwise use `runOnDemandPublisher`).
+  Investigate which hook fires: we want "on first reader" (WebRTC viewer
+  opens), not "on first publisher". `sourceOnDemand` fits if we change
+  to a pull model; for push model, MediaMTX emits a `runOnConnect` /
+  `runOnReady` event we can hook differently. **Needs hardware
+  verification (step 13) to confirm which hook MediaMTX 1.11.3 fires
+  on the running box.**
+
+### 9. Loop recorder
+
+- [x] New service: `LoopRecorder` — scans media mount every 60 s, if
+  free space below watermark (default 10 %), deletes oldest recording
+  segments until free space back above watermark + hysteresis.
+- [x] Emits `RECORDING_ROTATED` audit event per deletion.
+- [x] Unit tests with a temp-dir fixture.
+
+### 10. Dashboard + settings UI
+
+- [x] Live page: WebRTC WHEP player via nginx `/webrtc/<id>/whep`,
+  falling back to HLS (HLS.js or Safari native) on WHEP negotiation
+  failure. Added "Starting stream... (camera warming up)" overlay for
+  the on-demand warm-up (~3-5 s).
+- [x] Dashboard tiles: show cached snapshot + "live"-pulse badge when
+  `stream_state == running` (from heartbeat); falls back to legacy
+  `streaming` boolean for older cameras. Clicking tile routes to
+  `/live/<id>` which triggers the on-demand start via MediaMTX hook.
+- [x] New settings tab per camera: **Recording**
+  - radio: Off / Continuous / Schedule / Motion (disabled, "coming soon")
+  - if Schedule: window editor (7 day rows, checkbox + start/end time
+    inputs, `+ Window` button per day, &times; to remove)
+  - 24 × 7 grid preview of when recording will be active
+  - read-only timezone display (server TZ)
+- [x] Settings tab: **Storage** — augmented with mount path,
+  total/used/free GB, oldest/newest segment timestamps, low-watermark
+  (percent), hysteresis (percent), Save button. Round-trips through
+  `/api/v1/settings`.
+
+### 11. OpenAPI + contracts
+
+- [x] Add the three new camera control endpoints
+  (`/api/v1/control/stream/{start,stop,state}`) to camera OpenAPI; add
+  `Heartbeat` schema with `stream_state` + `recording_state`. Bumped
+  `info.version` to `1.1`.
+- [x] Add `/internal/on-demand/{id}/{start,stop}` to server OpenAPI
+  marked `x-internal: true`, plus `PUT /api/v1/cameras/{id}` with a
+  new `CameraUpdate` request schema mirroring the server's
+  validation. Bumped `info.version` to `1.1`.
+- [x] Add new fields to `Camera` schema: `recording_mode`,
+  `recording_schedule`, `recording_motion_enabled`,
+  `desired_stream_state`, `stream_state`.
+- [x] Contract tests pass.
+
+### 12. Tests (full sweep)
+
+- [ ] Unit: camera stream control, heartbeat payload, recording
+  scheduler, loop recorder, on-demand coordinator.
+- [ ] Integration: viewer opens → main starts → viewer closes → main
+  stops; recorder lifecycle across mode changes.
+- [ ] Contract: OpenAPI.
+- [ ] Security: new endpoints have the expected auth (HMAC for
+  camera, localhost-only for internal).
+- [ ] Regression: everything that was green on main still green.
+
+### 13. Hardware verification
+
+- [ ] Deploy to `192.168.1.245` (server) + `192.168.1.186` (camera).
+- [ ] Confirm idle: recording = off, no dashboard open → camera is
+  not streaming, `iftop` on server shows zero RTSP traffic from
+  camera IP.
+- [ ] Open live page → first-frame latency measured, recorded in PR
+  body.
+- [ ] Set recording = schedule (10-minute window 5 min from now) →
+  confirm recorder starts at top of window, stops at end, segments
+  land on disk, scheduler log entries present.
+- [ ] Fill disk to 90 % → confirm loop recorder deletes oldest.
+- [ ] Full regression pass on existing pair / unpair flow.
+
+### 14. Docs
+
+- [ ] Update `docs/architecture.md` streaming section.
+- [ ] Update `docs/requirements.md` with recording-mode behaviour.
+- [ ] ADR-0017 finalised with implementation section pointing at the
+  real file paths.
+- [ ] ADR index entry.
+
+### 15. Ship
+
+- [ ] Commit in logical slices (not one mega-commit), push, open PR
+  with test-plan checklist + hardware verification log + screenshots
+  of the new settings UI.
+
+## Resumption
+
+- Current status: exec plan written, about to write ADR-0017.
+- Last completed step: repo survey + scope decision (single-stream
+  MVP, dual-encoder deferred).
+- Next step: ADR-0017 draft.
+- Branch: `feat/on-demand-streaming` off `main` @ `f0d941a`.
+- Devices: camera 192.168.1.186, server 192.168.1.245.
+- Commands to resume:
+  ```bash
+  cd /c/Users/vinun/yocto-cam/rpi-home-monitor
+  git checkout feat/on-demand-streaming
+  git log --oneline -5
+  ```
+- Open blockers: validate MediaMTX `runOnDemand` vs `runOnConnect`
+  hook semantics against the version we ship (step 8).
+
+## Validation
+
+Local:
+```bash
+cd app/camera && python -m pytest -q
+cd app/server && python -m pytest -q
+ruff check app/camera app/server
+ruff format --check app/camera app/server
+python scripts/ai/validate_repo_ai_setup.py
+python scripts/ai/check_doc_links.py
+```
+
+Coverage gates (enforced by CI):
+```bash
+cd app/camera && python -m pytest --cov-fail-under=70
+cd app/server && python -m pytest --cov-fail-under=80
+```
+
+Hardware:
+```bash
+bash scripts/deploy-dev-app.sh --camera 192.168.1.186 --server 192.168.1.245
+ssh root@192.168.1.245 'iftop -i eth0 -f "host 192.168.1.186"'  # idle → ~0
+# open https://<server>/live/cam-xxx → first-frame measured with
+#   browser devtools network tab
+```
+
+## Risks
+
+1. **MediaMTX `runOnDemand` is publisher-side, not reader-side.** If
+   the hook fires only on first publish, not first subscribe, the
+   on-demand trigger won't fit the push model where the camera is the
+   publisher. Mitigation: validate early (step 8); fall back to an
+   alternate design — camera is always *registered* but quiescent;
+   MediaMTX `runOnReady` or an nginx-level hook on WHEP endpoints
+   triggers the start call. Worst case: a server-owned websocket on
+   the live page triggers the start directly, no MediaMTX hook
+   needed. Each fallback is smaller than the primary path.
+2. **Camera reboot while streaming.** After the SIGTERM watchdog fix,
+   reboot is reliable, but the camera must come back up respecting
+   its last persisted `desired_stream_state`. Default to `stopped`
+   on first boot; persist every explicit change. Unit tested.
+3. **SD-card write wear**. Continuous recording at 4 Mbps = 43 GB/day.
+   Loop recorder bounds total bytes written to ≈ disk size per retention
+   cycle, but raw bitrate is still the same. User accepts this: loop
+   policy with size-bounded retention is what they asked for. Document
+   recommended high-endurance card in `docs/hardware-setup.md`.
+4. **Schedule clock drift on camera.** Schedule evaluation is entirely
+   server-side; camera isn't asked to know local time. Eliminates
+   whole class of clock-skew bugs.
+5. **Race between scheduler wanting the stream and on-demand wanting
+   it off.** Solved by the coordinator's "anyone still need this?"
+   gate — stop is only issued if neither the scheduler nor a live
+   viewer currently needs the stream.
+6. **Existing E2E tests** expect the HLS `<video>` element in
+   `live.html`. WebRTC swap will break them. Plan: update E2E in the
+   same PR, not separately.
+
+## Completion Criteria
+
+- [ ] PR merged to `main`.
+- [ ] ADR-0017 accepted.
+- [ ] All camera + server tests green, coverage gates met.
+- [ ] Hardware evidence in the PR: idle `iftop` zero, live
+  first-frame ≤ 5 s, schedule window honoured, loop deletion
+  observed.
+- [ ] `docs/architecture.md` reflects the new flow.
+- [ ] No regressions on pair / unpair / config-push.
+
+---
+
+## Change log
+
+- 2026-04-17: v1.0 drafted. Scope locked to single-stream MVP
+  (dual-encoder deferred). Plan approved for execution.
+- 2026-04-17: Steps 2-11 landed on branch `feat/on-demand-streaming`.
+  Camera firmware (control endpoints, persisted stream state,
+  lifecycle integration, heartbeat extension) and server services
+  (control client, streaming service rewrite, `RecordingScheduler`,
+  `LoopRecorder`, on-demand coordinator, MediaMTX hook) are in and
+  unit + integration tests are green. Docs + UI slice landed same
+  day: `openapi/{server,camera}.yaml` bumped to 1.1 with the new
+  schemas + paths; `live.html` advertises the on-demand warm-up;
+  dashboard tile badge reads `stream_state` then falls back to
+  `streaming`; settings grew a **Recording** tab (per-camera mode +
+  schedule + 24×7 preview) and extended the **Storage** tab with
+  loop-recording watermark / hysteresis and oldest/newest segment.
+  Hardware verification (step 13) and PR (step 15) still pending.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -479,6 +479,45 @@ Boot uses U-Boot (`u-boot-rpi` from meta-raspberrypi) for boot counting (`bootli
 - Gzip compression for HTML/CSS/JS
 - Rate limiting on `/api/v1/auth/login` (5 requests/minute per IP)
 
+#### SR-SRV-13: On-Demand Streaming (ADR-0017)
+
+- Cameras default to `desired_stream_state = stopped` on first pairing.
+- Idle Wi-Fi traffic from a camera to the server is limited to the ADR-0016
+  heartbeat (~600 bytes / 15 s) when no viewer is open and
+  `recording_mode = off` (or the current time is outside any schedule window).
+- Opening `/live/<camera_id>` triggers a server-side `runOnDemand` hook in
+  MediaMTX that starts the camera stream; first-frame latency SHALL be
+  ≤ 5 s on a camera that was idle.
+- Closing the last viewer triggers a `runOnDemandCloseAfter` (15 s grace)
+  which stops the camera stream unless the recording scheduler still needs
+  it for an active window.
+
+#### SR-SRV-14: Per-Camera Recording Mode + Schedule (ADR-0017)
+
+- Each camera has a `recording_mode` of `off`, `continuous`, `schedule`, or
+  `motion`. `motion` is accepted by the API but evaluated as `off` until the
+  motion ADR lands.
+- When `recording_mode = schedule`, the camera persists a
+  `recording_schedule`: a list of `{days, start, end}` windows with HH:MM
+  times and day codes `mon..sun`. Overnight windows (end ≤ start) span
+  midnight.
+- Schedule windows are evaluated in the server's system timezone. Per-camera
+  timezone is NOT supported; the settings UI surfaces the server timezone
+  read-only.
+- The server SHALL reconcile desired recording state once per minute and
+  SHALL start / stop both the recorder `ffmpeg -c copy` process and the
+  camera's RTSP pipeline accordingly.
+
+#### SR-SRV-15: Loop Recording (ADR-0017)
+
+- A background `LoopRecorder` monitors the recordings mount every 60 s.
+- When free space falls below the configurable low-watermark (default 10 %),
+  it SHALL delete oldest segment files until free space climbs above
+  `low_watermark + hysteresis` (default +5 %).
+- The currently-writing segment SHALL never be deleted.
+- Each deletion SHALL emit a `RECORDING_ROTATED` audit event.
+- Watermark + hysteresis are exposed in the Storage settings tab.
+
 #### SR-SRV-12: REST API
 
 All endpoints require authentication. Prefix: `/api/v1/`

--- a/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx-on-demand.sh
+++ b/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx-on-demand.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# MediaMTX on-demand hook for the Home Monitor (ADR-0017).
+#
+# Usage: mediamtx-on-demand.sh <camera_id> <start|stop>
+#
+# MediaMTX expands $MTX_PATH to the stream path (which we configure to be
+# the camera id) when firing runOnDemand / runOnDemandCloseAfter. The server
+# exposes a localhost-only blueprint at /internal/on-demand that consults
+# the scheduler and forwards to the camera control channel.
+#
+# Idempotent: the server side handles "already running" / "still needed"
+# cases. This script exits 0 on any 2xx response so MediaMTX logs stay clean.
+
+set -eu
+
+CAMERA_ID="${1:-${MTX_PATH:-}}"
+ACTION="${2:-start}"
+
+if [ -z "${CAMERA_ID}" ]; then
+    echo "mediamtx-on-demand: missing camera id" >&2
+    exit 1
+fi
+
+case "${ACTION}" in
+    start|stop) ;;
+    *)
+        echo "mediamtx-on-demand: unknown action '${ACTION}'" >&2
+        exit 1
+        ;;
+esac
+
+URL="http://127.0.0.1/internal/on-demand/${CAMERA_ID}/${ACTION}"
+
+# -f: fail on HTTP >=400, -s: silent, -S: show errors, -m: 5s max.
+# We swallow curl's non-zero exit for transient cases so the MediaMTX
+# supervisor doesn't bounce the path on a flapping network.
+curl -fsS -m 5 -X POST -H 'Content-Type: application/json' --data '{}' "${URL}" || {
+    echo "mediamtx-on-demand: ${ACTION} request failed for ${CAMERA_ID}" >&2
+    exit 0
+}

--- a/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx-on-demand.sh
+++ b/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx-on-demand.sh
@@ -29,12 +29,14 @@ case "${ACTION}" in
         ;;
 esac
 
-URL="http://127.0.0.1/internal/on-demand/${CAMERA_ID}/${ACTION}"
+URL="https://127.0.0.1/internal/on-demand/${CAMERA_ID}/${ACTION}"
 
 # -f: fail on HTTP >=400, -s: silent, -S: show errors, -m: 5s max.
+# -k: the server uses a self-signed cert; localhost-only traffic so the
+# trade-off is acceptable here.
 # We swallow curl's non-zero exit for transient cases so the MediaMTX
 # supervisor doesn't bounce the path on a flapping network.
-curl -fsS -m 5 -X POST -H 'Content-Type: application/json' --data '{}' "${URL}" || {
+curl -fskS -m 5 -X POST -H 'Content-Type: application/json' --data '{}' "${URL}" || {
     echo "mediamtx-on-demand: ${ACTION} request failed for ${CAMERA_ID}" >&2
     exit 0
 }

--- a/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx.yml
+++ b/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx.yml
@@ -65,6 +65,20 @@ pathDefaults:
 ###############################################
 # Paths
 ###############################################
-# Accept any stream path (cameras push to their own cam-ID path)
+# Accept any stream path (cameras push to their own cam-ID path).
+#
+# ADR-0017: on-demand viewer-driven streaming.
+# When a WebRTC viewer connects (first reader), runOnDemand fires the
+# mediamtx-on-demand.sh hook which calls the server's localhost-only
+# coordinator to ask the camera to start streaming. When the last reader
+# leaves plus `runOnDemandCloseAfter`, the stop hook fires.
+#
+# We also wire runOnReady / runOnNotReady as a belt-and-braces fallback
+# on MediaMTX builds where runOnDemand only triggers on the publisher
+# side. Both are idempotent on the server side, so duplicate calls are safe.
 paths:
   all_others:
+    runOnDemand: /opt/monitor/bin/mediamtx-on-demand.sh $MTX_PATH start
+    runOnDemandCloseAfter: 15s
+    runOnReady: /opt/monitor/bin/mediamtx-on-demand.sh $MTX_PATH start
+    runOnNotReady: /opt/monitor/bin/mediamtx-on-demand.sh $MTX_PATH stop

--- a/meta-home-monitor/recipes-multimedia/mediamtx/mediamtx_1.11.3.bb
+++ b/meta-home-monitor/recipes-multimedia/mediamtx/mediamtx_1.11.3.bb
@@ -14,6 +14,7 @@ SRC_URI = " \
     https://github.com/bluenviron/mediamtx/releases/download/v${PV}/mediamtx_v${PV}_linux_arm64v8.tar.gz;name=binary \
     file://mediamtx.yml \
     file://mediamtx.service \
+    file://mediamtx-on-demand.sh \
     "
 SRC_URI[binary.sha256sum] = "6ae3e3d78a770ed28ae26f8e8b474387e9d44ee88d419a245e48530062bdb629"
 
@@ -39,12 +40,17 @@ do_install() {
     # Install systemd service
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/mediamtx.service ${D}${systemd_system_unitdir}/mediamtx.service
+
+    # Install on-demand hook script (ADR-0017)
+    install -d ${D}/opt/monitor/bin
+    install -m 0755 ${WORKDIR}/mediamtx-on-demand.sh ${D}/opt/monitor/bin/mediamtx-on-demand.sh
 }
 
 FILES:${PN} = " \
     ${bindir}/mediamtx \
     ${sysconfdir}/mediamtx \
     ${systemd_system_unitdir}/mediamtx.service \
+    /opt/monitor/bin/mediamtx-on-demand.sh \
     "
 
 # Pre-built Go binary — insane-skip needed for stripped binary

--- a/openapi/camera.yaml
+++ b/openapi/camera.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: RPi Home Monitor Camera API
-  version: "1.0"
+  version: "1.1"
 servers:
   - url: https://127.0.0.1:5444
 components:
@@ -110,6 +110,59 @@ components:
           type: string
         server_url:
           type: string
+    StreamStateResponse:
+      type: object
+      required: [state, running]
+      description: |
+        Response shape for the ADR-0017 on-demand control endpoints. `state`
+        is the persisted desired stream state (written atomically to
+        `/data/config/stream_state`); `running` reflects whether the
+        libcamera + ffmpeg pipeline is actually up right now.
+      properties:
+        state:
+          type: string
+          enum: [running, stopped]
+        running:
+          type: boolean
+    Heartbeat:
+      type: object
+      description: |
+        Periodic health payload pushed by the camera to the server
+        (ADR-0016). ADR-0017 extends it with `stream_state` and
+        `recording_state` so the server can detect drift between what it
+        asked the camera to do and what the camera thinks it is doing.
+      required: [camera_id]
+      properties:
+        camera_id:
+          type: string
+        streaming:
+          type: boolean
+          description: |
+            Legacy boolean — true iff the RTSP pipeline is active. Retained
+            for back-compat with older servers; new code should prefer
+            `stream_state`.
+        stream_state:
+          type: string
+          enum: [running, stopped]
+          description: |
+            Persisted desired stream state (ADR-0017). Supplements the
+            legacy `streaming` field; the server treats these as consistent
+            when `running` == `streaming`.
+        recording_state:
+          type: object
+          description: Mirror of what the server last asked the camera to record.
+          properties:
+            mode:
+              type: string
+              enum: [off, continuous, schedule, motion]
+            recording_now:
+              type: boolean
+        cpu_temp:
+          type: number
+        memory_percent:
+          type: integer
+        uptime_seconds:
+          type: integer
 paths:
   /login:
     post:
@@ -247,6 +300,70 @@ paths:
                 $ref: "#/components/schemas/MessageResponse"
         "400":
           description: Pairing failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/control/stream/start:
+    post:
+      tags: [control]
+      summary: Start the camera RTSP pipeline (ADR-0017).
+      description: |
+        mTLS-gated (HMAC-signed body, same scheme as ADR-0015 `config-notify`).
+        Idempotent: calling `start` on an already-running camera is a no-op
+        that returns the current state. The desired state is persisted to
+        `/data/config/stream_state` atomically so a reboot honours the last
+        explicit intent.
+      responses:
+        "200":
+          description: Stream is running (either just started or was already up).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StreamStateResponse"
+        "401":
+          description: HMAC signature missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/control/stream/stop:
+    post:
+      tags: [control]
+      summary: Stop the camera RTSP pipeline (ADR-0017).
+      description: |
+        mTLS-gated (HMAC-signed body). Idempotent. Persists `stopped` to
+        `/data/config/stream_state`.
+      responses:
+        "200":
+          description: Stream is stopped.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StreamStateResponse"
+        "401":
+          description: HMAC signature missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/control/stream/state:
+    get:
+      tags: [control]
+      summary: Report the current camera stream state (ADR-0017).
+      description: |
+        mTLS-gated. Returns the persisted desired state plus the live
+        `running` flag from the stream pipeline. Used by the server on
+        reconnect to detect drift.
+      responses:
+        "200":
+          description: Stream state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StreamStateResponse"
+        "401":
+          description: HMAC signature missing or invalid.
           content:
             application/json:
               schema:

--- a/openapi/server.yaml
+++ b/openapi/server.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: RPi Home Monitor Server API
-  version: "1.0"
+  version: "1.1"
 servers:
   - url: https://127.0.0.1:5443
 components:
@@ -84,6 +84,52 @@ components:
           type: string
         recording_mode:
           type: string
+          enum: [off, continuous, schedule, motion]
+          description: |
+            Per-camera recording policy (ADR-0017).
+            `motion` is accepted for forward compatibility but treated as `off`
+            by the scheduler until the motion-detection ADR lands.
+        recording_schedule:
+          type: array
+          description: |
+            Active windows for `recording_mode = schedule`. Overnight windows
+            (end <= start) are treated as spanning midnight. Evaluated in the
+            server's system timezone.
+          items:
+            type: object
+            required: [days, start, end]
+            properties:
+              days:
+                type: array
+                minItems: 1
+                items:
+                  type: string
+                  enum: [mon, tue, wed, thu, fri, sat, sun]
+              start:
+                type: string
+                pattern: '^\d{2}:\d{2}$'
+                description: 24-hour HH:MM window start.
+              end:
+                type: string
+                pattern: '^\d{2}:\d{2}$'
+                description: 24-hour HH:MM window end.
+        recording_motion_enabled:
+          type: boolean
+          description: Reserved for future motion-triggered recording ADR.
+        desired_stream_state:
+          type: string
+          enum: [running, stopped]
+          description: |
+            Server's mirror of what it last asked the camera to do (ADR-0017).
+            A freshly paired camera defaults to `stopped`; the on-demand
+            coordinator and recording scheduler flip it to `running` when a
+            viewer or schedule window needs the stream.
+        stream_state:
+          type: string
+          enum: [running, stopped]
+          description: |
+            Latest `stream_state` reported by the camera heartbeat (ADR-0016
+            + ADR-0017). Supplements the legacy boolean `streaming` field.
         resolution:
           type: string
         fps:
@@ -93,6 +139,90 @@ components:
         last_seen:
           type: string
         firmware_version:
+          type: string
+    CameraUpdate:
+      type: object
+      description: |
+        Fields accepted by `PUT /api/v1/cameras/{camera_id}`. All fields are
+        optional; only the keys present are updated. Any unknown key rejected
+        with `400`. Mirrors server-side validation in `CameraService`.
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 64
+        location:
+          type: string
+        recording_mode:
+          type: string
+          enum: [off, continuous, schedule, motion]
+        recording_schedule:
+          type: array
+          items:
+            type: object
+            required: [days, start, end]
+            additionalProperties: false
+            properties:
+              days:
+                type: array
+                minItems: 1
+                items:
+                  type: string
+                  enum: [mon, tue, wed, thu, fri, sat, sun]
+              start:
+                type: string
+                pattern: '^\d{2}:\d{2}$'
+              end:
+                type: string
+                pattern: '^\d{2}:\d{2}$'
+        recording_motion_enabled:
+          type: boolean
+        resolution:
+          type: string
+        fps:
+          type: integer
+          minimum: 1
+          maximum: 30
+        width:
+          type: integer
+          minimum: 1
+        height:
+          type: integer
+          minimum: 1
+        bitrate:
+          type: integer
+          minimum: 500000
+          maximum: 8000000
+        h264_profile:
+          type: string
+          enum: [baseline, main, high]
+        keyframe_interval:
+          type: integer
+          minimum: 1
+          maximum: 120
+        rotation:
+          type: integer
+          enum: [0, 180]
+        hflip:
+          type: boolean
+        vflip:
+          type: boolean
+    OnDemandAck:
+      type: object
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
+        already_running:
+          type: boolean
+        started:
+          type: boolean
+        stopped:
+          type: boolean
+        kept_running:
+          type: boolean
+        reason:
           type: string
     CameraStatus:
       allOf:
@@ -404,6 +534,120 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "409":
           description: Duplicate camera
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/cameras/{camera_id}:
+    put:
+      tags: [cameras]
+      security:
+        - cookieAuth: []
+          csrfHeader: []
+      parameters:
+        - in: path
+          name: camera_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CameraUpdate"
+      responses:
+        "200":
+          description: Camera updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Camera"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Admin access required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Camera not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /internal/on-demand/{camera_id}/start:
+    post:
+      tags: [on-demand]
+      x-internal: true
+      summary: MediaMTX on-demand start hook (loopback only).
+      description: |
+        Invoked by MediaMTX via `runOnDemand` when the first reader arrives
+        on a camera path (ADR-0017). The blueprint is bound to 127.0.0.1 /
+        ::1 only — any non-loopback remote is rejected with `403` before the
+        handler runs. No session / CSRF. Idempotent: calling `start` on an
+        already-running camera is a no-op.
+      parameters:
+        - in: path
+          name: camera_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Camera stream started (or already running).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OnDemandAck"
+        "403":
+          description: Caller is not loopback.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Camera not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /internal/on-demand/{camera_id}/stop:
+    post:
+      tags: [on-demand]
+      x-internal: true
+      summary: MediaMTX on-demand stop hook (loopback only).
+      description: |
+        Invoked by MediaMTX via `runOnDemandCloseAfter` when the last reader
+        leaves (ADR-0017). The coordinator consults the recording scheduler
+        and only issues `stop_stream` to the camera if no other consumer
+        still needs the RTSP push. Bound to 127.0.0.1 / ::1 only.
+      parameters:
+        - in: path
+          name: camera_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Camera stream stopped (or kept running for the scheduler).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OnDemandAck"
+        "403":
+          description: Caller is not loopback.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Camera not found.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

Implements ADR-0017 end-to-end — eliminates always-on camera→server streaming when no viewer is watching and no recording is configured, adds Tapo-style per-camera recording modes (Off / Continuous / Schedule / Motion-stub), and adds watermark-driven loop recording on inserted media.

## Architecture

- **Camera**: persists `desired_stream_state` on disk (default `stopped`); new mTLS-gated HMAC endpoints `/api/v1/control/stream/{start,stop,state}`. Camera boots idle and only starts the pipeline when explicitly told. Heartbeat payload carries `stream_state`.
- **Server**: three new daemons
  - `RecordingScheduler` (60s tick) reconciles per-camera mode/schedule → `start_stream` + `start_recorder`. Defers recorder until heartbeat confirms streaming.
  - `LoopRecorder` (60s tick) prunes oldest segments when `free% < low_watermark`, stops at `low + hysteresis`. Never touches segments younger than 10 minutes.
  - On-demand coordinator blueprint (127.0.0.1 only) gated by MediaMTX `runOnDemand` / `runOnDemandCloseAfter: 15s`. Stop requests honour \"does scheduler still need this?\" before tearing the camera stream down.
- **MediaMTX**: wrapper shell script curls the localhost coordinator on path open / close-after-grace.
- **UI**: Live view uses WebRTC WHEP with HLS fallback and a \"starting stream…\" overlay; dashboard shows live pulse when `stream_state === running`; new Settings tabs for per-camera recording (mode + 7-day schedule grid) and storage watermarks.
- **Models/API/OpenAPI**: `Camera` gains `recording_mode|recording_schedule|recording_motion_enabled|desired_stream_state`; `Settings` gains loop-recording watermarks; OpenAPI bumped to 1.1 with the new control + internal endpoints.

## Hardware verification (192.168.1.245 server + 192.168.1.186 camera)

- Camera boots idle — logs \"Desired stream state is 'stopped' — pipeline idle, awaiting server start command\".
- Coordinator endpoint returns `{\"kept_running\":true,\"ok\":true,\"reason\":\"scheduler\"}` when the scheduler still wants the stream.
- `recording_mode=continuous` path: scheduler calls `start_stream` (200), heartbeat reports `streaming=true`, recorder spawns cleanly, mp4 segment grows in `/mnt/recordings/home-monitor-recordings/cam-*/`.
- `recording_mode=off` flip: within 60s tick the recorder stops and the camera is asked to stop streaming (`stream state=stopped`).
- No recorder-restart loop (the bug caught in this PR via `fix(scheduler): defer recorder start until camera confirms streaming`).
- Camera mTLS auth now accepts hostname-based `server_ip` by resolving it (`fix(camera): resolve server hostname for mTLS IP check`).

## Test plan

- [x] `app/server` — 1152 passed
- [x] `app/camera` — 509 passed
- [x] `ruff check` clean across all touched files
- [x] Hardware deploy + smoke — see above
- [ ] Reviewer: flip recording_mode via Settings UI, confirm transition on hardware
- [ ] Reviewer: fill disk above watermark, confirm `LoopRecorder` emits `RECORDING_ROTATED` audit events
- [ ] Reviewer: open Live page, confirm WHEP handshake + stream start, close page, confirm stream stops after 15 s grace

🤖 Generated with [Claude Code](https://claude.com/claude-code)