### PR TITLE
feat(status): surface camera hardware faults on dashboard + camera UI

### DIFF
--- a/app/camera/camera_streamer/capture.py
+++ b/app/camera/camera_streamer/capture.py
@@ -27,6 +27,12 @@ class CaptureManager:
         self._device = device or DEFAULT_DEVICE
         self._available = False
         self._formats = []
+        # Short, user-facing error message populated by ``check()``.
+        # Surfaced on the dashboard camera card + camera status page
+        # via the heartbeat so operators know a freshly-paired camera
+        # is missing its sensor module (common cause: ribbon cable
+        # not seated, or Zero 2W plugged in without a camera module).
+        self._last_error = ""
 
     @property
     def device(self):
@@ -39,6 +45,16 @@ class CaptureManager:
     @property
     def formats(self):
         return list(self._formats)
+
+    @property
+    def last_error(self) -> str:
+        """Short user-facing description of the last hardware fault.
+
+        Empty string when the last ``check()`` succeeded or was not yet
+        run. Consumed by HeartbeatSender to surface in the dashboard
+        + camera status page.
+        """
+        return self._last_error
 
     def check(self):
         """Validate the camera device exists and is accessible.
@@ -65,6 +81,11 @@ class CaptureManager:
                 video_devs or "none",
             )
             self._available = False
+            self._last_error = (
+                "No camera module detected. Check the ribbon cable is "
+                "seated firmly and /boot/config.txt has dtoverlay=ov5647 "
+                "(for the PiHut ZeroCam) or the overlay for your sensor."
+            )
             return False
 
         # Check it's a character device (video device)
@@ -108,6 +129,7 @@ class CaptureManager:
                 self._device,
             )
         self._available = True
+        self._last_error = ""
         return True
 
     def supports_h264(self):

--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -149,6 +149,7 @@ class HeartbeatSender:
         stream_manager=None,
         thermal_path=None,
         control_handler=None,
+        capture_manager=None,
     ):
         self._config = config
         self._pairing = pairing_manager
@@ -159,6 +160,11 @@ class HeartbeatSender:
         # compares against to detect drift. Tests that don't care about
         # drift pass None and we fall back to the live streaming flag.
         self._control = control_handler
+        # Optional CaptureManager — when provided, the heartbeat reports
+        # ``hardware_ok`` + ``hardware_error`` so the server dashboard +
+        # camera status page can surface a "no camera module detected"
+        # banner without waiting for a stream-start failure.
+        self._capture = capture_manager
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
         # Track consecutive 401 Unknown-camera responses to detect server-side unpair
@@ -221,6 +227,17 @@ class HeartbeatSender:
         else:
             stream_state = "running" if streaming else "stopped"
 
+        # Hardware status — surfaces "no camera module detected" and
+        # similar faults on both the dashboard + camera status page.
+        # Defaults to ok=True so tests that omit CaptureManager don't
+        # light up a false warning banner.
+        if self._capture is not None:
+            hardware_ok = bool(self._capture.available)
+            hardware_error = "" if hardware_ok else (self._capture.last_error or "")
+        else:
+            hardware_ok = True
+            hardware_error = ""
+
         return {
             "camera_id": config.camera_id,
             "timestamp": int(time.time()),
@@ -230,6 +247,8 @@ class HeartbeatSender:
             "memory_percent": _get_memory_percent(),
             "uptime_seconds": _get_uptime_seconds(),
             "firmware_version": _get_firmware_version(),
+            "hardware_ok": hardware_ok,
+            "hardware_error": hardware_error,
             "stream_config": {
                 "width": config.width,
                 "height": config.height,

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -324,6 +324,10 @@ class CameraLifecycle:
             thermal_path=self._platform.thermal_path,
             pairing_manager=self._pairing,
             stream_state_path=self._stream_state_path,
+            # Capture manager flows into /api/status so the camera's
+            # own status page can show a "no camera module detected"
+            # banner. Set by _do_validating (the state before us).
+            capture_manager=self._capture,
         )
         self._status_server.start()
 
@@ -341,6 +345,9 @@ class CameraLifecycle:
             stream_manager=self._stream,
             thermal_path=self._platform.thermal_path,
             control_handler=self._status_server.control_handler,
+            # Surface hardware faults ("no camera module detected")
+            # to the server so the dashboard can show the user.
+            capture_manager=self._capture,
         )
         if self._config.is_configured and self._pairing.is_paired:
             self._heartbeat.start()

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -330,12 +330,17 @@ class CameraStatusServer:
         thermal_path=None,
         pairing_manager=None,
         stream_state_path=None,
+        capture_manager=None,
     ):
         self._config = config
         self._stream = stream_manager
         self._wifi_interface = wifi_interface
         self._thermal_path = thermal_path
         self._pairing = pairing_manager
+        # Optional CaptureManager — when provided, /api/status reports
+        # ``hardware_ok`` + ``hardware_error`` so the camera's own
+        # status page can show a "no camera module detected" banner.
+        self._capture = capture_manager
         # Let ControlHandler pick the default path when caller didn't override
         # so tests and production share the same default (ADR-0017).
         if stream_state_path is None:
@@ -362,6 +367,7 @@ class CameraStatusServer:
             self._thermal_path,
             self._pairing,
             self._control,
+            self._capture,
         )
         try:
             self._server = http.server.HTTPServer(("0.0.0.0", LISTEN_PORT), handler)
@@ -475,6 +481,7 @@ def _make_status_handler(
     thermal_path,
     pairing_manager,
     control_handler=None,
+    capture_manager=None,
 ):
     """Create HTTP handler for the camera status page."""
 
@@ -851,6 +858,19 @@ def _make_status_handler(
 
             paired = pairing_manager.is_paired if pairing_manager else False
 
+            # Hardware status for the status page banner. Defaults
+            # ok=True so environments that haven't wired up a
+            # CaptureManager (tests, early-boot) don't show a false
+            # warning.
+            if capture_manager is not None:
+                hardware_ok = bool(capture_manager.available)
+                hardware_error = (
+                    "" if hardware_ok else (capture_manager.last_error or "")
+                )
+            else:
+                hardware_ok = True
+                hardware_error = ""
+
             return {
                 "camera_id": config.camera_id,
                 "hostname": hostname,
@@ -865,6 +885,8 @@ def _make_status_handler(
                 "uptime": uptime,
                 "memory_total_mb": mem_total,
                 "memory_used_mb": mem_used,
+                "hardware_ok": hardware_ok,
+                "hardware_error": hardware_error,
                 "stream_config": {
                     "width": config.width,
                     "height": config.height,

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -471,6 +471,16 @@ details[open] summary::after { transform: rotate(45deg); }
 
 <!-- ============ STATUS ============ -->
 <section id="status">
+  <!-- Hardware fault banner. Hidden by default; loadStatus() flips
+       hidden off when /api/status reports hardware_ok=false. This
+       is the same "no camera module detected" signal the server
+       surfaces on its dashboard card. -->
+  <div id="hardware-alert" class="msg msg--warn" hidden
+       style="margin-bottom:var(--gap-3)">
+    <strong>Camera hardware issue.</strong>
+    <span id="hardware-alert-msg">No camera module detected.</span>
+  </div>
+
   <div class="hero">
     <div><span id="hero-dot" class="hero__dot"></span><span id="hero-line" class="hero__line">Loading status…</span></div>
     <dl class="hero__sub">
@@ -771,6 +781,19 @@ function loadStatus() {
         $("h-uptime").textContent = friendlyUptime(d.uptime);
         _currentFirmware = d.firmware_version || "";
         $("h-firmware").textContent = _currentFirmware || "--";
+
+        // Hardware fault banner — show when CaptureManager.check()
+        // failed. Server reports the same signal on the dashboard;
+        // this is the local mirror so an operator who SSH'd to the
+        // camera directly or is on its setup hotspot sees it too.
+        var hwAlert = $("hardware-alert");
+        if (d.hardware_ok === false) {
+            $("hardware-alert-msg").textContent =
+                d.hardware_error || "No camera module detected.";
+            hwAlert.hidden = false;
+        } else {
+            hwAlert.hidden = true;
+        }
 
         // Chips
         if (typeof d.cpu_temp === "number") {

--- a/app/camera/tests/contracts/test_api_contracts.py
+++ b/app/camera/tests/contracts/test_api_contracts.py
@@ -330,6 +330,10 @@ STATUS_API_FIELDS = {
     "memory_total_mb",
     "memory_used_mb",
     "stream_config",
+    # Hardware health surfaces the "no camera module detected" banner
+    # on both the camera's own status page and the server dashboard.
+    "hardware_ok",
+    "hardware_error",
 }
 
 

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -203,6 +203,36 @@ class TestHeartbeatSender:
         payload = sender._build_payload()
         assert payload["stream_state"] == "stopped"
 
+    def test_hardware_ok_defaults_true_without_capture_manager(self):
+        """When no CaptureManager is wired, hardware is assumed OK.
+
+        Prevents test stubs from lighting up a false "no camera
+        module" warning on the dashboard.
+        """
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing(), capture_manager=None)
+        payload = sender._build_payload()
+        assert payload["hardware_ok"] is True
+        assert payload["hardware_error"] == ""
+
+    def test_hardware_fields_reflect_capture_manager_state(self):
+        """Heartbeat mirrors CaptureManager.available + last_error."""
+        cfg = _make_config()
+        capture = MagicMock()
+        capture.available = False
+        capture.last_error = "No camera module detected."
+        sender = HeartbeatSender(cfg, _make_pairing(), capture_manager=capture)
+        payload = sender._build_payload()
+        assert payload["hardware_ok"] is False
+        assert payload["hardware_error"] == "No camera module detected."
+
+        # When hardware recovers, heartbeat clears the banner fields.
+        capture.available = True
+        capture.last_error = ""
+        payload = sender._build_payload()
+        assert payload["hardware_ok"] is True
+        assert payload["hardware_error"] == ""
+
     def test_stream_state_from_control_handler(self):
         """ADR-0017: with a handler, stream_state is the persisted desired value.
 

