### PR TITLE
test(e2e): fix stale regression spec failing nightly for 5+ runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,6 +80,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: |
+          python -m pip install --upgrade pip
+          pip install pytest
           python -m pytest tests/yocto
 
   hardware-smoke:

--- a/docs/roadmap-next-2-releases.md
+++ b/docs/roadmap-next-2-releases.md
@@ -2,13 +2,13 @@
 
 Date: 2026-04-20
 Purpose: Turn the market backlog into an AI-ready execution plan for the next two release cycles.
-Source: [market-feature-backlog-100.md](C:/Users/vinun/codex/rpi-home-monitor/docs/market-feature-backlog-100.md)
+Source: [market-feature-backlog-100.md](./market-feature-backlog-100.md)
 Execution pack:
-- [Release 01 plan](C:/Users/vinun/codex/rpi-home-monitor/docs/releases/release-01.md)
-- [Release 02 plan](C:/Users/vinun/codex/rpi-home-monitor/docs/releases/release-02.md)
-- [Feature specs index](C:/Users/vinun/codex/rpi-home-monitor/docs/specs/index.md)
-- [AI execution rules](C:/Users/vinun/codex/rpi-home-monitor/docs/ai/execution-rules.md)
-- [Connectivity and privacy constraints](C:/Users/vinun/codex/rpi-home-monitor/docs/connectivity-and-privacy-constraints.md)
+- [Release 01 plan](./releases/release-01.md)
+- [Release 02 plan](./releases/release-02.md)
+- [Feature specs index](./specs/index.md)
+- [AI execution rules](./ai/execution-rules.md)
+- [Connectivity and privacy constraints](./connectivity-and-privacy-constraints.md)
 
 ## Planning Rules
 
@@ -156,7 +156,7 @@ For AI-assisted implementation, the preferred order is:
 A feature is ready for implementation when it has:
 
 - a GitHub issue
-- a feature spec using [ai-feature-template.md](C:/Users/vinun/codex/rpi-home-monitor/docs/ai-feature-template.md)
+- a feature spec using [ai-feature-template.md](./ai-feature-template.md)
 - acceptance criteria
 - identified modules/files likely to change
 - test expectations

--- a/docs/spec-notifications-rich-motion.md
+++ b/docs/spec-notifications-rich-motion.md
@@ -3,7 +3,7 @@
 Status: Ready for AI implementation planning
 Priority: P0
 Roadmap Slot: Release Next
-Backlog Source: [market-feature-backlog-100.md](C:/Users/vinun/codex/rpi-home-monitor/docs/market-feature-backlog-100.md)
+Backlog Source: [market-feature-backlog-100.md](./market-feature-backlog-100.md)
 Related Issue: [#121](https://github.com/vinu-dev/rpi-home-monitor/issues/121)
 
 ## Problem

--- a/tests/e2e/playwright/regression/server-pages-and-camera-status.spec.ts
+++ b/tests/e2e/playwright/regression/server-pages-and-camera-status.spec.ts
@@ -1,10 +1,20 @@
 import { test, expect } from "@playwright/test";
 
+/**
+ * Regression: core post-login pages still render their structural anchors.
+ *
+ * Login is JS-driven (fetch + redirect to /dashboard), so we wait for the
+ * dashboard URL before navigating onward — otherwise the goto races against
+ * the cookie/redirect and lands back at /login.
+ */
 test("server live and recordings pages render core controls", async ({ page, baseURL }) => {
   await page.goto(`${baseURL}/login`);
   await page.locator("#login-username").fill("admin");
   await page.locator("#login-password").fill("pass1234");
-  await page.locator("#btn-login").click();
+  await Promise.all([
+    page.waitForURL(/\/dashboard/),
+    page.locator("#btn-login").click(),
+  ]);
 
   await page.goto(`${baseURL}/live`);
   await expect(page.getByRole("heading", { name: "Live View" })).toBeVisible();
@@ -12,17 +22,28 @@ test("server live and recordings pages render core controls", async ({ page, bas
   await expect(page.locator("#live-video")).toBeVisible();
 
   await page.goto(`${baseURL}/recordings`);
-  await expect(page.getByText(/recordings/i)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Recordings" })).toBeVisible();
 });
 
+/**
+ * Camera status page section labels were redesigned (issue #109 tap-target
+ * refresh). Old assertions (Device Info / Connection / Server Pairing /
+ * System Health) no longer exist — the navigation is now Status / Settings /
+ * Updates / Reset with an initial pairing banner when unpaired.
+ */
 test("camera status login and device page render", async ({ page }) => {
   await page.goto("https://127.0.0.1:5444/login");
   await page.locator("#username").fill("admin");
   await page.locator("#password").fill("pass1234");
-  await page.getByRole("button", { name: "Login" }).click();
+  await Promise.all([
+    page.waitForURL((url) => !url.pathname.endsWith("/login")),
+    page.getByRole("button", { name: /sign in|login/i }).click(),
+  ]);
 
-  await expect(page.getByText("Device Info")).toBeVisible();
-  await expect(page.getByText("Connection")).toBeVisible();
-  await expect(page.getByText("Server Pairing")).toBeVisible();
-  await expect(page.getByText("System Health")).toBeVisible();
+  // Section nav links — these are stable structural anchors per the
+  // rewritten status.html (see <nav aria-label="Page sections">).
+  await expect(page.getByRole("link", { name: "Status" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Updates" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Reset" })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
Nightly Validation > Browser E2E Full has been failing every run for 5+ consecutive days. Two independent issues in \`regression/server-pages-and-camera-status.spec.ts\`:

1. **Race condition on login.** Both tests clicked \`#btn-login\` and immediately called \`page.goto(next)\`, beating the login handler's redirect to \`/dashboard\`. The subsequent navigation fired without a session cookie and bounced back to \`/login\` — visible in the failing page snapshot. Wrapped the click in \`Promise.all([waitForURL(...), click()])\`.
2. **Stale text.** Camera status assertions looked for \"Device Info / Connection / Server Pairing / System Health\" — those sections were renamed to Status / Settings / Updates / Reset when \`status.html\` was restructured. Updated to \`getByRole('link', ...)\` against the \`<nav aria-label=\"Page sections\">\` anchors so future copy tweaks don't re-break the test.
3. Tightened the \`/recordings\` assertion to \`getByRole('heading', { name: 'Recordings' })\` (was a loose regex that matched nav links + arbitrary text).

Pre-existing bugs, not a regression from any of this session's PRs.

## Test plan
- [x] Updated test code reviewed against current templates
- [ ] Browser E2E Full passes in CI
- [ ] Nightly Validation green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)