### PR TITLE
release(1.2.1): CHANGELOG for #81 and #82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to RPi Home Monitor are documented here.
 
 (Nothing yet — next release will land here.)
 
+## [1.2.1] — 2026-04-19
+
+Quality-and-polish patch. No API changes, no migration needed.
+
+### Fixed
+- **Dashboard Recent events too long** ([#82](https://github.com/vinu-dev/rpi-home-monitor/pull/82)) — the feed rendered 8 rows, filling the viewport and making the dashboard feel like a recordings page in miniature. Dropped to 3 rows; header "All recordings →" link is the path to the full timeline.
+- **Dashboard Recent activity silently empty** ([#82](https://github.com/vinu-dev/rpi-home-monitor/pull/82)) — the x-show gate `auditAdmin && auditEvents.length > 0` collapsed the section during the render tick when `auditEvents` was an empty array (initial state before the async fetch resolved). Gated on `auditAdmin` alone now, with an explicit "No recent activity yet." empty state when the list is genuinely empty.
+- **WHEP proxy `AttributeError` on headerless `HTTPError`** ([#81](https://github.com/vinu-dev/rpi-home-monitor/pull/81)) — `api/webrtc.py` used `hasattr(e, "headers")` which returns True even when `e.headers is None`. Switched to `if e.headers is not None`.
+- **`subprocess` import in `api/ota.py`** ([#81](https://github.com/vinu-dev/rpi-home-monitor/pull/81)) — architecture fitness tests flagged the API layer calling `subprocess.run` directly. Moved reboot scheduling to `OTAService.schedule_reboot()`; same delay, same thread name, same behaviour.
+
+### Added
+- **World-class test suite** ([#81](https://github.com/vinu-dev/rpi-home-monitor/pull/81)) — 1585 server tests + 555 camera tests (was ~1280 server). 86 → 87.8% server coverage. Adds architecture fitness tests (AST rules for CSRF on mutating routes, M2M HMAC, Store-import layering), property-based tests via Hypothesis for auth + crypto, Playwright regression journeys, and mutation testing (gated behind `vars.RUN_SERVER_MUTATION`).
+- **Unified `logged_in_client` fixture** ([#81](https://github.com/vinu-dev/rpi-home-monitor/pull/81)) — replaces 13 duplicate `_login` helpers across the integration suite.
+
+### Known follow-up
+- Schemathesis fuzzing exposed ~33 pre-existing OpenAPI-vs-implementation gaps in the API contract. Reverted fuzzing to `examples` phase for v1.2.1; full fix tracked for a later contract-hardening PR.
+- `browser-e2e-full` job pulled — journey specs written without a live seeded server had guessed selectors. Smoke project still runs.
+
 ## [1.2.0] — 2026-04-19
 
 First commercial release. Bundles the OTA production-hardening work


### PR DESCRIPTION
## Summary

Patch release. No API changes, no migration. Bundles the post-1.2.0 quality + polish work from [#81](https://github.com/vinu-dev/rpi-home-monitor/pull/81) (world-class test suite) and [#82](https://github.com/vinu-dev/rpi-home-monitor/pull/82) (dashboard Tier-3 polish).

### Fixed
- Dashboard **Recent events** capped at 3 rows (was 8).
- Dashboard **Recent activity** section always renders when admin, with explicit empty-state copy.
- **WHEP proxy** `AttributeError` on HTTPError with `None` headers.
- **`subprocess` import in `api/ota.py`** moved to `OTAService.schedule_reboot()` per architecture-fitness rules.

### Added
- World-class test suite (1585 server + 555 camera), architecture fitness, Hypothesis property tests, mutation testing gated behind `RUN_SERVER_MUTATION`.

### Known follow-up
- ~33 pre-existing OpenAPI-vs-implementation gaps deferred (Schemathesis reverted to examples-only).
- E2E full journey specs removed — selectors guessed without a seeded live server.

## Test plan

- [x] Full server + camera suites already green on #81 / #82 PRs
- [x] Main HEAD tested locally (961 unit tests pass post-#81, #82)
- [x] Wiki refreshed in parallel: [`Testing-and-Quality-Gates`](https://github.com/vinu-dev/rpi-home-monitor/wiki/Testing-and-Quality-Gates), [`Operations-and-OTA`](https://github.com/vinu-dev/rpi-home-monitor/wiki/Operations-and-OTA)
- [ ] Tag `v1.2.1` + GitHub release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)