### PR TITLE
fix: control-channel mTLS + #117 Store method + #120 AGPL license labels

### DIFF
--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -179,23 +179,43 @@ def _ensure_tls_material(config):
 def _wrap_https_server(server, config):
     """Wrap the status server socket with TLS.
 
-    Uses CERT_NONE so browsers (Chrome/Edge) can connect without being
-    asked for a client certificate. Control API endpoints authenticate the
-    server by its IP address (config.server_ip) which is set during pairing
-    and is sufficient for a home LAN. Raw mTLS peer-cert verification is
-    kept as a secondary check for clients that voluntarily present a cert.
+    Uses ``CERT_OPTIONAL`` so browsers (Chrome/Edge) that don't have a
+    client cert can still reach the human-facing login + status pages,
+    while machine-facing ``/api/v1/control/*`` requests that DO present
+    a client cert have it validated against the paired CA. The control
+    handler itself (``_require_mtls``) then enforces the presence + CA
+    signature — no cert, no call. See ADR-0022 + issue #112.
+
+    Prior behaviour was CERT_NONE with ``_require_mtls`` falling back to
+    a source-IP check against ``config.server_ip``. That let anyone on
+    the same LAN who could spoof / inherit the server IP call machine
+    endpoints. Now the peer must hold a CA-signed client cert.
     """
     cert_path, key_path = _ensure_tls_material(config)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(cert_path, key_path)
     ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE  # don't request client cert — breaks Chrome
 
-    # Still load the CA so getpeercert() works if a client voluntarily sends one
     ca_path = os.path.join(config.certs_dir, "ca.crt")
     if os.path.isfile(ca_path):
         ctx.load_verify_locations(ca_path)
-        log.info("CA loaded for peer-cert inspection (CA: %s)", ca_path)
+        # CERT_OPTIONAL: ask for a client cert. If the peer sends one,
+        # the TLS layer validates it against ca.crt before the HTTP
+        # handler runs. If the peer sends nothing, the connection still
+        # completes (browsers need this) and the HTTP handler decides
+        # whether to allow the call based on the path.
+        ctx.verify_mode = ssl.CERT_OPTIONAL
+        log.info("TLS client-cert validation enabled (CA: %s)", ca_path)
+    else:
+        # Pre-pairing bring-up: no CA yet. The status server runs over
+        # plain TLS; control endpoints stay locked because no peer can
+        # present a CA-signed cert.
+        ctx.verify_mode = ssl.CERT_NONE
+        log.warning(
+            "CA not present at %s — control-endpoint mTLS cannot be enforced "
+            "until the camera is paired",
+            ca_path,
+        )
 
     server.socket = ctx.wrap_socket(server.socket, server_side=True)
     return server
