### PR TITLE
fix(ota): resolve standby partition on device, stop hardcoding p3

### DIFF
--- a/scripts/build-swu.sh
+++ b/scripts/build-swu.sh
@@ -89,9 +89,13 @@ case "$TARGET" in
         ;;
 esac
 
-# Detect current slot on device to determine target partition
-# Default: write to slot B (partition 3) since devices ship on slot A
-TARGET_PART="/dev/mmcblk0p3"
+# Target partition is NOT baked into the bundle.
+# Invariant: the STANDBY slot is the one we are NOT currently booted from.
+# post-update.sh `preinst` reads live `boot_slot` and symlinks
+# `/dev/monitor_standby` → correct standby partition; sw-description
+# references that stable name. This keeps the bundle partition-agnostic
+# and works regardless of which slot the device is currently on
+# (previously hardcoded to p3, which no-op'd on devices already on B).
 
 # Auto-detect version from rootfs path if not specified
 if [ -z "$VERSION" ]; then
@@ -105,12 +109,11 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo ">>> Building SWU bundle for $TARGET (version: $VERSION)"
 echo "    Rootfs: $ROOTFS"
-echo "    Target partition: $TARGET_PART"
+echo "    Target partition: resolved on device via /dev/monitor_standby"
 echo "    Working dir: $WORK_DIR"
 
 # 1. Generate sw-description from template
 sed -e "s|@@VERSION@@|$VERSION|g" \
-    -e "s|@@TARGET_PART@@|$TARGET_PART|g" \
     "$SW_DESC_TEMPLATE" > "$WORK_DIR/sw-description"
 
 echo ">>> sw-description:"

--- a/swupdate/post-update.sh
+++ b/swupdate/post-update.sh
@@ -91,17 +91,38 @@ carry_network_state() {
     rmdir "$MNT" 2>/dev/null || true
 }
 
+# Derive the standby slot + its partition from the live boot_slot.
+# Invariant: the STANDBY slot is the one we are NOT currently booted from,
+# so it is always safe to overwrite. Never assume a fixed "devices ship on
+# A, always write to B" (earlier `build-swu.sh` hardcoded p3) — that
+# silently no-op's once a device has ever been flipped to slot B: the
+# bundle rewrites the running partition and U-Boot boots the OLD standby,
+# leaving the device on the pre-OTA rootfs. We compute it here instead.
+compute_standby() {
+    CURRENT_SLOT=$(fw_printenv -n boot_slot 2>/dev/null || echo "A")
+    if [ "$CURRENT_SLOT" = "A" ]; then
+        NEW_SLOT="B"
+    else
+        NEW_SLOT="A"
+    fi
+    NEW_PART="$(slot_partition "$NEW_SLOT")" || {
+        echo "compute_standby: unknown slot '$NEW_SLOT'" >&2
+        return 1
+    }
+    export CURRENT_SLOT NEW_SLOT NEW_PART
+}
+
 case "$1" in
     preinst)
-        echo "Pre-install: rootfs will be written to standby slot"
+        # Point the stable name sw-description references at the ACTUAL
+        # standby partition for this install. The raw handler then writes
+        # to `/dev/monitor_standby` and lands on the correct slot.
+        compute_standby || exit 1
+        ln -sfn "$NEW_PART" /dev/monitor_standby
+        echo "Pre-install: standby slot $NEW_SLOT ($NEW_PART) → /dev/monitor_standby"
         ;;
     postinst)
-        CURRENT_SLOT=$(fw_printenv -n boot_slot 2>/dev/null || echo "A")
-        if [ "$CURRENT_SLOT" = "A" ]; then
-            NEW_SLOT="B"
-        else
-            NEW_SLOT="A"
-        fi
+        compute_standby || exit 1
         echo "Switching boot slot: $CURRENT_SLOT -> $NEW_SLOT"
 
         # Seed the newly-written rootfs with current network state
@@ -111,9 +132,11 @@ case "$1" in
         fw_setenv boot_slot "$NEW_SLOT"
         fw_setenv boot_count 0
         fw_setenv upgrade_available 1
+        rm -f /dev/monitor_standby 2>/dev/null || true
         echo "Boot environment updated. Reboot to activate."
         ;;
     postfailure)
+        rm -f /dev/monitor_standby 2>/dev/null || true
         echo "Install failed — keeping current boot slot"
         ;;
 esac

--- a/swupdate/sw-description.camera
+++ b/swupdate/sw-description.camera
@@ -7,7 +7,7 @@ software =
             {
                 filename = "rootfs.ext4.gz";
                 type = "raw";
-                device = "@@TARGET_PART@@";
+                device = "/dev/monitor_standby";
                 compressed = "zlib";
             }
         );

--- a/swupdate/sw-description.server
+++ b/swupdate/sw-description.server
@@ -7,7 +7,7 @@ software =
             {
                 filename = "rootfs.ext4.gz";
                 type = "raw";
-                device = "@@TARGET_PART@@";
+                device = "/dev/monitor_standby";
                 compressed = "zlib";
             }
         );


### PR DESCRIPTION
## Summary
- `build-swu.sh` hardcoded \`TARGET_PART=/dev/mmcblk0p3\` into every bundle, assuming "always flip A→B."
- Once a device has ever been flipped to slot B, the next bundle rewrites the RUNNING partition and post-update.sh flips boot_slot back to A — the pre-OTA rootfs. Mechanical success, actual no-op.
- **Caught on the camera today**: post-OTA fstab still showed the old wic-time format; the "new" rootfs was getting overwritten on every pass.

## Fix
- `post-update.sh preinst` computes the standby partition from live \`boot_slot\` and symlinks \`/dev/monitor_standby\` at it.
- Both sw-description templates reference \`device = "/dev/monitor_standby"\` — SWUpdate's raw handler follows the symlink.
- \`build-swu.sh\` drops the \`@@TARGET_PART@@\` substitution entirely.
- Bundles are now partition-agnostic and work on either starting slot (true A/B, per ADR-0008).

## Test plan
- [ ] Rebuild camera .swu with this fix on VM
- [ ] Flash camera — verify post-OTA fstab shows \`0 2\` for /data (image-layer injection, not wic-time)
- [ ] Rebuild + flash server — same check
- [ ] Verify a second OTA on each device also lands correctly (covers both slot starting states)