### PR TITLE
build: version-aware package_swu + pin BUILD_ID to DISTRO_VERSION

### DIFF
--- a/meta-home-monitor/conf/distro/home-monitor.conf
+++ b/meta-home-monitor/conf/distro/home-monitor.conf
@@ -7,8 +7,20 @@
 
 DISTRO = "home-monitor"
 DISTRO_NAME = "Home Monitor OS"
-DISTRO_VERSION = "1.0.0"
+# Bump on every tagged release. This string is stamped into
+# /etc/os-release on-device and surfaces in the admin UI's
+# "Current version" line. Keep it in sync with the git tag
+# that the release artefacts were built from.
+DISTRO_VERSION = "1.2.1"
 DISTRO_CODENAME = "phase1"
+
+# Pin BUILD_ID to the static DISTRO_VERSION. poky's os-release.bb
+# defaults BUILD_ID to a DATETIME-based expression, which was the
+# most likely source of the basehash non-determinism that produced
+# 30× "metadata is not deterministic" warnings per bitbake run in
+# v1.2.1 release builds. Pinning it eliminates the date-dependent
+# input to the task hash and makes os-release.bb reproducible.
+BUILD_ID = "${DISTRO_VERSION}"
 
 # Maintainer
 MAINTAINER = "vinu@engineer.com"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -181,7 +181,47 @@ package_swu() {
         echo "!!! rootfs not found at $rootfs — skipping .swu for $target"
         return 1
     fi
-    version="dev-$(date +%Y%m%d-%H%M)"
+
+    # Version selection (per-target, not a hardcoded dev-timestamp).
+    # Priority:
+    #   1. MONITOR_VERSION env var — explicit override for ad-hoc builds
+    #   2. git describe --tags HEAD — when the release tag is checked out
+    #      this returns e.g. "v1.2.1" (exact) or "v1.2.1-3-gabc123" (ahead)
+    #   3. fall-through per target mode
+    #
+    # Policy:
+    #   *-prod  must ship a real version. Refuses to build with a
+    #           dev-timestamp — signed bundles that impersonate a
+    #           release version are a supply-chain hazard. Operator
+    #           must either tag HEAD or set MONITOR_VERSION.
+    #   *-dev   accepts anything. Prefers git tag when clean, falls
+    #           back to a dated stamp so iterative dev builds don't
+    #           require a new tag each time.
+    local git_ver
+    git_ver=$(git -C "$YOCTO_DIR" describe --tags HEAD 2>/dev/null || true)
+    if [ -n "${MONITOR_VERSION:-}" ]; then
+        version="$MONITOR_VERSION"
+    elif [[ "$TARGET" == *-prod ]]; then
+        if [ -z "$git_ver" ] || [[ "$git_ver" == *-g* ]]; then
+            echo "ERROR: $TARGET requires an exact release tag on HEAD or" >&2
+            echo "       MONITOR_VERSION explicitly set. HEAD resolves to:" >&2
+            echo "       ${git_ver:-<untagged>}" >&2
+            echo "       Tag HEAD (e.g. 'git tag vX.Y.Z && git push --tags')" >&2
+            echo "       or rerun as 'MONITOR_VERSION=vX.Y.Z ./scripts/build.sh $TARGET'." >&2
+            return 1
+        fi
+        version="$git_ver"
+    else
+        # Dev path. Clean tag (no "-gNNN" suffix) → use it as "<tag>-dev"
+        # so the .swu carries the upstream version + dev marker. Otherwise
+        # fall back to the legacy timestamp.
+        if [ -n "$git_ver" ] && [[ "$git_ver" != *-g* ]]; then
+            version="${git_ver}-dev"
+        else
+            version="dev-$(date +%Y%m%d-%H%M)"
+        fi
+    fi
+
     echo ""
     echo ">>> Packaging $target .swu ($version)"
     ( cd "$YOCTO_DIR" && \


### PR DESCRIPTION
## Summary

Two release-build polish items, both follow-ups from the v1.2.1 artefact run.

### 1. `scripts/build.sh::package_swu()` — version selection

The function used to hardcode `version="dev-\$(date +%Y%m%d-%H%M)"` regardless of target, so prod builds produced filenames like `server-update-dev-20260419-1516.swu` and — more importantly — **the signed `sw-description` manifest stamped real release builds with a dev-timestamp**. Supply-chain smell: a signed bundle that advertises itself as a release should carry that version in its signed manifest.

New priority:

1. `MONITOR_VERSION` env var — explicit override
2. `git describe --tags HEAD` — when HEAD is on a tag
3. Per-target fall-through:
   - `*-prod` **refuses** to build with a dev-style version. Operator must tag HEAD or set `MONITOR_VERSION`.
   - `*-dev` prefers a clean tag as `<tag>-dev`, else the legacy `dev-YYYYMMDD-HHMM`.

Dev iteration behaviour on an untagged commit is unchanged.

### 2. `meta-home-monitor/conf/distro/home-monitor.conf`

- `DISTRO_VERSION` bumped `"1.0.0"` → `"1.2.1"` with a comment to bump on every tagged release. The string lands in `/etc/os-release` and the admin UI's "Current version" line; was stale.
- `BUILD_ID = "\${DISTRO_VERSION}"` added to pin poky's os-release `BUILD_ID` (defaults to a `DATETIME`-based expression otherwise, which was the most likely source of the 30× "metadata is not deterministic" bitbake warnings per build in v1.2.1).

## Test plan

- [x] `bash -n scripts/build.sh` passes
- [ ] CI: Ruff / Pre-commit / Shell Lint / Yocto Parse
- [ ] VM: next prod build should (a) tag HEAD on a fresh release, (b) produce a correctly-versioned `.swu` without the manual `build-swu.sh --version` workaround we used in v1.2.1, (c) run without the 30 cosmetic ERROR lines. Safe to roll back either change independently if Yocto objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)