### PR TITLE
fix(control): push motion_detection (not recording_motion_enabled) to camera

### DIFF
--- a/app/camera/camera_streamer/control.py
+++ b/app/camera/camera_streamer/control.py
@@ -58,6 +58,12 @@ PARAM_SCHEMA = {
     # thresholds at motion-pipeline start. See config.motion_sensitivity
     # + motion_runner.motion_config_from_sensitivity.
     "motion_sensitivity": {"type": int, "min": 1, "max": 10},
+    # Motion detection on/off gate. Maps to the MOTION_DETECTION
+    # config key on-device; stream.py gates the motion pipeline
+    # on it. The server's Camera model uses the longer name
+    # ``recording_motion_enabled`` for the same boolean and
+    # renames before pushing (see camera_service._translate_stream_params_for_wire).
+    "motion_detection": {"type": bool},
 }
 
 # Rate limit: minimum seconds between config changes
@@ -208,6 +214,7 @@ class ControlHandler:
                 "hflip": {"type": "bool"},
                 "vflip": {"type": "bool"},
                 "motion_sensitivity": {"type": "int", "min": 1, "max": 10},
+                "motion_detection": {"type": "bool"},
             },
         }
 
@@ -224,6 +231,7 @@ class ControlHandler:
             "hflip": self._config.hflip,
             "vflip": self._config.vflip,
             "motion_sensitivity": self._config.motion_sensitivity,
+            "motion_detection": self._config.motion_detection,
         }
 
     def set_config(self, params, request_id=0, origin="server"):

--- a/app/camera/tests/unit/test_control.py
+++ b/app/camera/tests/unit/test_control.py
@@ -59,6 +59,10 @@ class TestGetCapabilities:
             "vflip",
             # ADR-0021: per-camera motion sensitivity dial (1-10)
             "motion_sensitivity",
+            # MOTION_DETECTION on/off gate. Server pushes this
+            # (renamed from recording_motion_enabled) when the admin
+            # toggles motion on from the Camera Settings modal.
+            "motion_detection",
         }
         assert set(params.keys()) == expected
 
@@ -88,6 +92,10 @@ class TestGetConfig:
             "vflip",
             # ADR-0021: per-camera motion sensitivity dial (1-10)
             "motion_sensitivity",
+            # MOTION_DETECTION on/off gate. Server pushes this
+            # (renamed from recording_motion_enabled) when the admin
+            # toggles motion on from the Camera Settings modal.
+            "motion_detection",
         }
         assert set(cfg.keys()) == expected
 

