### PR TITLE
C:/Program Files/Git/diagnostics page + recorder layout fixes

### DIFF
--- a/app/server/monitor/services/recordings_service.py
+++ b/app/server/monitor/services/recordings_service.py
@@ -285,6 +285,7 @@ class RecordingsService:
             "filename": newest_path.name,
             "date": date_str,
             "start_time": start_time,
+            "duration_seconds": 180,
             "size_bytes": size,
             "thumbnail": f"{newest_path.stem}.thumb.jpg",
         }

--- a/app/server/monitor/services/recordings_service.py
+++ b/app/server/monitor/services/recordings_service.py
@@ -26,6 +26,33 @@ _CAMERA_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 # Recording date directories are always YYYY-MM-DD.
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
+# The dashboard has seen two on-disk layouts during its history:
+#   dated subdir: <cam>/YYYY-MM-DD/HH-MM-SS.mp4       (legacy recorder)
+#   flat:         <cam>/YYYYMMDD_HHMMSS.mp4           (loop recorder)
+# Both are still present on deployed hardware, so readers must cope with
+# either. Writers only ever produce the flat layout today.
+_FLAT_STEM_RE = re.compile(r"^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$")
+_DATED_STEM_RE = re.compile(r"^(\d{2})-(\d{2})-(\d{2})$")
+
+
+def _parse_clip_date_time(mp4: Path) -> tuple[str, str]:
+    """Extract (YYYY-MM-DD, HH:MM:SS) from a clip path.
+
+    Returns ("", "") if the path does not match either known layout —
+    callers should skip such entries rather than emit NaN to the UI.
+    """
+    stem = mp4.stem
+    m = _FLAT_STEM_RE.match(stem)
+    if m:
+        y, mo, d, hh, mm, ss = m.groups()
+        return f"{y}-{mo}-{d}", f"{hh}:{mm}:{ss}"
+    parent = mp4.parent.name
+    if _DATE_RE.match(parent):
+        m = _DATED_STEM_RE.match(stem)
+        if m:
+            return parent, stem.replace("-", ":")
+    return "", ""
+
 
 class RecordingsService:
     """Business logic for recording queries and management.
@@ -241,12 +268,26 @@ class RecordingsService:
         if newest_path is None:
             return None, "No recordings found", 404
 
-        recorder = self._get_recorder()
-        clip = recorder.get_latest_clip(newest_cam)
-        if clip is None:
+        # Build the response from the walk we already did — the recorder's
+        # get_latest_clip() only knows the dated-subdir layout, so falling
+        # back to it would miss flat-layout clips written by the loop
+        # recorder. We already have the newest path; parse it directly.
+        date_str, start_time = _parse_clip_date_time(newest_path)
+        if not date_str:
             return None, "No recordings found", 404
-        data = asdict(clip)
-        data["camera_name"] = self._camera_display_name(newest_cam)
+        try:
+            size = newest_path.stat().st_size
+        except OSError:
+            size = 0
+        data = {
+            "camera_id": newest_cam,
+            "camera_name": self._camera_display_name(newest_cam),
+            "filename": newest_path.name,
+            "date": date_str,
+            "start_time": start_time,
+            "size_bytes": size,
+            "thumbnail": f"{newest_path.stem}.thumb.jpg",
+        }
         return data, None, 200
 
     def recent_across_cameras(self, limit: int = 10):
@@ -289,20 +330,22 @@ class RecordingsService:
         entries.sort(reverse=True, key=lambda t: t[0])
         out: list[dict] = []
         for _mtime, cam_id, mp4 in entries[:limit]:
-            # Filename is HH-MM-SS.mp4, parent dir name is YYYY-MM-DD.
-            stem = mp4.stem
             try:
                 size = mp4.stat().st_size
             except OSError:
                 size = 0
-            thumb_name = f"{stem}.thumb.jpg"
+            date_str, start_time = _parse_clip_date_time(mp4)
+            if not date_str:
+                # Unrecognised on-disk naming — skip rather than return NaN.
+                continue
+            thumb_name = f"{mp4.stem}.thumb.jpg"
             out.append(
                 {
                     "camera_id": cam_id,
                     "camera_name": self._camera_display_name(cam_id),
                     "filename": mp4.name,
-                    "date": mp4.parent.name,
-                    "start_time": stem.replace("-", ":"),
+                    "date": date_str,
+                    "start_time": start_time,
                     "duration_seconds": 180,
                     "size_bytes": size,
                     "thumbnail": thumb_name,
@@ -347,6 +390,18 @@ class RecordingsService:
             return None, "Invalid path", 400
 
         if not clip_path.is_file():
+            # Flat-layout fallback: loop recorder writes clips directly under
+            # <recordings_root>/<camera_id>/ with YYYYMMDD_HHMMSS.mp4 stems.
+            # The UI still addresses them with the dated URL shape
+            # /<cam>/<YYYY-MM-DD>/<filename>, so check the flat location here
+            # before giving up.
+            try:
+                flat_path = (recordings_root / camera_id / filename).resolve()
+                flat_path.relative_to(recordings_root)
+            except (ValueError, OSError):
+                return None, "Clip not found", 404
+            if flat_path.is_file():
+                return flat_path, None, 200
             return None, "Clip not found", 404
 
         return clip_path, None, 200

--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -241,7 +241,7 @@ class SystemSummaryService:
             "free_gb": stats.get("free_gb", 0),
             "total_gb": stats.get("total_gb", 0),
         }
-        return state, detail, "/settings#storage"
+        return state, detail, "/diagnostics#storage"
 
     def _estimate_retention_days(self, stats: dict) -> float | None:
         """Retention = free_bytes / bytes_written_per_day (7-day trailing).
