### PR TITLE
feat: dashboard camera details panel + motion toggle + delete-all recordings (#106 #110)

### DIFF
--- a/app/server/monitor/api/recordings.py
+++ b/app/server/monitor/api/recordings.py
@@ -168,3 +168,22 @@ def delete_camera_recordings(camera_id):
     if error:
         return jsonify({"error": error}), status
     return jsonify(result), status
+
+
+@recordings_bp.route("", methods=["DELETE"])
+@admin_required
+@csrf_protect
+def delete_all_recordings():
+    """Nuke every clip across every camera. Danger-zone op (issue #106).
+
+    Gated by admin_required + csrf_protect like every other destructive
+    operation. Emits a single ``RECORDINGS_DELETED_ALL`` audit event
+    with the clip count and bytes freed for post-hoc review.
+    """
+    result, error, status = _svc().delete_all_recordings(
+        requesting_user=session.get("username", ""),
+        requesting_ip=request.remote_addr or "",
+    )
+    if error:
+        return jsonify({"error": error}), status
+    return jsonify(result), status

--- a/app/server/monitor/services/recordings_service.py
+++ b/app/server/monitor/services/recordings_service.py
@@ -602,3 +602,69 @@ class RecordingsService:
             detail=f"deleted all {count} clips for {camera_id}",
         )
         return {"message": f"Deleted {count} clips", "count": count}, None, 200
+
+    def delete_all_recordings(
+        self,
+        requesting_user: str = "",
+        requesting_ip: str = "",
+    ):
+        """Nuke every clip across every camera. Admin danger-zone op.
+
+        Issue #106. Walks every camera sub-directory of the recordings
+        root and removes it. The currently-writing segment (if any) is
+        deleted alongside — the recorder ffmpeg will recreate on its
+        next segment tick so recording isn't disabled, just zeroed out.
+
+        Returns: ``({cameras, clips, bytes_freed, message}, None, 200)``.
+        """
+        root = self._recordings_root()
+        if not root.is_dir():
+            return (
+                {
+                    "message": "No recordings directory",
+                    "cameras": 0,
+                    "clips": 0,
+                    "bytes_freed": 0,
+                },
+                None,
+                200,
+            )
+
+        total_clips = 0
+        total_bytes = 0
+        cameras_touched = 0
+        for cam_dir in list(root.iterdir()):
+            if not cam_dir.is_dir():
+                continue
+            # Only directories shaped like a camera id — skip any stray
+            # files or admin scratchpads that might sit in the root.
+            if not self._valid_camera_id(cam_dir.name):
+                continue
+            cameras_touched += 1
+            for mp4 in cam_dir.rglob("*.mp4"):
+                try:
+                    total_bytes += mp4.stat().st_size
+                except OSError:
+                    pass
+                total_clips += 1
+            shutil.rmtree(cam_dir, ignore_errors=True)
+
+        self._log_audit(
+            "RECORDINGS_DELETED_ALL",
+            user=requesting_user,
+            ip=requesting_ip,
+            detail=(
+                f"bulk delete: {total_clips} clips across {cameras_touched} "
+                f"cameras, {total_bytes} bytes freed"
+            ),
+        )
+        return (
+            {
+                "message": f"Deleted {total_clips} clips across {cameras_touched} cameras",
+                "cameras": cameras_touched,
+                "clips": total_clips,
+                "bytes_freed": total_bytes,
+            },
+            None,
+            200,
+        )

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -299,6 +299,44 @@ a:hover { text-decoration: underline; }
     display: flex;
     gap: var(--space-1);
 }
