### PR TITLE
release(1.2.0): prod Yocto targets + lockfile + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,47 @@
 
 All notable changes to RPi Home Monitor are documented here.
 
-## [v1.0.6-dev] — 2026-04-10
+## [Unreleased]
+
+(Nothing yet — next release will land here.)
+
+## [1.2.0] — 2026-04-19
+
+First commercial release. Bundles the OTA production-hardening work
+(signed bundles, dual-transport install, dashboard performance) with
+a round of release-readiness security fixes.
 
 ### Added
-- **Camera password authentication** — Camera status page now requires login with username/password set during provisioning. PBKDF2-SHA256 hashing (100k iterations, random 16-byte salt). Session-based auth with HttpOnly cookies and 2-hour timeout.
-- **Camera setup collects credentials** — First-boot wizard now asks for admin username and password. These protect the camera's status/settings page.
-- **Camera `.local` URL access** — Cameras are reachable via mDNS at `http://rpi-divinu-cam-XXXX.local` (XXXX = last 4 hex of CPU serial). URL shown on:
-  - Camera status page (top of page after login)
-  - Camera setup wizard (in success message after provisioning)
-  - Server dashboard (clickable "Settings" link on each camera card)
-- **Camera system health display** — Status page shows CPU temperature, memory usage, and uptime with color-coded thresholds.
-- **Camera WiFi change** — Authenticated users can change WiFi network and password from the status page.
-- **Camera password change** — Authenticated users can change the camera admin password.
-- **25 new tests** — 8 for password management, 17 for session management, provisioning, and system helpers.
-
-### Fixed
-- **Server settings WiFi card hidden** — Race condition where `auth.getMe()` async call hadn't completed before settings `init()` checked user role. Fixed by awaiting auth before rendering admin sections.
-- **Server settings uptime "[object Object]"** — API returns `{seconds, display}` object; JS was displaying the raw object. Fixed to use `data.uptime.display`.
-- **Server settings disk "0 B"** — API returns `disk.total_gb`; JS was using `data.disk.total` (undefined). Fixed to use `total_gb`/`used_gb`/`free_gb` with correct units.
+- **Production Yocto build targets** — `scripts/build.sh server-prod` and `camera-prod` now consume `config/<board>/local.conf.prod` which `require`s the dev config and flips `SWUPDATE_SIGNING = "1"` (see ADR-0014). Dev paths unchanged.
+- **Pre-upload `.swu` inspection in both GUIs** — browser reads the CPIO header + sw-description text before sending, rejecting unsigned bundles and cross-target bundles (server .swu dropped on the camera card and vice versa) at selection time.
+- **`/etc/sw-versions` stamped at install time** — `post-update.sh` parses the bundle version and writes it into the new slot so the "Current version" UI line reflects what's running, instead of the Yocto-baked `1.0.0`.
+- **`must_change_password` enforced server-side** — flagged sessions get `403 must_change_password: true` from every protected endpoint; allow-list covers password-change, logout, and `/me`.
+- **`requirements.lock`** — exact-version pin file for deterministic server installs (Flask 3.1.3, bcrypt 5.0.0, Jinja2 3.1.6, zeroconf 0.148.0 + transitive pins).
+- **USB "In use" state** — active backing device shows the badge + eject hint instead of a clickable Use button.
+- **`build-swu.sh` post-substitution check** — aborts if any `@@PLACEHOLDER@@` markers survived sed substitution.
+- **Recordings page supports flat-layout clips** — loop-recorder clips (`<cam>/YYYYMMDD_HHMMSS.mp4`) now listable via `get_dates_with_clips`, `list_clips`, `get_clip_path`.
+- **Signed-OTA validation record** — `docs/exec-plans/ota-signing-validation-2026-04-19.md` captures the 6/6 on-hardware tests.
 
 ### Changed
-- **Camera templates extracted** — Inline HTML (login, status, setup pages) moved from `wifi_setup.py` to separate template files in `templates/` directory. Reduces `wifi_setup.py` from 1573 to 976 lines.
-- Camera unique hostname set during first boot via CPU serial suffix for multi-device mDNS support.
+- **OTA bundle staging is atomic** — `shutil.move` swapped for `os.replace` via a per-request temp path. Concurrent uploads against the same filename no longer risk corruption.
+- **`SECRET_KEY` persistence fails loudly** — if `$CONFIG_DIR/.secret_key` can't be written we raise `RuntimeError` rather than returning an ephemeral key that rotates on restart.
+- **Dashboard tab-switching is instant again** — `<video>` elements in Recent Events only materialise after Play click (`x-if`, not `x-show`); `latest_across_cameras` / `recent_across_cameras` cache `rglob` results for 20 s.
+- **Retention estimate cached 5 min** — `_estimate_retention_days` was walking `/data/recordings` every 10 s from the dashboard poll.
 
