### PR TITLE
fix: camera boot stream-state default → stopped (ADR-0017) (#115)

### DIFF
--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -42,13 +42,14 @@ log = logging.getLogger("camera-streamer.lifecycle")
 
 
 def _read_desired_stream_state(path):
-    """Return the persisted desired stream state or ``running``.
+    """Return the persisted desired stream state or ``stopped``.
 
-    Design: the camera streams to MediaMTX whenever it is paired so the
-    Live page opens with zero cold-start latency. The persisted state
-    file exists only as an explicit *override* — e.g. an operator or the
-    server asks the camera to go quiet. A missing file (fresh boot,
-    fresh pair) defaults to ``running``.
+    Design (ADR-0017, issue #115): the camera is on-demand — it does not
+    stream until the server explicitly asks it to. A missing persisted
+    state file (fresh boot, fresh pair, corrupted file) therefore
+    collapses to ``stopped``. This matches ``ControlServer._load_stream_state``
+    in ``control.py`` so the boot-time default and the runtime default
+    cannot drift apart silently.
 
     Isolated as a module-level helper so the boot-time decision can be
     unit-tested without spinning up the full lifecycle.
@@ -57,10 +58,10 @@ def _read_desired_stream_state(path):
         with open(path) as f:
             value = f.read().strip()
     except OSError:
-        return "running"
+        return "stopped"
     if value in VALID_STREAM_STATES:
         return value
-    return "running"
+    return "stopped"
 
 
 class State:

--- a/app/camera/tests/unit/test_lifecycle_stream_state.py
+++ b/app/camera/tests/unit/test_lifecycle_stream_state.py
@@ -10,10 +10,15 @@ from camera_streamer.lifecycle import _read_desired_stream_state
 
 
 class TestReadDesiredStreamState:
-    def test_missing_file_defaults_to_running(self, tmp_path):
-        """Fresh boot with no override file → stream for instant Live view."""
+    def test_missing_file_defaults_to_stopped(self, tmp_path):
+        """Fresh boot / fresh pair with no override file → stopped.
+
+        ADR-0017 on-demand model (issue #115): the camera waits for the
+        server to ask for a stream. No file == no explicit ask == stopped.
+        Must match ControlHandler._load_stream_state in control.py.
+        """
         path = tmp_path / "stream_state"
-        assert _read_desired_stream_state(str(path)) == "running"
+        assert _read_desired_stream_state(str(path)) == "stopped"
 
     def test_reads_running(self, tmp_path):
         path = tmp_path / "stream_state"
@@ -26,16 +31,34 @@ class TestReadDesiredStreamState:
         path.write_text("stopped")
         assert _read_desired_stream_state(str(path)) == "stopped"
 
-    def test_garbage_collapses_to_running(self, tmp_path):
-        """Unreadable content falls back to streaming (instant-live default)."""
+    def test_garbage_collapses_to_stopped(self, tmp_path):
+        """Unreadable content falls back to stopped (ADR-0017 on-demand)."""
         path = tmp_path / "stream_state"
         path.write_text("maybe")
-        assert _read_desired_stream_state(str(path)) == "running"
+        assert _read_desired_stream_state(str(path)) == "stopped"
 
     def test_trailing_whitespace_is_stripped(self, tmp_path):
         path = tmp_path / "stream_state"
         path.write_text("running\n")
         assert _read_desired_stream_state(str(path)) == "running"
+
+    def test_matches_control_server_default(self, tmp_path):
+        """Regression for #115: lifecycle + control must agree on the default.
+
+        If a future refactor makes one of them default to 'running' again,
+        this test fails loudly — that drift was exactly what #115 reported.
+        """
+        from unittest.mock import MagicMock
+
+        from camera_streamer.control import ControlHandler
+
+        path = tmp_path / "stream_state"
+        cs = ControlHandler.__new__(ControlHandler)
+        cs._stream_state_path = str(path)
+        cs._stream = MagicMock()
+        lifecycle_default = _read_desired_stream_state(str(path))
+        control_default = cs._load_stream_state()
+        assert lifecycle_default == control_default == "stopped"
 
 
 class TestDoRunningHonoursStreamState:


### PR DESCRIPTION
## Summary
- Fresh-boot / corrupted-state-file default in \`lifecycle._read_desired_stream_state\` was \`running\` — drifted from \`control.py\` (\`stopped\`) and from ADR-0017 on-demand model.
- Aligned lifecycle to \`stopped\`. Fresh-paired camera now waits for server to explicitly start the stream.
- Added regression test that asserts \`lifecycle\` and \`ControlHandler\` agree — prevents silent future drift.

Fixes #115.

## Test plan
- [x] \`pytest app/camera/tests/unit\` — 363 pass
- [x] \`ruff check app/camera\` — clean
- [ ] Deploy to 192.168.1.245 + reboot a paired camera → Live stays off until page is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)