@@ -295,7 +295,7 @@ class SystemSummaryService:
             )
         except Exception as exc:
             log.warning("summary: get_health_summary failed: %s", exc)
-            return "green", {}, "/settings"
+            return "green", {}, "/diagnostics#recorder"
 
         cpu_temp = summary.get("cpu_temp_c", 0.0) or 0.0
         cpu_pct = summary.get("cpu_usage_percent", 0.0) or 0.0
@@ -316,7 +316,7 @@ class SystemSummaryService:
             "cpu_temp_c": round(cpu_temp, 1),
             "memory_percent": round(mem_pct, 1),
         }
-        return state, detail, "/settings#system"
+        return state, detail, "/diagnostics#recorder"
 
     # -- recent errors ------------------------------------------------------
 
@@ -380,7 +380,7 @@ class SystemSummaryService:
             return (
                 f"All systems normal — {online}/{total} cameras online, "
                 f"{disk_pct:.0f}% disk used"
-            ), "/"
+            ), "/diagnostics"
 
         # Priority of what to surface first: errors > red signals > amber.
         # Within the same severity, storage is most actionable.
@@ -414,7 +414,7 @@ class SystemSummaryService:
 
         # Fallback (should not happen): overall state isn't green but no
         # sub-signal claimed it. Keep something meaningful on screen.
-        return "System needs attention", "/settings"
+        return "System needs attention", "/diagnostics"
 
 
 def _camera_sentence(cam_detail: dict) -> str:

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -1408,3 +1408,48 @@ select.form-input {
     background: #000;
     display: block;
 }
