### PR TITLE
fix(ui): cap Live View player at 70vh (fits laptop viewports without scroll)

### DIFF
--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -475,7 +475,18 @@ select.form-input {
 .video-container {
     position: relative;
     width: 100%;
-    padding-bottom: 56.25%; /* 16:9 */
+    /* Use `aspect-ratio` (not the padding-bottom hack) so a viewport
+       height cap can actually constrain the box. On a typical laptop
+       (1440×900, sidebar + top nav + camera selector + controls row +
+       bottom nav consume ~270 px), an uncapped 16:9 at full content
+       width is taller than what's left — forcing the user to scroll
+       or enter fullscreen to see the whole frame. 70vh keeps the
+       player inside the viewport on laptops without compromising big
+       desktop monitors. Margin:auto centres the shrunken-by-height
+       player so the page doesn't look lopsided. */
+    aspect-ratio: 16 / 9;
+    max-height: 70vh;
+    margin: 0 auto;
     background: #000;
     border-radius: var(--radius-md);
     overflow: hidden;


### PR DESCRIPTION
Live page's .video-container used the padding-bottom:56.25% aspect-ratio hack with no height cap. On a 1440×900 laptop, content-width 16:9 = ~720 px, but the available vertical space after top nav + page title + camera selector + controls + bottom nav is ~630 px — so the player always ran past the fold. Switched to the modern `aspect-ratio: 16/9` + `max-height: 70vh` + `margin: 0 auto`. When the cap kicks in the browser preserves ratio by shrinking width and centres horizontally. Big monitors see no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)