### PR TITLE
build(yocto): declare LIC_FILES_CHKSUM on python3-videodev2

### DIFF
--- a/meta-home-monitor/recipes-multimedia/videodev2/python3-videodev2_0.0.4.bb
+++ b/meta-home-monitor/recipes-multimedia/videodev2/python3-videodev2_0.0.4.bb
@@ -5,9 +5,12 @@ V4L2_CID_MPEG_VIDEO_H264_* / V4L2_MPEG_VIDEO_H264_PROFILE_* constants \
 come from this module at import time."
 HOMEPAGE = "https://pypi.org/project/videodev2/"
 # Upstream sdist 0.0.4 does not ship a separate LICENSE file, but PyPI
-# classifier + setup.py declare BSD-2-Clause. We skip the on-disk check.
+# classifier + setup.py declare BSD-2-Clause. Point LIC_FILES_CHKSUM at
+# poky's bundled copy — an empty string fails populate_lic QA on
+# scarthgap ("Recipe file fetches files and does not have license file
+# information"). md5 matches poky/meta/files/common-licenses/BSD-2-Clause.
 LICENSE = "BSD-2-Clause"
-LIC_FILES_CHKSUM = ""
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-2-Clause;md5=cb641bc04cda31daea161b1bc15da69f"
 
 SRC_URI[sha256sum] = "c34ba70491d148c23a08cbacd8efabeb413cff5baa943a7548ac4abd1eb19e2a"
 


### PR DESCRIPTION
Blocking camera-prod build for v1.3.0. python3-videodev2 recipe had `LIC_FILES_CHKSUM = ""` — scarthgap rejects recipes that fetch files without license info. Points at poky's common BSD-2-Clause.

```
ERROR: python3-videodev2-0.0.4-r0 do_populate_lic: QA Issue:
  python3-videodev2: Recipe file fetches files and does not have
  license file information (LIC_FILES_CHKSUM)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)