### PR TITLE
security: must_change gate, SECRET_KEY hard-fail, atomic staging, SWU placeholder check

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -40,7 +40,16 @@ log = logging.getLogger("monitor")
 
 
 def _load_or_create_secret_key(config_dir):
-    """Load persistent secret key, or create one on first boot."""
+    """Load persistent secret key, or create one on first boot.
+
+    If the file is missing we generate a fresh 32-byte key and persist
+    it with 0o600 permissions. Previously this swallowed OSError on the
+    write path, silently returning an ephemeral key that would rotate
+    on every restart and invalidate every existing session. That is a
+    correctness-grade bug for a production box, so any I/O failure now
+    raises RuntimeError — the operator must fix the filesystem before
+    the app can come up, rather than silently losing sessions.
+    """
     key_file = os.path.join(config_dir, ".secret_key")
     try:
         with open(key_file) as f:
@@ -56,8 +65,12 @@ def _load_or_create_secret_key(config_dir):
         with open(key_file, "w") as f:
             f.write(key)
         os.chmod(key_file, 0o600)
-    except OSError:
-        pass
+    except OSError as exc:
+        raise RuntimeError(
+            f"Unable to persist SECRET_KEY to {key_file}: {exc}. "
+            "Fix filesystem permissions or the data volume before restart — "
+            "an ephemeral key would invalidate every session on the next boot."
+        ) from exc
     return key
 
 

--- a/app/server/monitor/api/users.py
+++ b/app/server/monitor/api/users.py
@@ -81,4 +81,10 @@ def change_password(user_id):
     )
     if status != 200:
         return jsonify({"error": msg}), status
+    # If the caller just cleared their OWN forced-change flag, drop the
+    # session-level gate so subsequent requests go straight through. A
+    # stale "True" here would keep the user locked on the change screen
+    # even though the DB flag has been cleared.
+    if user_id == session.get("user_id"):
+        session["must_change_password"] = False
     return jsonify({"message": msg}), status

--- a/app/server/monitor/auth.py
+++ b/app/server/monitor/auth.py
@@ -147,6 +147,30 @@ def _is_session_valid() -> bool:
     return True
 
 
+# Endpoints that stay reachable while a user is blocked on
+# must_change_password. The password-change endpoint itself has to be
+# callable or the user can never clear the flag; logout + /me are
+# included so the UI can render the "change your password" screen and
+# let the user sign out if they pick the wrong account.
+_MUST_CHANGE_ALLOWED_ENDPOINTS = frozenset(
+    {
+        "users.change_password",
+        "auth.logout",
+        "auth.me",
+    }
+)
+
+
+def _must_change_block() -> bool:
+    """Return True iff the current session must change password AND the
+    request is NOT targeting one of the allow-listed endpoints."""
+    if not session.get("must_change_password"):
+        return False
+    # request.endpoint is "<blueprint>.<view_func>" — use it instead of
+    # comparing paths so a URL rewrite doesn't silently unlock the gate.
+    return request.endpoint not in _MUST_CHANGE_ALLOWED_ENDPOINTS
+
+
 def login_required(f):
     """Decorator: require authenticated session."""
 
@@ -155,6 +179,13 @@ def login_required(f):
         if not _is_session_valid():
             session.clear()
             return jsonify({"error": "Authentication required"}), 401
+        if _must_change_block():
+            return jsonify(
+                {
+                    "error": "Password change required",
+                    "must_change_password": True,
+                }
+            ), 403
         session["last_active"] = time.time()
         return f(*args, **kwargs)
 
@@ -171,6 +202,13 @@ def admin_required(f):
             return jsonify({"error": "Authentication required"}), 401
         if session.get("role") != "admin":
             return jsonify({"error": "Admin access required"}), 403
+        if _must_change_block():
+            return jsonify(
+                {
+                    "error": "Password change required",
+                    "must_change_password": True,
+                }
+            ), 403
         session["last_active"] = time.time()
         return f(*args, **kwargs)
 
@@ -277,6 +315,12 @@ def login():
     session["role"] = user.role
     session["created_at"] = time.time()
     session["last_active"] = time.time()
+    # Carry the "forced change on next login" flag into the session so
+    # login_required / admin_required can refuse every non-password-change
+    # endpoint until the user completes the change. Without this the flag
+    # was a suggestion to the client (returned in the login response body)
+    # and any API client ignoring it could keep using default credentials.
+    session["must_change_password"] = bool(user.must_change_password)
 
     csrf_token = generate_csrf_token()
 

--- a/app/server/monitor/services/ota_service.py
+++ b/app/server/monitor/services/ota_service.py
@@ -223,9 +223,23 @@ class OTAService:
         os.makedirs(self.staging_dir, exist_ok=True)
         staged_path = os.path.join(self.staging_dir, filename)
 
+        # os.replace is atomic on POSIX within a single filesystem and
+        # atomically overwrites an existing destination; shutil.move falls
+        # back to copy+delete when source and destination live on different
+        # mounts. Two concurrent uploads against the same filename would
+        # happily interleave copy+delete and land a corrupted bundle in
+        # staging. Stage uploads to a per-request temp file under the same
+        # directory, then os.replace() into place.
+        tmp_path = f"{staged_path}.partial-{os.getpid()}-{os.urandom(4).hex()}"
         try:
