### PR TITLE
feat(dashboard): ADR-0018 + slice 1 — status strip + 4 summary tiles

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -30,6 +30,7 @@ from monitor.services.settings_service import SettingsService
 from monitor.services.storage_manager import StorageManager
 from monitor.services.storage_service import StorageService
 from monitor.services.streaming_service import StreamingService
+from monitor.services.system_summary_service import SystemSummaryService
 from monitor.services.tailscale_service import TailscaleService
 from monitor.services.user_service import UserService
 from monitor.store import Store
@@ -285,6 +286,18 @@ def _init_services(app):
     app.loop_recorder = LoopRecorder(
         base_dir=app.config["RECORDINGS_DIR"],
         audit=app.audit,
+    )
+
+    # ADR-0018: dashboard status-strip aggregator. Pure-read, no threads, no I/O
+    # in the constructor — each HTTP GET recomputes from live signals.
+    from monitor.services import health as _health_module
+
+    app.system_summary_service = SystemSummaryService(
+        store=app.store,
+        storage_manager=app.storage_manager,
+        audit=app.audit,
+        recordings_service=app.recordings_service,
+        health_module=_health_module,
     )
 
 

--- a/app/server/monitor/api/recordings.py
+++ b/app/server/monitor/api/recordings.py
@@ -30,6 +30,38 @@ def _svc():
     return current_app.recordings_service
 
 
+@recordings_bp.route("/latest", methods=["GET"])
+@login_required
+def latest_across_cameras():
+    """Return the newest clip across every camera (ADR-0018 Tier-2).
+
+    Distinct from ``/recordings/<camera_id>/latest`` — this variant has no
+    camera path segment and scans all paired cameras + orphan archives.
+    """
+    result, error, status = _svc().latest_across_cameras()
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
+
+
+@recordings_bp.route("/recent", methods=["GET"])
+@login_required
+def recent_across_cameras():
+    """Return the most recent N clips across every camera (ADR-0018 Tier-3).
+
+    Query params:
+      ``limit`` — rows to return (1..50, default 10).
+    """
+    try:
+        limit = int(request.args.get("limit", 10))
+    except ValueError:
+        limit = 10
+    result, error, status = _svc().recent_across_cameras(limit=limit)
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status
+
+
 @recordings_bp.route("/cameras", methods=["GET"])
 @login_required
 def list_camera_sources():

--- a/app/server/monitor/api/system.py
+++ b/app/server/monitor/api/system.py
@@ -39,10 +39,27 @@ def _read_os_release():
 @system_bp.route("/health", methods=["GET"])
 @login_required
 def health():
-    """Return system health metrics."""
+    """Return raw system health metrics.
+
+    Raw CPU/RAM/temp/disk numbers. The dashboard does **not** render these
+    directly (ADR-0018 rule: raw metrics belong on /diagnostics, derived
+    state belongs on the dashboard). The future /diagnostics page will
+    surface them; for now the dashboard uses /system/summary instead.
+    """
     data_dir = current_app.config.get("DATA_DIR", "/data")
     summary = get_health_summary(data_dir)
     return jsonify(summary), 200
+
+
+@system_bp.route("/summary", methods=["GET"])
+@login_required
+def summary():
+    """Return the ADR-0018 Tier-1 dashboard status-strip payload.
+
+    Derived state only — ``{state, summary, details, deep_link}``.
+    """
+    result = current_app.system_summary_service.compute_summary()
+    return jsonify(result), 200
 
 
 @system_bp.route("/info", methods=["GET"])

--- a/app/server/monitor/services/recordings_service.py
+++ b/app/server/monitor/services/recordings_service.py
@@ -60,6 +60,11 @@ class RecordingsService:
             recordings_dir = self._default_recordings_dir
         return RecorderService(recordings_dir, self._live_dir)
 
+    @property
+    def default_recordings_dir(self) -> str:
+        """Public accessor used by the system-summary aggregator."""
+        return self._default_recordings_dir
+
     def _recordings_root(self) -> Path:
         """Absolute path to the recordings root (one subdir per camera)."""
         return Path(self._get_recorder()._recordings_dir)
@@ -196,6 +201,124 @@ class RecordingsService:
             return None, "No recordings found", 404
 
         return asdict(clip), None, 200
