### PR TITLE
Triage open issues: #86 security, #87/#88 mobile UI, #89 storage, #90 IP fallback, #91 confirmed

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -387,7 +387,15 @@ def _startup(app):
             app.motion_clip_correlator.set_recordings_dir(recordings_dir)
 
     app.streaming.start()
-    app.storage_manager.start()
+    # NOTE: app.storage_manager is NOT started. LoopRecorder (ADR-0017)
+    # is the sole eviction path — it's layout-agnostic, protects clips
+    # ffmpeg is still writing (DEFAULT_LIVE_AGE), applies hysteresis
+    # around the low-watermark, and coordinates with the recorder.
+    # StorageManager remains constructed because multiple service
+    # constructors take it as a dependency (it still serves as the
+    # on-disk catalogue / listing helper), but its cleanup loop is
+    # intentionally never started. See issue #89 for the race
+    # conditions and data-loss bugs that forced this.
     app.cert_service.start()
     app.recording_scheduler.start()
     app.loop_recorder.start()

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -537,13 +537,14 @@ select.form-input {
 
 .recordings-player-col {
     min-width: 0;
-}
-@media (min-width: 1024px) {
-    .recordings-player-col {
-        position: sticky;
-        /* 60px top nav + breathing room; stays below the fixed navbar. */
-        top: calc(60px + var(--space-3));
-    }
+    /* Player is sticky on every breakpoint — on mobile it pins the video
+       to the top as the user scrolls through the (single-column) clip
+       list; on desktop it pins the left column while the right-hand list
+       scrolls. Issue #88. */
+    position: sticky;
+    top: calc(60px + var(--space-3));
+    z-index: 2;
+    background: var(--color-bg);
 }
 
 .recordings-list-col {
@@ -554,8 +555,9 @@ select.form-input {
 }
 @media (min-width: 1024px) {
     .recordings-list-col {
-        /* Independent scroll: viewport minus top nav (60), bottom nav (70)
-           and a little gutter on each side. */
+        /* Independent scroll on desktop: viewport minus top nav (60),
+           bottom nav (70) and a little gutter. On mobile the whole page
+           scrolls — the sticky player pins the video regardless. */
         max-height: calc(100vh - 60px - 70px - var(--space-4) * 2);
         overflow-y: auto;
         padding-right: var(--space-1);
@@ -807,9 +809,17 @@ select.form-input {
     background: var(--color-surface-alt);
     border-radius: var(--radius-md);
     overflow-x: auto;
+    /* Momentum scroll on iOS when the tab row overflows the viewport. */
+    -webkit-overflow-scrolling: touch;
+    /* Hide the scrollbar chrome — tabs are discoverable by swipe. */
+    scrollbar-width: thin;
 }
 .settings-tab {
-    flex: 1;
+    /* Each tab keeps its natural content width — the row overflows
+       horizontally and ``.settings-tabs``'s ``overflow-x: auto`` scrolls
+       it. Previously ``flex: 1`` squashed 7 tabs into one 375 px-wide
+       mobile viewport, overlapping the labels (issue #87). */
+    flex: 0 0 auto;
     padding: var(--space-2) var(--space-4);
     border: none;
     border-radius: var(--radius-sm);
@@ -820,7 +830,6 @@ select.form-input {
     cursor: pointer;
     transition: background var(--transition-base), color var(--transition-base);
     white-space: nowrap;
-    min-width: 0;
 }
 .settings-tab:hover { color: var(--color-text); }
 .settings-tab.active {

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -144,7 +144,10 @@
 <!-- Cameras roll-call (Tier 3 — to be restyled in Slice 3) -->
 <div id="cameras-section" class="section-header">
     Cameras
-    <span style="float:right;margin-top:-4px;display:flex;gap:8px;">
+    <!-- Scan + Add Camera are admin-only (backend enforces via @admin_required
+         on the underlying /api/v1/cameras POST + /api/v1/cameras/<id>/scan).
+         Issue #86. -->
+    <span x-show="isAdmin" style="float:right;margin-top:-4px;display:flex;gap:8px;">
         <button class="btn btn--secondary btn--small" @click="scanCameras()" :disabled="scanning">
             <span x-show="!scanning">&#x1F50D; Scan</span>
             <span x-show="scanning">Scanning...</span>
@@ -225,8 +228,11 @@
             <div class="camera-card__actions">
                 <span class="badge badge--pending">discovered</span>
                 <div class="camera-card__btns">
-                    <button class="btn btn--primary btn--small" @click.stop="initPairing(cam.id)">Pair</button>
-                    <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
+                    <!-- Pair is admin-only (backend requires admin to confirm);
+                         Delete likewise. Viewers get a read-only card. -->
+                    <button x-show="isAdmin" class="btn btn--primary btn--small" @click.stop="initPairing(cam.id)">Pair</button>
+                    <button x-show="isAdmin" class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)"
+                            aria-label="Remove camera">&#x2715;</button>
                 </div>
             </div>
         </div>
@@ -254,6 +260,17 @@
                         'text-muted': cam.config_sync === 'unknown'
                     }" x-show="cam.status !== 'pending'" x-text="cam.config_sync === 'synced' ? '\u2713 synced' : cam.config_sync === 'pending' ? '\u231B pending' : ''"></span>
                 </div>
+                <!-- Surface the camera's IP for admins — a necessary fallback
+                     when mDNS/.local resolution fails on the operator's
+                     network (issue #90). Click-to-copy eases typing into
+                     the browser URL bar without having to hand-edit. -->
+                <div class="camera-card__ip text-small text-muted"
+                     x-show="isAdmin && cam.ip"
+                     @click.stop="navigator.clipboard && navigator.clipboard.writeText(cam.ip)"
+                     :title="'IP: ' + cam.ip + ' (click to copy)'"
+                     style="cursor:copy; font-family:var(--font-mono, monospace);">
+                    <span x-text="cam.ip"></span>
+                </div>
                 <div class="camera-card__last-seen" x-show="cam.last_seen">
                     <span :class="{'text-danger': _staleSeconds(cam) > 45, 'text-warning': _staleSeconds(cam) > 30 && _staleSeconds(cam) <= 45}"
                           x-text="'Last seen: ' + _relativeTime(cam.last_seen)"></span>
@@ -279,8 +296,13 @@
                 }" :aria-label="((cam.stream_state === 'running') || cam.streaming) ? 'live' : 'idle'"
                    x-text="((cam.stream_state === 'running') || cam.streaming) ? '\u25CF live' : '\u25CB idle'"></span>
                 <div class="camera-card__btns">
-                    <button class="btn btn--secondary btn--small" @click.stop="openStreamSettings(cam)">Settings</button>
-                    <button class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)">&#x2715;</button>
+                    <!-- Settings + Delete are admin-only (backend enforces via
+                         @admin_required on PUT/DELETE /api/v1/cameras/<id>).
+                         Hide for viewers so they don't see the controls only
+                         to be rejected with a 403 on click. -->
+                    <button x-show="isAdmin" class="btn btn--secondary btn--small" @click.stop="openStreamSettings(cam)">Settings</button>
+                    <button x-show="isAdmin" class="btn btn--danger btn--small btn--icon" @click.stop="deleteCamera(cam.id)"
+                            aria-label="Remove camera">&#x2715;</button>
                 </div>
             </div>
         </div>
@@ -388,6 +410,12 @@ function dashboardPage() {
         health: { uptime: '' },
         auditEvents: [],      // Slice 3 log teaser
         auditAdmin: true,     // becomes false if /audit 403s (viewer role)
+        // Mirrors settings.html's isAdmin — resolved from /api/v1/auth/me
+        // on load and used to gate destructive UI controls (issue #86).
+        // Defaults to false (safe-by-default): UI hides Settings/Delete
+        // until the role check comes back "admin".
+        currentUser: null,
+        isAdmin: false,
 
         // --- Existing camera-list state (Tier-3 roll-call stub) ---
         cameras: [],
@@ -736,7 +764,26 @@ function dashboardPage() {
             }
         },
 
+        async loadCurrentUser() {
+            // Resolve role so destructive UI controls (Settings, Delete)
+            // are hidden for viewers. Defence in depth: the backend
+            // (@admin_required in auth.py) also rejects these calls.
+            try {
+                // /api/v1/auth/me returns {user: {id, username, role}, csrf_token}.
+                var resp = await window.HM.api.get('/api/v1/auth/me');
+                var user = resp && resp.user ? resp.user : resp;
+                this.currentUser = user;
+                this.isAdmin = !!(user && user.role === 'admin');
+            } catch (e) {
+                this.currentUser = null;
+                this.isAdmin = false;
+            }
+        },
+
         async deleteCamera(camId) {
+            // Defence in depth — UI hides the button for viewers, but
+            // double-guard the handler in case of DOM manipulation.
+            if (!this.isAdmin) return;
             if (!confirm('Remove this camera?')) return;
             try {
                 await window.HM.api.del('/api/v1/cameras/' + encodeURIComponent(camId));
@@ -793,6 +840,7 @@ function dashboardPage() {
         },
 
         async saveStreamSettings() {
+            if (!this.isAdmin) return;  // defence-in-depth alongside backend 403
             if (!this.editCam) return;
             this.savingStream = true;
             this.streamSaveMsg = '';
@@ -870,6 +918,7 @@ function dashboardPage() {
         },
 
         init() {
+            this.loadCurrentUser();
             this.loadSummary();
             this.loadCameras();
             // Summary: 10s (matches the existing health cadence; ADR-0018


### PR DESCRIPTION
Bundles the open-issue triage. Each fix is independent and small; see commit message for full per-issue rationale.

## Fixes

- **#86 (security)** — viewer role saw Settings/Delete/Scan/Add/Pair buttons and got 403s on click. UI now gates them behind an `isAdmin` flag derived from `/api/v1/auth/me`. Defence-in-depth handler guards added.
- **#87 (mobile UI)** — Settings tab bar squashed on narrow viewports. `flex: 0 0 auto` lets the row overflow and the existing `overflow-x: auto` scroll as intended. Added iOS momentum scrolling.
- **#88 (mobile UI)** — Recordings player not sticky on mobile. Lifted `position: sticky` out of the desktop `@media` gate.
- **#89 (storage)** — two competing cleanup services. `StorageManager.start()` no longer called. `LoopRecorder` (ADR-0017) is the sole eviction path: layout-agnostic, live-segment protection, hysteresis.
- **#90 (networking, partial)** — surface the camera IP on each dashboard card for admins with click-to-copy, so `.local` failure isn't a dead end. Structural mDNS fixes (Avahi readiness, retry, goodbye packets) need on-device testing and are deferred to a separate PR.
- **#91** — already fixed on `feat/motion-events-ui` (now in `main`). "Full log →" points to `/logs`. Marked for close, no code change.

## Test plan

- [x] `app/server` full suite — 1675 pass
- [x] Ruff clean, format clean
- [ ] CI green
- [ ] Manual: viewer login → confirm no Settings/Delete buttons visible on camera cards
- [ ] Manual: 375 px viewport → Settings tabs swipe horizontally
- [ ] Manual: mobile Recordings → scrolling list with pinned player
- [ ] Manual: admin dashboard → IP visible on each camera card, click copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)