-## [Unreleased]
+### Fixed
+- `must_change_password` API-bypass (client-side flag only).
+- `SECRET_KEY` silent reset on write failure.
+- `shutil.move` staging race under concurrent OTA uploads.
+- `build-swu.sh` shipping unresolved `@@NAME@@` placeholders on drift.
+- Recordings tab empty when only flat-layout clips exist.
+- Dashboard → live navigation stall (3-minute delay in field testing).
+- USB Storage "Use" button clickable for active device.
+
+### Security
+- CMS/PKCS7 signed `.swu` bundles accepted by server + camera installers (ADR-0014). Unsigned + tampered bundles rejected before any write.
+- `/etc/swupdate-enforce` marker + `-k cert` in `swupdate -c` give dual-defense; missing cert on a signing-enforced image is a hard fail.
+
+## [1.1.0] — 2026-04-13
 
 ### Added
 - **Dual-transport OTA, end-to-end validated** (ADR-0020) — three install paths now work on hardware:
@@ -64,6 +81,26 @@ All notable changes to RPi Home Monitor are documented here.
 - Server and camera systemd services now depend on `sys-subsystem-net-devices-wlan0.device` to ensure WiFi hardware is ready.
 - Server hotspot service has `TimeoutStartSec=90` to allow for WiFi retry loop.
 - Camera setup page server address field defaults to `homemonitor.local` instead of empty.
+
+## [v1.0.6-dev] — 2026-04-10
+
+### Added
+- **Camera password authentication** — Camera status page now requires login with username/password set during provisioning. PBKDF2-SHA256 hashing (100k iterations, random 16-byte salt). Session-based auth with HttpOnly cookies and 2-hour timeout.
+- **Camera setup collects credentials** — First-boot wizard now asks for admin username and password.
+- **Camera `.local` URL access** — Cameras are reachable via mDNS at `http://rpi-divinu-cam-XXXX.local` (XXXX = last 4 hex of CPU serial).
+- **Camera system health display** — Status page shows CPU temperature, memory usage, and uptime with color-coded thresholds.
+- **Camera WiFi change** — Authenticated users can change WiFi network and password from the status page.
+- **Camera password change** — Authenticated users can change the camera admin password.
+- **25 new tests** — 8 for password management, 17 for session management, provisioning, and system helpers.
+
+### Fixed
+- **Server settings WiFi card hidden** — Race condition where `auth.getMe()` async call hadn't completed before settings `init()` checked user role.
+- **Server settings uptime `[object Object]`** — API returns `{seconds, display}` object; JS was displaying the raw object.
+- **Server settings disk "0 B"** — API returns `disk.total_gb`; JS was using `data.disk.total` (undefined).
+
+### Changed
+- **Camera templates extracted** — Inline HTML moved from `wifi_setup.py` to separate template files in `templates/`.
+- Camera unique hostname set during first boot via CPU serial suffix for multi-device mDNS support.
 
 ---
 

--- a/app/server/requirements.lock
+++ b/app/server/requirements.lock
@@ -1,0 +1,24 @@
+# Exact-version pin lockfile for the server app — produced from the
+# development environment used to ship v1.2.0. Regenerate after every
+# `requirements.txt` change with:
+#
+#   python -m pip install -r app/server/requirements.txt
+#   python -m pip freeze --exclude-editable > app/server/requirements.lock
+#
+# Ship this file to deterministic targets (Yocto recipes, CI) so
+# upstream patch releases can't land unreviewed. `requirements.txt`
+# keeps the soft floors documented for human readers.
+
+# Direct dependencies (declared in requirements.txt)
+Flask==3.1.3
+bcrypt==5.0.0
+Jinja2==3.1.6
+zeroconf==0.148.0
+
+# Transitive dependencies (pinned for reproducibility)
+blinker==1.9.0
+click==8.3.2
+ifaddr==0.2.0
+itsdangerous==2.2.0
+MarkupSafe==3.0.3
+Werkzeug==3.1.8

