### PR TITLE
fix(ui): tab-switch perf, USB in-use state, camera OTA file lock

### DIFF
--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -1057,6 +1057,11 @@ function renderOta(s) {
     var err = (s && s.error) || "";
     var busy = state === "downloading" || state === "uploading" || state === "verifying" || state === "installing";
     $("btn-ota-upload").disabled = busy;
+    // Also lock the file input while busy so a mid-upload click doesn't
+    // open the browser's file picker. Without this the user could
+    // select a different (or the same) file and race the upload that's
+    // already in flight.
+    $("ota-file").disabled = busy;
     $("btn-ota-reboot").hidden = (state !== "installed");
 
     // Version diff row. Show it once the bundle has been staged —

--- a/app/server/monitor/services/storage_service.py
+++ b/app/server/monitor/services/storage_service.py
@@ -62,7 +62,9 @@ class StorageService:
         devices = usb.detect_devices()
         active_mount = self._active_mount_path()
         for d in devices:
-            d["in_use"] = bool(active_mount) and self._device_backs_mount(d, active_mount)
+            d["in_use"] = bool(active_mount) and self._device_backs_mount(
+                d, active_mount
+            )
         return devices
 
     def _active_mount_path(self) -> str:

--- a/app/server/monitor/services/storage_service.py
+++ b/app/server/monitor/services/storage_service.py
@@ -51,8 +51,39 @@ class StorageService:
         return stats, ""
 
     def list_devices(self) -> list[dict]:
-        """List available USB block devices."""
-        return usb.detect_devices()
+        """List available USB block devices.
+
+        Each device carries an ``in_use`` flag so the UI can render an
+        "In use" state instead of a clickable Use button for whichever
+        device is currently backing recordings. The flag is computed by
+        matching the device's mount point against the storage manager's
+        active recordings directory.
+        """
+        devices = usb.detect_devices()
+        active_mount = self._active_mount_path()
+        for d in devices:
+            d["in_use"] = bool(active_mount) and self._device_backs_mount(d, active_mount)
+        return devices
+
+    def _active_mount_path(self) -> str:
+        if not self._storage_manager:
+            return ""
+        rec_dir = getattr(self._storage_manager, "recordings_dir", "")
+        if not isinstance(rec_dir, str) or not rec_dir:
+            return ""
+        # recordings_dir is "<mount>/recordings" when a USB is active
+        # (see usb.prepare_recordings_dir). Strip the recordings suffix
+        # so the comparison is against the mount point itself.
+        if rec_dir.endswith("/recordings"):
+            return rec_dir[: -len("/recordings")]
+        return rec_dir
+
+    @staticmethod
+    def _device_backs_mount(device: dict, active_mount: str) -> bool:
+        # usb.detect_devices() fills in each device's current mountpoint
+        # from lsblk, so an exact match is enough. Only a single device
+        # can be mounted at a given path, so no ambiguity.
+        return bool(device.get("mountpoint")) and device["mountpoint"] == active_mount
 
     def select_device(
         self, device_path: str, user: str = "", ip: str = ""

--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -41,6 +41,11 @@ CAMERA_OFFLINE_RED_SECONDS = 60 * 60  # >= 1 h: red
 ERROR_WINDOW_SECONDS = 60 * 60  # "errors in last hour"
 
 RETENTION_SAMPLE_DAYS = 7  # trailing window for write-rate
+# Cache TTL for the retention estimate. Walking the recordings tree is
+# expensive (O(files)) and retention only drifts on the order of hours
+# with typical write rates; 5 minutes is a safe compromise between
+# freshness and dashboard responsiveness.
+RETENTION_CACHE_TTL_SECONDS = 300
 
 # Audit events treated as error-level for the status strip. Kept narrow so a
 # noisy login-failed storm (expected during a password-spray) doesn't flip
@@ -118,6 +123,13 @@ class SystemSummaryService:
         self._recordings = recordings_service
         # Injected so tests can stub host metrics without touching /proc.
         self._health = health_module
+        # Retention estimate walks the entire recordings tree (rglob +
+        # stat per file). That is ~O(thousands of files) and was firing
+        # on every /system/summary call — which the dashboard polls
+        # every 10 s, so each tab switch stalled on the walk. The
+        # walk's result barely moves minute-to-minute, so cache it for
+        # RETENTION_CACHE_TTL seconds and serve stale for that window.
+        self._retention_cache: tuple[float, float | None] | None = None
 
     # -- public API ---------------------------------------------------------
 
@@ -248,7 +260,21 @@ class SystemSummaryService:
 
         Returns None if there is less than a day of data to average against —
         better to show "—" than a confidently wrong number.
+
+        Cached for RETENTION_CACHE_TTL_SECONDS — the filesystem walk is
+        O(files) and the estimate drifts very slowly in practice.
         """
+        now = time.time()
+        if self._retention_cache is not None:
+            cached_at, cached_value = self._retention_cache
+            if now - cached_at < RETENTION_CACHE_TTL_SECONDS:
+                return cached_value
+
+        value = self._compute_retention_days(stats)
+        self._retention_cache = (now, value)
+        return value
+
+    def _compute_retention_days(self, stats: dict) -> float | None:
         rec_dir = stats.get("recordings_dir")
         free_gb = stats.get("free_gb", 0) or 0
         if not rec_dir or free_gb <= 0:
@@ -273,7 +299,6 @@ class SystemSummaryService:
                 if st.st_mtime < earliest:
                     earliest = st.st_mtime
 
-        # Less than ~24 h of sample → refuse to estimate.
         age_hours = (time.time() - earliest) / 3600
         if bytes_in_window <= 0 or age_hours < 24:
             return None

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -737,7 +737,10 @@
                 <template x-for="d in storage.devices" :key="d.path">
                     <div class="usb-device-item">
                         <div>
-                            <div style="font-weight:500;" x-text="d.model"></div>
+                            <div style="font-weight:500;">
+                                <span x-text="d.model"></span>
+                                <span x-show="d.in_use" class="badge badge--ok" style="margin-left:8px;">In use</span>
+                            </div>
                             <div class="text-small text-muted">
                                 <span x-text="d.path"></span> &middot;
                                 <span x-text="d.size"></span> &middot;
@@ -746,7 +749,8 @@
                                 <span x-show="!d.supported" style="color:#f87171;"> Needs format</span>
                             </div>
                         </div>
-                        <button x-show="d.supported" class="btn btn--primary btn--small" @click="selectUsb(d.path)">Use</button>
+                        <button x-show="d.supported && !d.in_use" class="btn btn--primary btn--small" @click="selectUsb(d.path)">Use</button>
+                        <span x-show="d.in_use" class="text-small text-muted">Active — eject below to switch</span>
                         <button x-show="!d.supported" class="btn btn--secondary btn--small" @click="showFormat(d)">Format</button>
                     </div>
                 </template>


### PR DESCRIPTION
## Summary

- **Dashboard tab-switch latency fixed.** `/api/v1/system/summary` used to `rglob('*.mp4')` the whole recordings tree on every call (ADR-0018 retention estimate). The dashboard polls it every 10 s and Flask is single-threaded, so the walk blocked the next tab-click request for seconds. The retention input (bytes/day) drifts on the order of hours, so we now cache the estimate for 5 min per service instance.
- **USB storage shows 'In use'.** `list_devices()` tags the device whose mountpoint matches the storage manager's active `recordings_dir` with `in_use=true`; the template shows an "In use" badge + "Active — eject below to switch" instead of a clickable Use button.
- **Camera OTA file picker locked during upload.** `renderOta()` now toggles `#ota-file.disabled` alongside `#btn-ota-upload.disabled`, so the picker can't open once the XHR is in flight.

## Test plan

- [x] 868/868 server unit tests pass locally (`pytest tests/unit/`)
- [x] Deployed live to 192.168.1.245 + 192.168.1.186
- [ ] Verify tab switches are instant on dashboard after login (user to confirm)
- [ ] Verify active USB device shows "In use" badge and no Use button
- [ ] Verify camera file input goes grey during OTA upload
- [ ] Existing CI: Ruff, Pre-commit, Server Unit/Integration/Contract/Security/Coverage, Camera Unit/Integration/Contract/Security/Coverage, Browser E2E, Yocto Parse, Workflow Lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)