### PR TITLE
fix(motion): motion-mode recordings + correlator tolerance for recorder spawn

### DIFF
--- a/app/server/monitor/api/cameras.py
+++ b/app/server/monitor/api/cameras.py
@@ -70,6 +70,26 @@ def _record_and_check_replay(camera_id: str, timestamp_str: str, sig: str) -> bo
 cameras_bp = Blueprint("cameras", __name__)
 
 
+def _nudge_scheduler(camera_id: str) -> None:
+    """Best-effort: wake the RecordingScheduler for ``camera_id`` now.
+
+    Motion events are typically 3-10 s long. The scheduler's periodic
+    tick is 60 s — far too coarse to catch a motion window via polling
+    alone. The motion-event POST handler calls this on both start and
+    end so the recorder spawns and tears down promptly without waiting
+    for the next tick. Never raises; a scheduler that's absent or in a
+    bad state just falls through to the periodic tick, which is still
+    correct for continuous / schedule modes.
+    """
+    scheduler = getattr(current_app, "recording_scheduler", None)
+    if scheduler is None:
+        return
+    try:
+        scheduler.nudge(camera_id)
+    except Exception:
+        pass
+
+
 def _verify_camera_hmac(request) -> tuple[str, str | None]:
     """Verify HMAC-signed camera request. Shared by heartbeat + config-notify.
 
@@ -369,6 +389,11 @@ def camera_motion_event():
             duration_seconds=0.0,
         )
         store.append(evt)
+        # Event-driven scheduler nudge. The periodic tick is 60 s which
+        # is far too slow for motion events (typical event length 3-10 s);
+        # without this, the recorder never spawns during motion-mode
+        # recording. See ADR-0021 + recording_scheduler.nudge().
+        _nudge_scheduler(camera_id)
         current_app.audit.log_event(
             event="MOTION_DETECTED",
             user="camera",
@@ -403,6 +428,11 @@ def camera_motion_event():
         )
         existing.duration_seconds = float(data.get("duration_seconds") or 0.0)
         store.append(existing)
+
+    # Nudge the scheduler again on "end" so motion-mode recordings
+    # cleanly enter post-roll and stop the recorder when the window
+    # closes, without waiting for the 60 s tick.
+    _nudge_scheduler(camera_id)
 
     current_app.audit.log_event(
         event="MOTION_ENDED",

--- a/app/server/monitor/services/motion_clip_correlator.py
+++ b/app/server/monitor/services/motion_clip_correlator.py
@@ -82,9 +82,21 @@ class MotionClipCorrelator:
         self,
         recordings_dir: str | Path,
         clip_duration_seconds: int = DEFAULT_CLIP_DURATION_SECONDS,
+        pre_event_tolerance_seconds: int = 30,
     ):
         self._recordings_dir = Path(recordings_dir)
         self._clip_duration = max(1, int(clip_duration_seconds))
+        # How far BEFORE a clip's start we still accept an event. In
+        # motion-recording mode the RecordingScheduler ticks every 10 s,
+        # so the recorder ffmpeg spawns several seconds after the motion
+        # event's ``started_at`` — the clip filename timestamp is always
+        # strictly later than the event. Without this tolerance those
+        # events never match and the /events/<id> router falls back to
+        # /live. 30 s comfortably covers the 10 s scheduler tick + a few
+        # seconds of ffmpeg / camera start latency. An event matched via
+        # this window lands at offset_seconds=0 (start of clip) because
+        # the recorder didn't capture anything before its own spawn.
+        self._pre_tol = max(0, int(pre_event_tolerance_seconds))
 
     def set_recordings_dir(self, new_dir: str | Path) -> None:
         """Update the recordings root at runtime.
@@ -199,11 +211,23 @@ class MotionClipCorrelator:
         date_str: str,
     ) -> dict | None:
         delta = (event_dt - clip_start).total_seconds()
+        # In-window: event falls inside the clip's time range.
         if 0 <= delta < self._clip_duration:
             return {
                 "camera_id": camera_id,
                 "date": date_str,
                 "filename": mp4.name,
                 "offset_seconds": int(delta),
+            }
+        # Pre-window: event fired shortly BEFORE the clip started. This is
+        # the normal motion-mode case (see _pre_tol docstring in __init__).
+        # Seek to the start of the clip — the event's leading edge wasn't
+        # captured because the recorder spawned in response to the event.
+        if -self._pre_tol <= delta < 0:
+            return {
+                "camera_id": camera_id,
+                "date": date_str,
+                "filename": mp4.name,
+                "offset_seconds": 0,
             }
         return None

