### PR TITLE
fix(ui): "N recent system event" strip clears when user visits /logs

### DIFF
--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -353,7 +353,26 @@ class SystemSummaryService:
             log.warning("summary: audit.get_events failed: %s", exc)
             return "green", 0, "/logs"
 
+        # Effective cutoff = max(1h-window, this-user's-last-seen).
+        # The per-user "I've read the log" timestamp is stored on the
+        # Flask session and stamped when they visit /logs — without it,
+        # an event could show "1 recent system event" for up to an hour
+        # even though the user has already reviewed the log.
         cutoff = datetime.now(UTC) - timedelta(seconds=ERROR_WINDOW_SECONDS)
+        try:
+            # Late import + optional — the summary service must not crash
+            # outside a request context (e.g. startup self-tests).
+            from flask import has_request_context, session
+
+            if has_request_context():
+                seen_iso = session.get("audit_seen_at")
+                if seen_iso:
+                    seen_dt = _parse_ts(seen_iso)
+                    if seen_dt is not None and seen_dt > cutoff:
+                        cutoff = seen_dt
+        except Exception:
+            pass
+
         errors = 0
         warnings = 0
         for ev in events:

--- a/app/server/monitor/views.py
+++ b/app/server/monitor/views.py
@@ -114,6 +114,14 @@ def logs():
         return redirect(url_for("views.setup"))
     if not _is_authenticated():
         return redirect(url_for("views.login"))
+    # "I've seen the log" ack — clears the dashboard status strip's
+    # "N recent system event…" callout without waiting the full hour
+    # for events to age out of the error window. Per-session so each
+    # admin clears their own view. Stamped at the instant the page
+    # is rendered; any event written after this is a fresh alert.
+    from datetime import UTC, datetime
+
+    session["audit_seen_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     return render_template("logs.html")
 
 


### PR DESCRIPTION
## Bug

The dashboard status strip shows *"1 recent system event — review log"* for up to 60 minutes after a transient error — even after the admin has already clicked the link, read the log, and moved on. There's no "I've seen it" handshake, so the strip lingers until the event ages out of the 1-hour window.

## Fix

- `/logs` render handler stamps `session["audit_seen_at"] = now()`.
- `SystemSummaryService._recent_errors` raises its cutoff to `max(1h-window, session["audit_seen_at"])` when a request context + session are available.

Per-session state so each admin clears their own view. New errors after the ack still fire on the strip. No schema change, no new endpoint; dashboard's 10 s poll picks up the cleared state on the next tick.

## Test plan

- [x] 1462 server unit + integration pass
- [x] Ruff + format clean
- [ ] Manual: force a warning event (e.g. a failed API call), confirm strip shows "1 recent system event"
- [ ] Manual: click "review log" → arrive on /logs
- [ ] Manual: return to dashboard → within 10 s the strip clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)