--- a/app/server/monitor/api/system.py
+++ b/app/server/monitor/api/system.py
@@ -13,6 +13,9 @@ Endpoints:
   POST /system/factory-reset           - Wipe all data and return to first-boot state
 """
 
+import time
+from datetime import datetime
+
 from flask import Blueprint, current_app, jsonify, request, session
 
 from monitor.auth import admin_required, csrf_protect, login_required
@@ -34,6 +37,34 @@ def _read_os_release():
             return result
     except OSError:
         return {}
+
+
+@system_bp.route("/time", methods=["GET"])
+@login_required
+def time_now():
+    """Return the server's current wall-clock time.
+
+    Used by the dashboard top-bar clock so the displayed time matches
+    what ends up in audit logs / motion event timestamps. The
+    dashboard fetches this once on load, computes offset from the
+    client clock, and ticks locally every second — re-syncing every
+    five minutes to avoid drift.
+    """
+    now = datetime.now().astimezone()
+    # Local-time ISO without microseconds + offset (e.g.
+    # "2026-04-22T07:34:02+01:00"). Clients can Date.parse() it
+    # directly.
+    iso = now.replace(microsecond=0).isoformat()
+    return jsonify(
+        {
+            "iso": iso,
+            "unix": int(time.time()),
+            "tz": now.tzname() or "UTC",
+            "tz_offset_seconds": int(now.utcoffset().total_seconds())
+            if now.utcoffset()
+            else 0,
+        }
+    )
 
 
 @system_bp.route("/health", methods=["GET"])

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -41,7 +41,32 @@ STREAM_PARAMS = {
     "hflip",
     "vflip",
     "motion_sensitivity",
+    # recording_motion_enabled is named for the RecordingScheduler
+    # on the server side, but on the wire it maps to the camera's
+    # MOTION_DETECTION flag that gates its on-device detector.
+    # See ``_translate_stream_params_for_wire`` below.
+    "recording_motion_enabled",
 }
+
+
+def _translate_stream_params_for_wire(params: dict) -> dict:
+    """Rename server-side model fields to the keys the camera expects.
+
+    The camera's ``ControlHandler.set_config`` upper-cases each key
+    and stores it in ``camera.conf`` as-is. The stream pipeline then
+    reads specific keys (``MOTION_DETECTION``, not
+    ``RECORDING_MOTION_ENABLED``), so without this translation a
+    toggled-on motion flag silently ends up in an unread config
+    bucket and the on-device detector stays off.
+
+    Keep this mapping narrow — only fields where the server model
+    name diverges from the camera config key. Most params already
+    agree by name (``width``, ``bitrate``, etc.) and pass through.
+    """
+    translated = dict(params)
+    if "recording_motion_enabled" in translated:
+        translated["motion_detection"] = translated.pop("recording_motion_enabled")
+    return translated
 
 
 def _validate_schedule(schedule) -> str:
@@ -301,10 +326,13 @@ class CameraService:
         for key, value in data.items():
             setattr(camera, key, value)
 
-        # Push stream params to camera if any changed (ADR-0015)
+        # Push stream params to camera if any changed (ADR-0015).
+        # Translate server-side names to the camera's wire keys
+        # (e.g. recording_motion_enabled → motion_detection).
         stream_changes = {k: v for k, v in data.items() if k in STREAM_PARAMS}
-        if stream_changes and camera.ip and self._control:
-            result, err = self._control.set_config(camera.ip, stream_changes)
+        wire_changes = _translate_stream_params_for_wire(stream_changes)
+        if wire_changes and camera.ip and self._control:
+            result, err = self._control.set_config(camera.ip, wire_changes)
             if err:
                 log.warning("Failed to push config to camera %s: %s", camera_id, err)
                 camera.config_sync = "pending"

--- a/app/server/monitor/static/css/style.css
+++ b/app/server/monitor/static/css/style.css
@@ -134,6 +134,27 @@ a:hover { text-decoration: underline; }
     color: var(--color-text-muted);
 }
 
+/* Server wall clock in the top bar.
+   Tabular-nums keeps each second tick the same width (no jiggle).
+   Hidden on narrow viewports (< 480 px) where space is tight; the
+   dashboard page has its own uptime/last-seen anyway. */
+.top-bar__clock {
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-muted);
+    letter-spacing: 0.02em;
+    padding: 2px 10px;
+    border-radius: var(--radius-sm);
+    background: rgba(255,255,255,0.04);
+    border: 1px solid var(--color-border);
+    white-space: nowrap;
+}
+@media (max-width: 480px) {
+    .top-bar__clock { display: none; }
+}
+
 .top-bar__logout {
     background: none;
     border: 1px solid var(--color-border);

--- a/app/server/monitor/templates/base.html
+++ b/app/server/monitor/templates/base.html
@@ -28,6 +28,13 @@
             <span class="top-bar__title">Home Monitor</span>
         </div>
         <div class="top-bar__right">
+            <!-- Server-side wall clock. Fetched once from /system/time
+                 to get the server's local offset, then ticks client-
+                 side every second. Re-syncs every 5 min to correct
+                 drift. Shows the same time as audit log + motion
+                 event timestamps (not the browser's clock). -->
+            <span class="top-bar__clock" id="topbar-clock" title="Server time"
+                  aria-label="Server time"></span>
             <span class="top-bar__user" id="topbar-username"></span>
             <button class="top-bar__logout" id="btn-logout" type="button">Logout</button>
         </div>
@@ -128,6 +135,58 @@
         link.addEventListener('touchstart', warm, { once: true, passive: true });
         // Also kick on focus for keyboard navigation.
         link.addEventListener('focus', warm, { once: true });
+    })();
+    </script>
+    <script>
+    // Server wall-clock in the top bar. Fetches once from /system/time
+    // to anchor the display to the server's clock + timezone, then
+    // ticks locally every second. Re-syncs every 5 minutes so long
+    // browser sessions don't drift. Works without Alpine — this
+    // runs on every authenticated page.
+    (function() {
+        var el = document.getElementById('topbar-clock');
+        if (!el) return;
+        var serverUnix = null;   // server-reported unix seconds at sync
+        var localUnix = null;    // client performance-time at that sync
+        var tzName = '';
+        var tzOffsetSeconds = 0;
+
+        function sync() {
+            fetch('/api/v1/system/time', { credentials: 'same-origin', cache: 'no-store' })
+                .then(function(r) { return r.ok ? r.json() : null; })
+                .then(function(d) {
+                    if (!d || typeof d.unix !== 'number') return;
+                    serverUnix = d.unix;
+                    localUnix = Date.now() / 1000;
+                    tzName = d.tz || '';
+                    tzOffsetSeconds = d.tz_offset_seconds || 0;
+                    render();
+                })
+                .catch(function() { /* keep last value */ });
+        }
+
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+
+        function render() {
+            if (serverUnix === null) {
+                el.textContent = '--:--:--';
+                return;
+            }
+            var elapsed = (Date.now() / 1000) - localUnix;
+            var t = serverUnix + elapsed;
+            // Convert unix + tz_offset to a "virtual local date" whose
+            // UTC fields match the server's local wall clock.
+            var d = new Date((t + tzOffsetSeconds) * 1000);
+            var hh = pad(d.getUTCHours());
+            var mm = pad(d.getUTCMinutes());
+            var ss = pad(d.getUTCSeconds());
+            el.textContent = hh + ':' + mm + ':' + ss;
+            el.title = 'Server time' + (tzName ? ' (' + tzName + ')' : '');
+        }
+
+        sync();
+        setInterval(render, 1000);
+        setInterval(sync, 5 * 60 * 1000);
     })();
     </script>
     {% block scripts %}{% endblock %}

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -744,6 +744,33 @@ class TestAcceptHeartbeat:
         assert len(cam.hardware_faults) == 1
         assert cam.hardware_faults[0]["code"] == "camera_sensor_missing"
 
+    def test_recording_motion_enabled_translates_to_motion_detection_on_wire(self):
+        """When the admin toggles motion on, the server must push ``motion_detection``
+        to the camera — not ``recording_motion_enabled`` (the server-side model
+        field name). The camera config reads ``MOTION_DETECTION``; using the
+        server-side name leaves motion detection off silently.
+
+        Regression for the bug discovered on 2026-04-22: Front Door
+        showed motion_enabled=true on the dashboard but was actually
+        running with motion off — no events ever fired.
+        """
+        cam = _make_camera(
+            id="cam-001", ip="192.168.1.148", recording_motion_enabled=False
+        )
+        cam.hardware_faults = []
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        control = MagicMock()
+        control.set_config.return_value = ({"applied": {}}, "")
+        svc = CameraService(store, control_client=control)
+        svc.update("cam-001", {"recording_motion_enabled": True})
+        # The key pushed to the control client must be motion_detection.
+        control.set_config.assert_called_once()
+        pushed = control.set_config.call_args[0][1]
+        assert "motion_detection" in pushed
+        assert pushed["motion_detection"] is True
+        assert "recording_motion_enabled" not in pushed
+
     def test_hardware_faults_caps_list_length(self):
         """Runaway camera can't bloat the store with thousands of faults."""
         cam = _make_camera()


### PR DESCRIPTION
Toggling motion detection in the dashboard modal silently did nothing — server never pushed to the camera, and the name mismatch meant even if it had, the wrong config key would land. Discovered because Front Door (192.168.1.148, has sensor) never fired motion events despite showing motion_enabled=true on the server.

## Fix
- Add `recording_motion_enabled` to STREAM_PARAMS so the update diff pushes to camera
- Translate to `motion_detection` before the wire call (matches camera config key MOTION_DETECTION)
- Accept `motion_detection` on the camera side (PARAM_SCHEMA + get_config + capabilities)

Regression test captures the missed push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)