### PR TITLE
feat(auth): admin password reset + CLI admin recovery (#99 slice 1, #100)

### DIFF
--- a/app/server/monitor/api/users.py
+++ b/app/server/monitor/api/users.py
@@ -71,6 +71,10 @@ def change_password(user_id):
     if not data:
         return jsonify({"error": "JSON body required"}), 400
 
+    # ``force_change`` is the admin-reset handshake (issue #99 slice 1):
+    # when true + admin + target != self, the target's must_change_password
+    # flag stays set so they have to rotate on next login. Accepted but
+    # silently ignored on self-change — enforced in user_service.
     msg, status = current_app.user_service.change_password(
         user_id=user_id,
         new_password=data.get("new_password", ""),
@@ -78,6 +82,7 @@ def change_password(user_id):
         requesting_user_id=session.get("user_id", ""),
         requesting_user=session.get("username", ""),
         requesting_ip=request.remote_addr or "",
+        force_change_next_login=bool(data.get("force_change", False)),
     )
     if status != 200:
         return jsonify({"error": msg}), status

--- a/app/server/monitor/services/user_service.py
+++ b/app/server/monitor/services/user_service.py
@@ -134,14 +134,29 @@ class UserService:
         requesting_user_id: str = "",
         requesting_user: str = "",
         requesting_ip: str = "",
+        force_change_next_login: bool = False,
     ) -> tuple[str, int]:
         """Change a user's password. Admin can change any, users change own.
+
+        Args:
+            force_change_next_login: When True, leave ``must_change_password``
+                set so the target user is forced to rotate their password on
+                next login. Intended for the admin-resets-another-user path
+                (issue #99 slice 1) — the admin never needs to know the final
+                password. Refused on self-reset so an admin can't loop
+                themselves.
 
         Returns (message, status_code).
         """
         # Authorization check
         if requesting_role != "admin" and requesting_user_id != user_id:
             return "Cannot change another user's password", 403
+
+        is_admin_reset = (
+            requesting_role == "admin"
+            and requesting_user_id != user_id
+            and force_change_next_login
+        )
 
         pw_error = validate_password(new_password)
         if pw_error:
@@ -151,16 +166,33 @@ class UserService:
         if not user:
             return "User not found", 404
 
+        # Safety rail: don't leave the only admin trapped in a must-change
+        # loop if the flag gets set on them by accident. The existing
+        # "can't demote the last admin" guard in update_user has the same
+        # spirit — extend it here.
+        if is_admin_reset and user.role == "admin":
+            admins = [u for u in self._store.list_users() if u.role == "admin"]
+            if len(admins) <= 1:
+                return "Cannot force-change the only admin", 400
+
         user.password_hash = hash_password(new_password)
-        user.must_change_password = False
+        user.must_change_password = bool(is_admin_reset)
         self._store.save_user(user)
 
-        self._log_audit(
-            "PASSWORD_CHANGED",
-            requesting_user,
-            requesting_ip,
-            f"password changed for user {user_id}",
-        )
+        if is_admin_reset:
+            self._log_audit(
+                "PASSWORD_RESET_BY_ADMIN",
+                requesting_user,
+                requesting_ip,
+                f"admin reset password for user {user_id}; must_change_password=true",
+            )
+        else:
+            self._log_audit(
+                "PASSWORD_CHANGED",
+                requesting_user,
+                requesting_ip,
+                f"password changed for user {user_id}",
+            )
 
         return "Password updated", 200
 

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -796,6 +796,36 @@ select.form-input {
     align-items: center;
     flex-wrap: wrap;
 }
