### PR TITLE
fix(ui): mobile recordings layout + date input width + camera tab tap delay (#104/#105/#109)

### DIFF
--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -104,7 +104,13 @@ body {
 .toc a {
     flex: 0 0 auto;
     display: inline-flex; align-items: center; gap: 6px;
-    padding: 8px 14px;
+    /* padding gives a 44×44 tap area (WCAG 2.5.5 / Apple HIG). Prior
+       8×14 produced ~30×85, which needed pixel-precise taps — and
+       combined with the 300 ms iOS tap delay the tabs felt dead
+       (issue #109). min-height locks the 44 px even when the glyph
+       and label would fit in less. */
+    padding: 12px 16px;
+    min-height: 44px;
     border-radius: 999px;
     background: rgba(255,255,255,0.03);
     color: var(--muted);
@@ -112,6 +118,14 @@ body {
     font-size: .85rem;
     font-weight: 500;
     border: 1px solid transparent;
+    /* iOS Safari waits 300 ms on any anchor tap to detect double-tap
+       zoom. ``touch-action: manipulation`` opts out of that detection
+       — tap fires immediately. Biggest single win for "why are the
+       tabs slow on my iPhone" (issue #109). */
+    touch-action: manipulation;
+    /* Matches the tap-highlight colour on the tab bar to the accent
+       instead of the browser's default blue box. */
+    -webkit-tap-highlight-color: rgba(255,92,124,0.25);
     transition: color .15s, border-color .15s, background .15s, transform .15s;
 }
 .toc a svg { width: 14px; height: 14px; stroke-width: 2; opacity: .85; }

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -648,9 +648,17 @@ select.form-input {
     flex-shrink: 0;
 }
 .clip-card__checkbox {
+    /* WCAG 2.5.5 minimum tap target is 24×24 px; Apple HIG says 44×44.
+       The visible checkbox stays at 18 px; padding expands the hit
+       area to 44 px so the label is tappable without pixel-precision
+       on mobile (issue #104). Negative margin collapses the extra
+       whitespace in the card's flex row. */
     display: flex;
     align-items: center;
-    margin-right: var(--space-2);
+    justify-content: center;
+    margin-right: var(--space-1);
+    margin-left: calc(-1 * var(--space-2));
+    padding: 13px;
     cursor: pointer;
 }
 .clip-card__checkbox input {
@@ -761,13 +769,9 @@ select.form-input {
 .inline-player__placeholder {
     width: 100%;
     aspect-ratio: 16 / 9;
-    /* Cap the player at ~45 % of the viewport so the clip list below
-       always has at least half the screen to scroll through — important
-       on short viewports (Echo Show, small tablets, narrow browser
-       windows). Without this cap a full-width 16:9 player eats the
-       entire visible area under the top nav on compact displays
-       (issue #95). object-fit contain keeps the frame aspect-correct
-       when the cap kicks in (letterbox instead of distort). */
+    /* Desktop cap — see issue #95. 45vh leaves ≥50% for the clip list
+       on typical monitors. object-fit contain keeps the frame aspect-
+       correct when the cap kicks in (letterbox instead of distort). */
     max-height: 45vh;
     object-fit: contain;
     border-radius: var(--radius-md);
@@ -1167,7 +1171,33 @@ select.form-input {
 }
 .inline-form__row .form-group {
     flex: 1;
-    min-width: 140px;
+    /* 120 px keeps two fields on one row on a 375 px viewport (iPhone SE)
+       with the --space-3 gap (issue #104). 140 would wrap to stacked. */
+    min-width: 120px;
+}
+
+/* Mobile-specific recordings layout (issue #104) — taller list, smaller
+   player cap on a phone (45vh still too much on a 430×932 screen). The
+   desktop @media (min-width: 1024px) rule gives the list its own scroll
+   region; below that we're single-column so the player's own cap is
+   what decides how much the list gets. */
+@media (max-width: 1023px) {
+    .inline-player video,
+    .inline-player__placeholder {
+        max-height: 38vh;
+    }
+}
+
+/* Date + datetime-local inputs need more horizontal room than bare
+   text inputs — iOS Safari renders "20 Apr 2026" as a formatted
+   value ~170 px wide; containers sized at 140 px cause clipping
+   (issue #105). */
+input[type="date"].form-input,
+input[type="datetime-local"].form-input {
+    min-width: 170px;
+    /* Keep the field from growing absurdly wide on desktop — 260 px
+       fits even the "20 Apr 2026, 17:22" datetime-local string. */
+    max-width: 260px;
 }
 
 /* --- Warnings list --- */


### PR DESCRIPTION
Three mobile UI fixes, all CSS/template-only.

### Closes #104 — Recordings on iPhone 14 Pro Max
- Player mobile cap 45vh → 38vh (desktop unchanged)
- Checkbox tap target 18×18 → 44×44 via padding (visible size kept)
- Filter row min-width 140 → 120 so two fields stay side-by-side at 375 px

### Closes #105 — Date inputs clipped on iOS
- Added global rule for \`input[type=date]\` / \`input[type=datetime-local]\`: min 170, max 260 — native iOS \"20 Apr 2026\" value now fits.

### Closes #109 — Camera status page tab tap delay
- \`touch-action: manipulation\` on \`.toc a\` kills the 300 ms iOS double-tap-zoom wait
- Padding 8×14 → 12×16, min-height 44 (WCAG / HIG compliant)
- Tap-highlight colour matches the accent

### Tests
- [x] 1020 camera unit + integration pass
- [x] server unit suite pass
- [x] Ruff + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)