@@ -463,37 +483,21 @@ def _make_status_handler(
             log.debug("Status HTTPS: " + format % args)
 
         def _has_mtls_client_cert(self):
-            """Check if the request is from the paired server.
+            """True iff the peer presented a client cert validated by OpenSSL.
 
-            Accepts the request if:
-            - The client IP matches config.server_ip (set during pairing,
-              either as an IP literal or as a hostname resolved to one), OR
-            - The client voluntarily presented a valid TLS peer certificate.
-
-            The SSL context uses CERT_NONE so browsers don't get a client-cert
-            challenge (which breaks Chrome/Edge). Server IP check is the primary
-            auth path; peer-cert is a fallback for future full mTLS enforcement.
+            The TLS layer (``CERT_OPTIONAL`` + ``load_verify_locations``)
+            already validated any cert the peer sent against the paired
+            CA before the HTTP handler runs — so ``getpeercert()``
+            returning a non-empty dict is proof of valid CA signature.
+            No peer cert → dict is empty → False. Issue #112 / #119.
+            Source-IP fallback was removed: a LAN attacker who could
+            spoof ``config.server_ip`` could previously bypass auth.
             """
-            server_ip = getattr(config, "server_ip", "") or ""
-            if server_ip:
-                client_ip = self.client_address[0]
-                if client_ip == server_ip:
-                    return True
-                # server_ip may be a hostname (e.g. "rpi-divinu.local").
-                # Resolve it so a fresh DNS/mDNS lookup matches the raw
-                # TCP client IP we see here.
-                try:
-                    resolved = socket.gethostbyname(server_ip)
-                except (socket.gaierror, socket.herror):
-                    resolved = ""
-                if resolved and client_ip == resolved:
-                    return True
-            # Fallback: TLS peer cert (only when client voluntarily sends one)
             try:
                 peer_cert = self.request.getpeercert()
-                return peer_cert is not None and len(peer_cert) > 0
             except (AttributeError, ValueError):
                 return False
+            return bool(peer_cert)
 
         def _require_mtls(self):
             """Require mTLS client certificate for control API endpoints."""

--- a/app/server/monitor/services/user_service.py
+++ b/app/server/monitor/services/user_service.py
@@ -169,9 +169,11 @@ class UserService:
         # Safety rail: don't leave the only admin trapped in a must-change
         # loop if the flag gets set on them by accident. The existing
         # "can't demote the last admin" guard in update_user has the same
-        # spirit — extend it here.
+        # spirit — extend it here. Issue #117: prior revision called
+        # ``self._store.list_users()`` which doesn't exist on the real
+        # Store class (the concrete method is ``get_users()``).
         if is_admin_reset and user.role == "admin":
-            admins = [u for u in self._store.list_users() if u.role == "admin"]
+            admins = [u for u in self._store.get_users() if u.role == "admin"]
             if len(admins) <= 1:
                 return "Cannot force-change the only admin", 400
 

--- a/app/server/tests/unit/test_user_service.py
+++ b/app/server/tests/unit/test_user_service.py
@@ -416,7 +416,7 @@ class TestAdminResetAnotherUser:
         so that admin can't be trapped in a must-change loop."""
         sole_admin = _make_user(id="user-001", role="admin")
         store.get_user.return_value = sole_admin
-        store.list_users.return_value = [sole_admin]
+        store.get_users.return_value = [sole_admin]
         msg, status = svc.change_password(
             "user-001",
             "newpassword12",
@@ -429,6 +429,47 @@ class TestAdminResetAnotherUser:
         assert status == 400
         assert "only admin" in msg.lower()
         store.save_user.assert_not_called()
+
+    def test_safety_rail_uses_real_store_method_name(self, tmp_path):
+        """Regression for issue #117 — the guard previously called
+        ``self._store.list_users()``, a method that doesn't exist on the
+        concrete ``Store``. Exercise the real class (not a MagicMock) so
+        any future rename of get_users → list_users fails loudly here
+        instead of crashing in production with AttributeError."""
+        from monitor.services.user_service import UserService
+        from monitor.store import Store
+
+        real_store = Store(config_dir=str(tmp_path))
+        # Seed two admins so the "only admin" guard is NOT triggered —
+        # we just want the code path that calls get_users() to execute.
+        from monitor.auth import hash_password
+        from monitor.models import User
+
+        for i, uname in enumerate(("alice", "bob"), start=1):
+            real_store.save_user(
+                User(
+                    id=f"user-{i:03d}",
+                    username=uname,
+                    password_hash=hash_password("temp" + "x" * 12),
+                    role="admin",
+                    must_change_password=False,
+                )
+            )
+
+        svc = UserService(real_store, audit=None)
+        msg, status = svc.change_password(
+            "user-001",
+            "new-temp-password-123",
+            requesting_role="admin",
+            requesting_user_id="user-002",  # the other admin
+            requesting_user="bob",
+            requesting_ip="10.0.0.1",
+            force_change_next_login=True,
+        )
+        # Must succeed — not crash with AttributeError.
+        assert status == 200, msg
+        reloaded = real_store.get_user("user-001")
+        assert reloaded.must_change_password is True
 
 
 # ---------------------------------------------------------------------------

--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -5,8 +5,11 @@
 SUMMARY = "Camera RTSP streamer for home monitoring"
 DESCRIPTION = "Captures video from the PiHut ZeroCam via v4l2 \
 and streams it over RTSPS to the home monitoring server."
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+# Project is AGPL-3.0-only (see repo-root LICENSE). A prior revision of
+# this recipe declared MIT — that was incorrect and contaminated SBOM /
+# license-report output for the shipped camera image (issue #120).
+LICENSE = "AGPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=eb1e647870add0502f8f010b19de32af"
 
 # Source files from app/camera/ directory in the repo
 FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/camera:"

--- a/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
+++ b/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
@@ -5,8 +5,11 @@
 SUMMARY = "Home monitoring server with web UI and video recording"
 DESCRIPTION = "Flask-based web server that manages RTSP camera streams, \
 records video using ffmpeg, and provides a mobile-friendly web interface."
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+# Project is AGPL-3.0-only (see repo-root LICENSE). A prior revision of
+# this recipe declared MIT — that was incorrect and contaminated SBOM /
+# license-report output for the shipped server image (issue #120).
+LICENSE = "AGPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=eb1e647870add0502f8f010b19de32af"
 
 # Source files from app/server/ directory in the repo
 FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/server:"


### PR DESCRIPTION
## Fixes three related auth/security bugs

### Closes #117 — admin password reset calls nonexistent \`Store.list_users()\`
PR #103 introduced a "cannot force-change the only admin" guard that called \`self._store.list_users()\` — which doesn't exist on the real \`Store\` class. Unit test hid the bug with a MagicMock. In prod, any admin-reset of another admin would have crashed with AttributeError.

**Fix**: rename to \`get_users()\`. New regression test instantiates the real \`Store\` class (not a MagicMock) so any future rename fails in CI, not in prod.

### Closes #112 + #119 — control-channel mTLS actually enforced
Control path was docs-says-mTLS but code-says-source-IP:
- Camera SSL context used \`ssl.CERT_NONE\`
- \`_require_mtls()\` accepted caller if source IP matched \`config.server_ip\` **or** any peer cert present

LAN attacker spoofing the server IP could bypass auth on every \`/api/v1/control/*\` endpoint.

**Fix**:
- Camera listener: \`ssl.CERT_OPTIONAL\` + \`load_verify_locations(ca.crt)\`. Any presented cert is validated against the paired CA before the HTTP handler runs.
- \`_require_mtls\` drops the source-IP fallback. Returns True only when \`getpeercert()\` returns a non-empty dict — i.e. the peer held a CA-signed cert.
- Browsers reach \`/login\` etc. unchanged (they don't trigger \`_require_mtls\`).
- Pre-pairing fallback keeps working (no CA → CERT_NONE + warning).

**Deferred**: camera's server-side HTTPS cert is still self-signed. Making server→camera direction fully mTLS requires re-issuing that cert at pair time; follow-up PR.

### Closes #120 — Yocto recipes mislabelled AGPL-3.0 as MIT
Both app recipes declared \`LICENSE = "MIT"\` — contaminating SBOM output for every image build. Now declare \`AGPL-3.0-only\` with correct checksum.

## Also: CLI recovery issues closed with comments
- #100, #116, #118 — all about the removed CLI script. Commented + closed with references to ADR-0022 / PR #111.

## Tests

- [x] 42 UserService unit (+1 real-Store regression test)
- [x] 362 camera unit + 149 camera integration + 48 camera security
- [x] 1467 server unit + integration
- [x] Ruff + format clean

## Still open
- #99 (slice 2 — reset token flow)
- #101 (secrets at rest — needs own ADR)
- #90 (mDNS structural)
- #104/#105/#106/#107/#109/#110 (UI polish — next batch)
- #113/#114/#115 (camera control-surface refactors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)