### PR TITLE
build: fix AGPL checksum to match poky scarthgap

### DIFF
--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -9,7 +9,7 @@ and streams it over RTSPS to the home monitoring server."
 # this recipe declared MIT — that was incorrect and contaminated SBOM /
 # license-report output for the shipped camera image (issue #120).
 LICENSE = "AGPL-3.0-only"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=eb1e647870add0502f8f010b19de32af"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=73f1eb20517c55bf9493b7dd6e480788"
 
 # Source files from app/camera/ directory in the repo
 FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/camera:"

--- a/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
+++ b/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
@@ -9,7 +9,7 @@ records video using ffmpeg, and provides a mobile-friendly web interface."
 # this recipe declared MIT — that was incorrect and contaminated SBOM /
 # license-report output for the shipped server image (issue #120).
 LICENSE = "AGPL-3.0-only"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=eb1e647870add0502f8f010b19de32af"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=73f1eb20517c55bf9493b7dd6e480788"
 
 # Source files from app/server/ directory in the repo
 FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/server:"


### PR DESCRIPTION
Blocking release 1.3.0 builds. Both \`monitor-server_1.0.bb\` and \`camera-streamer_1.0.bb\` used the upstream/FSF AGPL md5 (\`eb1e647870add0502f8f010b19de32af\`) from PR #122, but poky scarthgap's bundled copy at \`poky/meta/files/common-licenses/AGPL-3.0-only\` hashes to \`73f1eb20517c55bf9493b7dd6e480788\`. Same text, different normalization.

Build error:
\`\`\`
ERROR: QA Issue: monitor-server: The LIC_FILES_CHKSUM does not match for
  file:///.../poky/meta/files/common-licenses/AGPL-3.0-only;md5=eb1e647870add0502f8f010b19de32af
  The new md5 checksum is 73f1eb20517c55bf9493b7dd6e480788
\`\`\`

Refs #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)