--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -58,6 +58,14 @@ class Camera:
     cpu_temp: float = 0.0  # °C, from last heartbeat
     memory_percent: int = 0  # 0-100, from last heartbeat
     uptime_seconds: int = 0  # seconds since camera boot
+    # Hardware health reported by the camera in every heartbeat. Set
+    # to False (with a human-readable error in ``hardware_error``)
+    # when CaptureManager.check() fails — typically "no camera module
+    # detected" on a freshly paired Zero 2W whose ribbon cable is
+    # loose or sensor is missing. Surfaced as a banner on the
+    # dashboard card + camera status page.
+    hardware_ok: bool = True
+    hardware_error: str = ""
 
 
 @dataclass

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -179,6 +179,14 @@ class CameraService:
                 "recording_schedule": list(c.recording_schedule),
                 "recording_motion_enabled": c.recording_motion_enabled,
                 "desired_stream_state": c.desired_stream_state,
+                # Hardware health is not admin-gated — even viewers
+                # benefit from seeing "no camera module detected" on
+                # the dashboard so they don't wait for a broken
+                # stream to come up. ``getattr`` with defaults keeps
+                # test stubs (SimpleNamespace) working without having
+                # to enumerate every Camera field.
+                "hardware_ok": getattr(c, "hardware_ok", True),
+                "hardware_error": getattr(c, "hardware_error", ""),
             }
             if admin_view:
                 # Admin-only fields: network topology + health metrics