-            shutil.move(source_path, staged_path)
+            shutil.move(source_path, tmp_path)
+            os.replace(tmp_path, staged_path)
         except OSError as e:
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
             return None, f"Failed to stage file: {e}"
 
         target_version = extract_bundle_version(staged_path)

--- a/app/server/tests/unit/test_auth.py
+++ b/app/server/tests/unit/test_auth.py
@@ -447,6 +447,61 @@ class TestMustChangePassword:
         data = response.get_json()
         assert "must_change_password" not in data
 
+    def test_flagged_user_blocked_from_protected_endpoints(self, app, client):
+        # Flag-only gating used to be client-side: any API client ignoring
+        # the `must_change_password: true` field in the login response could
+        # keep using default credentials to hit every endpoint. The gate
+        # moved into login_required / admin_required — this asserts
+        # protected endpoints refuse to serve a flagged session.
+        user = _create_test_user(app)
+        user.must_change_password = True
+        app.store.save_user(user)
+
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"username": "admin", "password": "correct-password"},
+        )
+        assert login.status_code == 200
+
+        # /me is in the allow-list so the UI can still render the
+        # "password change required" screen.
+        me = client.get("/api/v1/auth/me")
+        assert me.status_code == 200
+
+        # A protected read (admin-only) must be refused with 403 and a
+        # machine-readable signal.
+        cams = client.get("/api/v1/cameras")
+        assert cams.status_code == 403
+        assert cams.get_json().get("must_change_password") is True
+
+    def test_flagged_user_can_complete_password_change(self, app, client):
+        user = _create_test_user(app)
+        user.must_change_password = True
+        app.store.save_user(user)
+
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"username": "admin", "password": "correct-password"},
+        )
+        csrf = login.get_json()["csrf_token"]
+        uid = login.get_json()["user"]["id"]
+
+        # The password-change endpoint itself must remain reachable or
+        # the user has no way out of the gate.
+        resp = client.put(
+            f"/api/v1/users/{uid}/password",
+            headers={"X-CSRF-Token": csrf},
+            json={
+                "current_password": "correct-password",
+                "new_password": "a-new-strong-password-42",
+            },
+        )
+        assert resp.status_code == 200
+
+        # After the change the user should no longer be blocked.
+        cams = client.get("/api/v1/cameras")
+        assert cams.status_code == 200
+
 
 class TestPasswordPolicy:
     """Test password policy enforcement (NIST SP 800-63B)."""

--- a/scripts/build-swu.sh
+++ b/scripts/build-swu.sh
@@ -142,6 +142,19 @@ fi
 echo ">>> sw-description:"
 cat "$WORK_DIR/sw-description"
 
+# Placeholder gate — catches typo'd `@@NAME@@` placeholders that neither
+# branch substituted nor stripped. Without this check a renamed field
+# in the template (say, `@@VERISON@@`) silently ships to devices as a
+# literal `@@VERISON@@` in sw-description, which SWUpdate may or may
+# not reject depending on the field.
+if grep -q '@@[A-Za-z0-9_]*@@' "$WORK_DIR/sw-description"; then
+    echo ""
+    echo "ABORT: sw-description still contains unresolved @@PLACEHOLDER@@ markers." >&2
+    echo "       Template added a new field without a matching sed rule in build-swu.sh?" >&2
+    grep -n '@@[A-Za-z0-9_]*@@' "$WORK_DIR/sw-description" >&2
+    exit 1
+fi
+
 # 3. Sign sw-description if requested (CMS/PKCS7 for SWUpdate)
 if [ "$SIGN" = true ]; then
     if [ ! -f "$SIGNING_KEY" ]; then


### PR DESCRIPTION
## Summary

Four pre-1.2.0 release-blocking hardening items, found during an independent audit.

| # | Issue | File |
|---|---|---|
| 1 | `must_change_password` was client-side only — API clients ignoring the flag retained full access | [auth.py](app/server/monitor/auth.py), [api/users.py](app/server/monitor/api/users.py) |
| 2 | `SECRET_KEY` silently fell back to ephemeral on write failure → session rotation on restart | [__init__.py](app/server/monitor/__init__.py) |
| 3 | OTA bundle staging used non-atomic `shutil.move` → concurrent-upload corruption risk | [ota_service.py](app/server/monitor/services/ota_service.py) |
| 4 | `build-swu.sh` shipped unresolved `@@PLACEHOLDER@@` on sed-rule drift | [build-swu.sh](scripts/build-swu.sh) |

Adds 2 tests for the must-change gate (flagged session refused 403 on protected endpoints; gate lifts after the user completes the change).

Release-readiness items that require new files or CI are in PR B (coming next): `local.conf.prod`, lockfile, CHANGELOG, SBOM.

## Test plan

- [x] 876/876 server unit tests pass locally
- [x] Ruff format + lint clean
- [ ] CI: all PR CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)