+
+/* Collapsible "Details" panel under each camera card (issue #110).
+   Collapsed by default so the card stays compact; expands to show
+   recording mode, motion detection state, firmware, bitrate, and
+   (admin-only) live health. */
+.camera-card__details {
+    margin-top: var(--space-2);
+    font-size: var(--text-xs);
+}
+.camera-card__details summary {
+    cursor: pointer;
+    user-select: none;
+    padding: 4px 0;
+    color: var(--color-text-muted);
+    /* Full 44×... tap area with padding below; visible "Details" label
+       stays compact. */
+    min-height: 28px;
+}
+.camera-card__details summary::marker { color: var(--color-text-muted); }
+.camera-card__details-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 12px;
+    margin: 4px 0 0;
+    padding: 8px 10px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-alt);
+    line-height: 1.4;
+}
+.camera-card__details-grid dt {
+    color: var(--color-text-muted);
+    font-weight: 500;
+}
+.camera-card__details-grid dd {
+    margin: 0;
+    color: var(--color-text);
+}
 .camera-card__actions {
     display: flex;
     flex-direction: column;

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -279,6 +279,57 @@
                     <span class="text-small text-muted" x-text="cam.cpu_temp ? cam.cpu_temp.toFixed(1) + '\u00B0C' : ''"></span>
                     <span class="text-small text-muted" x-show="cam.memory_percent" x-text="' \u00B7 ' + cam.memory_percent + '% mem'"></span>
                 </div>
+                <!-- Collapsible details panel (issue #110). All data already
+                     comes back from /api/v1/cameras — we were just not
+                     rendering most of it. Click "Details" (doesn't bubble to
+                     the outer "go to Live" handler — see @click.stop). -->
+                <details class="camera-card__details" x-show="cam.status !== 'pending'"
+                         @click.stop>
+                    <summary class="text-small text-muted">Details</summary>
+                    <dl class="camera-card__details-grid">
+                        <dt>Recording</dt>
+                        <dd x-text="_recordingModeLabel(cam)"></dd>
+
+                        <dt>Motion detect</dt>
+                        <dd>
+                            <span x-text="cam.recording_motion_enabled ? 'On' : 'Off'"
+                                  :class="cam.recording_motion_enabled ? 'text-success' : 'text-muted'"></span>
+                            <span class="text-small text-muted"
+                                  x-show="cam.recording_motion_enabled && cam.motion_sensitivity"
+                                  x-text="' \u00B7 sensitivity ' + cam.motion_sensitivity + '/10'"></span>
+                        </dd>
+
+                        <dt>Firmware</dt>
+                        <dd x-text="cam.firmware_version || '—'"></dd>
+
+                        <dt>Bitrate</dt>
+                        <dd>
+                            <span x-text="cam.bitrate ? (cam.bitrate / 1000000).toFixed(1) + ' Mbps' : '—'"></span>
+                            <span class="text-small text-muted"
+                                  x-show="cam.h264_profile"
+                                  x-text="' \u00B7 ' + (cam.h264_profile || 'high').toUpperCase()"></span>
+                            <span class="text-small text-muted"
+                                  x-show="cam.keyframe_interval"
+                                  x-text="' \u00B7 keyframe ' + cam.keyframe_interval"></span>
+                        </dd>
+
+                        <template x-if="isAdmin && cam.status === 'online' && (cam.cpu_temp || cam.memory_percent || cam.uptime_seconds)">
+                            <template x-for="(val, key) in {}">
+                                <span></span>
+                            </template>
+                        </template>
+                        <template x-if="isAdmin && cam.status === 'online'">
+                            <dt>Health</dt>
+                        </template>
+                        <template x-if="isAdmin && cam.status === 'online'">
+                            <dd>
+                                <span x-show="cam.cpu_temp" x-text="cam.cpu_temp.toFixed(1) + '\u00B0C'"></span>
+                                <span class="text-muted" x-show="cam.memory_percent" x-text="' \u00B7 ' + cam.memory_percent + '% mem'"></span>
+                                <span class="text-muted" x-show="cam.uptime_seconds" x-text="' \u00B7 up ' + _uptimeLabel(cam.uptime_seconds)"></span>
+                            </dd>
+                        </template>
+                    </dl>
+                </details>
             </div>
             <div class="camera-card__actions">
                 <span class="badge" :class="{
@@ -361,6 +412,22 @@
                     </label>
                 </div>
                 <div class="form-group">
+                    <!-- Motion detection on/off (issue #110). Backend field
+                         is recording_motion_enabled; server validates + stores
+                         + pushes over the control channel. Sensitivity slider
+                         below only matters when this is on, so gate its
+                         interactivity on the toggle. -->
+                    <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+                        <input type="checkbox" x-model="editForm.recording_motion_enabled">
+                        <span>Motion detection</span>
+                    </label>
+                    <div class="text-small text-muted" style="margin-top:4px;">
+                        Camera-side motion events trigger
+                        <em>recording_mode=motion</em> recordings and the dashboard's
+                        Recent Events feed (ADR-0021).
+                    </div>
+                </div>
+                <div class="form-group" :style="editForm.recording_motion_enabled ? '' : 'opacity:0.45; pointer-events:none;'">
                     <label style="display:flex; align-items:baseline; justify-content:space-between;">
                         <span>Motion sensitivity</span>
                         <span class="text-small" style="font-weight:600;"
@@ -425,7 +492,7 @@ function dashboardPage() {
         pairingCameraId: '',
         scanning: false,
         editCam: null,
-        editForm: { resolution: '1920x1080', fps: 25, bitrateMbps: 4, h264_profile: 'high', keyframe_interval: 30, rotation: 0, hflip: false, vflip: false, motion_sensitivity: 5, maxFps: 30 },
+        editForm: { resolution: '1920x1080', fps: 25, bitrateMbps: 4, h264_profile: 'high', keyframe_interval: 30, rotation: 0, hflip: false, vflip: false, recording_motion_enabled: false, motion_sensitivity: 5, maxFps: 30 },
         savingStream: false,
         streamSaveMsg: '',
         streamSaveOk: false,
@@ -808,6 +875,12 @@ function dashboardPage() {
                 rotation: cam.rotation || 0,
                 hflip: cam.hflip || false,
                 vflip: cam.vflip || false,
+                // Motion detection toggle (issue #110) — backend field
+                // recording_motion_enabled. Defaults to false on new
+                // cameras. Pulled and saved alongside the existing stream
+                // params in the same modal so operators don't have to
+                // hunt for the setting.
+                recording_motion_enabled: Boolean(cam.recording_motion_enabled),
                 // Motion sensitivity defaults to 5 (Medium) if the camera
                 // hasn't reported it yet — matches Camera model + camera
                 // /data/config default (ADR-0021).
@@ -855,6 +928,7 @@ function dashboardPage() {
                 rotation: parseInt(this.editForm.rotation),
                 hflip: this.editForm.hflip,
                 vflip: this.editForm.vflip,
+                recording_motion_enabled: Boolean(this.editForm.recording_motion_enabled),
                 motion_sensitivity: Math.max(1, Math.min(10,
                     parseInt(this.editForm.motion_sensitivity) || 5)),
             };
@@ -877,6 +951,29 @@ function dashboardPage() {
         _staleSeconds(cam) {
             if (!cam.last_seen) return 0;
             return Math.round((Date.now() - new Date(cam.last_seen).getTime()) / 1000);
+        },
+
+        // Friendly label for the recording_mode enum.
+        _recordingModeLabel(cam) {
+            var m = (cam && cam.recording_mode) || 'off';
+            if (m === 'off') return 'Off';
+            if (m === 'continuous') return 'Continuous';
+            if (m === 'schedule') return 'Schedule';
+            if (m === 'motion') return 'Motion-triggered';
+            return m;
+        },
+
+        // "2d 4h" / "3h 12m" / "7m" from an uptime seconds count. Used in
+        // the camera details panel (issue #110).
+        _uptimeLabel(seconds) {
+            seconds = parseInt(seconds) || 0;
+            if (seconds < 60) return seconds + 's';
+            var mins = Math.floor(seconds / 60);
+            if (mins < 60) return mins + 'm';
+            var hours = Math.floor(mins / 60);
+            if (hours < 24) return hours + 'h ' + (mins % 60) + 'm';
+            var days = Math.floor(hours / 24);
+            return days + 'd ' + (hours % 24) + 'h';
         },
 
         _relativeTime(iso) {

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -748,6 +748,49 @@
             </div>
         </template>
     </div>
+
+    <!-- Danger zone: bulk-delete all recordings across all cameras.
+         Mirrors the Factory Reset two-step confirm pattern. Issue #106. -->
+    <div class="settings-section">
+        <div class="settings-section__title" style="color: var(--color-danger);">
+            Danger Zone
+        </div>
+        <div class="card">
+            <p style="font-size:var(--text-sm); color:var(--color-text-muted); margin-bottom:var(--space-3);">
+                Permanently delete every saved clip across every camera.
+                Recording itself is not disabled — new motion + continuous
+                clips start accumulating immediately. This action cannot be
+                undone.
+            </p>
+            <template x-if="!deleteAllRecordingsConfirm">
+                <button class="btn btn--danger"
+                        @click="deleteAllRecordingsConfirm = true"
+                        :disabled="deletingAllRecordings">
+                    Delete all recordings
+                </button>
+            </template>
+            <template x-if="deleteAllRecordingsConfirm">
+                <div>
+                    <p style="color:var(--color-danger); font-weight:600; margin-bottom:var(--space-2);">
+                        This will permanently delete every recording on this
+                        server. Continue?
+                    </p>
+                    <div style="display:flex; gap:var(--space-2);">
+                        <button class="btn btn--danger"
+                                @click="doDeleteAllRecordings()"
+                                :disabled="deletingAllRecordings">
+                            <span x-text="deletingAllRecordings ? 'Deleting…' : 'Yes, delete every clip'"></span>
+                        </button>
+                        <button class="btn btn--secondary"
+                                @click="deleteAllRecordingsConfirm = false"
+                                :disabled="deletingAllRecordings">
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </template>
+        </div>
+    </div>
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════
@@ -1086,6 +1129,10 @@ function settingsPage() {
 
         resetConfirm: false,
         resetKeepRecordings: false,
+        // Danger-zone delete-all state (issue #106). Two-step confirm
+        // mirrors the factory reset flow so the pattern is familiar.
+        deleteAllRecordingsConfirm: false,
+        deletingAllRecordings: false,
 
         // OTA state (ADR-0020 dual-transport updates)
         ota: { server: { current_version: '', state: 'idle', progress: 0, error: '', staged_filename: '', busy: false }, cameras: [] },
@@ -1297,6 +1344,25 @@ function settingsPage() {
             } catch(e) {
                 window.HM.toast(e.message || 'Factory reset failed', 'error');
                 this.resetConfirm = false;
+            }
+        },
+
+        async doDeleteAllRecordings() {
+            // Bulk delete across every camera (issue #106). Server endpoint
+            // writes a single RECORDINGS_DELETED_ALL audit event with the
+            // deleted-clip count and bytes freed.
+            this.deletingAllRecordings = true;
+            try {
+                var res = await window.HM.api.del('/api/v1/recordings');
+                window.HM.toast(
+                    'Deleted ' + (res.clips || 0) + ' clips across ' +
+                    (res.cameras || 0) + ' cameras', 'success'
+                );
+                this.deleteAllRecordingsConfirm = false;
+            } catch(e) {
+                window.HM.toast(e.message || 'Failed to delete recordings', 'error');
+            } finally {
+                this.deletingAllRecordings = false;
             }
         },
 

--- a/app/server/tests/unit/test_svc_recordings.py
+++ b/app/server/tests/unit/test_svc_recordings.py
@@ -372,6 +372,66 @@ class TestDeleteCameraRecordings:
         assert result["count"] == 1
 
 
+class TestDeleteAllRecordings:
+    """Bulk delete every clip across every camera (issue #106)."""
+
+    def test_returns_counts_and_wipes_every_camera(self, svc, storage_manager, audit):
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-00-00")
+        _create_clip_file(storage_manager, "cam-001", "2026-04-10", "09-00-00")
+        _create_clip_file(storage_manager, "cam-002", "2026-04-09", "12-30-00")
+
+        result, error, status = svc.delete_all_recordings(
+            requesting_user="admin",
+            requesting_ip="127.0.0.1",
+        )
+
+        assert error is None and status == 200
+        assert result["clips"] == 3
+        assert result["cameras"] == 2
+        assert result["bytes_freed"] >= 0
+
+        from pathlib import Path
+
+        root = Path(storage_manager.recordings_dir)
+        assert not (root / "cam-001").exists()
+        assert not (root / "cam-002").exists()
+
+        audit.log_event.assert_called_once()
+        assert audit.log_event.call_args[0][0] == "RECORDINGS_DELETED_ALL"
+
+    def test_no_recordings_dir_returns_zero_counts(self, svc, storage_manager, audit):
+        import shutil
+        from pathlib import Path
+
+        shutil.rmtree(Path(storage_manager.recordings_dir), ignore_errors=True)
+
+        result, error, status = svc.delete_all_recordings()
+
+        assert error is None and status == 200
+        assert result["clips"] == 0
+        assert result["cameras"] == 0
+        # No audit event when there's nothing to delete — stays clean.
+        audit.log_event.assert_not_called()
+
+    def test_skips_invalid_camera_id_directories(self, svc, storage_manager):
+        """Stray directories that don't match the camera-id regex
+        shouldn't be touched — protects against a sibling tool or test
+        fixture that drops a scratch folder next to the camera trees."""
+        from pathlib import Path
+
+        root = Path(storage_manager.recordings_dir)
+        # Name that fails _CAMERA_ID_RE (contains a ``.`` which the
+        # regex doesn't allow) but is valid as a Windows/Linux path.
+        stray = root / "stray.tmp"
+        stray.mkdir(parents=True, exist_ok=True)
+        (stray / "keep.txt").write_text("x")
+        _create_clip_file(storage_manager, "cam-001", "2026-04-09", "14-00-00")
+
+        result, _, _ = svc.delete_all_recordings()
+        assert result["cameras"] == 1
+        assert stray.exists()
+
+
 class TestFallbackRecordingsDir:
     """Test fallback when storage_manager is None."""
 


### PR DESCRIPTION
### Closes #110 — dashboard camera info panel
Collapsible \`<details>\` per paired camera card. Shows recording mode, motion detect + sensitivity, firmware, bitrate/profile/keyframe, and admin-only health (cpu_temp / mem / uptime). All data was already in the API — just never rendered.

Stream Settings modal gains a **Motion detection** checkbox for \`recording_motion_enabled\` (backend field was wired; UI was the gap). Sensitivity slider below is greyed out when motion is off.

### Closes #106 — delete-all recordings
New **Danger Zone** section in Settings → Recording (mirrors the Factory Reset two-step confirm). New \`DELETE /api/v1/recordings\` endpoint walks every camera-shaped subdirectory of the recordings root and removes it, emits a single \`RECORDINGS_DELETED_ALL\` audit event with totals.

### Tests
- [x] 3 new \`TestDeleteAllRecordings\` unit tests
- [x] 1469 server unit + integration pass
- [x] Ruff + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)