@@ -351,6 +359,14 @@ class CameraService:
                 camera.uptime_seconds = int(data["uptime_seconds"])
             except (TypeError, ValueError):
                 pass
+        # Hardware health — "no camera module detected" + friends.
+        # Accept only the expected types; ignore garbage.
+        if "hardware_ok" in data:
+            camera.hardware_ok = bool(data["hardware_ok"])
+        if "hardware_error" in data and isinstance(data["hardware_error"], str):
+            # Clip to a sane length so a malformed camera can't bloat
+            # the persisted store.
+            camera.hardware_error = data["hardware_error"][:512]
         # Pick up the camera's post-OTA firmware version the first time
         # it reports in after a reboot. Heartbeat is the most reliable
         # channel — avahi TXT records refresh with noticeable lag and

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -260,6 +260,21 @@
                         'text-muted': cam.config_sync === 'unknown'
                     }" x-show="cam.status !== 'pending'" x-text="cam.config_sync === 'synced' ? '\u2713 synced' : cam.config_sync === 'pending' ? '\u231B pending' : ''"></span>
                 </div>
+                <!-- Hardware fault banner. Shows when the camera's
+                     CaptureManager.check() fails — typically "no
+                     camera module detected" on a freshly paired
+                     Zero 2W whose ribbon cable is loose or sensor
+                     is missing. Click doesn't bubble so tapping
+                     the banner doesn't trigger the outer "go to
+                     Live" handler (which would 500 on a broken
+                     stream). -->
+                <div class="camera-card__alert msg msg--warn"
+                     x-show="cam.hardware_ok === false && cam.status !== 'pending'"
+                     @click.stop
+                     style="margin-top:var(--space-2); font-size:var(--text-sm);">
+                    <strong>Camera hardware issue.</strong>
+                    <span x-text="cam.hardware_error || 'No camera module detected.'"></span>
+                </div>
                 <!-- Surface the camera's IP for admins — a necessary fallback
                      when mDNS/.local resolution fails on the operator's
                      network (issue #90). Click-to-copy eases typing into

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -145,6 +145,12 @@ CAMERA_LIST_FIELDS_ADMIN = {
     "desired_stream_state",
     # ADR-0021: per-camera motion detection sensitivity (1-10)
     "motion_sensitivity",
+    # Hardware health — reported by camera each heartbeat, surfaced on
+    # dashboard + camera status page. Intentionally non-admin-gated so
+    # viewers see "no camera module detected" instead of a mysteriously
+    # empty Live View.
+    "hardware_ok",
+    "hardware_error",
 }
 
 # Viewers see a subset — no IP (network topology) or health metrics (occupancy risk)

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -647,6 +647,57 @@ class TestAcceptHeartbeat:
         svc.accept_heartbeat("cam-001", self._basic_payload(streaming=False))
         assert cam.streaming is False
 
+    def test_accepts_hardware_fault_from_heartbeat(self):
+        """Camera reports a hardware fault — server stores + surfaces it.
+
+        Prevents the dashboard "no camera module detected" banner
+        from silently regressing to always-green.
+        """
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        payload = self._basic_payload(
+            hardware_ok=False,
+            hardware_error="No camera module detected.",
+        )
+        svc.accept_heartbeat("cam-001", payload)
+        assert cam.hardware_ok is False
+        assert cam.hardware_error == "No camera module detected."
+
+    def test_clears_hardware_fault_when_recovered(self):
+        """When the camera reports ok=true, the previously stored error is cleared.
+
+        Covers the "operator plugged the ribbon cable back in" path.
+        """
+        cam = _make_camera()
+        cam.hardware_ok = False
+        cam.hardware_error = "No camera module detected."
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat(
+            "cam-001",
+            self._basic_payload(hardware_ok=True, hardware_error=""),
+        )
+        assert cam.hardware_ok is True
+        assert cam.hardware_error == ""
+
+    def test_ignores_malformed_hardware_error(self):
+        """Non-string hardware_error is dropped silently."""
+        cam = _make_camera()
+        # Seed the real attribute name so we can assert it was left alone.
+        cam.hardware_error = "prior-value"
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat(
+            "cam-001",
+            self._basic_payload(hardware_error={"evil": "dict"}),
+        )
+        # Malformed value is ignored — prior value preserved, no exception.
+        assert cam.hardware_error == "prior-value"
+
     def test_updates_health_metrics(self):
         cam = _make_camera()
         store = MagicMock()

--- a/openapi/camera.yaml
+++ b/openapi/camera.yaml
@@ -47,6 +47,8 @@ components:
           uptime,
           memory_total_mb,
           memory_used_mb,
+          hardware_ok,
+          hardware_error,
         ]
       properties:
         camera_id:
@@ -73,6 +75,17 @@ components:
           type: integer
         memory_used_mb:
           type: integer
+        hardware_ok:
+          type: boolean
+          description: |
+            False when the CaptureManager couldn't open the V4L2 device
+            (typically "no camera module detected"). Surfaced as a
+            banner on the camera status page + server dashboard.
+        hardware_error:
+          type: string
+          description: |
+            Short, user-facing description of the hardware fault.
+            Empty when hardware_ok=true.
     NetworkList:
       type: object
       required: [networks]
@@ -163,6 +176,15 @@ components:
           type: integer
         uptime_seconds:
           type: integer
+        hardware_ok:
+          type: boolean
+          description: |
+            False when the camera's V4L2 device failed to open (e.g.
+            the ribbon cable is not seated). Server mirrors this to
+            the dashboard card.
+        hardware_error:
+          type: string
+          description: Short, user-facing fault string. Empty when hardware_ok=true.
 paths:
   /login:
     post:

--- a/openapi/server.yaml
+++ b/openapi/server.yaml
@@ -140,6 +140,18 @@ components:
           type: string
         firmware_version:
           type: string
+        hardware_ok:
+          type: boolean
+          description: |
+            Camera-reported hardware health. `false` surfaces a warning
+            banner on the dashboard card — typically "no camera module
+            detected" on a freshly paired Zero 2W without a sensor
+            connected. Updated on every heartbeat.
+        hardware_error:
+          type: string
+          description: |
+            Short, user-facing description of the hardware fault.
+            Empty string when `hardware_ok=true`.
     CameraUpdate:
       type: object
       description: |