--- a/config/rpi4b/local.conf.prod
+++ b/config/rpi4b/local.conf.prod
@@ -1,0 +1,27 @@
+# =============================================================
+# local.conf.prod — RPi 4 Model B (Server), PRODUCTION build
+#
+# Inherits everything from local.conf (single source of truth for
+# machine, kernel, hardware flags) and overrides only policy bits
+# that differ between dev and prod. See ADR-0014 for rationale
+# — per-user signing keypair, cert baked in, enforcement marker.
+#
+# Invocation:
+#   ./scripts/build.sh server-prod
+# which maps to this file via `require local.conf` below and then
+# the bitbake run proceeds normally. Keys are expected at
+# ~/.monitor-keys/ota-signing.{key,crt} — run
+# ./scripts/generate-ota-keys.sh on first prod build.
+# =============================================================
+
+# Inherit all dev settings (machine, kernel, hardware flags)
+require local.conf
+
+# Production overrides
+# -------------------
+
+# OTA signing (ADR-0014) — CONFIG_SIGNED_IMAGES enabled.
+# With this set, the image ships /etc/swupdate-enforce and rejects
+# any unsigned .swu at install time. build-swu.sh --sign must be
+# used for bundles targeting this image.
+SWUPDATE_SIGNING = "1"

--- a/config/zero2w/local.conf.prod
+++ b/config/zero2w/local.conf.prod
@@ -1,0 +1,27 @@
+# =============================================================
+# local.conf.prod — RPi Zero 2W (Camera Node), PRODUCTION build
+#
+# Inherits everything from local.conf (single source of truth for
+# machine, kernel, hardware flags) and overrides only policy bits
+# that differ between dev and prod. See ADR-0014 for rationale
+# — per-user signing keypair, cert baked in, enforcement marker.
+#
+# Invocation:
+#   ./scripts/build.sh camera-prod
+# which maps to this file via `require local.conf` below and then
+# the bitbake run proceeds normally. Keys are expected at
+# ~/.monitor-keys/ota-signing.{key,crt} — run
+# ./scripts/generate-ota-keys.sh on first prod build.
+# =============================================================
+
+# Inherit all dev settings (machine, kernel, hardware flags)
+require local.conf
+
+# Production overrides
+# -------------------
+
+# OTA signing (ADR-0014) — CONFIG_SIGNED_IMAGES enabled.
+# With this set, the image ships /etc/swupdate-enforce and rejects
+# any unsigned .swu at install time. build-swu.sh --sign must be
+# used for bundles targeting this image.
+SWUPDATE_SIGNING = "1"

--- a/docs/adr/0017-on-demand-viewer-driven-streaming.md
+++ b/docs/adr/0017-on-demand-viewer-driven-streaming.md
@@ -1,6 +1,6 @@
 # ADR-0017: On-Demand, Viewer-Driven Streaming + Recording Modes
 
-**Status:** Proposed
+**Status:** Accepted (shipped v1.1.0, 2026-04-13)
 **Date:** 2026-04-17
 **Deciders:** vinu-dev
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,7 +30,7 @@ is marked `Status: Superseded by ADR-XXXX` rather than deleted.
 | 0014 | [SWUpdate signing (dev / prod split)](0014-swupdate-signing-dev-prod.md)                        | Accepted   |
 | 0015 | [Server → camera control channel](0015-server-camera-control-channel.md)                        | Accepted   |
 | 0016 | [Camera health heartbeat protocol](0016-camera-health-heartbeat-protocol.md)                    | Accepted   |
-| 0017 | [On-demand, viewer-driven streaming + recording modes](0017-on-demand-viewer-driven-streaming.md) | Proposed |
+| 0017 | [On-demand, viewer-driven streaming + recording modes](0017-on-demand-viewer-driven-streaming.md) | Accepted   |
 | 0018 | [Dashboard information architecture](0018-dashboard-information-architecture.md)                 | Accepted   |
 | 0019 | [Time sync and timezone](0019-time-sync-and-timezone.md)                                         | Accepted   |
 | 0020 | [Dual-transport OTA (server upload + server-to-camera push)](0020-dual-transport-ota.md)         | Accepted   |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # RPi Home Monitor - Software Architecture
 
