### PR TITLE
[codex] align agent rules with validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Read next:
 - [`docs/ai/repo-map.md`](docs/ai/repo-map.md)
 - [`docs/ai/working-agreement.md`](docs/ai/working-agreement.md)
 - [`docs/ai/engineering-standards.md`](docs/ai/engineering-standards.md)
+- [`docs/ai/execution-rules.md`](docs/ai/execution-rules.md)
 - [`docs/ai/design-standards.md`](docs/ai/design-standards.md)
 - [`docs/ai/validation-and-release.md`](docs/ai/validation-and-release.md)
 - [`docs/exec-plans/template.md`](docs/exec-plans/template.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ Start here:
 1. [`docs/ai/index.md`](docs/ai/index.md)
 2. [`docs/ai/mission-and-goals.md`](docs/ai/mission-and-goals.md)
 3. [`docs/ai/repo-map.md`](docs/ai/repo-map.md)
-4. [`docs/ai/validation-and-release.md`](docs/ai/validation-and-release.md)
+4. [`docs/ai/execution-rules.md`](docs/ai/execution-rules.md)
+5. [`docs/ai/validation-and-release.md`](docs/ai/validation-and-release.md)
 
 Claude-specific notes:
 - respect [`.claude/settings.json`](.claude/settings.json)

--- a/docs/ai/validation-and-release.md
+++ b/docs/ai/validation-and-release.md
@@ -25,8 +25,8 @@
 - CI should run `pre-commit`, repository governance checks, Ruff, workflow lint,
   shell checks, and the relevant test suites.
 - Coverage is enforced, not just reported:
-  - server: `--cov-fail-under=80`
-  - camera: `--cov-fail-under=70`
+  - server: `--cov-fail-under=85`
+  - camera: `--cov-fail-under=80`
 - Path filters must include app code, Yocto layers, configs, workflows, docs,
   scripts, and generated adapters.
 

--- a/scripts/ai/build_instruction_files.py
+++ b/scripts/ai/build_instruction_files.py
@@ -36,6 +36,7 @@ def render_agents() -> str:
         - [`docs/ai/repo-map.md`](docs/ai/repo-map.md)
         - [`docs/ai/working-agreement.md`](docs/ai/working-agreement.md)
         - [`docs/ai/engineering-standards.md`](docs/ai/engineering-standards.md)
+        - [`docs/ai/execution-rules.md`](docs/ai/execution-rules.md)
         - [`docs/ai/design-standards.md`](docs/ai/design-standards.md)
         - [`docs/ai/validation-and-release.md`](docs/ai/validation-and-release.md)
         - [`docs/exec-plans/template.md`](docs/exec-plans/template.md)
@@ -78,7 +79,8 @@ def render_claude() -> str:
         1. [`docs/ai/index.md`](docs/ai/index.md)
         2. [`docs/ai/mission-and-goals.md`](docs/ai/mission-and-goals.md)
         3. [`docs/ai/repo-map.md`](docs/ai/repo-map.md)
-        4. [`docs/ai/validation-and-release.md`](docs/ai/validation-and-release.md)
+        4. [`docs/ai/execution-rules.md`](docs/ai/execution-rules.md)
+        5. [`docs/ai/validation-and-release.md`](docs/ai/validation-and-release.md)
 
         Claude-specific notes:
         - respect [`.claude/settings.json`](.claude/settings.json)

--- a/scripts/ai/validate_repo_ai_setup.py
+++ b/scripts/ai/validate_repo_ai_setup.py
@@ -12,6 +12,7 @@ REQUIRED_CANONICAL = [
     "docs/ai/repo-map.md",
     "docs/ai/working-agreement.md",
     "docs/ai/engineering-standards.md",
+    "docs/ai/execution-rules.md",
     "docs/ai/design-standards.md",
     "docs/ai/validation-and-release.md",
     "docs/exec-plans/template.md",


### PR DESCRIPTION
﻿## Summary

- Add `docs/ai/execution-rules.md` to generated agent starter read lists.
- Require `docs/ai/execution-rules.md` in the AI repo setup validator.
- Align documented coverage thresholds with the values enforced by CI.

## Why

The rules surface had drifted: the canonical index referenced execution rules, but adapters and validation did not consistently enforce or surface that file. The documented coverage thresholds also disagreed with CI, which could mislead contributors.

## Validation

- `python scripts/ai/validate_repo_ai_setup.py`
- `python scripts/ai/check_doc_links.py`
- `python scripts/ai/check_shell_scripts.py`
- `python -m pre_commit run --all-files`