### PR DESCRIPTION
## Summary

A paired camera with a missing / loose ribbon cable used to boot + pair fine but showed a healthy card in both UIs. The operator had no way to see \"no camera module detected\" until they opened Live View and watched it time out.

This wires a clean error surface end-to-end:

**Camera**
- \`CaptureManager.last_error\` — short, user-facing message when \`check()\` fails
- \`HeartbeatSender\` includes \`hardware_ok\` + \`hardware_error\` in every payload
- \`/api/status\` (camera's own HTTPS page) returns the same two fields

**Server**
- \`Camera\` model gains \`hardware_ok\` + \`hardware_error\`
- Heartbeat handler stores them (type-checked + 512-char cap on the error)
- \`GET /api/v1/cameras\` returns both for every camera (not admin-gated)

**UI**
- Dashboard card: yellow banner at top of each paired-card when \`hardware_ok === false\` (with \`@click.stop\` so it doesn't trigger \"go to Live\")
- Camera status page: same banner at top of the Status section

This is the \"good place for errors\" surface — extensible for future hardware/health faults (thermal limits, storage pressure, etc.) by adding more fields to the same sub-object.

## Test plan
- [x] 1026 server unit + 365 camera unit tests green
- [x] Ruff + format clean
- [x] Jinja dashboard template parses
- [ ] Flash a camera-prod SD card without a camera module → pair → confirm dashboard card + camera /status both show the banner
- [ ] Plug ribbon back in + reboot → banner clears within one heartbeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)