+
+/* Forgot-password disclosure on /login (issue #99 slice 1). Collapsed by
+   default so it doesn't clutter the typical success flow; opens inline
+   so the user doesn't leave the page. */
+.forgot-password {
+    margin-top: var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+}
+.forgot-password summary {
+    cursor: pointer;
+    user-select: none;
+    padding: 4px 0;
+}
+.forgot-password__body {
+    margin-top: var(--space-2);
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    line-height: 1.5;
+}
+.forgot-password__body p { margin: 0 0 var(--space-2); }
+.forgot-password__body pre {
+    background: var(--color-surface-alt);
+    padding: var(--space-2);
+    border-radius: var(--radius-sm);
+    overflow-x: auto;
+    font-size: var(--text-xs);
+    margin: var(--space-2) 0;
+}
 .inline-player__bar {
     display: flex;
     align-items: center;

--- a/app/server/monitor/templates/login.html
+++ b/app/server/monitor/templates/login.html
@@ -25,6 +25,21 @@
             <button type="submit" class="btn btn--primary btn--full" id="btn-login">
                 Sign In
             </button>
+            <!-- "Forgot password?" hint (issue #99 slice 1). No email or
+                 cloud reset flow exists (single-LAN device); the right
+                 paths are out-of-band. -->
+            <details class="forgot-password">
+                <summary>Forgot password?</summary>
+                <div class="forgot-password__body">
+                    <p><strong>Ask your admin</strong> to reset it for you from
+                    <em>Settings &rsaquo; Users &rsaquo; Reset password</em>.</p>
+                    <p>If <em>you</em> are the admin and have no other admin account,
+                    run this on the device over SSH or a keyboard/monitor:</p>
+                    <pre>sudo /opt/monitor/scripts/reset-admin-password.py \
+    --username admin --password 'temp-pass-12345'</pre>
+                    <p>You will be forced to change it on first login.</p>
+                </div>
+            </details>
         </form>
     </div>
 </div>

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -534,10 +534,24 @@
                                 </td>
                                 <td><span class="badge" :class="u.role === 'admin' ? 'badge--pending' : 'badge--offline'" x-text="u.role"></span></td>
                                 <td class="text-muted" x-text="u.created_at ? new Date(u.created_at).toLocaleDateString() : '--'"></td>
-                                <td>
+                                <td style="display:flex; gap:6px; align-items:center;">
+                                    <!-- Reset password — admin-only, and
+                                         hidden for the admin's own row (they
+                                         use Settings → Change Password). Sets
+                                         must_change_password on the target so
+                                         the user has to rotate on next login
+                                         without the admin ever knowing the
+                                         final password (issue #99 slice 1). -->
+                                    <button x-show="currentUser && currentUser.id !== u.id"
+                                            class="btn btn--secondary btn--small"
+                                            @click="openResetPassword(u)"
+                                            title="Reset this user's password">
+                                        Reset password
+                                    </button>
                                     <button x-show="!currentUser || currentUser.id !== u.id"
                                             class="btn btn--danger btn--icon"
-                                            @click="deleteUser(u.id, u.username)">
+                                            @click="deleteUser(u.id, u.username)"
+                                            title="Delete user">
                                         <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
                                     </button>
                                 </td>
@@ -545,6 +559,38 @@
                         </template>
                     </tbody>
                 </table>
+            </div>
+        </div>
+    </div>
+
+    <!-- Reset Password modal (admin resets another user's password).
+         Shown only when resetTarget is set. Same dark-theme dialog
+         pattern as the Stream Settings modal. Issue #99 slice 1. -->
+    <div x-show="resetTarget" x-cloak
+         style="position:fixed; inset:0; background:rgba(0,0,0,0.6); display:flex; align-items:center; justify-content:center; z-index:50;"
+         @click.self="closeResetPassword()">
+        <div class="card" style="max-width:420px; width:90%;">
+            <div class="settings-section__title">
+                Reset password for <span x-text="resetTarget && resetTarget.username"></span>
+            </div>
+            <div class="text-small text-muted" style="margin-bottom:12px; line-height:1.4;">
+                Pick a temporary password. <span x-text="resetTarget && resetTarget.username"></span>
+                will be forced to change it on their next login — you don't need to know the
+                final password they pick.
+            </div>
+            <div class="form-group">
+                <label>Temporary password</label>
+                <input type="text" class="form-input"
+                       x-model="resetTempPassword"
+                       placeholder="Minimum 12 characters"
+                       autocomplete="new-password">
+            </div>
+            <div style="display:flex; gap:8px; justify-content:flex-end;">
+                <button class="btn btn--secondary" @click="closeResetPassword()">Cancel</button>
+                <button class="btn btn--primary" @click="submitResetPassword()"
+                        :disabled="!resetTempPassword || resetTempPassword.length < 12">
+                    Reset &amp; force change
+                </button>
             </div>
         </div>
     </div>
@@ -1025,6 +1071,9 @@ function settingsPage() {
         },
         users: [],
         newUser: { username: '', password: '', role: 'viewer' },
+        // Admin reset-password modal state (issue #99 slice 1).
+        resetTarget: null,       // user object whose password is being reset
+        resetTempPassword: '',   // admin-picked temporary password (>=12 chars)
         pw: { newPassword: '', confirmPassword: '' },
 
         wifi: { currentSsid: '', networks: [], selectedSsid: '', password: '', scanning: false },
@@ -1342,6 +1391,39 @@ function settingsPage() {
                 window.HM.toast('User deleted', 'success');
                 this.loadUsers();
             } catch(e) { window.HM.toast(e.message || 'Failed to delete user', 'error'); }
+        },
+
+        // Admin-reset flow (issue #99 slice 1). Admin picks a temporary
+        // password; backend rotates the hash AND sets must_change_password=true
+        // so the user is forced to rotate on first login.
+        openResetPassword(user) {
+            this.resetTarget = user;
+            this.resetTempPassword = '';
+        },
+        closeResetPassword() {
+            this.resetTarget = null;
+            this.resetTempPassword = '';
+        },
+        async submitResetPassword() {
+            if (!this.resetTarget) return;
+            if (!this.resetTempPassword || this.resetTempPassword.length < 12) {
+                window.HM.toast('Temporary password must be at least 12 characters', 'error');
+                return;
+            }
+            try {
+                await window.HM.api.put(
+                    '/api/v1/users/' + encodeURIComponent(this.resetTarget.id) + '/password',
+                    { new_password: this.resetTempPassword, force_change: true }
+                );
+                window.HM.toast(
+                    'Password reset — ' + this.resetTarget.username +
+                    ' must change it on next login', 'success'
+                );
+                this.closeResetPassword();
+                this.loadUsers();
+            } catch (e) {
+                window.HM.toast(e.message || 'Failed to reset password', 'error');
+            }
         },
 
         async changePassword() {

--- a/app/server/tests/unit/test_user_service.py
+++ b/app/server/tests/unit/test_user_service.py
@@ -353,6 +353,85 @@ class TestChangePassword:
 
 
 # ---------------------------------------------------------------------------
+# Admin-reset-another-user path (issue #99 slice 1)
+# ---------------------------------------------------------------------------
+class TestAdminResetAnotherUser:
+    @patch("monitor.services.user_service.hash_password", return_value="$2b$12$h")
+    def test_force_change_sets_must_change_flag(self, mock_hash, svc, store):
+        target = _make_user(id="user-002", role="viewer")
+        target.must_change_password = False
+        store.get_user.return_value = target
+        msg, status = svc.change_password(
+            "user-002",
+            "temppassword123",
+            requesting_role="admin",
+            requesting_user_id="user-001",
+            requesting_user="admin",
+            requesting_ip="10.0.0.1",
+            force_change_next_login=True,
+        )
+        assert status == 200
+        saved = store.save_user.call_args[0][0]
+        assert saved.must_change_password is True
+        assert saved.password_hash == "$2b$12$h"
+
+    @patch("monitor.services.user_service.hash_password", return_value="$2b$12$h")
+    def test_admin_reset_logs_specific_audit_event(self, mock_hash, svc, store, audit):
+        store.get_user.return_value = _make_user(id="user-002", role="viewer")
+        svc.change_password(
+            "user-002",
+            "temppassword123",
+            requesting_role="admin",
+            requesting_user_id="user-001",
+            requesting_user="admin",
+            requesting_ip="10.0.0.1",
+            force_change_next_login=True,
+        )
+        audit.log_event.assert_called_once()
+        assert audit.log_event.call_args[0][0] == "PASSWORD_RESET_BY_ADMIN"
+
+    @patch("monitor.services.user_service.hash_password", return_value="$2b$12$h")
+    def test_self_change_never_sets_must_change_flag(self, mock_hash, svc, store):
+        """Defence in depth: even if a self-change somehow carries
+        force_change_next_login=True, the flag stays False so the user
+        can't lock themselves into an infinite must-change loop."""
+        target = _make_user(id="user-001")
+        target.must_change_password = False
+        store.get_user.return_value = target
+        svc.change_password(
+            "user-001",
+            "newpassword12",
+            requesting_role="admin",
+            requesting_user_id="user-001",  # same as target — self-change
+            requesting_user="admin",
+            requesting_ip="10.0.0.1",
+            force_change_next_login=True,
+        )
+        saved = store.save_user.call_args[0][0]
+        assert saved.must_change_password is False
+
+    @patch("monitor.services.user_service.hash_password", return_value="$2b$12$h")
+    def test_refuses_to_force_change_the_only_admin(self, mock_hash, svc, store):
+        """Safety rail: an admin-reset against the sole admin is refused
+        so that admin can't be trapped in a must-change loop."""
+        sole_admin = _make_user(id="user-001", role="admin")
+        store.get_user.return_value = sole_admin
+        store.list_users.return_value = [sole_admin]
+        msg, status = svc.change_password(
+            "user-001",
+            "newpassword12",
+            requesting_role="admin",
+            requesting_user_id="user-002",  # another admin trying to reset
+            requesting_user="other-admin",
+            requesting_ip="10.0.0.1",
+            force_change_next_login=True,
+        )
+        assert status == 400
+        assert "only admin" in msg.lower()
+        store.save_user.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # _log_audit (fail-silent behavior)
 # ---------------------------------------------------------------------------
 class TestAuditLogging:

--- a/docs/exec-plans/auth-recovery.md
+++ b/docs/exec-plans/auth-recovery.md
@@ -1,0 +1,114 @@
+# Exec Plan — Authentication Recovery
+
+**Status:** Accepted. Slice 1 (admin resets other user + CLI admin recovery) shipped with this plan.
+**Date:** 2026-04-20
+**Owner:** vinu-dev
+**Closes:** #99 (slice 1), #100. Slice 2 (self-service reset token) tracked in #99; secrets-at-rest tracked in #101.
+
+## Why
+
+Three related gaps in the current auth story, surfaced as issues #99 / #100 / #101:
+
+1. **Locked-out user** — an admin has no in-app way to reset another user's password. Today the admin deletes + recreates the account, losing the user's audit trail.
+2. **Locked-out admin** — if the *only* admin forgets their password, there is no recovery path short of a full factory reset (wipes cameras, pairings, settings). Disproportionate.
+3. **Stolen SD card** — everything on `/data/config/` is plain text: Flask secret key, pairing secrets, mTLS private keys. Physical access = full compromise.
+
+The first two are urgent usability bugs. The third is an architectural layer (LUKS / TPM / secret wrapping) that needs its own ADR and hardware work.
+
+## Design principles
+
+1. **One forced-change gate already works.** `auth.py:_must_change_block` already returns `403 { must_change_password: true }` on every endpoint when the flag is set on a user. Any recovery flow just has to set that flag on success; the existing gate does the rest.
+2. **Recovery requires out-of-band trust.** A forgotten admin password can't be reset over HTTPS by any sufficiently authenticated admin — because there are no authenticated admins. Recovery has to lean on physical / SSH / boot-partition access.
+3. **No email, no SMS, no cloud callback.** The device is single-LAN by design. All recovery is local.
+4. **Every reset writes an audit event.** Non-negotiable — the audit log is the only after-the-fact evidence that a recovery happened.
+
+## Scope map
+
+| Case                              | Who triggers it         | Who is authenticated at the time  | Chosen path                                   | Issue |
+|-----------------------------------|-------------------------|-----------------------------------|-----------------------------------------------|-------|
+| User forgets password             | Admin (helping user)    | Admin is logged in                | **Admin reset** via Settings → Users          | #99 s1 |
+| Admin self-service change         | Admin                   | Admin is logged in                | (already shipped) Settings → Change Password  | –     |
+| **All admins locked out**         | Device operator         | Nobody                            | **CLI recovery script** over SSH              | #100  |
+| User forgot, no admin available   | Admin issues OTP        | Admin is logged in *once*         | **One-shot reset token** (slice 2 — later)    | #99 s2 |
+| SD card stolen                    | Threat actor            | N/A — physical theft              | **Secrets at rest** — LUKS + wrapped keys (separate ADR) | #101 |
+
+## Slice 1 — what ships now
+
+### 1a. Admin resets another user's password (issue #99 case 1)
+
+**Backend.** `user_service.change_password(..., force_change_next_login: bool = False)`.
+  - Existing role check unchanged: admin can change any user's password; a non-admin can only change their own.
+  - When `force_change_next_login=True`, the user's `must_change_password` flag is set to **True** after the hash rotates (instead of cleared). The existing `_must_change_block()` gate forces the user to rotate again on next login — admin never knows their final password.
+  - Audit event `PASSWORD_RESET_BY_ADMIN` with the acting admin's id + target user id.
+
+**API.** `PUT /api/v1/users/<id>/password` accepts an additional `force_change` boolean. The admin-editing-another-user path sets it; the self-service path ignores it (can't force-flag yourself into a loop).
+
+**UI.** Settings → Users: add a **"Reset password"** button per user row (admin-only, hidden for viewers). A small modal asks for the temporary password (same 12-char minimum as create-user) and, on submit, calls the endpoint with `force_change: true`.
+
+**Safety rails.**
+  - Refuse to reset the only remaining admin. The service already guards "can't demote the last admin" — extend the same guard to "can't force-change the last admin" so the admin can't strand themselves in a must-change loop if the reset fails halfway.
+  - All reset flows audit-log.
+
+### 1b. CLI admin recovery (issue #100 Option A)
+
+**Script.** `scripts/reset-admin-password.py` — a standalone, argparse-driven Python script.
+  - Imports only stdlib at top-level so it runs on the camera image out of the box. The bcrypt / user-store modules are late-imported inside `main()` so `--help` works even when the monitor app isn't importable.
+  - Loads `/data/config/users.json` (path overridable via `--store`) using the same `JsonFileStore` the app uses — atomic writes, same on-disk format.
+  - Finds the first user whose `role == "admin"`. Refuses if there is zero, or prints all candidates if more than one and `--username` wasn't supplied.
+  - Writes a new bcrypt hash using the same `hash_password()` the app uses (cost 12) so the hash format matches exactly.
+  - Sets `must_change_password: true` so the admin is forced to rotate on first login.
+  - Writes a line to `/data/config/audit.log` recording `PASSWORD_RESET_VIA_CLI` with the acting Unix user. The audit event is ingested by the running app on its next poll.
+  - Does **not** restart the monitor service — the user store reads from disk on each `get_user` call via `JsonFileStore`, so a fresh bcrypt hash on disk takes effect immediately without a restart.
+
+**Invocation.**
+  ```
+  sudo python3 /opt/monitor/scripts/reset-admin-password.py \
+      --username admin \
+      --password 'temp-password-123'
+  ```
+  `--password` is mandatory (no interactive prompt) so the command is captured faithfully in shell history and the operator knows what to hand back to the user.
+
+**Security model.** The script is only effective to someone who can already `sudo` on the device. That's the same bar as `systemctl stop` or `rm -rf /data` — consistent with ADR-0009's trust boundary ("physical / SSH access = operator-trusted"). Not a new threat surface.
+
+### 1c. "Forgot password?" link on `/login`
+
+A `<a href="#" …>` on the login page that opens a short static note: *"Ask your admin to reset it from Settings → Users. If you are the admin and have no other admin account, run `sudo /opt/monitor/scripts/reset-admin-password.py --help` on the device."*
+
+This is a one-line documentation surface — sets expectations now, leaves room for the token flow later.
+
+## Slice 2 — deferred (#99 case 2)
+
+Admin issues a **one-shot, short-lived reset token** from Settings → Users. The admin hands it to the user out-of-band (phone / whiteboard). The login page gets a "Use reset code" link that takes a username + token, logs the user in with `must_change_password=true`, consumes the token, and audit-logs.
+
+Token design (to be revisited):
+  - 6-8 digit numeric code (easier to read out loud than a hex string).
+  - 15-minute TTL, single-use, per-user, rate-limited at 5 attempts / 15 min.
+  - Stored hashed in `users.json` (`reset_token_hash`, `reset_token_expires_at`).
+  - Separate audit events `PASSWORD_RESET_TOKEN_ISSUED` / `_USED`.
+
+Deferred because slice 1 solves the immediate pain (all the failure cases today are "user forgot + admin available" or "admin forgot + can ssh"). Slice 2 is for multi-user households where admin isn't always online; we can ship after some real usage data.
+
+## Slice 3 — secrets at rest (#101)
+
+Separate ADR work. Outline:
+
+1. **Short-term**: device-derived key wrapping. Generate a per-device key from `/proc/cpuinfo` serial + boot-time random, wrap the Flask secret key and `pairing_secret` with AES-GCM. Stolen SD card without the running device + kernel state is useless.
+2. **Medium-term**: move `/data/config/` onto a LUKS partition whose key is stored in the TPM (Pi 5 has a TPM header; Zero 2W / Pi 4B do not — this is hardware-refresh work).
+3. **Long-term**: mTLS private keys move into PKCS#11 via SoftHSM, then a real HSM on the server box.
+
+Tracked in #101. Not gated by this plan; doesn't change the flows designed here.
+
+## Rollout
+
+1. Ship slice 1 as a single PR touching `user_service.py`, `users.py` API, `settings.html` Users tab, and the new CLI script.
+2. Tests:
+   - Unit: `force_change_next_login` toggles `must_change_password`.
+   - Integration: admin resetting another user sets the flag; that user's next request returns 403 + `must_change_password: true`; password change completes the unlock.
+   - CLI: dry-run + actual rewrite against a tmp `users.json`; audit log line present.
+3. Manual on-device test: lock self out, run the script over SSH, confirm login requires rotation.
+4. Update `docs/hardware-setup.md` and `docs/requirements.md` (SR-SRV-xx for recovery).
+
+## Open questions
+
+- **Should the CLI script write the new temp password to stdout only, not to `audit.log`?** Leaning yes — the audit event records the *fact* of reset, not the temporary value. Currently drafted to match.
+- **Should admin's own password reset also set `must_change_password=true`?** No — an admin changing their own password is deliberate and already went through auth; forcing another change would be an infinite loop.

--- a/scripts/reset-admin-password.py
+++ b/scripts/reset-admin-password.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Reset an admin user's password from the device console.
+
+Recovery path for a forgotten admin password (issue #100). Must be run
+directly on the device — over SSH or an attached keyboard/monitor —
+because it requires read/write access to /data/config/users.json.
+
+Usage
+-----
+
+    sudo /opt/monitor/scripts/reset-admin-password.py \
+        --username admin \
+        --password 'temp-pass-12345'
+
+The target user's password is rewritten with a fresh bcrypt hash at the
+same cost factor as the running app (see monitor.auth.hash_password),
+and ``must_change_password`` is set to ``true`` so the admin is forced
+to pick a new password on their first login after this reset. The
+temporary password you pass in never needs to be remembered long-term.
+
+Security model
+--------------
+
+Anyone who can run this script can already ``sudo`` on the device —
+which is the same boundary as ``rm -rf /data`` or ``systemctl stop``.
+See ADR-0009: physical / SSH access = operator-trusted. The monitor
+service does **not** need to be restarted; ``Store.get_user`` reads
+``users.json`` from disk on each call, so the new hash takes effect
+immediately.
+
+Exit codes
+----------
+
+    0 — success
+    1 — usage error (missing args, short password, etc.)
+    2 — store file not found or unreadable
+    3 — no admin user in the store, or the named user is not an admin
+    4 — write failed (permissions, disk full, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# All third-party imports are deferred to main() so ``--help`` works on
+# a box where monitor isn't importable (fresh image, dependency issue).
+
+
+def _find_app_dir() -> Path:
+    """Return the directory containing the monitor app package.
+
+    The script can live in /opt/monitor/scripts on the deployed image or
+    in repo_root/scripts during development. Resolve by walking up
+    until we find a directory with ``app/server/monitor`` or
+    ``monitor``.
+    """
+    here = Path(__file__).resolve()
+    # Deployed layout: /opt/monitor/scripts/reset-admin-password.py,
+    # monitor package at /opt/monitor/monitor.
+    for up in (here.parent.parent, here.parent.parent.parent):
+        if (up / "monitor" / "__init__.py").is_file():
+            return up
+        if (up / "app" / "server" / "monitor" / "__init__.py").is_file():
+            return up / "app" / "server"
+    raise RuntimeError(
+        "Could not locate the monitor package. Expected it at "
+        "/opt/monitor/monitor/ (deployed) or app/server/monitor/ (repo)."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reset an admin user's password on a running Home Monitor device.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--username",
+        default=None,
+        help="Admin username to reset. Optional — if omitted and exactly one "
+        "admin exists, that user is reset automatically. Required when more "
+        "than one admin is present.",
+    )
+    parser.add_argument(
+        "--password",
+        required=True,
+        help="Temporary password to install (minimum 12 characters). The user "
+        "will be forced to change it on first login.",
+    )
+    parser.add_argument(
+        "--store",
+        default="/data/config",
+        help="Directory containing users.json (default: /data/config).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would change without writing users.json.",
+    )
+    args = parser.parse_args()
+
+    if len(args.password) < 12:
+        print("error: --password must be at least 12 characters", file=sys.stderr)
+        return 1
+
+    store_dir = Path(args.store)
+    users_path = store_dir / "users.json"
+    if not users_path.is_file():
+        print(f"error: {users_path} not found or not readable", file=sys.stderr)
+        return 2
+
+    # Import the monitor package via absolute path so the script works
+    # out-of-tree (i.e. the working directory is not the repo root).
+    try:
+        app_dir = _find_app_dir()
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    sys.path.insert(0, str(app_dir))
+
+    try:
+        from monitor.auth import hash_password  # type: ignore[import-not-found]
+        from monitor.store import Store  # type: ignore[import-not-found]
+    except ImportError as exc:
+        print(f"error: failed to import monitor package: {exc}", file=sys.stderr)
+        return 2
+
+    # Same Store instance the app uses — atomic writes, same on-disk format.
+    store = Store(data_dir=str(store_dir))
+
+    admins = [u for u in store.get_users() if u.role == "admin"]
+    if not admins:
+        print("error: no admin user present in users.json", file=sys.stderr)
+        return 3
+
+    if args.username:
+        target = next((u for u in admins if u.username == args.username), None)
+        if target is None:
+            names = ", ".join(u.username for u in admins)
+            print(
+                f"error: no admin user named {args.username!r}. "
+                f"Admin users present: {names}",
+                file=sys.stderr,
+            )
+            return 3
+    else:
+        if len(admins) > 1:
+            names = ", ".join(u.username for u in admins)
+            print(
+                f"error: multiple admin users present ({names}); "
+                "pass --username to choose one.",
+                file=sys.stderr,
+            )
+            return 3
+        target = admins[0]
+
+    print(f"Resetting password for admin user {target.username!r} (id={target.id})")
+    if args.dry_run:
+        print("--dry-run set; no changes written.")
+        return 0
+
+    target.password_hash = hash_password(args.password)
+    target.must_change_password = True
+    try:
+        store.save_user(target)
+    except OSError as exc:
+        print(f"error: failed to write users.json: {exc}", file=sys.stderr)
+        return 4
+
+    # Best-effort audit line — write directly to the audit file the app
+    # reads. If the file isn't present yet we skip; the event is less
+    # important than the reset itself. The running app ingests this on
+    # the next poll.
+    try:
+        from datetime import UTC, datetime
+
+        audit_path = store_dir / "audit.log"
+        line = {
+            "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "event": "PASSWORD_RESET_VIA_CLI",
+            "user": "cli",
+            "ip": "local",
+            "detail": f"admin password reset for user {target.id} via reset-admin-password.py",
+        }
+        import json as _json
+
+        with open(audit_path, "a", encoding="utf-8") as f:
+            f.write(_json.dumps(line) + "\n")
+    except Exception as exc:  # pragma: no cover
+        print(f"warning: failed to write audit line: {exc}", file=sys.stderr)
+
+    print(
+        f"OK — {target.username!r} must change their password on next login.\n"
+        "Temporary password is only valid once; the change-password flow "
+        "will run automatically when they sign in."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Slice 1 of the auth-recovery plan — new `docs/exec-plans/auth-recovery.md` covers full design. Two urgent failure modes addressed here; tracked follow-ups:

- **#99 case 1** (user forgot, admin available) — admin clicks **"Reset password"** in Settings → Users, picks a temp password, user is force-rotated on next login (admin never sees their final password).
- **#100** (admin forgot, only admin) — `scripts/reset-admin-password.py` run over SSH rewrites the admin's bcrypt hash in-place + sets `must_change_password`. No monitor restart required.
- **Login page "Forgot password?"** — inline disclosure pointing users to the right path.

## Safety rails

- Sole-admin guard: force-change on the only admin is refused to prevent must-change loops.
- Defence in depth: self-change never sets `must_change_password`, even if the caller passes `force_change=true`.
- Dedicated audit events: `PASSWORD_RESET_BY_ADMIN` + `PASSWORD_RESET_VIA_CLI` are distinguishable from normal self-change.

## Follow-up issues (kept open intentionally)

- **#99 slice 2** — one-shot reset token from Settings → Users (for multi-user households where admin isn't always online). Design in plan.
- **#101** — secrets at rest (LUKS + TPM). Slice 3 outlined in plan; needs its own ADR.

## Test plan

- [x] 41 `TestUserService` unit pass (+4 new)
- [x] 1466 server unit + integration pass
- [x] Ruff + format clean
- [x] `reset-admin-password.py --help` runs without importing monitor
- [ ] Manual: admin picks a temp pw for user B → user B's next request gets 403 + must_change_password:true → user B completes rotation
- [ ] Manual: on the device, `sudo python3 /opt/monitor/scripts/reset-admin-password.py --username admin --password 'temp-pass-12345'` → next login forces rotation

## Docs

- `docs/exec-plans/auth-recovery.md` (new) — full three-slice plan with security model, scope map, deferred work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)