### PR TITLE
fix(ui): player height cap, live player controls, and status-strip link to /logs

### DIFF
--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -351,7 +351,7 @@ class SystemSummaryService:
             events = self._audit.get_events(limit=500)
         except Exception as exc:
             log.warning("summary: audit.get_events failed: %s", exc)
-            return "green", 0, "/settings#audit"
+            return "green", 0, "/logs"
 
         cutoff = datetime.now(UTC) - timedelta(seconds=ERROR_WINDOW_SECONDS)
         errors = 0
@@ -371,7 +371,7 @@ class SystemSummaryService:
             state = "red"
         elif warnings > 0:
             state = "amber"
-        return state, errors + warnings, "/settings#audit"
+        return state, errors + warnings, "/logs"
 
     # -- summary sentence ---------------------------------------------------
 

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -746,18 +746,24 @@ select.form-input {
     display: block;
     margin: 0;
 }
-.inline-player video {
+.inline-player video,
+.inline-player__placeholder {
     width: 100%;
     aspect-ratio: 16 / 9;
+    /* Cap the player at ~45 % of the viewport so the clip list below
+       always has at least half the screen to scroll through — important
+       on short viewports (Echo Show, small tablets, narrow browser
+       windows). Without this cap a full-width 16:9 player eats the
+       entire visible area under the top nav on compact displays
+       (issue #95). object-fit contain keeps the frame aspect-correct
+       when the cap kicks in (letterbox instead of distort). */
+    max-height: 45vh;
+    object-fit: contain;
     border-radius: var(--radius-md);
     background: #000;
     display: block;
 }
 .inline-player__placeholder {
-    width: 100%;
-    aspect-ratio: 16 / 9;
-    border-radius: var(--radius-md);
-    background: #000;
     color: var(--color-text-muted);
     display: flex;
     align-items: center;
@@ -769,6 +775,16 @@ select.form-input {
 }
 .inline-player__placeholder.hidden { display: none; }
 .inline-player video.hidden { display: none; }
+
+/* Live player button row (issue #96) — Mute / PiP / Fullscreen / Snapshot
+   sit in a single flex row. Gap matches the overall small-button spacing
+   elsewhere in the app for visual consistency. */
+.live-controls {
+    display: inline-flex;
+    gap: var(--space-2);
+    align-items: center;
+    flex-wrap: wrap;
+}
 .inline-player__bar {
     display: flex;
     align-items: center;

--- a/app/server/monitor/templates/live.html
+++ b/app/server/monitor/templates/live.html
@@ -24,7 +24,24 @@
 <!-- Controls -->
 <div class="flex-between mt-8">
     <span id="live-stream-status" class="text-muted text-small"></span>
-    <div>
+    <!-- Player controls. The <video> element deliberately has no
+         native ``controls`` attribute (issue #96) — the dark theme
+         conflicts with native bars and the custom buttons need
+         disabled-gating on stream state. Icons are text glyphs to
+         avoid shipping an SVG icon set for four buttons. -->
+    <div class="live-controls">
+        <button class="btn btn--secondary btn--small" id="btn-mute"
+                disabled aria-label="Toggle sound" title="Toggle sound">
+            <span id="btn-mute-icon">&#x1F507;</span>
+        </button>
+        <button class="btn btn--secondary btn--small" id="btn-pip"
+                disabled aria-label="Picture in picture" title="Picture in picture">
+            &#x2B1A;
+        </button>
+        <button class="btn btn--secondary btn--small" id="btn-fullscreen"
+                disabled aria-label="Fullscreen" title="Fullscreen">
+            <span id="btn-fullscreen-icon">&#x26F6;</span>
+        </button>
         <button class="btn btn--secondary btn--small" id="btn-snapshot" disabled>Snapshot</button>
     </div>
 </div>
@@ -73,8 +90,27 @@
     var overlayText = document.getElementById('live-overlay-text');
     var selectEl = document.getElementById('live-camera-select');
     var btnSnapshot = document.getElementById('btn-snapshot');
+    var btnMute = document.getElementById('btn-mute');
+    var btnMuteIcon = document.getElementById('btn-mute-icon');
+    var btnPip = document.getElementById('btn-pip');
+    var btnFullscreen = document.getElementById('btn-fullscreen');
     var statusEl = document.getElementById('live-stream-status');
     var infoPanel = document.getElementById('live-camera-info');
+
+    // Player-control buttons share the same enabled/disabled state as
+    // Snapshot (enabled only while a stream is live). Centralised here so
+    // the cascade (WebRTC → HLS.js → native HLS) + destroyStream() all
+    // toggle a single helper.
+    function setControlsEnabled(enabled) {
+        btnSnapshot.disabled = !enabled;
+        btnMute.disabled = !enabled;
+        // PiP: only enable where the browser supports it.
+        var pipSupported = 'pictureInPictureEnabled' in document &&
+                           document.pictureInPictureEnabled;
+        btnPip.disabled = !(enabled && pipSupported);
+        // Fullscreen: universal support — enable if a stream is live.
+        btnFullscreen.disabled = !enabled;
+    }
 
     var peerConnection = null;
     var hlsInstance = null;
@@ -167,7 +203,7 @@
         videoEl.srcObject = null;
         videoEl.removeAttribute('src');
         videoEl.load();
-        btnSnapshot.disabled = true;
+        setControlsEnabled(false);
         statusEl.textContent = '';
         currentTransport = '';
     }
@@ -229,7 +265,7 @@
                     clearTimeout(timeout);
                     currentTransport = 'webrtc';
                     hideOverlay();
-                    btnSnapshot.disabled = false;
+                    setControlsEnabled(true);
                     statusEl.textContent = 'Live (WebRTC)';
                     resolve();
                 }
@@ -312,7 +348,7 @@
             videoEl.addEventListener('loadedmetadata', function onLoaded() {
                 videoEl.removeEventListener('loadedmetadata', onLoaded);
                 hideOverlay();
-                btnSnapshot.disabled = false;
+                setControlsEnabled(true);
                 statusEl.textContent = 'Live (HLS)';
             });
             videoEl.addEventListener('error', function onErr() {
@@ -337,7 +373,7 @@
 
             hlsInstance.on(Hls.Events.MANIFEST_PARSED, function() {
                 hideOverlay();
-                btnSnapshot.disabled = false;
+                setControlsEnabled(true);
                 statusEl.textContent = 'Live (HLS)';
                 videoEl.play().catch(function() {});
             });
@@ -373,6 +409,76 @@
             window.open('/api/v1/live/' + encodeURIComponent(cameraId) + '/snapshot', '_blank');
         }
     });
+
+    // --- Mute / unmute ---
+    // Stream starts muted (autoplay policy); unmute only on user gesture.
+    function refreshMuteIcon() {
+        // 🔇 when muted, 🔊 when unmuted.
+        btnMuteIcon.textContent = videoEl.muted ? '\u{1F507}' : '\u{1F50A}';
+        btnMute.setAttribute(
+            'aria-label', videoEl.muted ? 'Unmute' : 'Mute'
+        );
+        btnMute.setAttribute('title', videoEl.muted ? 'Unmute' : 'Mute');
+    }
+    btnMute.addEventListener('click', function() {
+        videoEl.muted = !videoEl.muted;
+        refreshMuteIcon();
+    });
+    videoEl.addEventListener('volumechange', refreshMuteIcon);
+
+    // --- Picture-in-picture ---
+    btnPip.addEventListener('click', function() {
+        if (!document.pictureInPictureEnabled) return;
+        if (document.pictureInPictureElement === videoEl) {
+            document.exitPictureInPicture().catch(function() {});
+        } else {
+            videoEl.requestPictureInPicture().catch(function() {
+                // User gesture required / not supported — silently ignore.
+            });
+        }
+    });
+
+    // --- Fullscreen ---
+    // Use the video container so custom overlays (status, snapshot
+    // flash) also enter fullscreen, not just the bare <video>.
+    var fsTarget = document.getElementById('live-video-container') || videoEl;
+    function enterFullscreen() {
+        var fn = fsTarget.requestFullscreen ||
+                 fsTarget.webkitRequestFullscreen ||
+                 videoEl.webkitEnterFullscreen;  // iOS Safari native video
+        if (fn) {
+            try { fn.call(fsTarget.webkitEnterFullscreen ? videoEl : fsTarget); }
+            catch (e) { /* silently ignore — user gesture required */ }
+        }
+        // Best-effort landscape lock on mobile; wrapped because
+        // screen.orientation is undefined on iOS Safari.
+        try {
+            if (screen.orientation && screen.orientation.lock) {
+                screen.orientation.lock('landscape').catch(function() {});
+            }
+        } catch (e) { /* noop */ }
+    }
+    function exitFullscreen() {
+        var fn = document.exitFullscreen || document.webkitExitFullscreen;
+        if (fn) fn.call(document);
+    }
+    btnFullscreen.addEventListener('click', function() {
+        var current = document.fullscreenElement || document.webkitFullscreenElement;
+        if (current) { exitFullscreen(); } else { enterFullscreen(); }
+    });
+    ['fullscreenchange', 'webkitfullscreenchange'].forEach(function(ev) {
+        document.addEventListener(ev, function() {
+            var active = document.fullscreenElement || document.webkitFullscreenElement;
+            btnFullscreen.setAttribute(
+                'aria-label', active ? 'Exit fullscreen' : 'Fullscreen'
+            );
+            btnFullscreen.setAttribute(
+                'title', active ? 'Exit fullscreen' : 'Fullscreen'
+            );
+        });
+    });
+
+    refreshMuteIcon();
 
     function init() { loadCameras(); }
 

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -1049,6 +1049,17 @@ function settingsPage() {
                 this.isAdmin = this.currentUser && this.currentUser.role === 'admin';
             } catch(e) {}
 
+            // Honour a URL fragment like /settings#storage so status-strip
+            // deep-links (/settings#system, /settings#storage etc.) open
+            // directly on the correct tab instead of bouncing the user
+            // through the default tab. Unknown fragments are ignored.
+            var validTabs = ['system','network','tailscale','users','recording','storage','updates'];
+            var frag = (window.location.hash || '').replace('#','').toLowerCase();
+            if (frag && validTabs.indexOf(frag) !== -1) {
+                this.tab = frag;
+                if (frag === 'updates' && this.isAdmin) { this.loadOtaStatus(); }
+            }
+
             this.loadSystemInfo();
             this.loadTimeStatus();
 


### PR DESCRIPTION
## Fixes

### Closes #95 — sticky player covers clip list on short viewports
Cap the recordings player at `max-height: 45vh` with `object-fit: contain`. Never consumes more than 45% of the viewport, so the clip list always has at least ~50% to scroll. Same cap on the `__placeholder` so the pre-play state matches.

### Closes #96 — Live player missing fullscreen + controls
- **Fullscreen** button — uses the video container (overlays follow), webkit + iOS-native fallbacks, best-effort landscape orientation lock, `fullscreenchange` updates aria-label.
- **Picture-in-Picture** — disabled automatically where unsupported.
- **Mute / unmute** — toggle with reactive 🔇 ↔ 🔊 icon driven by the video element's `volumechange`.
- Snapshot unchanged. No `controls` on the `<video>` — native bar conflicts with the dark theme.

### Plus: notification "review log" deep-link fixed
Reported today: clicking the status-strip "1 recent system event — review log" landed on `/settings` with no log visible. The link was `/settings#audit` — a fragment with no anchor (same class as the old #91). Pointed to `/logs` (the existing unified audit + motion surface). Separately, `/settings#system` / `/settings#storage` links did resolve to real sections but always opened on the System tab — added fragment-to-tab handling in `settings.html` so arriving with a valid hash selects that tab.

## Test plan

- [x] 1462 server unit + integration pass
- [x] Ruff + format clean
- [ ] Manual: short viewport (Echo Show or DevTools device-height ~400) → clip list visible under player
- [ ] Manual: Live View → Fullscreen button enters FS; Esc exits; icon/aria stays in sync
- [ ] Manual: Live View → Mute toggles 🔇↔🔊 without page reload
- [ ] Manual: Live View → PiP button works on Chromium; disabled on Firefox ESR (varies)
- [ ] Manual: click status-strip "review log" → lands on `/logs`
- [ ] Manual: open `/settings#storage` → Storage tab active

🤖 Generated with [Claude Code](https://claude.com/claude-code)