### PR TITLE
fix(recorder): read flat-layout clips so Recordings page isn't blank

### DIFF
--- a/app/server/monitor/services/recorder_service.py
+++ b/app/server/monitor/services/recorder_service.py
@@ -17,10 +17,42 @@ File layout:
   /data/live/<cam-id>/segment_NNN.ts
 """
 
+import re
 from datetime import date
 from pathlib import Path
 
 from monitor.models import Clip
+
+# Loop recorder produces flat filenames directly under the camera dir:
+#   cam-xxx/YYYYMMDD_HHMMSS.mp4
+# Legacy dated layout uses a YYYY-MM-DD subdir with HH-MM-SS.mp4 inside.
+# Writers today only produce the flat layout; readers must handle both
+# because real devices still have legacy dated clips on disk. The
+# recordings-service layer (recordings_service._parse_clip_date_time)
+# already knows both, but the recorder-service read methods used by
+# the Recordings page were dated-only — that's why the page showed
+# "No recordings found" on devices whose clips are all flat-layout.
+_FLAT_STEM_RE = re.compile(r"^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$")
+_DATED_DIR_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_DATED_STEM_RE = re.compile(r"^(\d{2})-(\d{2})-(\d{2})$")
+
+
+def _flat_clip_date(stem: str) -> str:
+    """Return "YYYY-MM-DD" if ``stem`` is a flat-layout filename, else ""."""
+    m = _FLAT_STEM_RE.match(stem)
+    if not m:
+        return ""
+    y, mo, d, _, _, _ = m.groups()
+    return f"{y}-{mo}-{d}"
+
+
+def _flat_clip_start_time(stem: str) -> str:
+    """Return "HH:MM:SS" if ``stem`` is a flat-layout filename, else ""."""
+    m = _FLAT_STEM_RE.match(stem)
+    if not m:
+        return ""
+    _, _, _, hh, mm, ss = m.groups()
+    return f"{hh}:{mm}:{ss}"
 
 
 class RecorderService:
@@ -40,39 +72,69 @@ class RecorderService:
 
         If no date is given, uses today's date.
         Returns clips sorted by start_time (ascending).
+        Handles both layouts (see module docstring): dated-subdir
+        legacy clips and flat-layout loop-recorder clips sharing the
+        camera directory.
         """
         if not clip_date:
             clip_date = date.today().isoformat()
 
-        cam_dir = self._recordings_dir / camera_id / clip_date
+        cam_dir = self._recordings_dir / camera_id
         if not cam_dir.is_dir():
             return []
 
-        clips = []
-        for mp4 in sorted(cam_dir.glob("*.mp4")):
-            # Filename format: HH-MM-SS.mp4
-            stem = mp4.stem  # e.g. "14-30-00"
-            start_time = stem.replace("-", ":")
-            thumb = mp4.with_suffix(".thumb.jpg")
+        clips: list[Clip] = []
 
+        # Dated layout: <cam>/YYYY-MM-DD/HH-MM-SS.mp4
+        dated_dir = cam_dir / clip_date
+        if dated_dir.is_dir():
+            for mp4 in sorted(dated_dir.glob("*.mp4")):
+                stem = mp4.stem  # "14-30-00"
+                if not _DATED_STEM_RE.match(stem):
+                    continue
+                thumb = mp4.with_suffix(".thumb.jpg")
+                clips.append(
+                    Clip(
+                        camera_id=camera_id,
+                        filename=mp4.name,
+                        date=clip_date,
+                        start_time=stem.replace("-", ":"),
+                        size_bytes=mp4.stat().st_size,
+                        thumbnail=thumb.name if thumb.exists() else "",
+                    )
+                )
+
+        # Flat layout: <cam>/YYYYMMDD_HHMMSS.mp4. Filter by requested date.
+        for mp4 in sorted(cam_dir.glob("*.mp4")):
+            if _flat_clip_date(mp4.stem) != clip_date:
+                continue
+            thumb = mp4.with_suffix(".thumb.jpg")
             clips.append(
                 Clip(
                     camera_id=camera_id,
                     filename=mp4.name,
                     date=clip_date,
-                    start_time=start_time,
+                    start_time=_flat_clip_start_time(mp4.stem),
                     size_bytes=mp4.stat().st_size,
                     thumbnail=thumb.name if thumb.exists() else "",
                 )
             )
 