-Version: 1.0
-Date: 2026-04-09
+Version: 1.2
+Date: 2026-04-19
 
 ---
 

--- a/docs/build-setup.md
+++ b/docs/build-setup.md
@@ -1,6 +1,6 @@
 # Build Machine Setup
 
-Version: 1.0
+Version: 1.2
 Date: 2026-04-09
 
 How to set up a fresh machine to build Home Monitor OS images.
@@ -142,10 +142,19 @@ We use a custom distribution instead of the reference `poky` distro. This is ind
 Both boards share `bblayers.conf` and the `home-monitor` distro. Only `local.conf` differs:
 
 ```text
-config/bblayers.conf        shared (identical layers for both)
-config/rpi4b/local.conf     MACHINE="raspberrypi4-64", GPU_MEM=128
-config/zero2w/local.conf    MACHINE="home-monitor-camera", GPU_MEM=64
+config/bblayers.conf                shared (identical layers for both)
+config/rpi4b/local.conf             MACHINE="raspberrypi4-64", GPU_MEM=128
+config/rpi4b/local.conf.prod        require local.conf; SWUPDATE_SIGNING="1"
+config/zero2w/local.conf            MACHINE="home-monitor-camera", GPU_MEM=64
+config/zero2w/local.conf.prod       require local.conf; SWUPDATE_SIGNING="1"
 ```
+
+Prod configs **inherit** the dev config via `require local.conf` and override
+only the signing policy. That way a change to machine/kernel settings in the
+dev `local.conf` propagates to prod automatically — no drift between the two.
+`build.sh server-prod` / `camera-prod` / `all-prod` select the prod layer.
+See [ADR-0014](adr/0014-swupdate-signing-dev-prod.md) for the signing contract
+and [OTA Key Management](ota-key-management.md) for the per-user keypair policy.
 
 The `home-monitor-camera` machine in `meta-home-monitor/conf/machine/`
 extends `raspberrypi0-2w-64` and carries the permanent OV5647 sensor

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,7 +1,7 @@
 # RPi Home Monitor - Development Guide
 
-Version: 1.0
-Date: 2026-04-09
+Version: 1.2
+Date: 2026-04-19
 
 **This document defines the rules for all development on this project.**
 Every contributor (human or AI) must follow these rules. They are not

--- a/docs/ota-key-management.md
+++ b/docs/ota-key-management.md
@@ -1,7 +1,7 @@
 # OTA Signing Key Management
 
-Version: 1.0
-Date: 2026-04-14
+Version: 1.2
+Date: 2026-04-19
 
 This document defines how the production OTA signing keypair is backed up,
 rotated, recovered, and wired into GitHub Actions without ever committing the

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,7 +1,7 @@
 # RPi Home Monitor - Requirements Specification
 
-Version: 1.0
-Date: 2026-04-13
+Version: 1.2
+Date: 2026-04-19
 
 ---
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -119,12 +119,22 @@ clone_layer "https://github.com/sbabic/meta-swupdate.git" "$YOCTO_DIR/meta-swupd
 
 build_image() {
     local board=$1 builddir=$2 configdir=$3 image=$4
+    # Optional 5th arg: config filename inside config/$configdir/.
+    # Defaults to local.conf (dev). Prod targets pass local.conf.prod,
+    # which `require`s local.conf and overrides SWUPDATE_SIGNING=1.
+    local conf_file=${5:-local.conf}
+    local src_conf="$YOCTO_DIR/config/$configdir/$conf_file"
+    if [ ! -f "$src_conf" ]; then
+        echo "ERROR: config file not found: $src_conf" >&2
+        exit 1
+    fi
 
     echo ""
     echo "============================================"
     echo " Building: $image"
     echo " Board: $board"
     echo " Build dir: $builddir"
+    echo " Config: $conf_file"
     echo " Cores: $NCPU"
     echo "============================================"
     echo ""
@@ -134,7 +144,15 @@ build_image() {
     source "$YOCTO_DIR/poky/oe-init-build-env" "$builddir"
     set -u
 
-    cp "$YOCTO_DIR/config/$configdir/local.conf" "$builddir/conf/local.conf"
+    cp "$src_conf" "$builddir/conf/local.conf"
+    # local.conf.prod uses `require local.conf` relative to itself. When
+    # we copy it into build/conf/ under the name local.conf we'd end up
+    # self-referencing. Resolve the `require` against the source dir so
+    # the prod override stays loadable from the build tree.
+    if [ "$conf_file" != "local.conf" ]; then
+        sed -i "s|^require local\\.conf$|require $YOCTO_DIR/config/$configdir/local.conf|" \
+            "$builddir/conf/local.conf"
+    fi
     cp "$YOCTO_DIR/config/bblayers.conf" "$builddir/conf/bblayers.conf"
     stage_local_ota_cert "$configdir" "$builddir"
 
@@ -177,7 +195,7 @@ case "$TARGET" in
         $BUILD_SWU && package_swu server "$YOCTO_DIR/build" "raspberrypi4-64" "home-monitor-image-dev"
         ;;
     server-prod)
-        build_image "RPi 4B" "$YOCTO_DIR/build" "rpi4b" "home-monitor-image-prod"
+        build_image "RPi 4B" "$YOCTO_DIR/build" "rpi4b" "home-monitor-image-prod" "local.conf.prod"
         $BUILD_SWU && package_swu server "$YOCTO_DIR/build" "raspberrypi4-64" "home-monitor-image-prod"
         ;;
     camera-dev|camera)
