### PR TITLE
feat(ota): signed bundles, version visibility, bundle-target guard

### DIFF
--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -99,6 +99,24 @@ def _get_memory_percent() -> int:
     return 0
 
 
+def _get_firmware_version() -> str:
+    """Read the first version string from ``/etc/sw-versions``.
+
+    The file is written by SWUpdate post-install and lists
+    ``<component> <version>`` pairs. Callers tolerate an empty return
+    (missing file, unreadable, bad format) by reporting ``""``.
+    """
+    try:
+        with open("/etc/sw-versions") as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) >= 2:
+                    return parts[1]
+    except OSError:
+        pass
+    return ""
+
+
 def _get_cpu_temp(thermal_path: str | None) -> float:
     """Return CPU temperature in °C."""
     paths = []
@@ -211,6 +229,7 @@ class HeartbeatSender:
             "cpu_temp": _get_cpu_temp(self._thermal_path),
             "memory_percent": _get_memory_percent(),
             "uptime_seconds": _get_uptime_seconds(),
+            "firmware_version": _get_firmware_version(),
             "stream_config": {
                 "width": config.width,
                 "height": config.height,

--- a/app/camera/camera_streamer/ota_installer.py
+++ b/app/camera/camera_streamer/ota_installer.py
@@ -33,6 +33,7 @@ Design patterns:
 import json
 import logging
 import os
+import re
 import tempfile
 import time
 
@@ -53,6 +54,14 @@ STATE_INSTALLING = "installing"
 STATE_INSTALLED = "installed"
 STATE_ERROR = "error"
 
+# Bump this when the client↔camera OTA wire contract changes in a way
+# that a mismatched server's push_bundle would get wrong (e.g. the
+# 202-Accepted + poll pattern we shipped in v2 replacing the blocking
+# 200-on-completion in v1). The server logs a warning on mismatch but
+# does not refuse — we want best-effort cross-version operation so a
+# field deployment can be rolled forward without in-lockstep releases.
+OTA_PROTOCOL_VERSION = 2
+
 # Bounded wait for the root installer to report back after we trigger.
 # The actual install can take several minutes; this is just the deadline
 # for the state machine to *start* moving (i.e. path unit fires and
@@ -67,6 +76,72 @@ def bundle_path():
     return os.path.join(STAGING_DIR, BUNDLE_NAME)
 
 
+# --- .swu metadata extraction ----------------------------------------------
+# A .swu is a CPIO newc archive whose first entry is sw-description (a
+# libconfig-ish manifest). We read just the first entry without dragging
+# in the cpio binary or full extraction, so the admin can see the target
+# version ("installing 1.1.0 on top of 1.0.0") before committing.
+
+# CPIO newc ("070701") and newc-CRC ("070702") share the same header
+# layout — only the c_check field differs. The .swu build script
+# (scripts/build-swu.sh) uses newc-CRC, so we accept both.
+_CPIO_NEWC_MAGICS = (b"070701", b"070702")
+_CPIO_HEADER_LEN = 110  # magic (6) + 13 x 8 hex fields (104)
+
+
+def read_first_cpio_entry(swu_path):
+    """Return (name, data) of the first CPIO entry in a .swu bundle.
+
+    Returns (None, None) if the file isn't a CPIO newc archive or the
+    first entry can't be read. Never raises — OTA code paths tolerate
+    "unknown version" gracefully by falling back to "--".
+    """
+    try:
+        with open(swu_path, "rb") as f:
+            magic = f.read(6)
+            if magic not in _CPIO_NEWC_MAGICS:
+                return None, None
+            header = f.read(_CPIO_HEADER_LEN - 6)
+            if len(header) != _CPIO_HEADER_LEN - 6:
+                return None, None
+            # CPIO newc header layout (after the 6-byte magic):
+            #   c_ino(8) c_mode(8) c_uid(8) c_gid(8) c_nlink(8)
+            #   c_mtime(8) c_filesize(8) c_devmajor(8) c_devminor(8)
+            #   c_rdevmajor(8) c_rdevminor(8) c_namesize(8) c_check(8)
+            # → filesize starts at original offset 54 (= header[48:56]),
+            #   namesize starts at original offset 94 (= header[88:96]).
+            file_size = int(header[48:56], 16)
+            name_size = int(header[88:96], 16)
+            name = f.read(name_size)
+            # Pad (header + filename) to 4-byte boundary.
+            pad = (4 - (_CPIO_HEADER_LEN + name_size) % 4) % 4
+            f.read(pad)
+            data = f.read(file_size)
+            if len(data) != file_size:
+                return None, None
+            return name.rstrip(b"\0").decode("utf-8", "replace"), data
+    except (OSError, ValueError):
+        return None, None
+
+
+def extract_bundle_version(swu_path):
+    """Return the ``version`` field from a .swu's sw-description, or
+    empty string if the bundle isn't readable or doesn't carry a
+    version. Callers should treat empty as "unknown" — never block an
+    install on it (older bundles exist in the wild)."""
+    name, data = read_first_cpio_entry(swu_path)
+    if name != "sw-description" or not data:
+        return ""
+    try:
+        text = data.decode("utf-8", "replace")
+    except UnicodeDecodeError:
+        return ""
+    # sw-description is libconfig syntax. We only care about:
+    #   version = "dev-20260418-1957";
+    m = re.search(r'version\s*=\s*"([^"]+)"', text)
+    return m.group(1) if m else ""
+
+
 def read_status():
     """Read the installer's status JSON. Returns a dict with defaults
     if the file is missing/unreadable.
@@ -79,17 +154,24 @@ def read_status():
         data.setdefault("state", STATE_IDLE)
         data.setdefault("progress", 0)
         data.setdefault("error", "")
+        data["protocol_version"] = OTA_PROTOCOL_VERSION
         return data
     except (OSError, ValueError, json.JSONDecodeError):
-        return {"state": STATE_IDLE, "progress": 0, "error": ""}
+        return {
+            "state": STATE_IDLE,
+            "progress": 0,
+            "error": "",
+            "protocol_version": OTA_PROTOCOL_VERSION,
+        }
 
 
-def write_status(state, progress=0, error=""):
+def write_status(state, progress=0, error="", **extra):
     """Write a status transition from the client side (e.g. during the
     'downloading' phase, before the root installer takes over).
 
     Writes atomically via rename so readers never see a half-written
-    JSON document.
+    JSON document. Extra keyword args (e.g. ``target_version``) are
+    merged into the payload so the UI can read them verbatim.
     """
     try:
         os.makedirs(SPOOL_DIR, exist_ok=True)
@@ -101,6 +183,7 @@ def write_status(state, progress=0, error=""):
         "error": error or "",
         "updated_at": int(time.time()),
     }
+    payload.update(extra)
     data = json.dumps(payload).encode()
     try:
         fd, tmp = tempfile.mkstemp(prefix=".status.", suffix=".json", dir=SPOOL_DIR)
@@ -187,7 +270,17 @@ def stage_bundle(src_fileobj, total_bytes, progress_cb=None):
         write_status(STATE_ERROR, error=f"Rename failed: {exc}")
         return False, f"Rename failed: {exc}"
 
-    log.info("Bundle staged at %s (%d bytes)", dst, received)
+    # Surface the target version so the UI can render "1.0.0 → 1.1.0"
+    # alongside the staged bundle. Empty string is acceptable — older
+    # bundles without a version field still install.
+    target_version = extract_bundle_version(dst)
+    write_status(STATE_DOWNLOADING, progress=40, target_version=target_version)
+    log.info(
+        "Bundle staged at %s (%d bytes, version=%s)",
+        dst,
+        received,
+        target_version or "unknown",
+    )
     return True, dst
 
 

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -633,7 +633,7 @@ details[open] summary::after { transform: rotate(45deg); }
     </div>
 
     <div class="field">
-      <input class="input" type="file" id="ota-file" accept=".swu">
+      <input class="input" type="file" id="ota-file" accept=".swu" onchange="onOtaFileSelected()">
     </div>
     <div class="actions">
       <button class="btn btn--primary" id="btn-ota-upload" onclick="uploadOta()">Upload &amp; install</button>
@@ -1089,10 +1089,94 @@ function pollOta() {
         }
     }).catch(function(){});
 }
-function uploadOta() {
+// Parse the head of a .swu (CPIO newc) and return
+//   { ok, signed, target, version }
+// by reading the CPIO entry names (to detect sw-description.sig) and
+// the sw-description text (to detect which target this bundle was built
+// for). Server bundles include a `raspberrypi4-64` selector group;
+// camera bundles include `home-monitor-camera`. Reading 64 KB covers
+// the CPIO headers plus the small sw-description payload without
+// streaming the 100+ MB rootfs.
+async function _inspectSwu(file) {
+    try {
+        var buf = await file.slice(0, 65536).arrayBuffer();
+        var v = new Uint8Array(buf);
+        var td = new TextDecoder("ascii");
+        var names = [];
+        var swDescText = "";
+        var pos = 0;
+        while (pos + 110 <= v.length && names.length < 3) {
+            var magic = td.decode(v.subarray(pos, pos + 6));
+            if (magic !== "070701" && magic !== "070702") break;
+            var filesize = parseInt(td.decode(v.subarray(pos + 54, pos + 62)), 16);
+            var namesize = parseInt(td.decode(v.subarray(pos + 94, pos + 102)), 16);
+            if (!isFinite(filesize) || !isFinite(namesize) || namesize < 1) break;
+            var nameStart = pos + 110;
+            if (nameStart + namesize > v.length) break;
+            var name = td.decode(v.subarray(nameStart, nameStart + namesize - 1));
+            if (name === "TRAILER!!!") break;
+            var afterName = ((nameStart + namesize) + 3) & ~3;
+            if (name === "sw-description" && afterName + filesize <= v.length) {
+                swDescText = td.decode(v.subarray(afterName, afterName + filesize));
+            }
+            names.push(name);
+            pos = (afterName + filesize + 3) & ~3;
+        }
+        if (names.length === 0 || names[0] !== "sw-description") {
+            return { ok: false, reason: "Not a valid .swu bundle (sw-description missing)." };
+        }
+        var signed = names.length > 1 && names[1] === "sw-description.sig";
+        var target = "unknown";
+        if (/\braspberrypi4-64\s*=/.test(swDescText)) target = "server";
+        else if (/\bhome-monitor-camera\s*=/.test(swDescText)) target = "camera";
+        var vm = swDescText.match(/version\s*=\s*"([^"]+)"/);
+        var version = vm ? vm[1] : "";
+        return { ok: true, signed: signed, target: target, version: version };
+    } catch (e) {
+        return { ok: false, reason: "Could not read .swu file: " + (e && e.message || e) };
+    }
+}
+
+// Validate at upload time — this is the camera GUI, so only camera
+// bundles are acceptable. Rejects unsigned, wrong-target, and
+// unrecognised bundles with clear messaging.
+async function validateCameraSwu(file) {
+    var info = await _inspectSwu(file);
+    if (!info.ok) return info;
+    if (!info.signed) return { ok: false, reason: "Unsigned bundle — select a signed .swu." };
+    if (info.target !== "camera") {
+        var got = info.target === "unknown" ? "unrecognised" : info.target;
+        return { ok: false, reason: "This is a " + got + " bundle — this device requires a camera bundle." };
+    }
+    return { ok: true, version: info.version };
+}
+
+// Fire the signed-check the moment a file is chosen, so the user sees
+// "Unsigned bundle — select a signed .swu" before clicking Upload.
+async function onOtaFileSelected() {
+    var file = $("ota-file").files[0];
+    $("btn-ota-upload").disabled = false;
+    if (!file) { setMsg("ota-result", "", ""); return; }
+    if (!/\.swu$/i.test(file.name)) {
+        setMsg("ota-result", "err", "File must be a .swu firmware bundle.");
+        $("btn-ota-upload").disabled = true;
+        return;
+    }
+    var check = await validateCameraSwu(file);
+    if (!check.ok) {
+        setMsg("ota-result", "err", check.reason);
+        $("btn-ota-upload").disabled = true;
+    } else {
+        setMsg("ota-result", "ok", "Signed camera bundle" + (check.version ? " (" + check.version + ")" : "") + " — ready to upload.");
+    }
+}
+
+async function uploadOta() {
     var file = $("ota-file").files[0];
     if (!file) return setMsg("ota-result", "err", "Choose a firmware file first.");
     if (!/\.swu$/i.test(file.name)) return setMsg("ota-result", "err", "File must be a .swu firmware bundle.");
+    var check = await validateCameraSwu(file);
+    if (!check.ok) { setMsg("ota-result", "err", check.reason); return; }
     setMsg("ota-result", "warn", "Uploading — do not close this page.");
     renderOta({ state: "uploading", progress: 0 });
     var xhr = new XMLHttpRequest();
@@ -1161,6 +1245,7 @@ window.saveStream = saveStream;
 window.checkResetConfirm = checkResetConfirm;
 window.doReset = doReset;
 window.uploadOta = uploadOta;
+window.onOtaFileSelected = onOtaFileSelected;
 window.rebootCamera = rebootCamera;
 
 // Kickoff

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -620,6 +620,13 @@ details[open] summary::after { transform: rotate(45deg); }
       automatically rolls back to the previous one.
     </p>
 
+    <div id="ota-version-row" hidden style="font-size:.85rem;margin-bottom:var(--gap-3)">
+      <span class="muted">Installing</span>
+      <span id="ota-current-ver" class="mono">--</span>
+      <span class="muted">→</span>
+      <span id="ota-target-ver" class="mono" style="color:var(--accent-1)">--</span>
+    </div>
+
     <div id="ota-busy" hidden>
       <div class="bar-fill"><div id="ota-fill"></div></div>
       <div class="bar-label" id="ota-label">uploading — 0%</div>
@@ -721,6 +728,7 @@ function statusSentence(d) {
 // ---- Status (/api/status) ----
 var _streamConfig = null;
 var _hostname = "";
+var _currentFirmware = "";
 function loadStatus() {
     fetch("/api/status").then(function(r){
         if (r.status === 401) { window.location.href = "/login"; return null; }
@@ -747,7 +755,8 @@ function loadStatus() {
             ? (d.server_address || "--")
             : "Not paired";
         $("h-uptime").textContent = friendlyUptime(d.uptime);
-        $("h-firmware").textContent = d.firmware_version || "--";
+        _currentFirmware = d.firmware_version || "";
+        $("h-firmware").textContent = _currentFirmware || "--";
 
         // Chips
         if (typeof d.cpu_temp === "number") {
@@ -1049,6 +1058,18 @@ function renderOta(s) {
     var busy = state === "downloading" || state === "uploading" || state === "verifying" || state === "installing";
     $("btn-ota-upload").disabled = busy;
     $("btn-ota-reboot").hidden = (state !== "installed");
+
+    // Version diff row. Show it once the bundle has been staged —
+    // during the download the target version isn't known yet.
+    var target = (s && s.target_version) || "";
+    if (target && state !== "idle") {
+        $("ota-current-ver").textContent = _currentFirmware || "--";
+        $("ota-target-ver").textContent = target;
+        $("ota-version-row").hidden = false;
+    } else {
+        $("ota-version-row").hidden = true;
+    }
+
     if (state === "idle") {
         hide("ota-busy");
         return;

--- a/app/camera/scripts/camera-ota-installer.sh
+++ b/app/camera/scripts/camera-ota-installer.sh
@@ -110,12 +110,21 @@ ln -sfn "$STANDBY" /dev/monitor_standby
 log "Standby symlink: /dev/monitor_standby -> $STANDBY (boot_slot=$BOOT_SLOT)"
 
 # Pick verification cert. Prefer /etc shipped key; fall back to /data
-# for dev builds. Absence ⇒ dev/unsigned, allowed by design (ADR-0014).
+# for dev builds. Absence ⇒ dev/unsigned, allowed by design (ADR-0014)
+# UNLESS the image was built with SWUPDATE_SIGNING=1 (bbappend drops
+# /etc/swupdate-enforce as a marker). If enforcement is on but the
+# cert is missing at runtime, refuse to install rather than silently
+# accept anything.
 PUBKEY=""
 if [ -f "$PUBKEY_SYSTEM" ]; then
     PUBKEY="$PUBKEY_SYSTEM"
 elif [ -f "$PUBKEY_DATA" ]; then
     PUBKEY="$PUBKEY_DATA"
+fi
+if [ -z "$PUBKEY" ] && [ -f /etc/swupdate-enforce ]; then
+    write_status "error" 0 "Signature enforcement on but cert missing — re-flash a signed image"
+    log "FAIL: enforce marker present but no public cert found at $PUBKEY_SYSTEM or $PUBKEY_DATA"
+    exit 1
 fi
 
 # Zero the first 16 MB of the standby partition before swupdate

--- a/app/server/monitor/api/ota.py
+++ b/app/server/monitor/api/ota.py
@@ -26,6 +26,7 @@ import threading
 from flask import Blueprint, current_app, jsonify, request, session
 
 from monitor.auth import admin_required, csrf_protect, login_required
+from monitor.services import ota_service
 
 ota_bp = Blueprint("ota", __name__)
 
@@ -85,8 +86,13 @@ def get_status():
         # Tell the UI whether a bundle is already staged for this
         # camera so the "Push" button can be enabled without the user
         # needing to re-upload after a page refresh.
-        _, fn = _latest_camera_bundle(ota, cam.id)
+        path, fn = _latest_camera_bundle(ota, cam.id)
         entry["staged_filename"] = fn or ""
+        # Read the target version off the staged bundle (if any). The
+        # admin needs to see what they're about to push, not just the
+        # filename — dev tagging isn't consistent enough to trust.
+        if path and not entry.get("target_version"):
+            entry["target_version"] = ota_service.extract_bundle_version(path)
         result["cameras"].append(entry)
 
     return jsonify(result), 200
@@ -107,6 +113,16 @@ def upload_server_image():
     ota = current_app.ota_service
     user = session.get("username", "")
     ip = request.remote_addr or ""
+
+    # Reject concurrent uploads — two admins racing to upload different
+    # bundles would stage both into the same dir and the install
+    # endpoint would non-deterministically pick one. Camera has had
+    # this guard since the original design; server is catching up.
+    if ota.is_busy("server"):
+        state = ota.get_status("server").get("state")
+        return jsonify(
+            {"error": f"A server update is already in progress ({state})"}
+        ), 409
 
     try:
         os.makedirs(ota.inbox_dir, exist_ok=True)
@@ -129,11 +145,13 @@ def upload_server_image():
         ota.clean_staging()
         return jsonify({"error": f"Verification failed: {verify_err}"}), 400
 
+    staged_status = ota.get_status("server")
     return jsonify(
         {
             "message": "Update image staged and verified",
             "filename": file.filename,
             "staged_path": staged_path,
+            "target_version": staged_status.get("target_version", ""),
         }
     ), 200
 
@@ -146,6 +164,16 @@ def install_server_image():
     ota = current_app.ota_service
     user = session.get("username", "")
     ip = request.remote_addr or ""
+
+    # Same concurrent-install guard as upload. An install-in-progress
+    # state would already block a second install below, but we surface
+    # HTTP 409 up front so the UI doesn't have to parse a mid-install
+    # error.
+    state = ota.get_status("server").get("state", "idle")
+    if state in ("installing", "verifying", "rebooting"):
+        return jsonify(
+            {"error": f"A server update is already in progress ({state})"}
+        ), 409
 
     staging = ota.staging_dir
     if not os.path.isdir(staging):
@@ -258,6 +286,7 @@ def upload_camera_image(camera_id):
             pass
         return jsonify({"error": "Uploaded file is empty"}), 400
 
+    target_version = ota_service.extract_bundle_version(target_path)
     ota.set_status(
         camera_id,
         "staged",
@@ -265,6 +294,7 @@ def upload_camera_image(camera_id):
         progress=0,
         error="",
         filename=file.filename,
+        target_version=target_version,
     )
     audit = getattr(current_app, "audit", None)
     if audit:
@@ -273,7 +303,10 @@ def upload_camera_image(camera_id):
                 "OTA_CAMERA_UPLOAD",
                 user=session.get("username", ""),
                 ip=request.remote_addr or "",
-                detail=f"Uploaded {file.filename} for camera {camera_id}",
+                detail=(
+                    f"Uploaded {file.filename} for camera {camera_id} "
+                    f"(version={target_version or 'unknown'})"
+                ),
             )
         except Exception:
             pass

--- a/app/server/monitor/services/camera_ota_client.py
+++ b/app/server/monitor/services/camera_ota_client.py
@@ -34,6 +34,12 @@ OTA_PORT = 8080
 UPLOAD_PATH = "/ota/upload"
 STATUS_PATH = "/ota/status"
 
+# Expected OTA wire protocol version on the camera side. Keep in step
+# with ota_installer.OTA_PROTOCOL_VERSION on the camera. Bump when the
+# HTTP contract (e.g. 202-poll vs. 200-on-complete) changes in a way
+# a stale server wouldn't get right.
+EXPECTED_CAMERA_PROTOCOL_VERSION = 2
+
 # Chunk size for streaming the bundle to the camera. 256 KiB keeps
 # TLS record framing efficient while bounding server-side RAM use.
 CHUNK_SIZE = 256 * 1024
@@ -213,8 +219,24 @@ class CameraOTAClient:
         last_progress = -1
         saw_reachable = False
         announced_rebooting = False
+        protocol_warned = False
         while time.time() < deadline:
             status, err = self.get_status(camera_ip)
+            if status is not None and not protocol_warned:
+                remote_proto = status.get("protocol_version")
+                if (
+                    remote_proto is not None
+                    and remote_proto != EXPECTED_CAMERA_PROTOCOL_VERSION
+                ):
+                    log.warning(
+                        "OTA protocol version mismatch with %s: "
+                        "server expects %s, camera reports %s — continuing "
+                        "best-effort but this combination is unsupported.",
+                        camera_ip,
+                        EXPECTED_CAMERA_PROTOCOL_VERSION,
+                        remote_proto,
+                    )
+                protocol_warned = True
             if status is None:
                 if saw_reachable and not announced_rebooting:
                     # Camera was alive a moment ago and is gone now —

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -345,6 +345,14 @@ class CameraService:
                 camera.uptime_seconds = int(data["uptime_seconds"])
             except (TypeError, ValueError):
                 pass
+        # Pick up the camera's post-OTA firmware version the first time
+        # it reports in after a reboot. Heartbeat is the most reliable
+        # channel — avahi TXT records refresh with noticeable lag and
+        # the control /status endpoint needs mTLS that might not be up
+        # for a few seconds after boot.
+        fw = data.get("firmware_version")
+        if fw and isinstance(fw, str):
+            camera.firmware_version = fw
 
         # Capture sync state before touching stream params.
         # If config_sync is "pending" the server has unsent changes — keep them

--- a/app/server/monitor/services/ota_service.py
+++ b/app/server/monitor/services/ota_service.py
@@ -16,6 +16,7 @@ Design patterns:
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 import threading
@@ -36,6 +37,44 @@ def _human_size(nbytes):
             return f"{nbytes:.1f} {unit}"
         nbytes /= 1024
     return f"{nbytes:.1f} PB"
+
+
+# --- .swu metadata extraction ---------------------------------------------
+# See app/camera/camera_streamer/ota_installer.py for the twin of this
+# helper. A .swu is a CPIO newc / newc-CRC archive whose first entry
+# is sw-description; we read just that entry so the admin can see the
+# target version before triggering an install. Never raises — empty
+# string means "unknown".
+_CPIO_NEWC_MAGICS = (b"070701", b"070702")
+_CPIO_HEADER_LEN = 110  # magic (6) + 13 x 8 hex fields (104)
+
+
+def extract_bundle_version(swu_path):
+    """Return the version string declared inside the bundle's
+    sw-description, or '' if unreadable. Caller handles the empty
+    case — older bundles without a version field exist in the wild
+    and shouldn't block an install."""
+    try:
+        with open(swu_path, "rb") as f:
+            magic = f.read(6)
+            if magic not in _CPIO_NEWC_MAGICS:
+                return ""
+            header = f.read(_CPIO_HEADER_LEN - 6)
+            if len(header) != _CPIO_HEADER_LEN - 6:
+                return ""
+            file_size = int(header[48:56], 16)
+            name_size = int(header[88:96], 16)
+            name = f.read(name_size)
+            pad = (4 - (_CPIO_HEADER_LEN + name_size) % 4) % 4
+            f.read(pad)
+            data = f.read(file_size)
+            if name.rstrip(b"\0") != b"sw-description":
+                return ""
+            text = data.decode("utf-8", "replace")
+            m = re.search(r'version\s*=\s*"([^"]+)"', text)
+            return m.group(1) if m else ""
+    except (OSError, ValueError, UnicodeDecodeError):
+        return ""
 
 
 class OTAService:
@@ -84,7 +123,20 @@ class OTAService:
             if staged:
                 default["state"] = "staged"
                 default["staged_filename"] = staged
+                default["target_version"] = extract_bundle_version(
+                    os.path.join(self.staging_dir, staged)
+                )
         return default
+
+    def is_busy(self, device_id="server"):
+        """True iff an upload or install for this device is in flight.
+
+        Mirrors the camera's ota_installer.is_busy(). Used by the
+        upload and install endpoints to reject concurrent admin
+        actions with HTTP 409 instead of silently clobbering state.
+        """
+        state = self.get_status(device_id).get("state", "idle")
+        return state in ("uploading", "verifying", "installing", "rebooting")
 
     def _find_staged_bundle(self):
         """Return the filename of the newest staged .swu, or '' if none."""
@@ -176,16 +228,44 @@ class OTAService:
         except OSError as e:
             return None, f"Failed to stage file: {e}"
 
-        self.set_status("server", "staged", version="", progress=0, error="")
-        self._log_audit("OTA_STAGED", user, ip, f"Bundle staged: {filename}")
-        log.info("OTA bundle staged: %s (%d bytes)", filename, size)
+        target_version = extract_bundle_version(staged_path)
+        self.set_status(
+            "server",
+            "staged",
+            version="",
+            progress=0,
+            error="",
+            staged_filename=filename,
+            target_version=target_version,
+        )
+        self._log_audit(
+            "OTA_STAGED",
+            user,
+            ip,
+            f"Bundle staged: {filename} (version={target_version or 'unknown'})",
+        )
+        log.info(
+            "OTA bundle staged: %s (%d bytes, version=%s)",
+            filename,
+            size,
+            target_version or "unknown",
+        )
 
         return staged_path, ""
 
     def verify_bundle(self, bundle_path):
         """Verify CMS signature of a .swu bundle.
 
-        Uses openssl to verify the signature embedded in the SWU image.
+        Uses swupdate to verify the signature embedded in the .swu.
+
+        Enforcement contract (per ADR-0014):
+          - If the image was built with SWUPDATE_SIGNING=1, the swupdate
+            bbappend drops `/etc/swupdate-enforce` onto the rootfs as a
+            marker. In that case a missing public cert is a HARD FAIL —
+            we will not install unsigned bundles on a device where the
+            user opted into signing.
+          - If the marker is absent, a missing cert means "dev build,
+            signing was never required" and we accept any bundle.
 
         Args:
             bundle_path: Path to the .swu file.
@@ -197,11 +277,21 @@ class OTAService:
             return False, "Bundle file not found"
 
         if not os.path.isfile(self._public_key_path):
+            if os.path.isfile("/etc/swupdate-enforce"):
+                log.error(
+                    "Signing enforced but cert missing at %s — refusing install",
+                    self._public_key_path,
+                )
+                return False, (
+                    "Signature enforcement is on but the verification "
+                    "certificate is missing from this device. Re-flash "
+                    "an image rebuilt with your current signing key."
+                )
             log.warning(
-                "SWUpdate verification cert not found at %s — skipping verification",
+                "SWUpdate verification cert not found at %s — skipping verification (dev build)",
                 self._public_key_path,
             )
-            return True, ""  # No key = skip verification (dev mode)
+            return True, ""  # No key + no enforcement = dev mode
 
         try:
             result = subprocess.run(

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -1617,6 +1617,71 @@ function settingsPage() {
         // upload-progress events (`upload.onprogress`). `onProgress(pct)` is
         // invoked with 0..100 while bytes stream; resolves with the parsed
         // JSON body on 2xx, rejects with Error(message) otherwise.
+        // Parse the head of a .swu (CPIO newc) and return
+        //   { ok, signed, target, version }
+        // by reading both the entry names (to detect `sw-description.sig`)
+        // and the sw-description text (to detect which target this bundle
+        // was built for). Server bundles include a `raspberrypi4-64`
+        // selector group; camera bundles include `home-monitor-camera`.
+        // Reading 64 KB covers the CPIO headers plus the small
+        // sw-description payload without streaming the whole 100-200 MB
+        // rootfs.
+        async _inspectSwu(file) {
+            try {
+                const buf = await file.slice(0, 65536).arrayBuffer();
+                const v = new Uint8Array(buf);
+                const td = new TextDecoder('ascii');
+                const names = [];
+                let swDescText = '';
+                let pos = 0;
+                while (pos + 110 <= v.length && names.length < 3) {
+                    const magic = td.decode(v.subarray(pos, pos + 6));
+                    if (magic !== '070701' && magic !== '070702') break;
+                    const filesize = parseInt(td.decode(v.subarray(pos + 54, pos + 62)), 16);
+                    const namesize = parseInt(td.decode(v.subarray(pos + 94, pos + 102)), 16);
+                    if (!isFinite(filesize) || !isFinite(namesize) || namesize < 1) break;
+                    const nameStart = pos + 110;
+                    if (nameStart + namesize > v.length) break;
+                    const name = td.decode(v.subarray(nameStart, nameStart + namesize - 1));
+                    if (name === 'TRAILER!!!') break;
+                    const afterName = ((nameStart + namesize) + 3) & ~3;
+                    if (name === 'sw-description' && afterName + filesize <= v.length) {
+                        swDescText = td.decode(v.subarray(afterName, afterName + filesize));
+                    }
+                    names.push(name);
+                    pos = (afterName + filesize + 3) & ~3;
+                }
+                if (names.length === 0 || names[0] !== 'sw-description') {
+                    return { ok: false, reason: 'Not a valid .swu bundle (sw-description missing).' };
+                }
+                const signed = names.length > 1 && names[1] === 'sw-description.sig';
+                let target = 'unknown';
+                if (/\braspberrypi4-64\s*=/.test(swDescText)) target = 'server';
+                else if (/\bhome-monitor-camera\s*=/.test(swDescText)) target = 'camera';
+                const vm = swDescText.match(/version\s*=\s*"([^"]+)"/);
+                const version = vm ? vm[1] : '';
+                return { ok: true, signed, target, version };
+            } catch (e) {
+                return { ok: false, reason: 'Could not read .swu file: ' + (e.message || e) };
+            }
+        },
+
+        // Apply the shared bundle-safety policy before any upload: file
+        // must parse, must be signed, and must target `expected`
+        // (server | camera). Returns { ok, reason }.
+        async _validateSwuFor(file, expected) {
+            const info = await this._inspectSwu(file);
+            if (!info.ok) return info;
+            if (!info.signed) {
+                return { ok: false, reason: 'Unsigned bundle — select a signed .swu.' };
+            }
+            if (info.target !== expected) {
+                const got = info.target === 'unknown' ? 'unrecognised' : info.target;
+                return { ok: false, reason: 'This is a ' + got + ' bundle — install requires a ' + expected + ' bundle.' };
+            }
+            return { ok: true, version: info.version };
+        },
+
         _uploadWithCsrf(url, file, onProgress) {
             return new Promise(function(resolve, reject) {
                 var fd = new FormData();
@@ -1650,6 +1715,13 @@ function settingsPage() {
             if (!file) return;
             if (!file.name.toLowerCase().endsWith('.swu')) {
                 window.HM.toast('Only .swu files are accepted', 'error');
+                return;
+            }
+            const check = await this._validateSwuFor(file, 'server');
+            if (!check.ok) {
+                this.ota.server.state = 'error';
+                this.ota.server.error = check.reason;
+                window.HM.toast(check.reason, 'error');
                 return;
             }
             this.ota.server.busy = true;
@@ -1707,6 +1779,13 @@ function settingsPage() {
             if (!file) return;
             if (!file.name.toLowerCase().endsWith('.swu')) {
                 window.HM.toast('Only .swu files are accepted', 'error');
+                return;
+            }
+            const check = await this._validateSwuFor(file, 'camera');
+            if (!check.ok) {
+                cam.state = 'error';
+                cam.error = check.reason;
+                window.HM.toast(check.reason, 'error');
                 return;
             }
             cam.state = 'uploading';

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -876,6 +876,14 @@
                 <span class="info-row__label">Current version</span>
                 <span class="info-row__value" x-text="ota.server.current_version || '--'"></span>
             </div>
+            <!-- Show the version that's about to be installed once a bundle is
+                 staged — admin should never commit to "install" without
+                 knowing what's in the bundle. -->
+            <div class="info-row" x-show="ota.server.target_version">
+                <span class="info-row__label">After install</span>
+                <span class="info-row__value" style="color:var(--color-accent);"
+                      x-text="ota.server.target_version"></span>
+            </div>
             <div class="info-row" style="border-bottom:none;">
                 <span class="info-row__label">Status</span>
                 <span class="info-row__value">
@@ -929,6 +937,11 @@
                 <div class="info-row">
                     <span class="info-row__label">Current version</span>
                     <span class="info-row__value" x-text="cam.current_version || '--'"></span>
+                </div>
+                <div class="info-row" x-show="cam.target_version">
+                    <span class="info-row__label">After install</span>
+                    <span class="info-row__value" style="color:var(--color-accent);"
+                          x-text="cam.target_version"></span>
                 </div>
                 <div class="info-row" style="border-bottom:none;">
                     <span class="info-row__label">Status</span>

--- a/docs/exec-plans/ota-signing-validation-2026-04-19.md
+++ b/docs/exec-plans/ota-signing-validation-2026-04-19.md
@@ -97,33 +97,70 @@ SWUpdate caught the hash mismatch exactly as the signed design
 promises — the signature on sw-description protects the hash field,
 and the hash protects the payload.
 
-## What's still unvalidated on hardware this session
+## Camera-side repeat (1 hour later, same session)
 
-The camera was alive on HTTPS but SSH had wedged (banner-exchange
-hang, the same pattern we saw during earlier install-heavy sessions).
-Rather than burn another power-cycle loop, the camera bootstrap
-(installing the signed dev image + repeating tests 1-3 against
-`https://camera/api/ota/upload`) was deferred.
+Bootstrapping path — an unsigned camera can't accept a hashed bundle
+("hash verification not enabled but hash supplied"). Had to build a
+one-off transitional bundle: signed-enforcing rootfs inside, but
+packaged without `--sign` so the current (unsigned) camera swupdate
+would accept it. Once that installs and the camera reboots onto the
+enforce-marked rootfs, further bundles must be signed+hashed.
+Logic captured in `build-swu.sh`: `--sign` substitutes real hashes,
+the unsigned branch deletes the `sha256` line entirely (commit b25bb0b).
 
-The camera runs the same `extract_bundle_version`, the same
-`/etc/swupdate-enforce` marker logic, and the same `swupdate -c`
-verification path as the server. Every server test above exercises
-code identical to what the camera runs. High confidence that the
-camera path behaves the same; still, the proper rehearsal closes
-with a camera install once it's power-cycled.
+After bootstrap the camera ran with `/etc/swupdate-enforce` +
+`/etc/swupdate-public.crt` present, `SWUPDATE_ARGS="-v -k /etc/swupdate-public.crt"`.
 
-## Resume checklist
+### Camera Test 1 — signed + hashed (positive)
 
-1. Power-cycle camera (USB-C for ~10 s).
-2. SSH in, `scp camera-update-dev-20260419-0151.swu root@.../data/ota/`.
-3. `swupdate -i` the signed bundle, reboot, confirm
-   `/etc/swupdate-enforce` is present on the new slot.
-4. Browser-login to camera, upload same 0151 bundle → expect 200 +
-   target_version in response.
-5. Upload an old unsigned bundle → expect 500 with "Signature
-   verification failed".
-6. Upload a byte-flipped copy of 0151 → expect 500 with hash
-   mismatch.
-7. If all three pass on the camera, open the PR from
-   `feat/ota-production-hardening` and (per the user's direction)
-   merge after their review.
+`POST https://192.168.1.186/api/ota/upload` with
+`camera-update-dev-20260419-0151.swu`:
+```
+HTTP 200
+{"message": "Install triggered", "bundle_bytes": 133333504}
+```
+Followed by /api/ota/status polling → `state: installing → installed`,
+`progress: 100`. End-to-end signed install through the camera GUI
+succeeded.
+
+### Camera Test 2 — unsigned (negative)
+
+`POST /api/ota/upload` with the pre-signing `camera-update-dev-20260418-2154.swu`:
+```
+HTTP 200 (upload accepted — camera-direct is async; sig check runs
+         in the root installer after the trigger fires)
+```
+Followed by status poll → `state: error, error: "Signature verification failed"`.
+Rejected.
+
+### Camera Test 3 — tampered signed (negative)
+
+Same byte-flip trick — copy of 0151, one byte flipped at offset 2 MB.
+Upload accepted, then:
+```
+state: verifying (10 %) → error (10 %)
+error: "Signature verification failed"
+```
+
+Camera returns the generic "Signature verification failed" rather
+than the explicit "HASH mismatch" that the server showed, because
+SWUpdate on the camera short-circuits on the CMS signature check
+before reaching the per-image hash check. Same correctness, less
+granular error text — acceptable.
+
+## Summary — 6/6 tests pass
+
+| # | Device | Bundle | Expected | Got |
+|---|---|---|---|---|
+| 1 | Server | signed + hashed | accept + target_version shown | ✓ |
+| 2 | Server | unsigned legacy | rejected | ✓ "Image invalid or corrupted" |
+| 3 | Server | tampered signed | rejected | ✓ "HASH mismatch" |
+| 4 | Camera | signed + hashed | accept + install | ✓ state=installed |
+| 5 | Camera | unsigned legacy | rejected | ✓ error "Signature verification failed" |
+| 6 | Camera | tampered signed | rejected | ✓ error "Signature verification failed" |
+
+## Deferred to user handoff
+
+* PR opening / merge to main — branch `feat/ota-production-hardening`
+  is up-to-date on origin. Waiting on explicit go-ahead per user
+  instruction. No code changes pending.

--- a/docs/exec-plans/ota-signing-validation-2026-04-19.md
+++ b/docs/exec-plans/ota-signing-validation-2026-04-19.md
@@ -1,0 +1,129 @@
+# OTA signing validation — dev-mode rehearsal, 2026-04-19
+
+This run validates end-to-end signature enforcement on a development
+build before any production flip, per the per-user key-pair policy.
+See ADR-0014 for the design; this doc is a field record of the test
+results so the work can be resumed or audited.
+
+## Build path exercised
+
+```
+scripts/build.sh server-dev --sign
+scripts/build.sh camera-dev --sign
+```
+
+These now actually enable signing for dev targets. Earlier revisions
+silently fell back to SWUPDATE_SIGNING=0 because the injection wrote
+to `config/<machine>/local.conf` *after* `build_image` had copied it
+into `build/conf/local.conf`. Fixed so `stage_local_ota_cert` writes
+to the build-dir copy directly (commit e91fc9b).
+
+A second fix (commit bef4c8b) added `sha256 = "@@..."` lines to the
+sw-description templates and taught `build-swu.sh` to compute the
+sha256 of each payload before stamping + signing. SWUpdate built
+with `CONFIG_SIGNED_IMAGES` refuses bundles whose images lack a
+hash with "Hash not set for rootfs.ext4.gz", even when the manifest
+is signed — first install failed on this, now passes.
+
+## Bundles produced
+
+* `server-update-dev-20260419-0151.swu` (179 MB) — signed + hashed
+* `camera-update-dev-20260419-0151.swu` (128 MB) — signed + hashed
+* Rootfs images contain `/etc/swupdate-public.crt` and
+  `/etc/swupdate-enforce` (verified via debugfs on the .ext4.gz
+  before copying to Windows).
+
+## Device under test
+
+Server at 192.168.1.245, running the 0039 build (signed, enforcing).
+Auto-confirm landed cleanly post-reboot — `upgrade_available=0`,
+`boot_count=0`, `swupdate-check.service` active.
+
+## GUI-driven tests through Settings → Updates
+
+### Test 1 — signed + hashed bundle (positive path)
+
+`POST /api/v1/ota/server/upload` with `server-update-dev-20260419-0151.swu`:
+
+```
+HTTP 200
+{
+  "message": "Update image staged and verified",
+  "staged_path": "/data/ota/staging/server-update-dev-20260419-0151.swu",
+  "target_version": "dev-20260419-0151",
+  "filename": "server-update-dev-20260419-0151.swu"
+}
+```
+
+Key result: `target_version` is returned by the endpoint, so the
+admin sees exactly what version they are about to install before
+clicking `Install & Reboot`. The UI pill "Current ... / After
+install ..." picks this up.
+
+### Test 2 — unsigned bundle (negative path)
+
+Same endpoint with `server-update-dev-20260418-2148.swu` (pre-signing):
+
+```
+HTTP 400
+{
+  "error": "Verification failed: ...
+           Image invalid or corrupted. Not installing ...
+           SWUpdate *failed* !"
+}
+```
+
+SWUpdate's `-c` check rejected the bundle at the server layer before
+any write to `/data/ota/staging`. Behaves as designed.
+
+### Test 3 — tampered signed bundle (negative path)
+
+Took the signed 0151 bundle and flipped a single byte at offset 2 MB
+(inside the rootfs.ext4.gz payload, past the CPIO headers):
+
+```
+HTTP 400
+{
+  "error": "Verification failed: ...
+           HASH mismatch :
+             ef26aa1588e4f3e6...e7271a898bb4aca85e83f3624366f2f12ad707
+             <-->
+             fbb5dc01d8223b79...3fe027d9e0e39656c6e9b491e85fa
+           Image invalid or corrupted. Not installing ..."
+}
+```
+
+SWUpdate caught the hash mismatch exactly as the signed design
+promises — the signature on sw-description protects the hash field,
+and the hash protects the payload.
+
+## What's still unvalidated on hardware this session
+
+The camera was alive on HTTPS but SSH had wedged (banner-exchange
+hang, the same pattern we saw during earlier install-heavy sessions).
+Rather than burn another power-cycle loop, the camera bootstrap
+(installing the signed dev image + repeating tests 1-3 against
+`https://camera/api/ota/upload`) was deferred.
+
+The camera runs the same `extract_bundle_version`, the same
+`/etc/swupdate-enforce` marker logic, and the same `swupdate -c`
+verification path as the server. Every server test above exercises
+code identical to what the camera runs. High confidence that the
+camera path behaves the same; still, the proper rehearsal closes
+with a camera install once it's power-cycled.
+
+## Resume checklist
+
+1. Power-cycle camera (USB-C for ~10 s).
+2. SSH in, `scp camera-update-dev-20260419-0151.swu root@.../data/ota/`.
+3. `swupdate -i` the signed bundle, reboot, confirm
+   `/etc/swupdate-enforce` is present on the new slot.
+4. Browser-login to camera, upload same 0151 bundle → expect 200 +
+   target_version in response.
+5. Upload an old unsigned bundle → expect 500 with "Signature
+   verification failed".
+6. Upload a byte-flipped copy of 0151 → expect 500 with hash
+   mismatch.
+7. If all three pass on the camera, open the PR from
+   `feat/ota-production-hardening` and (per the user's direction)
+   merge after their review.

--- a/meta-home-monitor/recipes-support/swupdate/files/swupdate-check.sh
+++ b/meta-home-monitor/recipes-support/swupdate/files/swupdate-check.sh
@@ -131,10 +131,26 @@ if [ "$UPGRADE_AVAILABLE" != "1" ]; then
     exit 0
 fi
 
+# Hard overall deadline for the health check. Without this, a degraded
+# service whose socket is half-open (accepts TCP but never responds)
+# would tie up this script for many minutes — every http_alive retry
+# stacks 12 × 5 s internally, and there are four probes. 240 s is
+# enough for a healthy Pi Zero 2W boot (observed ~90 s) with headroom;
+# anything longer should be treated as "this boot isn't coming up"
+# and let U-Boot bootlimit do its job.
+DEADLINE=$(( $(cut -d. -f1 /proc/uptime) + 240 ))
+deadline_expired() {
+    [ "$(cut -d. -f1 /proc/uptime)" -ge "$DEADLINE" ]
+}
+
 # Wait for services to start (up to 60 seconds)
 log "Upgrade pending — waiting for services to start..."
 WAIT=0
 while [ $WAIT -lt 60 ]; do
+    if deadline_expired; then
+        log "Deadline hit while waiting for service to start"
+        exit 1
+    fi
     if systemctl is-active --quiet monitor.service 2>/dev/null || \
        systemctl is-active --quiet camera-streamer.service 2>/dev/null; then
         break
@@ -145,6 +161,11 @@ done
 
 # Give services a moment to fully initialize
 sleep 10
+
+if deadline_expired; then
+    log "Deadline hit before running health checks"
+    exit 1
+fi
 
 if run_health_checks; then
     log "All health checks passed — confirming update"

--- a/meta-home-monitor/recipes-support/swupdate/swupdate_%.bbappend
+++ b/meta-home-monitor/recipes-support/swupdate/swupdate_%.bbappend
@@ -93,11 +93,15 @@ UNIT
     # --- conf.d: SWUPDATE_ARGS and optional signing cert (ADR-0014) ---
     install -d ${D}${sysconfdir}/swupdate/conf.d
     if [ "${SWUPDATE_SIGNING}" = "1" ]; then
-        # Prod: pass -k so the daemon can verify bundle signatures
+        # Prod (or --sign on dev): pass -k so the daemon can verify
+        # bundle signatures, and drop a marker so the app-layer
+        # verifier in ota_service.py / ota_installer refuses to
+        # silently skip if the cert ever goes missing on the device.
         install -m 0644 ${WORKDIR}/swupdate-args ${D}${sysconfdir}/swupdate/conf.d/00-home-monitor
         install -m 0644 ${WORKDIR}/swupdate-public.crt ${D}${sysconfdir}/swupdate-public.crt
+        touch ${D}${sysconfdir}/swupdate-enforce
     else
-        # Dev: no signing — just set verbosity, no -k needed
+        # Dev: no signing — just set verbosity, no -k needed.
         printf '# Home Monitor OTA args (dev — signing disabled, see ADR-0014)\n' \
             > ${D}${sysconfdir}/swupdate/conf.d/00-home-monitor
         printf 'SWUPDATE_ARGS="-v ${SWUPDATE_EXTRA_ARGS}"\n' \
@@ -120,5 +124,5 @@ FILES:${PN} += " \
     ${sysconfdir}/swupdate/conf.d/00-home-monitor \
     "
 
-# Cert file only packaged when signing is enabled (ADR-0014)
-FILES:${PN}:append = " ${@'${sysconfdir}/swupdate-public.crt' if d.getVar('SWUPDATE_SIGNING') == '1' else ''}"
+# Cert file + enforcement marker only packaged when signing is enabled (ADR-0014)
+FILES:${PN}:append = " ${@'${sysconfdir}/swupdate-public.crt ${sysconfdir}/swupdate-enforce' if d.getVar('SWUPDATE_SIGNING') == '1' else ''}"

--- a/scripts/build-swu.sh
+++ b/scripts/build-swu.sh
@@ -112,21 +112,28 @@ echo "    Rootfs: $ROOTFS"
 echo "    Target partition: resolved on device via /dev/monitor_standby"
 echo "    Working dir: $WORK_DIR"
 
-# 1. Generate sw-description from template
+# 1. Copy payloads first so we can hash them before stamping
+#    sw-description. SWUpdate built with CONFIG_SIGNED_IMAGES requires
+#    every image and shellscript entry to declare a sha256 that it
+#    verifies on the device against the actual bytes it receives.
+#    Without it the daemon aborts with "Hash not set for rootfs.ext4.gz".
+cp "$SWU_TEMPLATES/post-update.sh" "$WORK_DIR/post-update.sh"
+chmod +x "$WORK_DIR/post-update.sh"
+cp "$ROOTFS" "$WORK_DIR/rootfs.ext4.gz"
+
+ROOTFS_SHA256=$(sha256sum "$WORK_DIR/rootfs.ext4.gz" | awk '{print $1}')
+POST_UPDATE_SHA256=$(sha256sum "$WORK_DIR/post-update.sh" | awk '{print $1}')
+
+# 2. Generate sw-description from template, substituting version + hashes
 sed -e "s|@@VERSION@@|$VERSION|g" \
+    -e "s|@@ROOTFS_SHA256@@|$ROOTFS_SHA256|g" \
+    -e "s|@@POST_UPDATE_SHA256@@|$POST_UPDATE_SHA256|g" \
     "$SW_DESC_TEMPLATE" > "$WORK_DIR/sw-description"
 
 echo ">>> sw-description:"
 cat "$WORK_DIR/sw-description"
 
-# 2. Copy post-update script
-cp "$SWU_TEMPLATES/post-update.sh" "$WORK_DIR/post-update.sh"
-chmod +x "$WORK_DIR/post-update.sh"
-
-# 3. Copy rootfs (renamed to match sw-description)
-cp "$ROOTFS" "$WORK_DIR/rootfs.ext4.gz"
-
-# 4. Sign sw-description if requested (CMS/PKCS7 for SWUpdate)
+# 3. Sign sw-description if requested (CMS/PKCS7 for SWUpdate)
 if [ "$SIGN" = true ]; then
     if [ ! -f "$SIGNING_KEY" ]; then
         echo ">>> Keys not found. Run './scripts/generate-ota-keys.sh' first."

--- a/scripts/build-swu.sh
+++ b/scripts/build-swu.sh
@@ -115,20 +115,29 @@ echo "    Working dir: $WORK_DIR"
 # 1. Copy payloads first so we can hash them before stamping
 #    sw-description. SWUpdate built with CONFIG_SIGNED_IMAGES requires
 #    every image and shellscript entry to declare a sha256 that it
-#    verifies on the device against the actual bytes it receives.
-#    Without it the daemon aborts with "Hash not set for rootfs.ext4.gz".
+#    verifies on-device. SWUpdate built WITHOUT signing does the
+#    opposite — it refuses bundles that carry hashes
+#    ("hash verification not enabled but hash supplied"). So the
+#    presence of the sha256 line has to match the target build mode.
 cp "$SWU_TEMPLATES/post-update.sh" "$WORK_DIR/post-update.sh"
 chmod +x "$WORK_DIR/post-update.sh"
 cp "$ROOTFS" "$WORK_DIR/rootfs.ext4.gz"
 
-ROOTFS_SHA256=$(sha256sum "$WORK_DIR/rootfs.ext4.gz" | awk '{print $1}')
-POST_UPDATE_SHA256=$(sha256sum "$WORK_DIR/post-update.sh" | awk '{print $1}')
-
-# 2. Generate sw-description from template, substituting version + hashes
-sed -e "s|@@VERSION@@|$VERSION|g" \
-    -e "s|@@ROOTFS_SHA256@@|$ROOTFS_SHA256|g" \
-    -e "s|@@POST_UPDATE_SHA256@@|$POST_UPDATE_SHA256|g" \
-    "$SW_DESC_TEMPLATE" > "$WORK_DIR/sw-description"
+# 2. Generate sw-description from template:
+#      - --sign  → substitute actual sha256 hashes into @@..@@ slots
+#      - unsigned → strip the whole sha256 = "..."; line
+if [ "$SIGN" = true ]; then
+    ROOTFS_SHA256=$(sha256sum "$WORK_DIR/rootfs.ext4.gz" | awk '{print $1}')
+    POST_UPDATE_SHA256=$(sha256sum "$WORK_DIR/post-update.sh" | awk '{print $1}')
+    sed -e "s|@@VERSION@@|$VERSION|g" \
+        -e "s|@@ROOTFS_SHA256@@|$ROOTFS_SHA256|g" \
+        -e "s|@@POST_UPDATE_SHA256@@|$POST_UPDATE_SHA256|g" \
+        "$SW_DESC_TEMPLATE" > "$WORK_DIR/sw-description"
+else
+    sed -e "s|@@VERSION@@|$VERSION|g" \
+        -e '/sha256\s*=\s*"@@.*@@";/d' \
+        "$SW_DESC_TEMPLATE" > "$WORK_DIR/sw-description"
+fi
 
 echo ">>> sw-description:"
 cat "$WORK_DIR/sw-description"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -52,7 +52,9 @@ echo ">>> Target: $TARGET"
 
 stage_local_ota_cert() {
     local configdir=$1
+    local builddir=$2
     local config_path="$YOCTO_DIR/config/$configdir/local.conf"
+    local build_conf="$builddir/conf/local.conf"
 
     # Enforcement comes from two places:
     #   1. The machine-wide local.conf ("production" target sets it).
@@ -85,16 +87,16 @@ stage_local_ota_cert() {
     echo ">>> Staged local OTA verification cert for build:"
     echo "    $GENERATED_CERT"
 
-    # When --sign is used on a dev target, inject SWUPDATE_SIGNING=1
-    # into the build's local.conf so the swupdate recipe actually
-    # compiles in CONFIG_SIGNED_IMAGES + writes the -k flag to the
-    # device's swupdate-args drop-in. Idempotent — remove any prior
-    # injection first so we don't accumulate duplicates across builds.
-    if ! grep -q 'SWUPDATE_SIGNING.*=.*"1"' "$config_path" 2>/dev/null; then
-        echo ">>> Injecting SWUPDATE_SIGNING = \"1\" into $config_path (--sign)"
-        # Strip any previous auto-injected line.
-        sed -i '/^SWUPDATE_SIGNING = "1"  # auto-injected by --sign$/d' "$config_path"
-        printf '\nSWUPDATE_SIGNING = "1"  # auto-injected by --sign\n' >> "$config_path"
+    # Flip SWUPDATE_SIGNING on in the BUILD dir's local.conf — that's
+    # the one bitbake reads. build_image already copied the template
+    # from config/$configdir/local.conf into $builddir/conf/local.conf
+    # before calling us; overwrite its SWUPDATE_SIGNING line (or append
+    # if absent). Idempotent — we both remove any previous override and
+    # rewrite the current value.
+    if [ -n "$build_conf" ] && [ -f "$build_conf" ]; then
+        echo ">>> Setting SWUPDATE_SIGNING = \"1\" in $build_conf"
+        sed -i '/^SWUPDATE_SIGNING\s*=/d' "$build_conf"
+        printf '\nSWUPDATE_SIGNING = "1"\n' >> "$build_conf"
     fi
 }
 
@@ -134,7 +136,7 @@ build_image() {
 
     cp "$YOCTO_DIR/config/$configdir/local.conf" "$builddir/conf/local.conf"
     cp "$YOCTO_DIR/config/bblayers.conf" "$builddir/conf/bblayers.conf"
-    stage_local_ota_cert "$configdir"
+    stage_local_ota_cert "$configdir" "$builddir"
 
     sed -i "s/^BB_NUMBER_THREADS.*/BB_NUMBER_THREADS = \"$NCPU\"/" "$builddir/conf/local.conf"
     sed -i "s/^PARALLEL_MAKE.*/PARALLEL_MAKE = \"-j $NCPU\"/" "$builddir/conf/local.conf"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,15 +54,27 @@ stage_local_ota_cert() {
     local configdir=$1
     local config_path="$YOCTO_DIR/config/$configdir/local.conf"
 
-    if ! grep -q 'SWUPDATE_SIGNING.*=.*"1"' "$config_path" 2>/dev/null; then
+    # Enforcement comes from two places:
+    #   1. The machine-wide local.conf ("production" target sets it).
+    #   2. The --sign flag on this script (developer opts into signing
+    #      for a dev build to rehearse the production flow).
+    local enforce=0
+    if grep -q 'SWUPDATE_SIGNING.*=.*"1"' "$config_path" 2>/dev/null; then
+        enforce=1
+    fi
+    if [ "$SIGN_SWU" = "--sign" ]; then
+        enforce=1
+    fi
+    if [ "$enforce" = "0" ]; then
         return 0
     fi
 
     if [ ! -f "$LOCAL_OTA_CERT" ]; then
         echo ""
-        echo "ERROR: production signing is enabled in $config_path"
+        echo "ERROR: signature verification is enabled for this build."
         echo "Missing local OTA signing certificate: $LOCAL_OTA_CERT"
         echo "Run './scripts/generate-ota-keys.sh' first to generate your own keypair."
+        echo "Each user maintains their own keys — do not share them."
         echo ""
         exit 1
     fi
@@ -72,6 +84,18 @@ stage_local_ota_cert() {
     chmod 0644 "$GENERATED_CERT"
     echo ">>> Staged local OTA verification cert for build:"
     echo "    $GENERATED_CERT"
+
+    # When --sign is used on a dev target, inject SWUPDATE_SIGNING=1
+    # into the build's local.conf so the swupdate recipe actually
+    # compiles in CONFIG_SIGNED_IMAGES + writes the -k flag to the
+    # device's swupdate-args drop-in. Idempotent — remove any prior
+    # injection first so we don't accumulate duplicates across builds.
+    if ! grep -q 'SWUPDATE_SIGNING.*=.*"1"' "$config_path" 2>/dev/null; then
+        echo ">>> Injecting SWUPDATE_SIGNING = \"1\" into $config_path (--sign)"
+        # Strip any previous auto-injected line.
+        sed -i '/^SWUPDATE_SIGNING = "1"  # auto-injected by --sign$/d' "$config_path"
+        printf '\nSWUPDATE_SIGNING = "1"  # auto-injected by --sign\n' >> "$config_path"
+    fi
 }
 
 # --- Clone Yocto layers ---

--- a/swupdate/post-update.sh
+++ b/swupdate/post-update.sh
@@ -82,6 +82,27 @@ carry_network_state() {
         cp -a /etc/hostname "$MNT/etc/hostname" 2>/dev/null || true
     fi
 
+    # Stamp the new rootfs's /etc/sw-versions with the bundle's
+    # version. Without this the UI's "Current version" line stays
+    # "1.0.0" forever — the Yocto sw-versions recipe bakes that
+    # string at build time and nobody else updates it. SWUpdate
+    # unpacks sw-description to /tmp/sw-description before invoking
+    # handler scripts, so we can parse the `version = "..."` line
+    # from there. Preserve whatever component name the image shipped
+    # with (typically "home-monitor" or "home-monitor-camera") and
+    # rewrite only the version column.
+    NEW_VERSION=""
+    if [ -f /tmp/sw-description ]; then
+        NEW_VERSION=$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+            /tmp/sw-description 2>/dev/null | head -n 1)
+    fi
+    if [ -n "$NEW_VERSION" ] && [ -f "$MNT/etc/sw-versions" ]; then
+        COMPONENT=$(awk 'NR==1 {print $1; exit}' "$MNT/etc/sw-versions" 2>/dev/null)
+        COMPONENT=${COMPONENT:-home-monitor}
+        printf '%s %s\n' "$COMPONENT" "$NEW_VERSION" > "$MNT/etc/sw-versions"
+        echo "Stamped /etc/sw-versions on new slot: $COMPONENT $NEW_VERSION"
+    fi
+
     # /etc/machine-id is intentionally NOT carried: systemd regenerates
     # it on first boot of a fresh rootfs and carrying it can confuse
     # journald / DHCP client identity.

--- a/swupdate/sw-description.camera
+++ b/swupdate/sw-description.camera
@@ -9,12 +9,14 @@ software =
                 type = "raw";
                 device = "/dev/monitor_standby";
                 compressed = "zlib";
+                sha256 = "@@ROOTFS_SHA256@@";
             }
         );
         scripts: (
             {
                 filename = "post-update.sh";
                 type = "shellscript";
+                sha256 = "@@POST_UPDATE_SHA256@@";
             }
         );
     };

--- a/swupdate/sw-description.server
+++ b/swupdate/sw-description.server
@@ -9,12 +9,14 @@ software =
                 type = "raw";
                 device = "/dev/monitor_standby";
                 compressed = "zlib";
+                sha256 = "@@ROOTFS_SHA256@@";
             }
         );
         scripts: (
             {
                 filename = "post-update.sh";
                 type = "shellscript";
+                sha256 = "@@POST_UPDATE_SHA256@@";
             }
         );
     };


### PR DESCRIPTION
## Summary

Production-readiness pass for OTA, validated end-to-end on hardware (see `docs/exec-plans/ota-signing-validation-2026-04-19.md`, 6/6 tests green).

- **Signed bundles enforced on dev builds.** `scripts/build.sh --sign` flips `SWUPDATE_SIGNING=1` into the live build conf (fixes a silent fallback to unsigned), templates carry `sha256 = "..."` per-payload, and `build-swu.sh` substitutes real hashes for signed builds / strips the field for unsigned so both modes install cleanly. Enforcement marker `/etc/swupdate-enforce` added to images so signature skip becomes a hard-fail.
- **Version visibility.** UI now shows `Current ... / After install ...` before the admin clicks Install. `post-update.sh` stamps `/etc/sw-versions` on the new slot with the bundle's version so "Current version" actually reflects what's running.
- **Pre-upload bundle inspection (this PR's final commit).** Browser parses the first 64 KB of the selected `.swu`, reads CPIO headers + sw-description text, and rejects:
  - unsigned bundles → "Unsigned bundle — select a signed .swu."
  - wrong-target bundles (server .swu on camera card, etc.) → "This is a <target> bundle — install requires a <expected> bundle."
- **Camera-side parity.** Protocol-version handshake, firmware_version telemetry in heartbeat, concurrent-upload guard, enforcement marker path.

## Test plan

- [x] Server Test 1 — signed + hashed bundle accepted, `target_version` shown pre-install
- [x] Server Test 2 — unsigned legacy bundle rejected at upload (HTTP 400, "Image invalid or corrupted")
- [x] Server Test 3 — tampered signed bundle rejected with "HASH mismatch"
- [x] Camera Test 1 — signed + hashed bundle installed end-to-end
- [x] Camera Test 2 — unsigned legacy bundle rejected ("Signature verification failed")
- [x] Camera Test 3 — tampered signed bundle rejected ("Signature verification failed")
- [x] Client-side pre-upload check — unsigned and cross-target rejects without uploading
- [x] `/etc/sw-versions` updated after signed install on server (verified via serial + UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)