+        clips.sort(key=lambda c: c.start_time)
         return clips
 
     def get_clip_path(self, camera_id: str, clip_date: str, filename: str):
-        """Get the full path to a clip file. Returns None if not found."""
-        path = self._recordings_dir / camera_id / clip_date / filename
-        if path.is_file():
-            return path
+        """Get the full path to a clip file. Returns None if not found.
+
+        The UI always builds the dated URL (``/<cam>/<date>/<file>``) but
+        files may live under either layout — probe both.
+        """
+        dated_path = self._recordings_dir / camera_id / clip_date / filename
+        if dated_path.is_file():
+            return dated_path
+        flat_path = self._recordings_dir / camera_id / filename
+        if flat_path.is_file():
+            return flat_path
         return None
 
     def delete_clip(self, camera_id: str, clip_date: str, filename: str) -> bool:
@@ -112,16 +174,31 @@ class RecorderService:
         return True
 
     def get_dates_with_clips(self, camera_id: str) -> list[str]:
-        """List dates that have recordings for a camera."""
+        """List dates that have recordings for a camera.
+
+        Merges both on-disk layouts:
+          dated-subdir:  <cam>/YYYY-MM-DD/*.mp4   → YYYY-MM-DD
+          flat:          <cam>/YYYYMMDD_*.mp4     → derive YYYY-MM-DD
+        Result is deduped and sorted ascending.
+        """
         cam_dir = self._recordings_dir / camera_id
         if not cam_dir.is_dir():
             return []
 
-        dates = []
-        for d in sorted(cam_dir.iterdir()):
-            if d.is_dir() and any(d.glob("*.mp4")):
-                dates.append(d.name)
-        return dates
+        dates: set[str] = set()
+        try:
+            for entry in cam_dir.iterdir():
+                if entry.is_dir():
+                    if _DATED_DIR_RE.match(entry.name) and any(entry.glob("*.mp4")):
+                        dates.add(entry.name)
+                elif entry.is_file() and entry.suffix == ".mp4":
+                    d = _flat_clip_date(entry.stem)
+                    if d:
+                        dates.add(d)
+        except OSError:
+            return []
+
+        return sorted(dates)
 
     def get_latest_clip(self, camera_id: str):
         """Get the most recent clip for a camera. Returns None if no clips."""

--- a/app/server/tests/unit/test_svc_recorder.py
+++ b/app/server/tests/unit/test_svc_recorder.py
@@ -145,6 +145,63 @@ class TestGetDatesWithClips:
         assert dates == ["2026-04-07", "2026-04-08", "2026-04-09"]
 
 
+class TestFlatLayoutReads:
+    """Loop-recorder produces <cam>/YYYYMMDD_HHMMSS.mp4 with no date
+    subdir. All read methods must surface those clips — without these
+    the Recordings page shows "No recordings found" even when the disk
+    is full of footage (pre-fix symptom reported 2026-04-19).
+    """
+
+    def _make_flat(self, tmp_path, cam, stem, size=512):
+        cam_dir = tmp_path / cam
+        cam_dir.mkdir(parents=True, exist_ok=True)
+        mp4 = cam_dir / f"{stem}.mp4"
+        mp4.write_bytes(b"x" * size)
+        return mp4
+
+    def test_dates_from_flat_files(self, tmp_path):
+        self._make_flat(tmp_path, "cam-001", "20260417_132730")
+        self._make_flat(tmp_path, "cam-001", "20260417_170727")
+        self._make_flat(tmp_path, "cam-001", "20260419_104351")
+        svc = RecorderService(str(tmp_path), str(tmp_path / "live"))
+        assert svc.get_dates_with_clips("cam-001") == ["2026-04-17", "2026-04-19"]
+
+    def test_dates_merge_flat_and_dated(self, tmp_path):
+        self._make_flat(tmp_path, "cam-001", "20260419_104351")
+        _make_clip(tmp_path, "cam-001", "2026-04-18", "10-00-00")
+        svc = RecorderService(str(tmp_path), str(tmp_path / "live"))
+        assert svc.get_dates_with_clips("cam-001") == ["2026-04-18", "2026-04-19"]
+
+    def test_list_clips_flat(self, tmp_path):
+        self._make_flat(tmp_path, "cam-001", "20260419_104351", size=1024)
+        (tmp_path / "cam-001" / "20260419_104351.thumb.jpg").write_bytes(b"t")
+        self._make_flat(tmp_path, "cam-001", "20260419_104051", size=2048)
+        svc = RecorderService(str(tmp_path), str(tmp_path / "live"))
+        clips = svc.list_clips("cam-001", "2026-04-19")
+        assert len(clips) == 2
+        assert clips[0].filename == "20260419_104051.mp4"
+        assert clips[0].start_time == "10:40:51"
+        assert clips[0].size_bytes == 2048
+        assert clips[0].thumbnail == ""
+        assert clips[1].filename == "20260419_104351.mp4"
+        assert clips[1].thumbnail == "20260419_104351.thumb.jpg"
+        assert clips[1].date == "2026-04-19"
+
+    def test_list_clips_filters_by_date(self, tmp_path):
+        self._make_flat(tmp_path, "cam-001", "20260417_132730")
+        self._make_flat(tmp_path, "cam-001", "20260419_104351")
+        svc = RecorderService(str(tmp_path), str(tmp_path / "live"))
+        clips = svc.list_clips("cam-001", "2026-04-19")
+        assert len(clips) == 1
+        assert clips[0].start_time == "10:43:51"
+
+    def test_get_clip_path_falls_back_to_flat(self, tmp_path):
+        flat = self._make_flat(tmp_path, "cam-001", "20260419_104351")
+        svc = RecorderService(str(tmp_path), str(tmp_path / "live"))
+        path = svc.get_clip_path("cam-001", "2026-04-19", "20260419_104351.mp4")
+        assert path == flat
+
+
 class TestGetLatestClip:
     """Test latest clip retrieval."""
 