+
+/* ====================================================================
+   Diagnostics page (ADR-0018 — raw metrics surface)
+   The dashboard stays glance-only; /diagnostics is where the actual
+   numbers live. Styling is intentionally plain — this page is for the
+   operator, not a marketing surface.
+   ================================================================== */
+.diagnostics-header {
+    margin-bottom: var(--space-4);
+}
+.diag-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--space-3);
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 0.9rem;
+}
+.diag-row:last-child {
+    border-bottom: none;
+}
+.diag-row__label {
+    color: var(--color-text-muted);
+    flex: 0 0 auto;
+}
+.diag-row__value {
+    color: var(--color-text);
+    text-align: right;
+    word-break: break-all;
+    font-variant-numeric: tabular-nums;
+}
+.diag-json {
+    background: var(--color-bg-alt, #111);
+    color: var(--color-text);
+    padding: var(--space-3);
+    border-radius: var(--radius-sm);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.8rem;
+    line-height: 1.4;
+    overflow-x: auto;
+    white-space: pre;
+    max-height: 420px;
+    overflow-y: auto;
+}

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -46,7 +46,7 @@
     </a>
 
     <!-- Storage -->
-    <a class="tile" href="/settings#storage" :class="tileStateClass('storage')">
+    <a class="tile" href="/diagnostics#storage" :class="tileStateClass('storage')">
         <div class="tile__label">Storage</div>
         <div class="tile__value">
             <span x-text="storagePercentLabel"></span>
@@ -55,7 +55,7 @@
     </a>
 
     <!-- Recorder host -->
-    <a class="tile" href="/settings#system" :class="tileStateClass('recorder')">
+    <a class="tile" href="/diagnostics#recorder" :class="tileStateClass('recorder')">
         <div class="tile__label">Recorder host</div>
         <div class="tile__value" x-text="recorderStateLabel"></div>
         <div class="tile__caption" x-text="health.uptime || '\u2014'"></div>
@@ -431,11 +431,9 @@ function dashboardPage() {
             return 'Nominal';
         },
 
-        onStatusClick(ev) {
-            // A green strip links to "/"; don't scroll when already there.
-            if ((this.summary.state || 'green') === 'green') {
-                ev.preventDefault();
-            }
+        onStatusClick(_ev) {
+            // Strip always navigates to its deep_link (green → /diagnostics,
+            // amber/red → the page that lets the user act). Nothing to cancel.
         },
 
         // --- Loaders ---

--- a/app/server/monitor/templates/diagnostics.html
+++ b/app/server/monitor/templates/diagnostics.html
@@ -1,0 +1,187 @@
+{% extends "base.html" %}
+
+{% block title %}Diagnostics - Home Monitor{% endblock %}
+
+{% block content %}
+<div x-data="diagnosticsPage()" x-init="init()">
+
+<div class="diagnostics-header">
+    <a href="/dashboard" class="text-small text-muted">&larr; Dashboard</a>
+    <h1 class="page-title" style="margin-top:4px;">System Diagnostics</h1>
+    <div class="text-small text-muted">
+        Raw metrics and host telemetry. The dashboard shows derived state
+        (green / amber / red); this page shows the numbers behind that judgement.
+    </div>
+</div>
+
+<!-- ==================== Recorder host ==================== -->
+<div id="recorder" class="section-header">Recorder host</div>
+<div class="grid grid--health">
+    <div class="card health-card">
+        <div class="health-card__value" :class="tempColor(health.temp)" x-text="health.temp !== null ? health.temp.toFixed(1) + '\u00B0C' : '--'"></div>
+        <div class="health-card__label">CPU Temp</div>
+        <div class="health-card__detail">amber &ge; 72 &deg;C &middot; red &ge; 80 &deg;C</div>
+    </div>
+    <div class="card health-card">
+        <div class="health-card__value" :class="usageColor(health.cpu)" x-text="health.cpu !== null ? health.cpu.toFixed(0) + '%' : '--'"></div>
+        <div class="health-card__label">CPU Usage</div>
+        <div class="health-card__detail">amber &ge; 85 %</div>
+    </div>
+    <div class="card health-card">
+        <div class="health-card__value" :class="usageColor(health.mem)" x-text="health.mem !== null ? health.mem.toFixed(0) + '%' : '--'"></div>
+        <div class="health-card__label">Memory</div>
+        <div class="health-card__detail" x-text="health.memDetail"></div>
+    </div>
+    <div class="card health-card">
+        <div class="health-card__value" :class="usageColor(health.disk)" x-text="health.disk !== null ? health.disk.toFixed(0) + '%' : '--'"></div>
+        <div class="health-card__label">Disk</div>
+        <div class="health-card__detail" x-text="health.diskDetail"></div>
+    </div>
+</div>
+
+<!-- Warnings (mirror of what the health API flagged) -->
+<div class="warnings-list" x-show="health.warnings.length > 0">
+    <template x-for="w in health.warnings" :key="w">
+        <div class="warning-item" x-text="w"></div>
+    </template>
+</div>
+
+<!-- ==================== Storage ==================== -->
+<div id="storage" class="section-header">Storage</div>
+<div class="card">
+    <div class="diag-row">
+        <span class="diag-row__label">Recordings directory</span>
+        <span class="diag-row__value" x-text="storage.recordings_dir || '\u2014'"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">Total</span>
+        <span class="diag-row__value" x-text="storage.total_gb !== undefined ? storage.total_gb + ' GB' : '\u2014'"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">Used</span>
+        <span class="diag-row__value" x-text="storage.used_gb !== undefined ? storage.used_gb + ' GB (' + storage.percent + '%)' : '\u2014'"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">Free</span>
+        <span class="diag-row__value" x-text="storage.free_gb !== undefined ? storage.free_gb + ' GB' : '\u2014'"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">Estimated retention</span>
+        <span class="diag-row__value" x-text="summary.details && summary.details.storage && summary.details.storage.retention_days !== null ? '~' + summary.details.storage.retention_days + ' days (7-day trailing)' : 'not enough data'"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">Thresholds (ADR-0018)</span>
+        <span class="diag-row__value">amber &ge; 70 % &middot; red &ge; 90 %</span>
+    </div>
+</div>
+
+<!-- ==================== Host info ==================== -->
+<div id="host" class="section-header">Host</div>
+<div class="card">
+    <div class="diag-row">
+        <span class="diag-row__label">Hostname</span>
+        <span class="diag-row__value" x-text="info.hostname || '\u2014'"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">Firmware</span>
+        <span class="diag-row__value" x-text="info.firmware_version || '\u2014'"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">OS</span>
+        <span class="diag-row__value" x-text="(info.os_name || '\u2014') + (info.os_version ? ' ' + info.os_version : '')"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">Uptime</span>
+        <span class="diag-row__value" x-text="(info.uptime && info.uptime.display) || '\u2014'"></span>
+    </div>
+    <div class="diag-row">
+        <span class="diag-row__label">Last refresh</span>
+        <span class="diag-row__value" x-text="lastRefresh || '\u2014'"></span>
+    </div>
+</div>
+
+<!-- ==================== Raw JSON for advanced users ==================== -->
+<div class="section-header">
+    Raw JSON
+    <button class="btn btn--secondary btn--small" @click="showRaw = !showRaw" style="float:right;margin-top:-4px;">
+        <span x-text="showRaw ? 'Hide' : 'Show'"></span>
+    </button>
+</div>
+<template x-if="showRaw">
+    <div class="card">
+        <div class="diag-row__label" style="margin-bottom:4px;">/system/summary</div>
+        <pre class="diag-json" x-text="JSON.stringify(summary, null, 2)"></pre>
+        <div class="diag-row__label" style="margin-top:12px;margin-bottom:4px;">/system/health</div>
+        <pre class="diag-json" x-text="JSON.stringify(raw, null, 2)"></pre>
+    </div>
+</template>
+
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function diagnosticsPage() {
+    return {
+        health: { temp: null, cpu: null, mem: null, memDetail: '', disk: null, diskDetail: '', warnings: [] },
+        storage: {},
+        info: {},
+        summary: { details: null },
+        raw: {},
+        lastRefresh: '',
+        showRaw: false,
+        _interval: null,
+
+        tempColor(c) {
+            if (c === null) return '';
+            if (c < 72) return 'health-card__value--green';
+            if (c < 80) return 'health-card__value--yellow';
+            return 'health-card__value--red';
+        },
+        usageColor(p) {
+            if (p === null) return '';
+            if (p < 70) return 'health-card__value--green';
+            if (p < 85) return 'health-card__value--yellow';
+            return 'health-card__value--red';
+        },
+
+        async loadAll() {
+            try {
+                this.raw = await window.HM.api.get('/api/v1/system/health');
+                this.health.temp = this.raw.cpu_temp_c;
+                this.health.cpu = this.raw.cpu_usage_percent;
+                this.health.mem = (this.raw.memory && this.raw.memory.percent) || 0;
+                this.health.memDetail = this.raw.memory ? (this.raw.memory.used_mb + ' / ' + this.raw.memory.total_mb + ' MB') : '';
+                this.health.disk = (this.raw.disk && this.raw.disk.percent) || 0;
+                this.health.diskDetail = this.raw.disk ? (this.raw.disk.used_gb + ' / ' + this.raw.disk.total_gb + ' GB') : '';
+                this.health.warnings = this.raw.warnings || [];
+                this.storage = this.raw.disk || {};
+                if (this.raw.disk && this.raw.disk.recordings_dir === undefined) {
+                    // /system/health response exposes disk but not the dir;
+                    // storage.recordings_dir is filled in from the summary below.
+                }
+            } catch(e) {}
+            try {
+                this.info = await window.HM.api.get('/api/v1/system/info');
+            } catch(e) {}
+            try {
+                this.summary = await window.HM.api.get('/api/v1/system/summary');
+                // Merge storage metadata (retention_days, recordings_dir) from summary.
+                if (this.summary.details && this.summary.details.storage) {
+                    this.storage = Object.assign({}, this.storage, this.summary.details.storage);
+                }
+            } catch(e) {}
+            this.lastRefresh = new Date().toLocaleTimeString();
+        },
+
+        init() {
+            this.loadAll();
+            this._interval = setInterval(() => { this.loadAll(); }, 10000);
+        },
+        destroy() {
+            if (this._interval) clearInterval(this._interval);
+        }
+    };
+}
+</script>
+{% endblock %}

--- a/app/server/monitor/templates/recordings.html
+++ b/app/server/monitor/templates/recordings.html
@@ -19,8 +19,14 @@
             <input type="date" id="rec-date-input" class="form-input">
         </div>
     </div>
-    <div id="rec-available-dates" class="text-small text-muted mt-8" style="display:none;">
-        Available dates: <span id="rec-dates-list"></span>
+    <!--
+      "Available dates" hint was removed — the native date picker already
+      exposes the full range, and the server falls back to the newest date
+      with clips on load. Keeping the hidden IDs so the existing JS can
+      still reference them (refactor deferred) without rendering any UI.
+    -->
+    <div id="rec-available-dates" hidden>
+        <span id="rec-dates-list"></span>
     </div>
 </div>
 
@@ -287,7 +293,18 @@
 
         countEl.textContent = clips.length + (clips.length === 1 ? ' clip' : ' clips');
 
-        clips.forEach(function(clip) {
+        // Latest first — users almost always want the most recent clip on
+        // top when scrubbing a day's recordings. The API returns clips
+        // sorted ascending by start_time, so reverse here.
+        var ordered = clips.slice().sort(function(a, b) {
+            var ax = (a.start_time || '') + '/' + (a.filename || '');
+            var bx = (b.start_time || '') + '/' + (b.filename || '');
+            if (ax < bx) return 1;
+            if (ax > bx) return -1;
+            return 0;
+        });
+
+        ordered.forEach(function(clip) {
             clipList.appendChild(buildClipCard(clip));
         });
 

--- a/app/server/monitor/templates/recordings.html
+++ b/app/server/monitor/templates/recordings.html
@@ -21,13 +21,9 @@
     </div>
     <!--
       "Available dates" hint was removed — the native date picker already
-      exposes the full range, and the server falls back to the newest date
-      with clips on load. Keeping the hidden IDs so the existing JS can
-      still reference them (refactor deferred) without rendering any UI.
+      covers the range, and it wouldn't scale past a handful of days.
+      The server defaults to the newest date with clips on load.
     -->
-    <div id="rec-available-dates" hidden>
-        <span id="rec-dates-list"></span>
-    </div>
 </div>
 
 <!-- Two-pane layout: sticky player on the left, scrolling clip list on the right.
@@ -124,8 +120,6 @@
     var placeholderEl = document.getElementById('rec-placeholder');
     var playingLabel = document.getElementById('rec-playing-label');
     var btnClose = document.getElementById('btn-close-player');
-    var datesWrap = document.getElementById('rec-available-dates');
-    var datesList = document.getElementById('rec-dates-list');
     var countEl = document.getElementById('rec-count');
     var archiveBanner = document.getElementById('rec-archive-banner');
     var selectionBar = document.getElementById('rec-selection-bar');
@@ -242,9 +236,6 @@
             .then(function(data) {
                 availableDates = data.dates || [];
                 if (availableDates.length > 0) {
-                    datesWrap.style.display = '';
-                    datesList.textContent = availableDates.slice(-10).join(', ');
-
                     var params = new URLSearchParams(window.location.search);
                     var dateParam = params.get('date');
                     if (dateParam && availableDates.indexOf(dateParam) >= 0) {
@@ -254,13 +245,11 @@
                     }
                     loadClips(cameraId, dateInput.value);
                 } else {
-                    datesWrap.style.display = 'none';
                     dateInput.value = '';
                     showEmpty();
                 }
             })
             .catch(function() {
-                datesWrap.style.display = 'none';
                 showEmpty();
             });
     }
@@ -535,7 +524,6 @@
                 // removed camera disappears from the Archive section.
                 loadCameras();
                 availableDates = [];
-                datesWrap.style.display = 'none';
                 dateInput.value = '';
                 showEmpty();
                 dangerZone.style.display = 'none';
@@ -567,7 +555,6 @@
             updateUrl();
         } else {
             availableDates = [];
-            datesWrap.style.display = 'none';
             dateInput.value = '';
             showEmpty();
         }

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -6,6 +6,16 @@
 <div x-data="settingsPage()" x-init="init()">
 <h1 class="page-title">Settings</h1>
 
+<!--
+  ADR-0018 moved raw system metrics to /diagnostics. Surface the entry
+  here so operators can still reach them from Settings (where they used
+  to live) without cluttering the dashboard.
+-->
+<div class="text-small text-muted" style="margin-bottom: var(--space-4);">
+    Looking for CPU / temp / memory / disk numbers?
+    <a href="/diagnostics">Open System diagnostics &rarr;</a>
+</div>
+
 <!-- Settings Tab Bar -->
 <div class="settings-tabs" x-show="isAdmin">
     <button class="settings-tab" :class="{ active: tab === 'system' }" @click="tab = 'system'">System</button>

--- a/app/server/monitor/views.py
+++ b/app/server/monitor/views.py
@@ -91,6 +91,21 @@ def recordings():
     return render_template("recordings.html")
 
 
+@views_bp.route("/diagnostics")
+def diagnostics():
+    """System diagnostics — raw metrics behind the dashboard's derived state.
+
+    ADR-0018 moved CPU/temp/mem/disk numbers off the dashboard to keep
+    that surface glance-only. This page is their new home — linked
+    from the status strip and the Storage / Recorder tiles.
+    """
+    if not _setup_complete():
+        return redirect(url_for("views.setup"))
+    if not _is_authenticated():
+        return redirect(url_for("views.login"))
+    return render_template("diagnostics.html")
+
+
 @views_bp.route("/settings")
 def settings():
     """System settings and user management."""

--- a/app/server/tests/unit/test_svc_recordings.py
+++ b/app/server/tests/unit/test_svc_recordings.py
@@ -388,3 +388,76 @@ class TestFallbackRecordingsDir:
         result, error, status = svc.list_clips("cam-001", "2026-04-09")
         assert error is None
         assert result == []
+
+
+class TestRecentAcrossCamerasLayouts:
+    """Dashboard feed must handle both on-disk layouts.
+
+    The loop recorder writes flat ``<cam>/YYYYMMDD_HHMMSS.mp4`` clips
+    while older clips still sit in ``<cam>/YYYY-MM-DD/HH-MM-SS.mp4``.
+    Regression: before the fix we parsed flat stems with the dated
+    rule, producing ``date=<camera_id>`` and NaN timestamps on the UI.
+    """
+
+    def test_parses_flat_and_dated_layouts(self, svc, storage_manager):
+        from pathlib import Path
+
+        root = Path(storage_manager.recordings_dir)
+        cam_dir = root / "cam-001"
+        cam_dir.mkdir()
+        # Flat clip (newest).
+        flat = cam_dir / "20260417_101530.mp4"
+        flat.write_bytes(b"x" * 10)
+        # Dated clip (older).
+        dated_dir = cam_dir / "2026-04-10"
+        dated_dir.mkdir()
+        dated = dated_dir / "09-00-00.mp4"
+        dated.write_bytes(b"x" * 10)
+        import os
+        import time
+
+        old = time.time() - 3600
+        os.utime(dated, (old, old))
+
+        result, error, status = svc.recent_across_cameras(limit=10)
+        assert error is None and status == 200
+        assert len(result) == 2
+        # Newest first.
+        assert result[0]["filename"] == "20260417_101530.mp4"
+        assert result[0]["date"] == "2026-04-17"
+        assert result[0]["start_time"] == "10:15:30"
+        # Dated layout still handled.
+        assert result[1]["filename"] == "09-00-00.mp4"
+        assert result[1]["date"] == "2026-04-10"
+        assert result[1]["start_time"] == "09:00:00"
+
+    def test_skips_unrecognised_stems(self, svc, storage_manager):
+        from pathlib import Path
+
+        root = Path(storage_manager.recordings_dir)
+        cam_dir = root / "cam-001"
+        cam_dir.mkdir()
+        (cam_dir / "weird-name.mp4").write_bytes(b"x")
+
+        result, error, status = svc.recent_across_cameras(limit=10)
+        assert error is None and status == 200
+        assert result == []
+
+
+class TestResolveClipPathFlatFallback:
+    def test_flat_clip_resolves_via_dated_url(self, svc, storage_manager):
+        from pathlib import Path
+
+        root = Path(storage_manager.recordings_dir)
+        cam_dir = root / "cam-001"
+        cam_dir.mkdir()
+        flat = cam_dir / "20260417_101530.mp4"
+        flat.write_bytes(b"x" * 10)
+
+        # UI addresses the clip as /<cam>/<YYYY-MM-DD>/<filename>;
+        # the service must find the flat file underneath.
+        path, error, status = svc.resolve_clip_path(
+            "cam-001", "2026-04-17", "20260417_101530.mp4"
+        )
+        assert error is None and status == 200
+        assert path == flat.resolve()

--- a/app/server/tests/unit/test_svc_system_summary.py
+++ b/app/server/tests/unit/test_svc_system_summary.py
@@ -105,7 +105,10 @@ class TestGreenBaseline:
         out = svc.compute_summary()
         assert out["state"] == "green"
         assert "All systems normal" in out["summary"]
-        assert out["deep_link"] == "/"
+        # ADR-0018: green strip points at /diagnostics so operators can
+        # still reach raw metrics in one click, without demoting the
+        # dashboard to a metrics screen.
+        assert out["deep_link"] == "/diagnostics"
         assert out["details"]["cameras"]["online"] == 1
         assert out["details"]["cameras"]["total"] == 1
         assert out["details"]["recent_errors"] == 0
@@ -159,7 +162,7 @@ class TestStorageStateTransitions:
         )
         out = svc.compute_summary()
         assert out["state"] == "red"
-        assert out["deep_link"].startswith("/settings")
+        assert out["deep_link"] == "/diagnostics#storage"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New **/diagnostics** page hosts the raw CPU/temp/mem/disk numbers that ADR-0018 moved off the dashboard. Reached from the status strip, Storage + Recorder tiles, and a pointer in Settings — deliberately kept off the bottom nav.
- Fixes recent-events feed showing `NaNd ago` on hardware: the loop recorder writes flat `<cam>/YYYYMMDD_HHMMSS.mp4` but the parser assumed the legacy dated-subdir layout. Both layouts are now understood by `recent_across_cameras`, `latest_across_cameras`, and `resolve_clip_path`.
- Recordings page: removes the "Available dates: …" hint (native date picker already shows the range) and sorts clips latest-first.

## Test plan
- [x] `pytest` server unit suite green (incl. 3 new tests covering flat/dated parsing + flat-fallback clip resolve)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Deploy to recorder Pi, verify /diagnostics renders + Recent events shows real times + Recordings latest-on-top

🤖 Generated with [Claude Code](https://claude.com/claude-code)