@@ -185,7 +203,7 @@ case "$TARGET" in
         $BUILD_SWU && package_swu camera "$YOCTO_DIR/build-zero2w" "home-monitor-camera" "home-camera-image-dev"
         ;;
     camera-prod)
-        build_image "RPi Zero 2W" "$YOCTO_DIR/build-zero2w" "zero2w" "home-camera-image-prod"
+        build_image "RPi Zero 2W" "$YOCTO_DIR/build-zero2w" "zero2w" "home-camera-image-prod" "local.conf.prod"
         $BUILD_SWU && package_swu camera "$YOCTO_DIR/build-zero2w" "home-monitor-camera" "home-camera-image-prod"
         ;;
     all-dev|all)
@@ -197,8 +215,8 @@ case "$TARGET" in
         fi
         ;;
     all-prod)
-        build_image "RPi 4B" "$YOCTO_DIR/build" "rpi4b" "home-monitor-image-prod"
-        build_image "RPi Zero 2W" "$YOCTO_DIR/build-zero2w" "zero2w" "home-camera-image-prod"
+        build_image "RPi 4B" "$YOCTO_DIR/build" "rpi4b" "home-monitor-image-prod" "local.conf.prod"
+        build_image "RPi Zero 2W" "$YOCTO_DIR/build-zero2w" "zero2w" "home-camera-image-prod" "local.conf.prod"
         if $BUILD_SWU; then
             package_swu server "$YOCTO_DIR/build" "raspberrypi4-64" "home-monitor-image-prod"
             package_swu camera "$YOCTO_DIR/build-zero2w" "home-monitor-camera" "home-camera-image-prod"


### PR DESCRIPTION
## Summary

Release-ops for v1.2.0. No runtime code changes.

- **Production Yocto configs per board** — `config/rpi4b/local.conf.prod` and `config/zero2w/local.conf.prod` `require local.conf` and override just `SWUPDATE_SIGNING = "1"`. Dev and prod layer, they don't fork. `build.sh` server-prod / camera-prod / all-prod targets pass the prod config file through a new 5th arg to `build_image`; dev paths unchanged (ADR-0014).
- **`app/server/requirements.lock`** — exact-version pins for deterministic installs. `requirements.txt` keeps the soft floors.
- **CHANGELOG** restructured: `[Unreleased]` empty, `[1.2.0] 2026-04-19` holds the release-readiness work from PR #77, #78, #79, and `[1.1.0] 2026-04-13` aligns prior "Unreleased" content with the existing tag.

Docs review pass is queued as a separate follow-up per user request — those are text-only, no code impact.

## Test plan

- [x] CHANGELOG sections in chronological order (`1.2.0` > `1.1.0` > `v1.0.6-dev`)
- [x] `build.sh` still uses `local.conf` for dev targets (no behaviour change for dev)
- [x] `local.conf.prod` inherits via `require local.conf` (single source of truth for machine/kernel)
- [ ] CI: existing workflow green (new files are Yocto-only, no CI coverage needed)
- [ ] Local VM: `./scripts/build.sh server-prod` builds a signed bundle (user validates post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)