@@ -160,3 +217,16 @@ class TestGetLatestClip:
         clip = svc.get_latest_clip("cam-001")
         assert clip.date == "2026-04-09"
         assert clip.start_time == "15:30:00"
+
+    def test_returns_latest_flat(self, tmp_path):
+        # Flat-layout clips must be returned by get_latest_clip too,
+        # otherwise the dashboard's "Last activity" tile stays blank.
+        cam_dir = tmp_path / "cam-001"
+        cam_dir.mkdir()
+        (cam_dir / "20260419_104051.mp4").write_bytes(b"x")
+        (cam_dir / "20260419_104351.mp4").write_bytes(b"x")
+        svc = RecorderService(str(tmp_path), str(tmp_path / "live"))
+        clip = svc.get_latest_clip("cam-001")
+        assert clip is not None
+        assert clip.date == "2026-04-19"
+        assert clip.start_time == "10:43:51"


### PR DESCRIPTION
## Symptom

Recordings tab shows "No recordings found" with an empty date picker, even though:
- Camera is paired and listed in the dropdown
- Clips exist on disk (`/mnt/recordings/home-monitor-recordings/cam-351ad8ee/20260419_104351.mp4` and many others)

## Root cause

The loop recorder writes clips **flat**: `<cam>/YYYYMMDD_HHMMSS.mp4` with no date subdir. `RecorderService.get_dates_with_clips()` and `list_clips()` only walked the legacy **dated** layout `<cam>/YYYY-MM-DD/HH-MM-SS.mp4`. On any device whose clips are all flat, those methods return `[]`, so the Recordings page has no dates to populate and no clips to list.

`delete_clip()` already knew both layouts (commit ce226e7), but the read side never got the same treatment — so writes land, deletes work, but reads show nothing.

## Fix

Teach the three read paths to recognise both layouts:
- `get_dates_with_clips` — iterates the camera dir, picks up YYYY-MM-DD subdir names AND YYYYMMDD-prefixed flat filenames, returns a deduped sorted list.
- `list_clips(camera_id, date)` — merges dated-subdir clips under `<cam>/<date>/` with flat clips matching the date prefix under `<cam>/`.
- `get_clip_path` — probes the dated URL first (UI builds dated URLs) then falls back to the flat path.

Adds six tests covering flat-only discovery, merge of both layouts, date filtering on flat, `get_clip_path` flat fallback, and the dashboard "Last activity" tile picking up a flat clip.

## Test plan

- [x] 23/23 recorder unit tests pass (6 new)
- [x] 874/874 server unit tests pass
- [x] Deployed to live server; user to verify the Recordings tab now lists dates + clips
- [ ] CI: Ruff, Pre-commit, Server Unit/Integration/Contract/Security/Coverage, Camera suites, Browser E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)