--- a/app/server/monitor/services/recording_scheduler.py
+++ b/app/server/monitor/services/recording_scheduler.py
@@ -157,6 +157,31 @@ class RecordingScheduler:
             except Exception as exc:
                 log.warning("Scheduler reconcile failed for %s: %s", cam.id, exc)
 
+    def nudge(self, camera_id: str) -> None:
+        """Reconcile a single camera *right now*, bypassing the tick loop.
+
+        The periodic tick is 60 s by default (fine for continuous /
+        schedule modes where recording windows are minutes long). For
+        motion mode, typical events are 3-10 s so a 60 s poll misses
+        the window entirely — by the time the scheduler notices, both
+        motion and its post-roll are over. Call this when a new motion
+        event arrives to start the recorder without waiting for the
+        next tick. Safe from any thread; best-effort.
+        """
+        try:
+            camera = self._store.get_camera(camera_id)
+        except Exception as exc:
+            log.debug(
+                "Scheduler nudge: store.get_camera(%s) failed: %s", camera_id, exc
+            )
+            return
+        if camera is None:
+            return
+        try:
+            self._reconcile_camera(camera, datetime.now())
+        except Exception as exc:
+            log.warning("Scheduler nudge reconcile failed for %s: %s", camera_id, exc)
+
     @staticmethod
     def evaluate(
         camera,

--- a/app/server/tests/unit/test_motion_clip_correlator.py
+++ b/app/server/tests/unit/test_motion_clip_correlator.py
@@ -33,13 +33,28 @@ class TestFlatLayout:
         assert ref["filename"] == "20260419_143000.mp4"
         assert ref["offset_seconds"] == 75
 
-    def test_no_match_before_clip_start(self, recordings_dir):
+    def test_match_just_before_clip_start_seeks_to_zero(self, recordings_dir):
+        """Motion-mode recorders spawn a few seconds after the event fires
+        (10 s scheduler tick), so events whose timestamp is just before
+        the clip's start should still match — with ``offset_seconds=0``
+        because the recorder didn't capture anything earlier."""
         cam = recordings_dir / "cam-001"
         _make_clip(cam, "20260419_143000.mp4")
         corr = MotionClipCorrelator(recordings_dir)
 
-        # Event 1 s before the clip started.
         ref = corr.find_clip("cam-001", "2026-04-19T14:29:59Z")
+        assert ref is not None
+        assert ref["offset_seconds"] == 0
+        assert ref["filename"] == "20260419_143000.mp4"
+
+    def test_no_match_far_before_clip_start(self, recordings_dir):
+        """Beyond the pre-event tolerance (default 30 s) we still reject."""
+        cam = recordings_dir / "cam-001"
+        _make_clip(cam, "20260419_143000.mp4")
+        corr = MotionClipCorrelator(recordings_dir, pre_event_tolerance_seconds=30)
+
+        # Event 31 s before the clip started — outside tolerance.
+        ref = corr.find_clip("cam-001", "2026-04-19T14:29:29Z")
         assert ref is None
 
     def test_no_match_after_clip_ends(self, recordings_dir):


### PR DESCRIPTION
## Bug

User set `recording_mode=motion`, motion events fired as expected, but clicking any event landed on `/live` instead of seeking into a recording. On inspection: no clips were being written for motion events at all.

## Root cause

Two issues stacking on top of each other:

1. **Scheduler latency** — `RecordingScheduler` ticks every **60 s**. Motion events are typically 3-10 s long with a 10 s post-roll. The scheduler always noticed too late; the recorder never spawned.
2. **Correlator intolerance** — even when the recorder *did* spawn, ffmpeg's first-segment open takes ~1-2 s, so the clip's filename timestamp is always after the motion event's `started_at`. The correlator required `0 <= event_dt - clip_start < clip_duration`, so every motion-mode event had `clip_ref=None` and the UI fell through to Live.

## Fix

1. **Event-driven scheduling.** Add `RecordingScheduler.nudge(camera_id)` — reconciles one camera immediately. The motion-event POST handler calls it on both `phase=start` (spawn recorder while motion is still active) and `phase=end` (clean transition into post-roll). Periodic tick remains the authoritative reconciliation for continuous + schedule modes.
2. **Pre-event tolerance window.** Correlator accepts events up to 30 s before a clip's start, matching with `offset_seconds=0`. Configurable via `pre_event_tolerance_seconds`.

## Test plan

- [x] Server unit + integration — 1462 pass
- [x] `test_match_just_before_clip_start_seeks_to_zero` — new
- [x] `test_no_match_far_before_clip_start` — new (tolerance boundary)
- [ ] On hardware: `recording_mode=motion`, wave at camera → clip appears in `/data/recordings/<cam>/`, motion event shows `clip_ref`, click seeks into the recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)