### PR TITLE
fix(storage): populate oldest_segment / newest_segment in storage stats

### DIFF
--- a/app/server/monitor/services/storage_manager.py
+++ b/app/server/monitor/services/storage_manager.py
@@ -20,7 +20,7 @@ import logging
 import shutil
 import threading
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 log = logging.getLogger("monitor.storage")
@@ -130,12 +130,17 @@ class StorageManager:
                 "clip_count": 0,
                 "recordings_dir": str(rec_dir),
                 "is_usb": self._is_usb_path(rec_dir),
+                "oldest_segment": None,
+                "newest_segment": None,
             }
 
-        # Count clips per camera
+        # Count clips per camera; track oldest/newest mtime across all clips
+        # in the same pass so we don't pay an extra rglob.
         camera_stats = {}
         total_clips = 0
         recordings_bytes = 0
+        oldest_mtime: float | None = None
+        newest_mtime: float | None = None
         if rec_dir.is_dir():
             for cam_dir in rec_dir.iterdir():
                 if not cam_dir.is_dir():
@@ -145,7 +150,13 @@ class StorageManager:
                 for mp4 in cam_dir.rglob("*.mp4"):
                     count += 1
                     try:
-                        cam_bytes += mp4.stat().st_size
+                        st = mp4.stat()
+                        cam_bytes += st.st_size
+                        mtime = st.st_mtime
+                        if oldest_mtime is None or mtime < oldest_mtime:
+                            oldest_mtime = mtime
+                        if newest_mtime is None or mtime > newest_mtime:
+                            newest_mtime = mtime
                     except OSError:
                         pass
                 camera_stats[cam_dir.name] = {
@@ -168,6 +179,8 @@ class StorageManager:
             "is_usb": self._is_usb_path(rec_dir),
             "reserve_mb": self._reserve_mb,
             "threshold_percent": self._threshold_percent,
+            "oldest_segment": _epoch_to_iso(oldest_mtime),
+            "newest_segment": _epoch_to_iso(newest_mtime),
         }
 
     def needs_cleanup(self) -> bool:
@@ -266,6 +279,13 @@ class StorageManager:
     def _is_usb_path(self, path) -> bool:
         """Check if path is on USB (not under /data)."""
         return not str(path).startswith(str(self._data_dir))
+
+
+def _epoch_to_iso(epoch: float | None) -> str | None:
+    """Convert a POSIX timestamp to an ISO 8601 UTC string, or None."""
+    if epoch is None:
+        return None
+    return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def create_recording_dirs(recordings_dir, cam_id):

--- a/app/server/tests/unit/test_storage_manager.py
+++ b/app/server/tests/unit/test_storage_manager.py
@@ -295,6 +295,56 @@ class TestGetStorageStats:
         stats = mgr.get_storage_stats()
         assert stats["is_usb"] is True
 
+    def test_oldest_newest_segment_none_when_no_clips(self, tmp_path):
+        mgr, _ = _make_manager(tmp_path)
+        stats = mgr.get_storage_stats()
+        assert stats["oldest_segment"] is None
+        assert stats["newest_segment"] is None
+
+    def test_oldest_newest_segment_present_after_clips(self, tmp_path):
+        """oldest/newest are ISO 8601 UTC strings once clips exist."""
+        mgr, rec_dir = _make_manager(tmp_path)
+        _make_clip(rec_dir, "cam-001", "2026-01-01", "06-00-00")
+        _make_clip(rec_dir, "cam-001", "2026-04-01", "12-00-00")
+        stats = mgr.get_storage_stats()
+        assert stats["oldest_segment"] is not None
+        assert stats["newest_segment"] is not None
+        # Both must be ISO 8601 UTC (end with Z)
+        assert stats["oldest_segment"].endswith("Z")
+        assert stats["newest_segment"].endswith("Z")
+        # oldest must be strictly before newest (different mtimes)
+        assert stats["oldest_segment"] <= stats["newest_segment"]
+
+    def test_oldest_newest_segment_order_across_cameras(self, tmp_path):
+        """The oldest/newest scan crosses camera subdirectories."""
+        import os
+        import time as _time
+
+        mgr, rec_dir = _make_manager(tmp_path)
+        old_clip = _make_clip(rec_dir, "cam-001", "2026-01-01", "00-00-00")
+        new_clip = _make_clip(rec_dir, "cam-002", "2026-04-01", "12-00-00")
+
+        # Force distinct mtimes so the test isn't filesystem-resolution-sensitive.
+        t_old = _time.time() - 10000
+        t_new = _time.time() - 1
+        os.utime(old_clip, (t_old, t_old))
+        os.utime(new_clip, (t_new, t_new))
+
+        stats = mgr.get_storage_stats()
+        assert stats["oldest_segment"] < stats["newest_segment"]
+
+    def test_oldest_newest_segment_none_in_oserror_path(self, tmp_path):
+        """The OSError early-return must include the two keys as None."""
+        mgr, _ = _make_manager(tmp_path)
+        with patch(
+            "monitor.services.storage_manager.shutil.disk_usage", side_effect=OSError
+        ):
+            stats = mgr.get_storage_stats()
+        assert "oldest_segment" in stats
+        assert "newest_segment" in stats
+        assert stats["oldest_segment"] is None
+        assert stats["newest_segment"] is None
+
 
 # ===========================================================================
 # start / stop lifecycle


### PR DESCRIPTION
## Summary

- `get_storage_stats()` iterated over all `.mp4` files to count clips but never tracked their mtimes — `oldest_segment` / `newest_segment` were always absent from the API response, so the settings page permanently showed `--`.
- Track min/max `mtime` during the **same** rglob pass already done for clip counting (zero extra I/O cost).
- Return ISO 8601 UTC strings (`"2026-04-15T14:30:00Z"`) so the JS `x-text` renders them directly.
- Both the `OSError` early-return and the zero-clip path now include `oldest_segment: null` / `newest_segment: null` so the JS `|| '--'` fallback works correctly.

Closes #166

## Design decisions

- **Same pass, no extra I/O**: `st = mp4.stat()` already called for `st_size`; `st_mtime` is free from the same syscall.
- **ISO 8601 UTC string, not epoch float**: Consistent with every other timestamp in this codebase (audit log, motion events). Frontend displays it directly.
- **`None` (not omitting the key) in error/empty paths**: Ensures the API contract is stable — callers can always destructure `oldest_segment` without a `KeyError` / `undefined`.

## Test plan

- [x] 4 new unit tests in `TestGetStorageStats`: no-clips path, clips present, cross-camera ordering, OSError path — all pass
- [x] Full server test suite: all 38 storage-manager tests pass
- [ ] Deploy and confirm Settings → Storage → Loop Recording shows real timestamps

## Deployment impact

Server-only change. Deploy with:
```
./scripts/deploy-dev-app.sh --server 192.168.1.245
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)