### PR TITLE
fix(ui): hide audit teaser by default to stop viewer role flash (#148)

### DIFF
--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -515,7 +515,11 @@ function dashboardPage() {
         playingKey: '',
         health: { uptime: '' },
         auditEvents: [],      // Slice 3 log teaser
-        auditAdmin: true,     // becomes false if /audit 403s (viewer role)
+        // Safe default: viewers must never see the admin-only audit
+        // teaser flash before the /audit/events call resolves (#148).
+        // Flipped to true by loadAuditEvents() on HTTP 200, left false
+        // on 403 so the section stays hidden for non-admin roles.
+        auditAdmin: false,
         // Mirrors settings.html's isAdmin — resolved from /api/v1/auth/me
         // on load and used to gate destructive UI controls (issue #86).
         // Defaults to false (safe-by-default): UI hides Settings/Delete


### PR DESCRIPTION
## Summary

Closes #148.

- Flip `auditAdmin` Alpine state from `true` → `false` in `dashboard.html`.
- `loadAuditEvents()` already sets `true` on 200 and `false` on 403/error, so no other change is needed.
- Stops the "Recent activity" admin-only teaser from briefly rendering for viewer-role users on every dashboard load.

## Why it was `true` before

A prior fix (the block comment at line 118) kept the section visible for admins during the render tick before `/audit/events` resolved. That concern applies to admins only. The cost — flashing an admin-only heading and "No recent activity yet." at viewers for ~100–400 ms — is a role-boundary leak, which is strictly worse than an admin seeing one extra render tick. Safe-by-default wins.

## Test plan

- [x] `pre-commit run --files app/server/monitor/templates/dashboard.html` — passed
- [x] `pytest app/server/tests/ --no-cov` — 1691 passed
- [ ] Manual viewer-role dashboard load in browser — **pending**, requires a viewer-role Playwright fixture we don't have yet. Filed as a follow-up rather than blocking this tiny fix.
- [ ] Admin dashboard load — confirm the teaser still appears once `/audit/events` returns. One extra render tick of delay is the intentional tradeoff.

## Deployment impact

None. Template-only change. No migrations, no new routes, no config.

## Doc impact

None.