+
+    def latest_across_cameras(self):
+        """Return the newest clip across every camera (or orphaned archive).
+
+        ADR-0018 Tier-2 dashboard tile. Returns the same shape as
+        :meth:`latest_clip` plus a ``camera_name`` field (looked up from
+        the Store; orphans fall back to the camera_id).
+
+        Returns:
+            (dict, None, 200)  — newest clip, including ``camera_name``.
+            (None, msg, 404)   — no clips anywhere.
+        """
+        root = self._recordings_root()
+        if not root.is_dir():
+            return None, "No recordings found", 404
+
+        newest_mtime = -1.0
+        newest_path: Path | None = None
+        newest_cam = ""
+        try:
+            for cam_dir in root.iterdir():
+                if not cam_dir.is_dir():
+                    continue
+                if not self._valid_camera_id(cam_dir.name):
+                    continue
+                for mp4 in cam_dir.rglob("*.mp4"):
+                    try:
+                        mtime = mp4.stat().st_mtime
+                    except OSError:
+                        continue
+                    if mtime > newest_mtime:
+                        newest_mtime = mtime
+                        newest_path = mp4
+                        newest_cam = cam_dir.name
+        except OSError:
+            return None, "No recordings found", 404
+
+        if newest_path is None:
+            return None, "No recordings found", 404
+
+        recorder = self._get_recorder()
+        clip = recorder.get_latest_clip(newest_cam)
+        if clip is None:
+            return None, "No recordings found", 404
+        data = asdict(clip)
+        data["camera_name"] = self._camera_display_name(newest_cam)
+        return data, None, 200
+
+    def recent_across_cameras(self, limit: int = 10):
+        """List the most recent N clips across every camera.
+
+        Used by ADR-0018 Tier-3 "Recent events" feed. Returns clips
+        reverse-chronologically, each row carrying ``camera_name`` for
+        display.
+
+        Args:
+            limit: Maximum rows to return (1..50). Clamped to range.
+
+        Returns:
+            (list[dict], None, 200)  — zero or more rows.
+        """
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 10
+        limit = max(1, min(limit, 50))
+
+        root = self._recordings_root()
+        if not root.is_dir():
+            return [], None, 200
+
+        # Walk once, collect (mtime, cam_id, Path) tuples, then sort + take top N.
+        entries: list[tuple[float, str, Path]] = []
+        try:
+            for cam_dir in root.iterdir():
+                if not cam_dir.is_dir() or not self._valid_camera_id(cam_dir.name):
+                    continue
+                for mp4 in cam_dir.rglob("*.mp4"):
+                    try:
+                        entries.append((mp4.stat().st_mtime, cam_dir.name, mp4))
+                    except OSError:
+                        continue
+        except OSError:
+            return [], None, 200
+
+        entries.sort(reverse=True, key=lambda t: t[0])
+        out: list[dict] = []
+        for _mtime, cam_id, mp4 in entries[:limit]:
+            # Filename is HH-MM-SS.mp4, parent dir name is YYYY-MM-DD.
+            stem = mp4.stem
+            try:
+                size = mp4.stat().st_size
+            except OSError:
+                size = 0
+            thumb_name = f"{stem}.thumb.jpg"
+            out.append(
+                {
+                    "camera_id": cam_id,
+                    "camera_name": self._camera_display_name(cam_id),
+                    "filename": mp4.name,
+                    "date": mp4.parent.name,
+                    "start_time": stem.replace("-", ":"),
+                    "duration_seconds": 180,
+                    "size_bytes": size,
+                    "thumbnail": thumb_name,
+                }
+            )
+        return out, None, 200
+
+    def _camera_display_name(self, camera_id: str) -> str:
+        """Resolve a human-readable camera name; falls back to the id."""
+        try:
+            cam = self._store.get_camera(camera_id)
+        except Exception:
+            cam = None
+        if cam is None:
+            return camera_id
+        return getattr(cam, "name", "") or camera_id
 
     def resolve_clip_path(self, camera_id: str, date: str, filename: str):
         """Resolve the full path to a clip file.

--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 log = logging.getLogger("monitor.system_summary")
 
@@ -30,17 +30,17 @@ log = logging.getLogger("monitor.system_summary")
 DISK_AMBER_PERCENT = 70
 DISK_RED_PERCENT = 90
 
-CPU_AMBER_PERCENT = 85          # recorder host CPU, sustained
-CPU_TEMP_AMBER_C = 72           # recorder host SoC temperature
+CPU_AMBER_PERCENT = 85  # recorder host CPU, sustained
+CPU_TEMP_AMBER_C = 72  # recorder host SoC temperature
 CPU_TEMP_RED_C = 80
 MEMORY_AMBER_PERCENT = 85
 
-CAMERA_OFFLINE_AMBER_SECONDS = 60          # < 1 h: amber
-CAMERA_OFFLINE_RED_SECONDS = 60 * 60       # >= 1 h: red
+CAMERA_OFFLINE_AMBER_SECONDS = 60  # < 1 h: amber
+CAMERA_OFFLINE_RED_SECONDS = 60 * 60  # >= 1 h: red
 
-ERROR_WINDOW_SECONDS = 60 * 60             # "errors in last hour"
+ERROR_WINDOW_SECONDS = 60 * 60  # "errors in last hour"
 
-RETENTION_SAMPLE_DAYS = 7                  # trailing window for write-rate
+RETENTION_SAMPLE_DAYS = 7  # trailing window for write-rate
 
 # Audit events treated as error-level for the status strip. Kept narrow so a
 # noisy login-failed storm (expected during a password-spray) doesn't flip
@@ -190,7 +190,7 @@ class SystemSummaryService:
         online = [c for c in paired if getattr(c, "status", "") == "online"]
         offline = [c for c in paired if getattr(c, "status", "") == "offline"]
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         worst = "green"
         for cam in offline:
             last_seen = _parse_ts(getattr(cam, "last_seen", None))
@@ -328,9 +328,7 @@ class SystemSummaryService:
             log.warning("summary: audit.get_events failed: %s", exc)
             return "green", 0, "/settings#audit"
 
-        cutoff = datetime.now(timezone.utc) - timedelta(
-            seconds=ERROR_WINDOW_SECONDS
-        )
+        cutoff = datetime.now(UTC) - timedelta(seconds=ERROR_WINDOW_SECONDS)
         errors = 0
         warnings = 0
         for ev in events:
@@ -387,18 +385,25 @@ class SystemSummaryService:
         # Priority of what to surface first: errors > red signals > amber.
         # Within the same severity, storage is most actionable.
         order = [
-            (err_state, err_count > 0,
-             f"{err_count} recent system event{'s' if err_count != 1 else ''} — review log",
-             err_link),
-            (disk_state, True,
-             f"Recorder disk {disk_detail.get('percent', 0):.0f}% full",
-             disk_link),
-            (cam_state, cam_detail.get("offline_names"),
-             _camera_sentence(cam_detail),
-             cam_link),
-            (host_state, True,
-             "Recorder under load — check host metrics",
-             host_link),
+            (
+                err_state,
+                err_count > 0,
+                f"{err_count} recent system event{'s' if err_count != 1 else ''} — review log",
+                err_link,
+            ),
+            (
+                disk_state,
+                True,
+                f"Recorder disk {disk_detail.get('percent', 0):.0f}% full",
+                disk_link,
+            ),
+            (
+                cam_state,
+                cam_detail.get("offline_names"),
+                _camera_sentence(cam_detail),
+                cam_link,
+            ),
+            (host_state, True, "Recorder under load — check host metrics", host_link),
         ]
 
         # Red first, then amber.

--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -1,0 +1,421 @@
+"""
+System summary service — the Tier-1 dashboard aggregator (ADR-0018).
+
+Produces **derived state**, not raw metrics. The rule from ADR-0018:
+
+    Raw metrics belong on /diagnostics. Derived state belongs on the
+    dashboard. A number without a threshold is decoration.
+
+So this service does not return "CPU is at 87 %". It returns
+``state = "amber"``, a one-sentence ``summary``, and a ``deep_link`` to
+whichever page lets the user act on the condition.
+
+Thresholds are locked constants — see the ADR for why.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+
+log = logging.getLogger("monitor.system_summary")
+
+
+# ---------------------------------------------------------------------------
+# Thresholds (LOCKED — see ADR-0018). Changing these degrades user trust in
+# the status-strip colour. Any change must go through a new ADR.
+# ---------------------------------------------------------------------------
+
+DISK_AMBER_PERCENT = 70
+DISK_RED_PERCENT = 90
+
+CPU_AMBER_PERCENT = 85          # recorder host CPU, sustained
+CPU_TEMP_AMBER_C = 72           # recorder host SoC temperature
+CPU_TEMP_RED_C = 80
+MEMORY_AMBER_PERCENT = 85
+
+CAMERA_OFFLINE_AMBER_SECONDS = 60          # < 1 h: amber
+CAMERA_OFFLINE_RED_SECONDS = 60 * 60       # >= 1 h: red
+
+ERROR_WINDOW_SECONDS = 60 * 60             # "errors in last hour"
+
+RETENTION_SAMPLE_DAYS = 7                  # trailing window for write-rate
+
+# Audit events treated as error-level for the status strip. Kept narrow so a
+# noisy login-failed storm (expected during a password-spray) doesn't flip
+# the dashboard red.
+ERROR_EVENT_TYPES = frozenset(
+    {
+        "OTA_FAILED",
+        "OTA_ROLLBACK",
+        "CAMERA_REMOVED_UNEXPECTEDLY",
+        "FIRMWARE_INSTALL_FAILED",
+        "RECORDER_CRASH",
+        "STORAGE_FAILED",
+        "CERT_RENEWAL_FAILED",
+    }
+)
+
+WARNING_EVENT_TYPES = frozenset(
+    {
+        "CAMERA_OFFLINE",
+        "STORAGE_THRESHOLD_EXCEEDED",
+        "CERT_EXPIRING_SOON",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 audit/heartbeat timestamp. Returns None on failure."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _worst(*states: str) -> str:
+    """Return the worst state of the supplied set (red > amber > green)."""
+    order = {"green": 0, "amber": 1, "red": 2}
+    best_seen = "green"
+    for s in states:
+        if order.get(s, -1) > order[best_seen]:
+            best_seen = s
+    return best_seen
+
+
+# ---------------------------------------------------------------------------
+# SystemSummaryService
+# ---------------------------------------------------------------------------
+
+
+class SystemSummaryService:
+    """Aggregate signals into the Tier-1 dashboard status strip payload.
+
+    Dependencies are passed explicitly (service-layer pattern, ADR-0003).
+    No I/O in ``__init__`` — all work happens in ``compute_summary()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        store,
+        storage_manager,
+        audit,
+        recordings_service,
+        health_module,
+    ):
+        self._store = store
+        self._storage = storage_manager
+        self._audit = audit
+        self._recordings = recordings_service
+        # Injected so tests can stub host metrics without touching /proc.
+        self._health = health_module
+
+    # -- public API ---------------------------------------------------------
+
+    def compute_summary(self) -> dict:
+        """Return the dashboard status-strip payload.
+
+        Shape:
+            {
+              "state": "green" | "amber" | "red",
+              "summary": "...",              # one sentence, human-readable
+              "details": {
+                "cameras": {"online": N, "total": M, "offline_names": [...]},
+                "storage": {"percent": X, "retention_days": D | None},
+                "recorder": {"cpu_percent": X, "cpu_temp_c": T,
+                              "memory_percent": M},
+                "recent_errors": N,
+              },
+              "deep_link": "/..."            # where to go to act on it
+            }
+
+        This method must never raise. Any sub-signal failure degrades to
+        a neutral value for that signal; the rest of the payload is still
+        delivered so the dashboard renders something useful.
+        """
+        cam_state, cam_detail, cam_link = self._cameras()
+        disk_state, disk_detail, disk_link = self._storage_state()
+        host_state, host_detail, host_link = self._recorder_host()
+        err_state, err_count, err_link = self._recent_errors()
+
+        state = _worst(cam_state, disk_state, host_state, err_state)
+
+        summary, deep_link = self._build_summary(
+            state,
+            cam_state=cam_state,
+            cam_detail=cam_detail,
+            cam_link=cam_link,
+            disk_state=disk_state,
+            disk_detail=disk_detail,
+            disk_link=disk_link,
+            host_state=host_state,
+            host_link=host_link,
+            err_state=err_state,
+            err_count=err_count,
+            err_link=err_link,
+        )
+
+        return {
+            "state": state,
+            "summary": summary,
+            "deep_link": deep_link,
+            "details": {
+                "cameras": cam_detail,
+                "storage": disk_detail,
+                "recorder": host_detail,
+                "recent_errors": err_count,
+            },
+        }
+
+    # -- cameras ------------------------------------------------------------
+
+    def _cameras(self) -> tuple[str, dict, str]:
+        try:
+            cameras = self._store.get_cameras()
+        except Exception as exc:
+            log.warning("summary: get_cameras failed: %s", exc)
+            return "green", {"online": 0, "total": 0, "offline_names": []}, "/"
+
+        # ADR-0018 counts paired cameras only (pending are mid-onboarding).
+        paired = [c for c in cameras if getattr(c, "status", "") != "pending"]
+        online = [c for c in paired if getattr(c, "status", "") == "online"]
+        offline = [c for c in paired if getattr(c, "status", "") == "offline"]
+
+        now = datetime.now(timezone.utc)
+        worst = "green"
+        for cam in offline:
+            last_seen = _parse_ts(getattr(cam, "last_seen", None))
+            if last_seen is None:
+                # Never seen → treat as long-offline.
+                worst = _worst(worst, "red")
+                continue
+            elapsed = (now - last_seen).total_seconds()
+            if elapsed >= CAMERA_OFFLINE_RED_SECONDS:
+                worst = _worst(worst, "red")
+            elif elapsed >= CAMERA_OFFLINE_AMBER_SECONDS:
+                worst = _worst(worst, "amber")
+
+        detail = {
+            "online": len(online),
+            "total": len(paired),
+            "offline_names": [
+                getattr(c, "name", "") or getattr(c, "id", "") for c in offline
+            ],
+        }
+        # Deep-link to the first offline camera if any, else the dashboard itself.
+        link = "/"
+        if offline:
+            link = "/#camera-" + (offline[0].id if hasattr(offline[0], "id") else "")
+        return worst, detail, link
+
+    # -- storage ------------------------------------------------------------
+
+    def _storage_state(self) -> tuple[str, dict, str]:
+        try:
+            stats = self._storage.get_storage_stats()
+        except Exception as exc:
+            log.warning("summary: get_storage_stats failed: %s", exc)
+            return "green", {"percent": 0.0, "retention_days": None}, "/settings"
+
+        percent = float(stats.get("percent", 0.0) or 0.0)
+        if percent >= DISK_RED_PERCENT:
+            state = "red"
+        elif percent >= DISK_AMBER_PERCENT:
+            state = "amber"
+        else:
+            state = "green"
+
+        retention = self._estimate_retention_days(stats)
+        detail = {
+            "percent": round(percent, 1),
+            "retention_days": retention,
+            "free_gb": stats.get("free_gb", 0),
+            "total_gb": stats.get("total_gb", 0),
+        }
+        return state, detail, "/settings#storage"
+
+    def _estimate_retention_days(self, stats: dict) -> float | None:
+        """Retention = free_bytes / bytes_written_per_day (7-day trailing).
+
+        Returns None if there is less than a day of data to average against —
+        better to show "—" than a confidently wrong number.
+        """
+        rec_dir = stats.get("recordings_dir")
+        free_gb = stats.get("free_gb", 0) or 0
+        if not rec_dir or free_gb <= 0:
+            return None
+
+        from pathlib import Path
+
+        root = Path(rec_dir)
+        if not root.is_dir():
+            return None
+
+        cutoff = time.time() - RETENTION_SAMPLE_DAYS * 86400
+        earliest = time.time()
+        bytes_in_window = 0
+        for mp4 in root.rglob("*.mp4"):
+            try:
+                st = mp4.stat()
+            except OSError:
+                continue
+            if st.st_mtime >= cutoff:
+                bytes_in_window += st.st_size
+                if st.st_mtime < earliest:
+                    earliest = st.st_mtime
+
+        # Less than ~24 h of sample → refuse to estimate.
+        age_hours = (time.time() - earliest) / 3600
+        if bytes_in_window <= 0 or age_hours < 24:
+            return None
+
+        days_in_sample = max(age_hours / 24, 1.0)
+        bytes_per_day = bytes_in_window / days_in_sample
+        if bytes_per_day <= 0:
+            return None
+
+        free_bytes = free_gb * (1024**3)
+        return round(free_bytes / bytes_per_day, 1)
+
+    # -- recorder host ------------------------------------------------------
+
+    def _recorder_host(self) -> tuple[str, dict, str]:
+        try:
+            summary = self._health.get_health_summary(
+                self._recordings.default_recordings_dir or "/data"
+            )
+        except Exception as exc:
+            log.warning("summary: get_health_summary failed: %s", exc)
+            return "green", {}, "/settings"
+
+        cpu_temp = summary.get("cpu_temp_c", 0.0) or 0.0
+        cpu_pct = summary.get("cpu_usage_percent", 0.0) or 0.0
+        mem_pct = (summary.get("memory") or {}).get("percent", 0.0) or 0.0
+
+        state = "green"
+        if cpu_temp >= CPU_TEMP_RED_C:
+            state = _worst(state, "red")
+        elif cpu_temp >= CPU_TEMP_AMBER_C:
+            state = _worst(state, "amber")
+        if cpu_pct >= CPU_AMBER_PERCENT:
+            state = _worst(state, "amber")
+        if mem_pct >= MEMORY_AMBER_PERCENT:
+            state = _worst(state, "amber")
+
+        detail = {
+            "cpu_percent": round(cpu_pct, 1),
+            "cpu_temp_c": round(cpu_temp, 1),
+            "memory_percent": round(mem_pct, 1),
+        }
+        return state, detail, "/settings#system"
+
+    # -- recent errors ------------------------------------------------------
+
+    def _recent_errors(self) -> tuple[str, int, str]:
+        try:
+            # Pull a wide page; we filter in-memory by time + type.
+            events = self._audit.get_events(limit=500)
+        except Exception as exc:
+            log.warning("summary: audit.get_events failed: %s", exc)
+            return "green", 0, "/settings#audit"
+
+        cutoff = datetime.now(timezone.utc) - timedelta(
+            seconds=ERROR_WINDOW_SECONDS
+        )
+        errors = 0
+        warnings = 0
+        for ev in events:
+            ts = _parse_ts(ev.get("timestamp"))
+            if ts is None or ts < cutoff:
+                continue
+            ev_type = ev.get("event", "")
+            if ev_type in ERROR_EVENT_TYPES:
+                errors += 1
+            elif ev_type in WARNING_EVENT_TYPES:
+                warnings += 1
+
+        state = "green"
+        if errors > 0:
+            state = "red"
+        elif warnings > 0:
+            state = "amber"
+        return state, errors + warnings, "/settings#audit"
+
+    # -- summary sentence ---------------------------------------------------
+
+    @staticmethod
+    def _build_summary(
+        state: str,
+        *,
+        cam_state: str,
+        cam_detail: dict,
+        cam_link: str,
+        disk_state: str,
+        disk_detail: dict,
+        disk_link: str,
+        host_state: str,
+        host_link: str,
+        err_state: str,
+        err_count: int,
+        err_link: str,
+    ) -> tuple[str, str]:
+        """Produce (sentence, deep_link) matching the overall state.
+
+        Green is quiet (no "what's wrong" pointer). Amber/Red pick the
+        single worst offender and deep-link to it — the dashboard does
+        not try to enumerate every fault in the status strip; the tiles
+        below do that.
+        """
+        if state == "green":
+            online = cam_detail.get("online", 0)
+            total = cam_detail.get("total", 0)
+            disk_pct = disk_detail.get("percent", 0)
+            return (
+                f"All systems normal — {online}/{total} cameras online, "
+                f"{disk_pct:.0f}% disk used"
+            ), "/"
+
+        # Priority of what to surface first: errors > red signals > amber.
+        # Within the same severity, storage is most actionable.
+        order = [
+            (err_state, err_count > 0,
+             f"{err_count} recent system event{'s' if err_count != 1 else ''} — review log",
+             err_link),
+            (disk_state, True,
+             f"Recorder disk {disk_detail.get('percent', 0):.0f}% full",
+             disk_link),
+            (cam_state, cam_detail.get("offline_names"),
+             _camera_sentence(cam_detail),
+             cam_link),
+            (host_state, True,
+             "Recorder under load — check host metrics",
+             host_link),
+        ]
+
+        # Red first, then amber.
+        for wanted in ("red", "amber"):
+            for sig_state, present, sentence, link in order:
+                if sig_state == wanted and present and sentence:
+                    return sentence, link
+
+        # Fallback (should not happen): overall state isn't green but no
+        # sub-signal claimed it. Keep something meaningful on screen.
+        return "System needs attention", "/settings"
+
+
+def _camera_sentence(cam_detail: dict) -> str:
+    names = cam_detail.get("offline_names") or []
+    if not names:
+        return ""
+    if len(names) == 1:
+        return f"{names[0]} is offline"
+    return f"{len(names)} cameras are offline"

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -1344,3 +1344,67 @@ select.form-input {
 .tile--red    { border-left-color: var(--color-danger); }
 .tile--amber .tile__value { color: var(--color-warning); }
 .tile--red   .tile__value { color: var(--color-danger); }
+
+/* Recent events feed — compact list, inline expand-to-play */
+.events-feed {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    margin-bottom: var(--space-5);
+}
+
+.event-row {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    transition: border-color var(--transition-fast);
+}
+.event-row--active { border-color: var(--color-accent); }
+
+.event-row__trigger {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 90px 1fr auto auto;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-2) var(--space-3);
+    background: transparent;
+    border: none;
+    color: var(--color-text);
+    font-size: var(--text-sm);
+    text-align: left;
+    cursor: pointer;
+}
+.event-row__trigger:hover { background: rgba(255,255,255,0.03); }
+
+.event-row__time {
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.event-row__camera {
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.event-row__duration {
+    color: var(--color-text-dim);
+    font-variant-numeric: tabular-nums;
+}
+.event-row__chevron {
+    color: var(--color-text-muted);
+    font-size: var(--text-xs);
+}
+
+.event-row__player {
+    padding: var(--space-2) var(--space-3) var(--space-3);
+    background: #000;
+}
+.event-row__player video {
+    width: 100%;
+    max-height: 420px;
+    border-radius: var(--radius-sm);
+    background: #000;
+    display: block;
+}

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -1213,3 +1213,134 @@ select.form-input {
     justify-content: space-between;
     align-items: center;
 }
+
+/* ============================================================
+   Dashboard IA (ADR-0018) — Tier-1 status strip + Tier-2 tiles
+   ============================================================
+   Derived state, not raw metrics. Colour tokens on the strip and
+   tiles come from --color-success/warning/danger so the dashboard
+   reads at a glance. Thresholds live server-side — see
+   system_summary_service.py. */
+
+.status-strip {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: var(--text-base);
+    margin-bottom: var(--space-4);
+    transition: background var(--transition-base), border-color var(--transition-base);
+}
+
+.status-strip:hover { text-decoration: none; }
+
+.status-strip__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--color-text-dim);
+    box-shadow: 0 0 0 2px rgba(255,255,255,0.04);
+}
+
+.status-strip__text {
+    flex: 1;
+    min-width: 0;
+    line-height: 1.4;
+}
+
+.status-strip__arrow {
+    font-size: var(--text-lg);
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+}
+
+.status-strip--green {
+    border-color: rgba(46,204,113,0.35);
+    background: linear-gradient(90deg, rgba(46,204,113,0.08), var(--color-surface));
+}
+.status-strip--green .status-strip__dot { background: var(--color-success); box-shadow: 0 0 0 3px rgba(46,204,113,0.2); }
+
+.status-strip--amber {
+    border-color: rgba(243,156,18,0.45);
+    background: linear-gradient(90deg, rgba(243,156,18,0.12), var(--color-surface));
+}
+.status-strip--amber .status-strip__dot { background: var(--color-warning); box-shadow: 0 0 0 3px rgba(243,156,18,0.25); }
+
+.status-strip--red {
+    border-color: rgba(231,76,60,0.55);
+    background: linear-gradient(90deg, rgba(231,76,60,0.15), var(--color-surface));
+}
+.status-strip--red .status-strip__dot {
+    background: var(--color-danger);
+    box-shadow: 0 0 0 3px rgba(231,76,60,0.3);
+    animation: pulse-red 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse-red {
+    0%, 100% { box-shadow: 0 0 0 3px rgba(231,76,60,0.3); }
+    50%      { box-shadow: 0 0 0 6px rgba(231,76,60,0.15); }
+}
+
+/* Tier-2 summary tiles (4-up) */
+.tile-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-3);
+    margin-bottom: var(--space-5);
+}
+
+.tile {
+    display: block;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    color: var(--color-text);
+    transition: transform var(--transition-fast), border-color var(--transition-base);
+}
+.tile:hover {
+    text-decoration: none;
+    transform: translateY(-1px);
+    border-color: var(--color-accent);
+}
+
+.tile__label {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-1);
+}
+
+.tile__value {
+    font-size: var(--text-2xl);
+    font-weight: 600;
+    line-height: 1.1;
+    margin-bottom: 2px;
+}
+
+.tile__value-sub {
+    font-size: var(--text-lg);
+    font-weight: 400;
+    color: var(--color-text-muted);
+}
+
+.tile__caption {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tile--green  { border-left-color: var(--color-success); }
+.tile--amber  { border-left-color: var(--color-warning); }
+.tile--red    { border-left-color: var(--color-danger); }
+.tile--amber .tile__value { color: var(--color-warning); }
+.tile--red   .tile__value { color: var(--color-danger); }

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -6,44 +6,71 @@
 <div x-data="dashboardPage()" x-init="init()">
 <h1 class="page-title">Dashboard</h1>
 
-<!-- System Health -->
-<div class="section-header">System Health</div>
-<div class="grid grid--health" id="health-grid">
-    <div class="card health-card">
-        <div class="health-card__value" :class="tempColor(health.temp)" x-text="health.temp !== null ? health.temp.toFixed(1) + '\u00B0C' : '--'"></div>
-        <div class="health-card__label">CPU Temp</div>
-    </div>
-    <div class="card health-card">
-        <div class="health-card__value" :class="usageColor(health.cpu)" x-text="health.cpu !== null ? health.cpu.toFixed(0) + '%' : '--'"></div>
-        <div class="health-card__label">CPU Usage</div>
-    </div>
-    <div class="card health-card">
-        <div class="health-card__value" :class="usageColor(health.mem)" x-text="health.mem !== null ? health.mem.toFixed(0) + '%' : '--'"></div>
-        <div class="health-card__label">Memory</div>
-        <div class="health-card__detail" x-text="health.memDetail"></div>
-    </div>
-    <div class="card health-card">
-        <div class="health-card__value" :class="usageColor(health.disk)" x-text="health.disk !== null ? health.disk.toFixed(0) + '%' : '--'"></div>
-        <div class="health-card__label">Disk</div>
-        <div class="health-card__detail" x-text="health.diskDetail"></div>
-    </div>
+<!--
+  Tier 1 — Status strip (ADR-0018)
+  One banner. State colour + one sentence. A deep link to wherever the
+  user needs to go to act on the condition. Green is quiet.
+-->
+<a class="status-strip" :class="summaryStateClass"
+   :href="summary.deep_link || '#'"
+   :aria-label="'System status: ' + (summary.state || 'unknown')"
+   @click="onStatusClick($event)">
+    <span class="status-strip__dot"></span>
+    <span class="status-strip__text" x-text="summary.summary || 'Loading system status...'"></span>
+    <span class="status-strip__arrow" x-show="summary.state && summary.state !== 'green'">&rarr;</span>
+</a>
+
+<!--
+  Tier 2 — Four summary tiles (ADR-0018)
+  Cameras · Last activity · Storage · Recorder host.
+  Each tile shows derived state (badge + one value + one caption), never
+  raw metrics. Raw metrics live on /diagnostics.
+-->
+<div class="tile-grid">
+
+    <!-- Cameras -->
+    <a class="tile" href="#cameras-section" :class="tileStateClass('cameras')">
+        <div class="tile__label">Cameras</div>
+        <div class="tile__value">
+            <span x-text="(summary.details && summary.details.cameras) ? summary.details.cameras.online : '\u2014'"></span>
+            <span class="tile__value-sub"> / <span x-text="(summary.details && summary.details.cameras) ? summary.details.cameras.total : '\u2014'"></span></span>
+        </div>
+        <div class="tile__caption" x-text="camerasCaption"></div>
+    </a>
+
+    <!-- Last activity -->
+    <a class="tile" :href="latestClip ? ('/recordings?camera=' + encodeURIComponent(latestClip.camera_id)) : '/recordings'">
+        <div class="tile__label">Last activity</div>
+        <div class="tile__value" x-text="latestRelativeTime"></div>
+        <div class="tile__caption" x-text="latestCaption"></div>
+    </a>
+
+    <!-- Storage -->
+    <a class="tile" href="/settings#storage" :class="tileStateClass('storage')">
+        <div class="tile__label">Storage</div>
+        <div class="tile__value">
+            <span x-text="storagePercentLabel"></span>
+        </div>
+        <div class="tile__caption" x-text="storageCaption"></div>
+    </a>
+
+    <!-- Recorder host -->
+    <a class="tile" href="/settings#system" :class="tileStateClass('recorder')">
+        <div class="tile__label">Recorder host</div>
+        <div class="tile__value" x-text="recorderStateLabel"></div>
+        <div class="tile__caption" x-text="health.uptime || '\u2014'"></div>
+    </a>
 </div>
 
-<!-- Warnings -->
-<div class="warnings-list">
-    <template x-for="w in health.warnings" :key="w">
-        <div class="warning-item" x-text="w"></div>
-    </template>
-</div>
+<!--
+  Slice 2 will add: Recent events feed (inline-player chip list).
+  Slice 3 will turn the section below into a compact "camera roll-call".
+  For now the existing pairing + camera-card UI is preserved under the
+  "Cameras" heading so admins can still onboard hardware.
+-->
 
-<!-- Uptime -->
-<div class="card mt-16" style="text-align:center;">
-    <span class="text-muted text-small">Uptime: </span>
-    <span class="text-small" x-text="health.uptime || '--'"></span>
-</div>
-
-<!-- Cameras -->
-<div class="section-header">
+<!-- Cameras roll-call (Tier 3 — to be restyled in Slice 3) -->
+<div id="cameras-section" class="section-header">
     Cameras
     <span style="float:right;margin-top:-4px;display:flex;gap:8px;">
         <button class="btn btn--secondary btn--small" @click="scanCameras()" :disabled="scanning">
@@ -258,7 +285,12 @@
 <script>
 function dashboardPage() {
     return {
-        health: { temp: null, cpu: null, mem: null, memDetail: '', disk: null, diskDetail: '', warnings: [], uptime: '' },
+        // --- ADR-0018 Tier-1 + Tier-2 state ---
+        summary: { state: '', summary: '', deep_link: '/', details: null },
+        latestClip: null,
+        health: { uptime: '' },
+
+        // --- Existing camera-list state (Tier-3 roll-call stub) ---
         cameras: [],
         showAddForm: false,
         newCam: { id: '', name: '', location: '' },
@@ -270,41 +302,136 @@ function dashboardPage() {
         savingStream: false,
         streamSaveMsg: '',
         streamSaveOk: false,
-        _healthInterval: null,
+
+        _summaryInterval: null,
         _cameraInterval: null,
 
         // Derived lists — split pending (discovered) from paired (online/offline)
         get discoveredCameras() { return this.cameras.filter(c => c.status === 'pending'); },
         get pairedCameras() { return this.cameras.filter(c => c.status !== 'pending'); },
 
-        tempColor(c) {
-            if (c === null) return '';
-            if (c < 60) return 'health-card__value--green';
-            if (c < 75) return 'health-card__value--yellow';
-            return 'health-card__value--red';
-        },
-        usageColor(p) {
-            if (p === null) return '';
-            if (p < 70) return 'health-card__value--green';
-            if (p < 85) return 'health-card__value--yellow';
-            return 'health-card__value--red';
+        // --- Tier-1 status strip ---
+        get summaryStateClass() {
+            var s = this.summary.state || 'green';
+            return 'status-strip--' + s;
         },
 
-        async loadHealth() {
+        // Route a single signal's colour onto the right tile. Keeps the
+        // tile-level cue consistent with the top-strip rollup.
+        tileStateClass(which) {
+            var d = this.summary.details;
+            if (!d) return '';
+            if (which === 'cameras') {
+                return this._camerasTileState(d.cameras);
+            }
+            if (which === 'storage') {
+                return this._storageTileState(d.storage);
+            }
+            if (which === 'recorder') {
+                return this._recorderTileState(d.recorder);
+            }
+            return '';
+        },
+
+        _camerasTileState(c) {
+            if (!c || !c.total) return '';
+            var offline = c.total - c.online;
+            if (offline <= 0) return 'tile--green';
+            // Without per-camera last_seen durations we can't distinguish
+            // amber/red here — fall back to amber and let the top strip
+            // escalate via its own check.
+            if (this.summary.state === 'red') return 'tile--red';
+            return 'tile--amber';
+        },
+
+        _storageTileState(s) {
+            if (!s) return '';
+            if (s.percent >= 90) return 'tile--red';
+            if (s.percent >= 70) return 'tile--amber';
+            return 'tile--green';
+        },
+
+        _recorderTileState(r) {
+            if (!r) return '';
+            // Mirror the server thresholds (ADR-0018 locked values).
+            if (r.cpu_temp_c >= 80) return 'tile--red';
+            if (r.cpu_temp_c >= 72 || r.cpu_percent >= 85 || r.memory_percent >= 85) return 'tile--amber';
+            return 'tile--green';
+        },
+
+        // --- Tile captions ---
+        get camerasCaption() {
+            var d = this.summary.details;
+            if (!d || !d.cameras) return '\u2014';
+            var off = d.cameras.offline_names || [];
+            if (off.length === 0) return 'All online';
+            if (off.length === 1) return off[0] + ' offline';
+            return off.length + ' offline';
+        },
+
+        get latestRelativeTime() {
+            if (!this.latestClip) return '\u2014';
+            // Prefer start_time + date if present.
+            var iso = this._clipIso(this.latestClip);
+            return iso ? this._relativeTime(iso) : '\u2014';
+        },
+
+        get latestCaption() {
+            if (!this.latestClip) return 'No recordings yet';
+            return this.latestClip.camera_name || this.latestClip.camera_id || '';
+        },
+
+        get storagePercentLabel() {
+            var s = this.summary.details && this.summary.details.storage;
+            if (!s || s.percent === undefined || s.percent === null) return '\u2014';
+            return s.percent.toFixed(0) + '%';
+        },
+
+        get storageCaption() {
+            var s = this.summary.details && this.summary.details.storage;
+            if (!s) return '';
+            if (s.retention_days !== null && s.retention_days !== undefined) {
+                return '~' + s.retention_days + ' days retention';
+            }
+            if (s.free_gb !== undefined) {
+                return s.free_gb + ' GB free';
+            }
+            return '';
+        },
+
+        get recorderStateLabel() {
+            var state = this._recorderTileState(this.summary.details && this.summary.details.recorder);
+            if (state === 'tile--red') return 'Overheat';
+            if (state === 'tile--amber') return 'Under load';
+            return 'Nominal';
+        },
+
+        onStatusClick(ev) {
+            // A green strip links to "/"; don't scroll when already there.
+            if ((this.summary.state || 'green') === 'green') {
+                ev.preventDefault();
+            }
+        },
+
+        // --- Loaders ---
+
+        async loadSummary() {
             try {
-                var data = await window.HM.api.get('/api/v1/system/health');
-                this.health.temp = data.cpu_temp_c || 0;
-                this.health.cpu = data.cpu_usage_percent || 0;
-                this.health.mem = (data.memory && data.memory.percent) || 0;
-                this.health.memDetail = data.memory ? (data.memory.used_mb + ' / ' + data.memory.total_mb + ' MB') : '';
-                this.health.disk = (data.disk && data.disk.percent) || 0;
-                this.health.diskDetail = data.disk ? (data.disk.used_gb + ' / ' + data.disk.total_gb + ' GB') : '';
-                this.health.warnings = data.warnings || [];
-            } catch(e) {}
+                this.summary = await window.HM.api.get('/api/v1/system/summary');
+            } catch(e) {
+                // Leave last-good summary visible; never crash the dashboard.
+            }
+            // Uptime — still useful on the recorder tile.
             try {
                 var info = await window.HM.api.get('/api/v1/system/info');
-                this.health.uptime = (info.uptime && info.uptime.display) || '--';
+                this.health.uptime = (info.uptime && info.uptime.display) || '';
             } catch(e) {}
+            // Last clip across all cameras (Tier-2 "Last activity" tile).
+            try {
+                this.latestClip = await window.HM.api.get('/api/v1/recordings/latest');
+            } catch(e) {
+                this.latestClip = null;
+            }
         },
 
         async loadCameras() {
@@ -316,10 +443,8 @@ function dashboardPage() {
         async scanCameras() {
             this.scanning = true;
             try {
-                // POST to /cameras/scan — triggers mDNS PTR query and returns current list
                 this.cameras = await window.HM.api.post('/api/v1/cameras/scan', {});
             } catch(e) {
-                // Fallback: just reload existing list
                 await this.loadCameras();
             } finally {
                 setTimeout(() => { this.scanning = false; }, 1000);
@@ -420,6 +545,8 @@ function dashboardPage() {
             }
         },
 
+        // --- helpers ---
+
         _staleSeconds(cam) {
             if (!cam.last_seen) return 0;
             return Math.round((Date.now() - new Date(cam.last_seen).getTime()) / 1000);
@@ -431,20 +558,33 @@ function dashboardPage() {
             if (secs < 5) return 'just now';
             if (secs < 60) return secs + 's ago';
             if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
-            return Math.floor(secs / 3600) + 'h ago';
+            if (secs < 86400) return Math.floor(secs / 3600) + 'h ago';
+            return Math.floor(secs / 86400) + 'd ago';
+        },
+
+        _clipIso(clip) {
+            // RecorderService clips expose date (YYYY-MM-DD) and start_time
+            // (HH:MM:SS). Combine into an ISO string for relative-time calc.
+            if (!clip) return '';
+            if (clip.started_at) return clip.started_at;
+            if (clip.date && clip.start_time) {
+                return clip.date + 'T' + clip.start_time;
+            }
+            return '';
         },
 
         init() {
-            this.loadHealth();
+            this.loadSummary();
             this.loadCameras();
-            // Health: 10s (CPU/mem/disk change frequently, matches requirements SR-SRV-07)
-            // Cameras: 15s (heartbeats arrive every 15s — keep display fresh)
-            this._healthInterval = setInterval(() => { this.loadHealth(); }, 10000);
+            // Summary: 10s (matches the existing health cadence; ADR-0018
+            // expects the strip to reflect the last heartbeat window).
+            // Cameras: 15s (heartbeat cadence).
+            this._summaryInterval = setInterval(() => { this.loadSummary(); }, 10000);
             this._cameraInterval = setInterval(() => { this.loadCameras(); }, 15000);
         },
 
         destroy() {
-            if (this._healthInterval) clearInterval(this._healthInterval);
+            if (this._summaryInterval) clearInterval(this._summaryInterval);
             if (this._cameraInterval) clearInterval(this._cameraInterval);
         }
     };

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -63,11 +63,34 @@
 </div>
 
 <!--
-  Slice 2 will add: Recent events feed (inline-player chip list).
-  Slice 3 will turn the section below into a compact "camera roll-call".
-  For now the existing pairing + camera-card UI is preserved under the
-  "Cameras" heading so admins can still onboard hardware.
+  Tier 3 (slice 2) — Recent events feed
+  Reverse-chronological clip list across every camera. Clicking a row
+  opens inline playback using the existing /recordings/<cam>/<date>/<file>
+  stream; no navigation, so the dashboard stays the "situational glance"
+  surface ADR-0018 describes.
+  Slice 3 will turn the Cameras section below into a compact roll-call.
 -->
+<div class="section-header" x-show="recentEvents.length > 0">
+    Recent events
+    <a class="text-small" style="float:right;" href="/recordings">All recordings &rarr;</a>
+</div>
+<div class="events-feed" x-show="recentEvents.length > 0">
+    <template x-for="ev in recentEvents" :key="ev.camera_id + '/' + ev.date + '/' + ev.filename">
+        <div class="event-row" :class="{ 'event-row--active': playingKey === (ev.camera_id + '/' + ev.date + '/' + ev.filename) }">
+            <button class="event-row__trigger" @click="playEvent(ev)">
+                <span class="event-row__time" x-text="_relativeTime(_clipIso(ev))"></span>
+                <span class="event-row__camera" x-text="ev.camera_name || ev.camera_id"></span>
+                <span class="event-row__duration" x-text="_durationLabel(ev.duration_seconds)"></span>
+                <span class="event-row__chevron" x-text="playingKey === (ev.camera_id + '/' + ev.date + '/' + ev.filename) ? '\u25BC' : '\u25B6'"></span>
+            </button>
+            <div class="event-row__player" x-show="playingKey === (ev.camera_id + '/' + ev.date + '/' + ev.filename)" x-transition>
+                <video x-ref="player"
+                       controls autoplay preload="none"
+                       :src="'/api/v1/recordings/' + encodeURIComponent(ev.camera_id) + '/' + encodeURIComponent(ev.date) + '/' + encodeURIComponent(ev.filename)"></video>
+            </div>
+        </div>
+    </template>
+</div>
 
 <!-- Cameras roll-call (Tier 3 — to be restyled in Slice 3) -->
 <div id="cameras-section" class="section-header">
@@ -285,9 +308,11 @@
 <script>
 function dashboardPage() {
     return {
-        // --- ADR-0018 Tier-1 + Tier-2 state ---
+        // --- ADR-0018 Tier-1 + Tier-2 + Tier-3 state ---
         summary: { state: '', summary: '', deep_link: '/', details: null },
         latestClip: null,
+        recentEvents: [],
+        playingKey: '',
         health: { uptime: '' },
 
         // --- Existing camera-list state (Tier-3 roll-call stub) ---
@@ -432,6 +457,26 @@ function dashboardPage() {
             } catch(e) {
                 this.latestClip = null;
             }
+            // Tier-3 recent events feed (top 8).
+            try {
+                this.recentEvents = await window.HM.api.get('/api/v1/recordings/recent?limit=8');
+            } catch(e) {
+                this.recentEvents = [];
+            }
+        },
+
+        playEvent(ev) {
+            var key = ev.camera_id + '/' + ev.date + '/' + ev.filename;
+            // Toggle — click the same row again to collapse.
+            this.playingKey = (this.playingKey === key) ? '' : key;
+        },
+
+        _durationLabel(secs) {
+            if (!secs || secs <= 0) return '';
+            if (secs < 60) return secs + 's';
+            var m = Math.floor(secs / 60);
+            var s = secs % 60;
+            return m + 'm' + (s ? ' ' + s + 's' : '');
         },
 
         async loadCameras() {

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -559,6 +559,49 @@ class TestSystemInfoContract:
         )
 
 
+class TestSystemSummaryContract:
+    """GET /api/v1/system/summary (ADR-0018 dashboard status strip)."""
+
+    def test_top_level_shape(self, app, client):
+        _login(app, client)
+        resp = client.get("/api/v1/system/summary")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        _assert_fields(data, {"state", "summary", "details", "deep_link"})
+        assert data["state"] in {"green", "amber", "red"}
+        assert isinstance(data["summary"], str) and data["summary"]
+        assert isinstance(data["deep_link"], str) and data["deep_link"].startswith("/")
+
+    def test_details_shape(self, app, client):
+        _login(app, client)
+        resp = client.get("/api/v1/system/summary")
+        data = resp.get_json()
+        _assert_fields(
+            data["details"],
+            {"cameras", "storage", "recorder", "recent_errors"},
+            msg="summary.details",
+        )
+        _assert_has_fields(
+            data["details"]["cameras"],
+            {"online", "total", "offline_names"},
+            msg="summary.details.cameras",
+        )
+        _assert_has_fields(
+            data["details"]["storage"],
+            {"percent", "retention_days", "free_gb", "total_gb"},
+            msg="summary.details.storage",
+        )
+        _assert_has_fields(
+            data["details"]["recorder"],
+            {"cpu_percent", "cpu_temp_c", "memory_percent"},
+            msg="summary.details.recorder",
+        )
+
+    def test_requires_login(self, client):
+        resp = client.get("/api/v1/system/summary")
+        assert resp.status_code == 401
+
+
 # ===========================================================================
 # Recordings contracts (/api/v1/recordings/*)
 # ===========================================================================
@@ -635,6 +678,58 @@ class TestRecordingsLatestContract:
         resp = client.get("/api/v1/recordings/cam-001/latest")
         data = resp.get_json()
         _assert_fields(data, {"error"})
+
+
+class TestRecordingsLatestAcrossContract:
+    """GET /api/v1/recordings/latest — cross-camera newest clip (ADR-0018)."""
+
+    def test_success_fields(self, app, client):
+        _login(app, client)
+        _add_camera(app, cam_id="cam-a")
+        _add_camera(app, cam_id="cam-b")
+        rec_dir = app.config["RECORDINGS_DIR"]
+        for cam, t in (("cam-a", "10-00-00"), ("cam-b", "14-30-00")):
+            clip_dir = os.path.join(rec_dir, cam, "2026-04-11")
+            os.makedirs(clip_dir, exist_ok=True)
+            with open(os.path.join(clip_dir, f"{t}.mp4"), "wb") as f:
+                f.write(b"\x00" * 1024)
+
+        resp = client.get("/api/v1/recordings/latest")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        _assert_has_fields(data, CLIP_FIELDS | {"camera_name"})
+
+    def test_no_clips_error(self, app, client):
+        _login(app, client)
+        resp = client.get("/api/v1/recordings/latest")
+        assert resp.status_code == 404
+        _assert_fields(resp.get_json(), {"error"})
+
+
+class TestRecordingsRecentContract:
+    """GET /api/v1/recordings/recent?limit=N — recent events feed (ADR-0018)."""
+
+    def test_returns_list_with_camera_name(self, app, client):
+        _login(app, client)
+        _add_camera(app, cam_id="cam-a")
+        rec_dir = app.config["RECORDINGS_DIR"]
+        clip_dir = os.path.join(rec_dir, "cam-a", "2026-04-11")
+        os.makedirs(clip_dir, exist_ok=True)
+        for t in ("10-00-00", "14-30-00", "18-00-00"):
+            with open(os.path.join(clip_dir, f"{t}.mp4"), "wb") as f:
+                f.write(b"\x00" * 512)
+
+        resp = client.get("/api/v1/recordings/recent?limit=5")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list) and data
+        _assert_has_fields(data[0], CLIP_FIELDS | {"camera_name"})
+
+    def test_empty_returns_empty_list(self, app, client):
+        _login(app, client)
+        resp = client.get("/api/v1/recordings/recent")
+        assert resp.status_code == 200
+        assert resp.get_json() == []
 
 
 class TestRecordingsDeleteContract:

--- a/app/server/tests/unit/test_svc_system_summary.py
+++ b/app/server/tests/unit/test_svc_system_summary.py
@@ -1,0 +1,374 @@
+"""
+Unit tests for SystemSummaryService (ADR-0018).
+
+Each test exercises one threshold transition so that the aggregator's
+colour contract is pinned — the ADR locks these thresholds for user
+muscle-memory reasons, so regressions here are silent trust breakers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from monitor.services.system_summary_service import (
+    CAMERA_OFFLINE_AMBER_SECONDS,
+    CAMERA_OFFLINE_RED_SECONDS,
+    CPU_AMBER_PERCENT,
+    CPU_TEMP_AMBER_C,
+    CPU_TEMP_RED_C,
+    DISK_AMBER_PERCENT,
+    DISK_RED_PERCENT,
+    MEMORY_AMBER_PERCENT,
+    SystemSummaryService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _cam(**kwargs):
+    """Build a minimal Camera-like namespace for store.get_cameras()."""
+    defaults = {
+        "id": "cam-1",
+        "name": "Cam 1",
+        "status": "online",
+        "last_seen": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _build(**overrides):
+    """Build a SystemSummaryService with mocked dependencies."""
+    store = MagicMock()
+    store.get_cameras.return_value = overrides.get("cameras", [_cam()])
+    store.get_camera.return_value = None
+
+    storage = MagicMock()
+    storage.get_storage_stats.return_value = overrides.get(
+        "stats",
+        {
+            "percent": 10.0,
+            "free_gb": 100,
+            "total_gb": 200,
+            "recordings_dir": "/tmp/empty-dir-that-does-not-exist",
+        },
+    )
+
+    audit = MagicMock()
+    audit.get_events.return_value = overrides.get("events", [])
+
+    rec_svc = MagicMock()
+    rec_svc.default_recordings_dir = "/tmp"
+
+    health = MagicMock()
+    health.get_health_summary.return_value = overrides.get(
+        "health_summary",
+        {
+            "cpu_temp_c": 45.0,
+            "cpu_usage_percent": 5.0,
+            "memory": {"percent": 30.0},
+        },
+    )
+
+    return SystemSummaryService(
+        store=store,
+        storage_manager=storage,
+        audit=audit,
+        recordings_service=rec_svc,
+        health_module=health,
+    )
+
+
+def _iso_ago(seconds: float) -> str:
+    """Return an ISO-8601 timestamp `seconds` ago."""
+    return (
+        datetime.now(timezone.utc) - timedelta(seconds=seconds)
+    ).isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# Green baseline
+# ---------------------------------------------------------------------------
+
+
+class TestGreenBaseline:
+    def test_all_quiet_returns_green(self):
+        svc = _build()
+        out = svc.compute_summary()
+        assert out["state"] == "green"
+        assert "All systems normal" in out["summary"]
+        assert out["deep_link"] == "/"
+        assert out["details"]["cameras"]["online"] == 1
+        assert out["details"]["cameras"]["total"] == 1
+        assert out["details"]["recent_errors"] == 0
+
+    def test_pending_cameras_excluded_from_totals(self):
+        svc = _build(cameras=[_cam(status="online"), _cam(id="cam-2", status="pending")])
+        out = svc.compute_summary()
+        assert out["details"]["cameras"]["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Storage thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestStorageStateTransitions:
+    def test_disk_below_amber_stays_green(self):
+        svc = _build(
+            stats={
+                "percent": DISK_AMBER_PERCENT - 0.1,
+                "free_gb": 10,
+                "total_gb": 100,
+                "recordings_dir": "",
+            }
+        )
+        assert svc.compute_summary()["state"] == "green"
+
+    def test_disk_at_amber_boundary_is_amber(self):
+        svc = _build(
+            stats={
+                "percent": DISK_AMBER_PERCENT,
+                "free_gb": 5,
+                "total_gb": 100,
+                "recordings_dir": "",
+            }
+        )
+        out = svc.compute_summary()
+        assert out["state"] == "amber"
+        assert "disk" in out["summary"].lower()
+
+    def test_disk_at_red_boundary_is_red(self):
+        svc = _build(
+            stats={
+                "percent": DISK_RED_PERCENT,
+                "free_gb": 1,
+                "total_gb": 100,
+                "recordings_dir": "",
+            }
+        )
+        out = svc.compute_summary()
+        assert out["state"] == "red"
+        assert out["deep_link"].startswith("/settings")
+
+
+# ---------------------------------------------------------------------------
+# Camera thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestCameraStateTransitions:
+    def test_recently_offline_is_amber(self):
+        cam = _cam(
+            status="offline", last_seen=_iso_ago(CAMERA_OFFLINE_AMBER_SECONDS + 5)
+        )
+        svc = _build(cameras=[cam])
+        out = svc.compute_summary()
+        assert out["state"] == "amber"
+        assert "offline" in out["summary"].lower()
+        assert out["deep_link"].startswith("/")
+
+    def test_long_offline_is_red(self):
+        cam = _cam(
+            status="offline", last_seen=_iso_ago(CAMERA_OFFLINE_RED_SECONDS + 60)
+        )
+        svc = _build(cameras=[cam])
+        out = svc.compute_summary()
+        assert out["state"] == "red"
+
+    def test_never_seen_offline_is_red(self):
+        cam = _cam(status="offline", last_seen=None)
+        svc = _build(cameras=[cam])
+        assert svc.compute_summary()["state"] == "red"
+
+    def test_single_offline_summary_names_camera(self):
+        cam = _cam(
+            id="cam-front", name="Front Door",
+            status="offline", last_seen=_iso_ago(120)
+        )
+        svc = _build(cameras=[cam])
+        assert "Front Door" in svc.compute_summary()["summary"]
+
+    def test_multi_offline_summary_counts(self):
+        cams = [
+            _cam(id="cam-1", name="Front", status="offline", last_seen=_iso_ago(120)),
+            _cam(id="cam-2", name="Back", status="offline", last_seen=_iso_ago(120)),
+        ]
+        svc = _build(cameras=cams)
+        assert "2 cameras are offline" in svc.compute_summary()["summary"]
+
+
+# ---------------------------------------------------------------------------
+# Recorder host thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestRecorderHostTransitions:
+    def test_cpu_above_amber_flips_amber(self):
+        svc = _build(
+            health_summary={
+                "cpu_temp_c": 40,
+                "cpu_usage_percent": CPU_AMBER_PERCENT + 5,
+                "memory": {"percent": 10},
+            }
+        )
+        assert svc.compute_summary()["state"] == "amber"
+
+    def test_temp_amber_flips_amber(self):
+        svc = _build(
+            health_summary={
+                "cpu_temp_c": CPU_TEMP_AMBER_C + 1,
+                "cpu_usage_percent": 5,
+                "memory": {"percent": 10},
+            }
+        )
+        assert svc.compute_summary()["state"] == "amber"
+
+    def test_temp_red_flips_red(self):
+        svc = _build(
+            health_summary={
+                "cpu_temp_c": CPU_TEMP_RED_C + 1,
+                "cpu_usage_percent": 5,
+                "memory": {"percent": 10},
+            }
+        )
+        assert svc.compute_summary()["state"] == "red"
+
+    def test_memory_amber_flips_amber(self):
+        svc = _build(
+            health_summary={
+                "cpu_temp_c": 40,
+                "cpu_usage_percent": 5,
+                "memory": {"percent": MEMORY_AMBER_PERCENT + 1},
+            }
+        )
+        assert svc.compute_summary()["state"] == "amber"
+
+
+# ---------------------------------------------------------------------------
+# Audit event surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestRecentErrors:
+    def test_error_in_window_flips_red(self):
+        events = [
+            {"timestamp": _iso_ago(60), "event": "OTA_FAILED", "detail": ""},
+        ]
+        svc = _build(events=events)
+        out = svc.compute_summary()
+        assert out["state"] == "red"
+        assert "event" in out["summary"].lower() or "log" in out["summary"].lower()
+
+    def test_warning_in_window_flips_amber(self):
+        events = [
+            {"timestamp": _iso_ago(60), "event": "CAMERA_OFFLINE", "detail": ""},
+        ]
+        svc = _build(events=events)
+        assert svc.compute_summary()["state"] == "amber"
+
+    def test_old_errors_are_ignored(self):
+        events = [
+            {"timestamp": _iso_ago(3600 * 3), "event": "OTA_FAILED", "detail": ""},
+        ]
+        svc = _build(events=events)
+        assert svc.compute_summary()["state"] == "green"
+
+    def test_login_failed_storm_does_not_flip_colour(self):
+        # ADR-0018: LOGIN_FAILED is intentionally excluded from the status
+        # strip so a password-spray attempt doesn't turn the dashboard red.
+        events = [
+            {"timestamp": _iso_ago(30), "event": "LOGIN_FAILED", "detail": ""}
+            for _ in range(50)
+        ]
+        svc = _build(events=events)
+        assert svc.compute_summary()["state"] == "green"
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation:
+    def test_store_exception_does_not_raise(self):
+        store = MagicMock()
+        store.get_cameras.side_effect = RuntimeError("boom")
+
+        svc = SystemSummaryService(
+            store=store,
+            storage_manager=MagicMock(
+                get_storage_stats=lambda: {
+                    "percent": 10, "free_gb": 10, "total_gb": 100,
+                    "recordings_dir": "",
+                }
+            ),
+            audit=MagicMock(get_events=lambda **_: []),
+            recordings_service=MagicMock(default_recordings_dir="/tmp"),
+            health_module=MagicMock(
+                get_health_summary=lambda _: {
+                    "cpu_temp_c": 40,
+                    "cpu_usage_percent": 5,
+                    "memory": {"percent": 10},
+                }
+            ),
+        )
+        out = svc.compute_summary()
+        assert out["state"] == "green"
+        assert out["details"]["cameras"]["total"] == 0
+
+    def test_all_services_failing_does_not_raise(self):
+        store = MagicMock(); store.get_cameras.side_effect = RuntimeError()
+        storage = MagicMock(); storage.get_storage_stats.side_effect = RuntimeError()
+        audit = MagicMock(); audit.get_events.side_effect = RuntimeError()
+        rec_svc = MagicMock(default_recordings_dir="/tmp")
+        health = MagicMock(); health.get_health_summary.side_effect = RuntimeError()
+
+        svc = SystemSummaryService(
+            store=store, storage_manager=storage, audit=audit,
+            recordings_service=rec_svc, health_module=health,
+        )
+        out = svc.compute_summary()
+        # Must not crash; best-effort green with zeros.
+        assert out["state"] in {"green", "amber", "red"}
+        assert "summary" in out
+
+
+# ---------------------------------------------------------------------------
+# Priority ordering — worst signal wins
+# ---------------------------------------------------------------------------
+
+
+class TestPriority:
+    def test_red_from_error_overrides_disk_amber(self):
+        svc = _build(
+            stats={
+                "percent": DISK_AMBER_PERCENT + 1,
+                "free_gb": 5, "total_gb": 100,
+                "recordings_dir": "",
+            },
+            events=[{"timestamp": _iso_ago(30), "event": "OTA_FAILED", "detail": ""}],
+        )
+        assert svc.compute_summary()["state"] == "red"
+
+    def test_red_disk_overrides_amber_camera(self):
+        svc = _build(
+            cameras=[_cam(status="offline", last_seen=_iso_ago(120))],
+            stats={
+                "percent": DISK_RED_PERCENT + 1,
+                "free_gb": 1, "total_gb": 100,
+                "recordings_dir": "",
+            },
+        )
+        assert svc.compute_summary()["state"] == "red"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/app/server/tests/unit/test_svc_system_summary.py
+++ b/app/server/tests/unit/test_svc_system_summary.py
@@ -8,7 +8,7 @@ muscle-memory reasons, so regressions here are silent trust breakers.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -26,7 +26,6 @@ from monitor.services.system_summary_service import (
     SystemSummaryService,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -38,7 +37,7 @@ def _cam(**kwargs):
         "id": "cam-1",
         "name": "Cam 1",
         "status": "online",
-        "last_seen": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "last_seen": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
     }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -89,8 +88,10 @@ def _build(**overrides):
 def _iso_ago(seconds: float) -> str:
     """Return an ISO-8601 timestamp `seconds` ago."""
     return (
-        datetime.now(timezone.utc) - timedelta(seconds=seconds)
-    ).isoformat().replace("+00:00", "Z")
+        (datetime.now(UTC) - timedelta(seconds=seconds))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +111,9 @@ class TestGreenBaseline:
         assert out["details"]["recent_errors"] == 0
 
     def test_pending_cameras_excluded_from_totals(self):
-        svc = _build(cameras=[_cam(status="online"), _cam(id="cam-2", status="pending")])
+        svc = _build(
+            cameras=[_cam(status="online"), _cam(id="cam-2", status="pending")]
+        )
         out = svc.compute_summary()
         assert out["details"]["cameras"]["total"] == 1
 
@@ -190,8 +193,7 @@ class TestCameraStateTransitions:
 
     def test_single_offline_summary_names_camera(self):
         cam = _cam(
-            id="cam-front", name="Front Door",
-            status="offline", last_seen=_iso_ago(120)
+            id="cam-front", name="Front Door", status="offline", last_seen=_iso_ago(120)
         )
         svc = _build(cameras=[cam])
         assert "Front Door" in svc.compute_summary()["summary"]
@@ -306,7 +308,9 @@ class TestGracefulDegradation:
             store=store,
             storage_manager=MagicMock(
                 get_storage_stats=lambda: {
-                    "percent": 10, "free_gb": 10, "total_gb": 100,
+                    "percent": 10,
+                    "free_gb": 10,
+                    "total_gb": 100,
                     "recordings_dir": "",
                 }
             ),
@@ -325,15 +329,22 @@ class TestGracefulDegradation:
         assert out["details"]["cameras"]["total"] == 0
 
     def test_all_services_failing_does_not_raise(self):
-        store = MagicMock(); store.get_cameras.side_effect = RuntimeError()
-        storage = MagicMock(); storage.get_storage_stats.side_effect = RuntimeError()
-        audit = MagicMock(); audit.get_events.side_effect = RuntimeError()
+        store = MagicMock()
+        store.get_cameras.side_effect = RuntimeError()
+        storage = MagicMock()
+        storage.get_storage_stats.side_effect = RuntimeError()
+        audit = MagicMock()
+        audit.get_events.side_effect = RuntimeError()
         rec_svc = MagicMock(default_recordings_dir="/tmp")
-        health = MagicMock(); health.get_health_summary.side_effect = RuntimeError()
+        health = MagicMock()
+        health.get_health_summary.side_effect = RuntimeError()
 
         svc = SystemSummaryService(
-            store=store, storage_manager=storage, audit=audit,
-            recordings_service=rec_svc, health_module=health,
+            store=store,
+            storage_manager=storage,
+            audit=audit,
+            recordings_service=rec_svc,
+            health_module=health,
         )
         out = svc.compute_summary()
         # Must not crash; best-effort green with zeros.
@@ -351,7 +362,8 @@ class TestPriority:
         svc = _build(
             stats={
                 "percent": DISK_AMBER_PERCENT + 1,
-                "free_gb": 5, "total_gb": 100,
+                "free_gb": 5,
+                "total_gb": 100,
                 "recordings_dir": "",
             },
             events=[{"timestamp": _iso_ago(30), "event": "OTA_FAILED", "detail": ""}],
@@ -363,7 +375,8 @@ class TestPriority:
             cameras=[_cam(status="offline", last_seen=_iso_ago(120))],
             stats={
                 "percent": DISK_RED_PERCENT + 1,
-                "free_gb": 1, "total_gb": 100,
+                "free_gb": 1,
+                "total_gb": 100,
                 "recordings_dir": "",
             },
         )

--- a/docs/adr/0018-dashboard-information-architecture.md
+++ b/docs/adr/0018-dashboard-information-architecture.md
@@ -122,7 +122,12 @@ Below the fold. Three sections:
 - **Camera roll-call** — one row per camera: name, status dot,
   last-seen timestamp, last-clip timestamp. No live preview, no
   per-camera CPU/temp on the dashboard — those live on the camera's
-  detail page.
+  detail page. The section header carries the existing pairing
+  affordances (Scan / Add camera / Pair PIN / Remove); these are
+  preserved verbatim from today's dashboard because first-run
+  onboarding ("I just unboxed a camera") lives here by user
+  expectation and by Frigate/UniFi precedent. Stream-settings modal
+  stays too.
 - **System log teaser** — last 5 warn-or-error entries from the audit
   log. "View all →" links to Settings > Audit.
 
@@ -227,10 +232,14 @@ free without sacrificing desktop density.
 
 ### Negative / costs
 
-- Requires a new aggregator endpoint (`/api/v1/system/health`) that
-  joins signals from the camera registry, the recordings filesystem,
-  the disk, and the audit log. Tested as one unit — any one signal
-  missing must degrade gracefully, never 500.
+- Requires a **new** aggregator endpoint — `/api/v1/system/summary` —
+  that joins signals from the camera registry, the recordings
+  filesystem, the disk, and the audit log. The existing
+  `/api/v1/system/health` (CPU/RAM/temp/disk/warnings) is kept
+  untouched as raw-metrics data and will back the future
+  `/diagnostics` page; `summary` is purely derived state (green /
+  amber / red + one sentence + deep-link target). Tested as one
+  unit — any one signal missing must degrade gracefully, never 500.
 - Retention-days estimate requires a 7-day trailing write-rate — for
   slice 1 we compute it from directory `stat()` at request time
   (acceptable up to ~hundreds of clips); it will need a cached
@@ -265,15 +274,19 @@ decorators, no DB migrations in any of them.
 
 ### Slice 1 — Status strip + four tiles (≈ 2 days)
 
-- `GET /api/v1/system/health` — aggregator: paired cameras + online
-  count, disk %, retention-days estimate, recorder CPU/temp snapshot,
-  last-error-in-1 h flag. Returns `{state: green|amber|red,
-  summary: "...", details: {...}}`.
+- `GET /api/v1/system/summary` — **new** aggregator: paired cameras
+  + online count, disk %, retention-days estimate, recorder
+  CPU/temp snapshot, last-error-in-1 h flag. Returns
+  `{state: green|amber|red, summary: "...", details: {...},
+  deep_link: "/..."}`. Pure derived state.
 - `GET /api/v1/recordings/latest` — latest clip across all cameras
   (extends the existing per-camera `latest_clip`).
-- Template rewrite of `dashboard.html`: status strip + four tiles,
-  no live players.
-- Contract tests for both endpoints; unit tests for the health
+- Template rewrite of `dashboard.html`: status strip + four tiles
+  above the fold. Existing pairing / add-camera / stream-settings
+  UI is **not removed** — it moves down into the Tier-3 camera
+  roll-call section in slice 3 (kept on a feature-flag / hidden
+  section in slice 1 so nothing breaks in between).
+- Contract tests for both endpoints; unit tests for the summary
   aggregator's state transitions at each threshold boundary.
 
 ### Slice 2 — Recent events + inline player (≈ 1 day)

--- a/docs/adr/0018-dashboard-information-architecture.md
+++ b/docs/adr/0018-dashboard-information-architecture.md
@@ -1,0 +1,331 @@
+# ADR-0018: Dashboard Information Architecture
+
+**Status:** Proposed
+**Date:** 2026-04-17
+**Deciders:** vinu-dev
+
+---
+
+## Context
+
+### Problem
+
+The current `/` dashboard is a grid of live-video tiles — one tile per
+paired camera, each running a WebRTC/HLS player on mount. That is a
+**wall display**, not a dashboard:
+
+1. It answers none of the four questions a homeowner actually has when
+   they open the app:
+   - "Is everything OK right now?" (glance)
+   - "Did anything happen while I was away?" (investigate)
+   - "Is the system healthy?" (health-check, e.g. after a power cut)
+   - "Where do I change X?" (configure — already served by the nav bar)
+2. It burns bandwidth and camera CPU to render live tiles the user is
+   not watching — directly at odds with ADR-0017's on-demand streaming
+   goals. Opening the dashboard starts every camera.
+3. It surfaces no system state: a camera can be offline, the recorder
+   disk can be 98 % full, the audit log can be full of errors, and the
+   dashboard shows none of it until the user opens Settings.
+4. Raw telemetry (CPU %, RAM, temperature) is exposed nowhere — or, if
+   we simply add it, it becomes decoration because there are no
+   thresholds that turn numbers into states.
+
+### Goal
+
+- A user who opens the app and sees green closes the tab in under five
+  seconds and feels confident — the dashboard's primary job.
+- A user who sees amber or red knows **what** is wrong and **where to
+  go** to fix it, without scrolling.
+- Live video stays on `/live` where it belongs; the dashboard does
+  **not** start camera streams.
+- Raw metrics live on a future `/diagnostics` page; the dashboard only
+  shows **derived state** (healthy / warning / critical).
+- The design survives feature growth: motion events, multiple recorder
+  hosts, off-LAN access — each should slot in without a re-layout.
+
+### Non-Goals
+
+- User-customisable widgets / drag-resize. Homeowners do not customise
+  dashboards; they expect the vendor to have thought about it.
+- Long-range graphs (7 d / 30 d). Time-series belongs on
+  `/diagnostics` and needs a time-series store (deferred — see
+  "Deferred" below).
+- Weather, clock, welcome banner, or any non-product widget.
+- Replacing `/live`. The live grid remains, unchanged, on its own tab.
+- Motion detection. Surfaced as "last activity = last clip recorded"
+  until a motion ADR lands; the API shape already accommodates
+  `event_type = motion` for the future.
+
+---
+
+## Decision
+
+Adopt a **three-tier information architecture** for the dashboard:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Tier 1 — status strip (always visible, one line)        │
+│  ● All systems normal · 3 cams online · 68 % disk        │
+├─────────────┬──────────────────────┬─────────────────────┤
+│  Tier 2 — four summary tiles (above the fold)            │
+│  Cameras    │ Last activity        │ Storage │ Recorder  │
+├─────────────┴──────────────────────┴─────────────────────┤
+│  Tier 3 — on-demand detail (scroll)                      │
+│  Recent events (last 10) · Camera roll-call · Log teaser │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Tier 1 — System health strip
+
+One sentence, one colour, rendered from a single
+`GET /api/v1/system/health` call. Three states, derived by the server
+from existing signals (no new metrics collection needed):
+
+| State | Condition |
+|---|---|
+| **Green** — "All systems normal" | All paired cameras online; recorder disk < 70 %; no error-level audit entries in the last hour |
+| **Amber** — "{what} needs attention" | Any one of: a camera offline < 1 h; disk 70–90 %; any warn-level audit entry in the last hour; recorder CPU > 85 % sustained 5 min |
+| **Red** — "{what} requires action" | Any one of: a camera offline ≥ 1 h; disk > 90 %; any error-level audit entry in the last hour; recorder unreachable from the server's own health probe |
+
+The strip is a link — clicking it deep-links to the worst offender
+(the offline camera's detail, the Settings > Storage page, etc.).
+Thresholds are constants in `monitor/services/health_service.py`,
+not user-configurable in slice 1.
+
+### Tier 2 — Four summary tiles
+
+Each tile answers exactly one question in one glance. No tile starts a
+video stream.
+
+1. **Cameras** — `3 / 4 online`. Subtitle: name of the offline one, if
+   any. Click → `/live`.
+2. **Last activity** — latest clip across all cameras. Thumbnail
+   (existing snapshot endpoint), camera name, "12 min ago", duration.
+   Click → inline plays on the dashboard (reusing the Recordings
+   sticky player pattern from ADR-0017 work), **not** a page jump.
+3. **Storage** — ring gauge `68 %` with subtitle "~12 days retention at
+   current rate." Retention estimate = `free_bytes /
+   bytes_per_day_7d_trailing_avg` (falls back to "—" if < 1 day of
+   data). Click → Settings > Storage.
+4. **Recorder host** — single-line mini-status: `Healthy` (green dot),
+   `Warm — 72 °C` (amber, only shown when thresholds crossed), or
+   `Unreachable` (red). No raw CPU/RAM numbers on the dashboard. Click
+   → `/diagnostics` (future; for slice 1, → Settings > System).
+
+### Tier 3 — On-demand detail
+
+Below the fold. Three sections:
+
+- **Recent events (last 10)** — flat list across all cameras, reverse
+  chronological. Row: thumbnail, camera, time, duration, click-to-play
+  inline. "View all →" links to `/recordings`.
+- **Camera roll-call** — one row per camera: name, status dot,
+  last-seen timestamp, last-clip timestamp. No live preview, no
+  per-camera CPU/temp on the dashboard — those live on the camera's
+  detail page.
+- **System log teaser** — last 5 warn-or-error entries from the audit
+  log. "View all →" links to Settings > Audit.
+
+### Information classification rule
+
+This is the rule that governs *every* future dashboard decision:
+
+> **Raw metrics belong on `/diagnostics`. Derived state belongs on
+> the dashboard.**
+
+A number without a threshold is decoration. If we cannot articulate
+"below X this is green, above X it is amber," the number does not go
+on the dashboard — it goes on the diagnostics page for engineers.
+
+---
+
+## Rationale
+
+### Why three tiers and not a single grid?
+
+The four user intents have different latency budgets. The glance
+("is it OK?") must resolve in under a second — that forces a single
+summary line at the top. Investigation ("what happened?") is visual
+and wants thumbnails — that fits tiles. Health-check is comparative
+across components — that wants a list. A single grid would compromise
+all three.
+
+### Why no live video on the dashboard?
+
+Two reasons. First, ADR-0017 pivoted the whole system to on-demand
+streaming precisely to stop 24 × 7 camera CPU / Wi-Fi burn; auto-
+starting streams on dashboard load would undo that. Second, live
+video is the highest-attention UI element on any page — putting it on
+the dashboard means the user watches video instead of scanning state,
+which defeats the dashboard's purpose. Frigate NVR and UniFi Protect
+both separate the two; Home Assistant does not and is widely
+criticised for it.
+
+### Why derived state over raw metrics?
+
+Homeowners are not SREs. "Recorder CPU 87 %" is meaningless to them;
+"Recorder is working harder than usual" is actionable. Raw numbers are
+still collected and exposed — just on `/diagnostics`, where an
+engineer (or a support session) can read them. This also future-proofs
+threshold tuning: we can change "amber at 85 % CPU" to "amber at 90 %"
+without touching the UI.
+
+### Why status-strip colours instead of numbers?
+
+Users develop muscle memory around the colour of the top bar after
+two or three logins. That muscle memory is the single most valuable
+UX asset the dashboard can build — so we must (a) pick thresholds
+conservatively so green really means green, and (b) never change the
+thresholds once users rely on them. This ADR locks the thresholds
+above for exactly that reason.
+
+---
+
+## Alternatives Considered
+
+### A. Keep the live-tile grid, add a status banner on top
+
+Cheaper change, but leaves the "dashboard auto-starts every camera"
+problem in place, continues to bury system state, and the banner on
+top of a wall of video just gets ignored. Rejected.
+
+### B. User-configurable widgets (Home Assistant / Grafana style)
+
+Maximum flexibility. Rejected because (1) the target user is a
+homeowner, not an integrator; (2) every support call becomes "what
+does your dashboard look like?"; (3) widget-config UIs are
+disproportionately expensive to build and test well.
+
+### C. Firehose dashboard — every metric we can collect
+
+Temperature gauges, RAM bars, network graphs, event heatmaps.
+Rejected on the "numbers without thresholds are decoration" rule.
+This *is* the right UI for `/diagnostics`, not for the dashboard.
+
+### D. Mobile-first single-column list (no tiles at all)
+
+Simpler, and the dashboard already must work on phones. Rejected
+because on ≥ 1024 px screens four tiles side-by-side are noticeably
+faster to scan than a list; the responsive grid already collapses to
+one column below 1024 px, so we get the mobile-list experience for
+free without sacrificing desktop density.
+
+---
+
+## Consequences
+
+### Positive
+
+- Glance-in-five-seconds UX; green tab closes fast, amber/red
+  surfaces exactly one actionable thing.
+- Dashboard load no longer starts any camera stream → ADR-0017
+  savings preserved.
+- New signals (motion events, multi-recorder, off-LAN state) each
+  have an obvious home in the existing three-tier structure.
+- `/diagnostics` becomes a natural place for the "power user" page
+  without cluttering the landing.
+
+### Negative / costs
+
+- Requires a new aggregator endpoint (`/api/v1/system/health`) that
+  joins signals from the camera registry, the recordings filesystem,
+  the disk, and the audit log. Tested as one unit — any one signal
+  missing must degrade gracefully, never 500.
+- Retention-days estimate requires a 7-day trailing write-rate — for
+  slice 1 we compute it from directory `stat()` at request time
+  (acceptable up to ~hundreds of clips); it will need a cached
+  rollup once clip counts grow. Flagged for the SQLite ADR.
+- Thumbnail generation for "last activity" and "recent events" reuses
+  the existing snapshot endpoint; cold-cache cost is one ffmpeg
+  invocation per row, one-time per clip. Acceptable for slice 1;
+  revisit if we add motion events at higher rate.
+- Locks the status-strip thresholds (see table above). Changing them
+  later costs user muscle-memory trust and must go through a new ADR.
+
+### Deferred (explicit non-decisions)
+
+- **Per-camera sparklines** (24 h uptime, frame-drop rate). Need
+  time-series storage → waits for the SQLite ADR.
+- **Thermal push from cameras.** `camera_streamer` currently does not
+  push its Pi temperature to the server. Once it does (small protocol
+  extension on the health-heartbeat channel — ADR-0016), the Tier 2
+  "Recorder host" tile gains a sibling per-camera thermal view in
+  Tier 3.
+- **Long-range history charts.** `/diagnostics` page, separate ADR.
+- **Multi-recorder topology.** Single-recorder assumption throughout;
+  the status strip and storage tile will need to aggregate once we
+  support more than one recorder host.
+
+---
+
+## Rollout
+
+Three independently-shippable slices, each behind the existing auth
+decorators, no DB migrations in any of them.
+
+### Slice 1 — Status strip + four tiles (≈ 2 days)
+
+- `GET /api/v1/system/health` — aggregator: paired cameras + online
+  count, disk %, retention-days estimate, recorder CPU/temp snapshot,
+  last-error-in-1 h flag. Returns `{state: green|amber|red,
+  summary: "...", details: {...}}`.
+- `GET /api/v1/recordings/latest` — latest clip across all cameras
+  (extends the existing per-camera `latest_clip`).
+- Template rewrite of `dashboard.html`: status strip + four tiles,
+  no live players.
+- Contract tests for both endpoints; unit tests for the health
+  aggregator's state transitions at each threshold boundary.
+
+### Slice 2 — Recent events + inline player (≈ 1 day)
+
+- `GET /api/v1/recordings/recent?limit=10` — flat list across
+  cameras.
+- Reuse the Recordings tab's sticky-player component.
+- Hooks for future `event_type` filter (motion) — accepted as a
+  query param, ignored until the motion ADR lands.
+
+### Slice 3 — Camera roll-call + log teaser (≈ 1 day)
+
+- Camera roll-call reuses `/api/v1/cameras` + per-camera
+  `last_seen` (already present).
+- Log teaser reuses `/api/v1/audit?level=warn&limit=5`.
+- No new endpoints.
+
+### Out-of-scope for this ADR's rollout
+
+- `/diagnostics` page (own ADR when raw-metrics exposure becomes
+  necessary).
+- Dashboard internationalisation (existing app is English-only;
+  dashboard does not regress this).
+- Any mobile-app / PWA work.
+
+---
+
+## Open Questions
+
+1. **Inline player on the dashboard vs. deep-link to `/recordings`.**
+   This ADR chooses inline (one click, player pops in-place) because
+   the glance-then-investigate pattern is the high-traffic path. If
+   telemetry later shows most investigations end with the user
+   navigating to `/recordings` for the clip list, collapse Tier 2's
+   "Last activity" into a link-only tile in a follow-up.
+2. **Is "recorder host" the right fourth tile?** For a
+   single-recorder home, yes — disk already covers the main concern.
+   If a home ever runs multiple recorders, the tile grows into a
+   per-recorder list and may need its own page. Revisit under the
+   multi-recorder ADR.
+3. **How loud is amber?** No push / email / toast in slice 1 — amber
+   is a visual cue, nothing more. Notification channels belong in
+   their own ADR.
+
+---
+
+## References
+
+- ADR-0012: UI Architecture (HTMX + Alpine.js patterns, dark-first)
+- ADR-0016: Camera Health Heartbeat Protocol (source of per-camera
+  online / last-seen signal)
+- ADR-0017: On-Demand Viewer-Driven Streaming (why the dashboard
+  must not auto-start streams)
+- Frigate NVR dashboard (status-first, video on its own tab)
+- UniFi Protect "Protect Home" screen (summary tiles + recent events)

--- a/docs/adr/0018-dashboard-information-architecture.md
+++ b/docs/adr/0018-dashboard-information-architecture.md
@@ -1,6 +1,6 @@
 # ADR-0018: Dashboard Information Architecture
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-17
 **Deciders:** vinu-dev
 

--- a/tests/e2e/playwright/smoke/server-auth-and-dashboard.spec.ts
+++ b/tests/e2e/playwright/smoke/server-auth-and-dashboard.spec.ts
@@ -8,6 +8,9 @@ test("server setup and dashboard flows are reachable", async ({ page, baseURL })
 
   await expect(page).toHaveURL(/\/dashboard/);
   await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
-  await expect(page.getByText("System Health")).toBeVisible();
+  // ADR-0018: the health grid was replaced by a status strip + four
+  // summary tiles. "Recorder host" is the Tier-2 tile that subsumes the
+  // old "System Health" section.
+  await expect(page.getByText("Recorder host")).toBeVisible();
   await expect(page.getByText("Cameras")).toBeVisible();
 });

--- a/tests/e2e/playwright/smoke/server-auth-and-dashboard.spec.ts
+++ b/tests/e2e/playwright/smoke/server-auth-and-dashboard.spec.ts
@@ -12,5 +12,8 @@ test("server setup and dashboard flows are reachable", async ({ page, baseURL })
   // summary tiles. "Recorder host" is the Tier-2 tile that subsumes the
   // old "System Health" section.
   await expect(page.getByText("Recorder host")).toBeVisible();
-  await expect(page.getByText("Cameras")).toBeVisible();
+  // The word "Cameras" now appears in the status strip, the Tier-2 tile
+  // and the roll-call section header — pin this assertion to the unique
+  // section header id so it doesn't trip strict-mode multi-match.
+  await expect(page.locator("#cameras-section")).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- **ADR-0018** (Accepted) — dashboard information architecture: three tiers (status strip · four tiles · detail on demand). Thresholds locked so state colour stays predictable.
- **Slice 1 backend** — `SystemSummaryService` aggregates cameras / storage / recorder host / recent audit events into `{state, summary, deep_link, details}`. New endpoints: `GET /api/v1/system/summary`, `GET /api/v1/recordings/latest` (cross-camera), `GET /api/v1/recordings/recent`.
- **Slice 1 frontend** — Tier-1 strip + Tier-2 tiles replace the raw-metric health grid. Green is quiet, amber/red deep-link to the actionable page. Camera pairing UI preserved; Slice 2/3 will rework the roll-call + add the recent events feed.

## Test plan

- [x] 22 unit tests (`test_svc_system_summary.py`) — all thresholds, graceful degradation, priority, LOGIN_FAILED storm doesn't flip red
- [x] 7 new contract tests for `/system/summary`, `/recordings/latest`, `/recordings/recent`; full contract suite still green (91 pass)
- [x] Ruff + ruff format clean repo-wide
- [ ] CI green
- [ ] Hardware smoke test on Pi recorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)