### PR TITLE
fix(loop-recorder): update base_dir when USB storage is mounted

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -311,6 +311,8 @@ def _init_services(app):
         app.streaming.update_recordings_dir(new_dir)
         if getattr(app, "motion_clip_correlator", None) is not None:
             app.motion_clip_correlator.set_recordings_dir(new_dir)
+        if getattr(app, "loop_recorder", None) is not None:
+            app.loop_recorder.set_base_dir(new_dir)
 
     app.storage_manager.set_dir_change_callback(_on_recording_dir_change)
 
@@ -385,6 +387,7 @@ def _startup(app):
         app.streaming.update_recordings_dir(recordings_dir)
         if getattr(app, "motion_clip_correlator", None) is not None:
             app.motion_clip_correlator.set_recordings_dir(recordings_dir)
+        app.loop_recorder.set_base_dir(recordings_dir)
 
     app.streaming.start()
     # NOTE: app.storage_manager is NOT started. LoopRecorder (ADR-0017)

--- a/app/server/monitor/services/loop_recorder.py
+++ b/app/server/monitor/services/loop_recorder.py
@@ -87,6 +87,18 @@ class LoopRecorder:
             self._hys,
         )
 
+    def set_base_dir(self, new_dir: str | Path) -> None:
+        """Redirect the recorder to a new recordings root (e.g. after USB mount).
+
+        Must be called whenever the recordings directory changes so that
+        free-space checks and segment enumeration target the right filesystem.
+        Without this, the recorder watches the old path (typically the internal
+        /data partition which is nearly empty) and never triggers cleanup on the
+        USB drive that is actually full.
+        """
+        self._base_dir = Path(new_dir)
+        log.info("LoopRecorder base_dir updated: %s", self._base_dir)
+
     # --- Public API -------------------------------------------------------
 
     def tick(self) -> int:

--- a/app/server/tests/unit/test_loop_recorder.py
+++ b/app/server/tests/unit/test_loop_recorder.py
@@ -113,3 +113,48 @@ class TestLoopRecorderEdgeCases:
         lr = LoopRecorder(tmp_path, audit=MagicMock())
         lr._free_percent = lambda: 1.0
         assert lr.tick() == 0
+
+
+class TestLoopRecorderSetBaseDir:
+    def test_set_base_dir_redirects_cleanup(self, tmp_path):
+        """set_base_dir must redirect both free-space checks and segment scans.
+
+        Regression: when USB storage is selected the recordings directory
+        changes from /data/recordings to /mnt/recordings/home-monitor-recordings.
+        Before the fix, LoopRecorder kept watching the original internal path
+        (nearly empty → free_pct always ≥ low watermark → tick() → 0) so the
+        USB drive filled to 100% and was never pruned.
+        """
+        internal = tmp_path / "internal"
+        internal.mkdir()
+        usb = tmp_path / "usb"
+        usb.mkdir()
+
+        # Old segment sits on USB; internal is empty.
+        old_seg = _mkseg(usb, "cam1", "old.mp4", 5000)
+
+        lr = LoopRecorder(internal, audit=MagicMock(), low_watermark=10, hysteresis=5)
+
+        # Before redirect: free_percent targets internal (plenty of space) →
+        # tick does nothing even though USB is full.
+        lr._free_percent = lambda: 80.0
+        assert lr.tick() == 0
+        assert old_seg.exists()
+
+        # Simulate USB mount: redirect the recorder to the USB path.
+        lr.set_base_dir(usb)
+        assert lr._base_dir == usb
+
+        # Now free_percent is patched to reflect the full USB; tick prunes.
+        seq = iter([2.0, 2.0, 20.0, 20.0])
+        lr._free_percent = lambda: next(seq)
+        deleted = lr.tick()
+        assert deleted == 1
+        assert not old_seg.exists()
+
+    def test_set_base_dir_accepts_string(self, tmp_path):
+        lr = LoopRecorder(tmp_path, audit=MagicMock())
+        lr.set_base_dir(str(tmp_path / "new"))
+        from pathlib import Path
+
+        assert lr._base_dir == Path(tmp_path / "new")


### PR DESCRIPTION
## Summary

- `LoopRecorder._base_dir` was never updated when USB storage was selected, so the recorder watched the internal `/data/recordings` partition (always ~100% free) instead of the USB drive — disk fills to 100% and nothing is ever deleted.
- Add `LoopRecorder.set_base_dir()` and call it from the `_on_recording_dir_change` callback (runtime USB select/eject) and the `_startup()` auto-mount block (boot with previously configured USB).
- Two new regression tests: one verifies cleanup resumes after `set_base_dir()` redirects to USB, one verifies string input is accepted.

Closes #164

## Test plan

- [x] `pytest app/server/tests/unit/test_loop_recorder.py -v` — all 10 tests pass (8 existing + 2 new)
- [ ] Deploy to `192.168.1.245` and confirm loop recorder prunes oldest segments as USB fills up
- [ ] Verify oldest/newest segment fields in Settings → Loop Recording reflect real files

## Deployment impact

Server-only change. Deploy with:
```
./scripts/deploy-dev-app.sh --server 192.168.1.245
```
Service restart required (deploy script handles this). No schema or config migration needed.

## Doc impact

None — internal implementation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)