### PR TITLE
feat(camera): firmware sensor auto-detect + idempotent overlay reconciliation

### DIFF
--- a/app/camera/config/ensure-camera-overlay.sh
+++ b/app/camera/config/ensure-camera-overlay.sh
@@ -1,54 +1,164 @@
 #!/bin/sh
 # =============================================================================
-# ensure-camera-overlay.sh — Verify config.txt has the camera sensor overlay
+# ensure-camera-overlay.sh — Reconcile /boot/config.txt with sensor policy
 #
-# Runs early on boot (before camera-streamer) to ensure the RPi firmware
-# has loaded the correct device tree overlay for the camera sensor.
+# Runs early on boot (before camera-streamer) so the firmware has the right
+# camera sensor configuration regardless of which image originally flashed
+# the boot partition.
 #
-# This is needed because OTA updates (SWUpdate) only write the rootfs
-# partitions (A/B), not the boot partition where config.txt lives.
-# After an A/B slot switch, config.txt may be stale if the original
-# image was flashed without the overlay or if a different image was
-# used for the initial flash.
+# Background: SWUpdate writes only the rootfs A/B partitions; /boot is never
+# touched by an OTA. So a camera updated from an older image carries that
+# image's /boot/config.txt forever unless something on the rootfs reconciles
+# it. This script is that something.
 #
-# Idempotent: only writes if the overlay line is missing.
+# Default policy: ``camera_auto_detect=1`` and no explicit ``dtoverlay=<sensor>``.
+# The firmware probes the CSI bus and picks whichever sensor is connected —
+# OV5647, IMX219, IMX477, IMX708 all work out of the box.
+#
+# Override: if ``/data/config/camera-sensor`` exists and contains a recognised
+# sensor name, the script pins that overlay explicitly (``camera_auto_detect=0``
+# + ``dtoverlay=<name>``). The file lives on /data so it survives OTAs.
+#
+# Idempotent: running multiple times against any input leaves the file in
+# the same final state. Running against a clean image is a no-op.
 # =============================================================================
 
 set -eu
 
-BOOT_MOUNT="/boot"
-BOOT_DEV="/dev/mmcblk0p1"
-BOOT_CONFIG="${BOOT_MOUNT}/config.txt"
-OVERLAY="dtoverlay=ov5647"
-AUTO_DETECT="camera_auto_detect=0"
+BOOT_MOUNT="${BOOT_MOUNT:-/boot}"
+BOOT_DEV="${BOOT_DEV:-/dev/mmcblk0p1}"
+BOOT_CONFIG="${BOOT_CONFIG:-${BOOT_MOUNT}/config.txt}"
+SENSOR_OVERRIDE_FILE="${SENSOR_OVERRIDE_FILE:-/data/config/camera-sensor}"
 
-# Mount boot partition if not already mounted
-if ! mountpoint -q "${BOOT_MOUNT}"; then
-    mkdir -p "${BOOT_MOUNT}"
-    mount -t vfat "${BOOT_DEV}" "${BOOT_MOUNT}" || {
-        echo "ensure-camera-overlay: cannot mount ${BOOT_DEV}" >&2
-        exit 1
-    }
+# Sensors with overlays shipped in the image. Add to this list (and to
+# RPI_KERNEL_DEVICETREE_OVERLAYS in the machine conf) when adding hardware
+# support for a new sensor.
+SUPPORTED_SENSORS="ov5647 imx219 imx477 imx708"
+
+# Marker tag included in every line this script writes/comments, so a
+# follow-up run can recognise its own work and stay idempotent.
+MARKER="ensure-camera-overlay"
+
+log() {
+    echo "${MARKER}: $*"
+}
+
+# True if $1 is in the space-separated SUPPORTED_SENSORS list.
+is_supported_sensor() {
+    case " ${SUPPORTED_SENSORS} " in
+        *" $1 "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Read /data/config/camera-sensor, trim whitespace, lowercase. Empty if
+# missing or unrecognised.
+read_sensor_override() {
+    if [ ! -f "${SENSOR_OVERRIDE_FILE}" ]; then
+        return 0
+    fi
+    raw=$(tr -d '[:space:]' < "${SENSOR_OVERRIDE_FILE}" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    if [ -z "${raw}" ]; then
+        return 0
+    fi
+    if is_supported_sensor "${raw}"; then
+        echo "${raw}"
+    else
+        log "ignoring unrecognised override '${raw}' (supported: ${SUPPORTED_SENSORS})" >&2
+    fi
+}
+
+# Reconcile the camera lines in $BOOT_CONFIG against the desired state.
+# Desired state:
+#   - if $1 is empty (auto-detect): exactly one active "camera_auto_detect=1"
+#     line; no active "camera_auto_detect=0", no active "dtoverlay=<sensor>"
+#   - if $1 is a sensor name (override): exactly one active
+#     "camera_auto_detect=0" and one active "dtoverlay=<sensor>"; no other
+#     active sensor overlays, no active camera_auto_detect=1
+#
+# All disabled lines are kept (commented out, with a marker) so an operator
+# inspecting /boot/config.txt sees the history.
+reconcile() {
+    desired_sensor="$1"
+    tmp=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f '${tmp}'" EXIT
+
+    # Strip ALL camera-streamer-managed lines from the working copy AND any
+    # trailing blank lines, in one pass. We re-emit the canonical block at
+    # the end. Lines already commented out by an earlier run carry the
+    # MARKER; lines from older Yocto bakes or from the original
+    # ensure-camera-overlay.sh do not — the regex matches both forms.
+    awk -v marker="${MARKER}" '
+        # Active or marker-commented "camera_auto_detect=N" (any leading
+        # whitespace, optional "#", any whitespace before the keyword).
+        /^[[:space:]]*#?[[:space:]]*camera_auto_detect=[0-9]+/ { next }
+        # Active or marker-commented "dtoverlay=<sensor>" — restricted to
+        # the sensor names we manage so unrelated dtoverlay lines
+        # (vc4-fkms-v3d, act-led, ...) are preserved.
+        /^[[:space:]]*#?[[:space:]]*dtoverlay=(ov5647|imx219|imx477|imx708)/ { next }
+        # Section header the original ensure-camera-overlay.sh appended.
+        /^[[:space:]]*#[[:space:]]*Camera sensor \(added by ensure-camera-overlay\)/ { next }
+        # Section header this version appends (substring match — matches
+        # whatever marker text we use).
+        index($0, "# Camera sensor (managed by " marker ")") { next }
+        { lines[++n] = $0 }
+        END {
+            # Drop trailing blank lines so the file does not grow on every run.
+            while (n > 0 && lines[n] ~ /^[[:space:]]*$/) n--
+            for (i = 1; i <= n; i++) print lines[i]
+        }
+    ' "${BOOT_CONFIG}" > "${tmp}"
+
+    # Append the canonical managed block.
+    {
+        # Single trailing newline before the block, regardless of input shape
+        echo ""
+        echo "# Camera sensor (managed by ${MARKER})"
+        if [ -z "${desired_sensor}" ]; then
+            echo "camera_auto_detect=1"
+        else
+            echo "camera_auto_detect=0"
+            echo "dtoverlay=${desired_sensor}"
+        fi
+    } >> "${tmp}"
+
+    # Compare. If the desired state already matches, do not touch the boot
+    # partition — keeps the script a true no-op on healthy images.
+    if cmp -s "${tmp}" "${BOOT_CONFIG}"; then
+        log "config.txt already in desired state — no changes"
+        return 0
+    fi
+
+    # Mount /boot rw, write, sync, mount ro.
+    if ! mountpoint -q "${BOOT_MOUNT}"; then
+        mkdir -p "${BOOT_MOUNT}"
+        mount -t vfat "${BOOT_DEV}" "${BOOT_MOUNT}" || {
+            log "cannot mount ${BOOT_DEV} on ${BOOT_MOUNT}" >&2
+            return 1
+        }
+    fi
+    mount -o remount,rw "${BOOT_MOUNT}" 2>/dev/null || true
+    cp "${tmp}" "${BOOT_CONFIG}"
+    sync
+    mount -o remount,ro "${BOOT_MOUNT}" 2>/dev/null || true
+    log "config.txt updated (desired_sensor='${desired_sensor:-auto}')"
+}
+
+# Self-test mode: when invoked with --self-test <fixture-file>, treat the
+# fixture as $BOOT_CONFIG and never touch a real boot partition. Used by
+# the integration test in app/camera/tests/integration/test_ensure_camera_overlay.py.
+if [ "${1:-}" = "--self-test" ]; then
+    [ -n "${2:-}" ] || { echo "usage: $0 --self-test <config.txt>" >&2; exit 2; }
+    BOOT_CONFIG="$2"
+    BOOT_MOUNT=$(dirname "$2")
+    SENSOR_OVERRIDE_FILE="${HM_OVERRIDE_FILE:-/dev/null}"
+    # In self-test we skip the real mount cycle; reconcile() must still
+    # see "$BOOT_MOUNT mounted" — fake it by making mountpoint(1) succeed.
+    mountpoint() { return 0; }
+    mount() { return 0; }
+    sync() { return 0; }
 fi
 
-# Check if overlay is already present
-if grep -q "^${OVERLAY}$" "${BOOT_CONFIG}" 2>/dev/null; then
-    echo "ensure-camera-overlay: ${OVERLAY} already present"
-    exit 0
-fi
-
-# Remount read-write if needed
-mount -o remount,rw "${BOOT_MOUNT}" 2>/dev/null || true
-
-# Add camera overlay settings
-{
-    echo ""
-    echo "# Camera sensor (added by ensure-camera-overlay)"
-    grep -q "^${AUTO_DETECT}$" "${BOOT_CONFIG}" 2>/dev/null || echo "${AUTO_DETECT}"
-    echo "${OVERLAY}"
-} >> "${BOOT_CONFIG}"
-
-# Remount read-only
-mount -o remount,ro "${BOOT_MOUNT}" 2>/dev/null || true
-
-echo "ensure-camera-overlay: added ${OVERLAY} to config.txt — reboot required for camera detection"
+override=$(read_sensor_override || true)
+reconcile "${override}"

--- a/app/camera/tests/integration/test_ensure_camera_overlay.py
+++ b/app/camera/tests/integration/test_ensure_camera_overlay.py
@@ -1,0 +1,288 @@
+"""Integration tests for ensure-camera-overlay.sh.
+
+The script reconciles ``/boot/config.txt`` to a canonical "managed block"
+that selects the camera sensor (firmware auto-detect by default, explicit
+override via ``/data/config/camera-sensor``).
+
+These tests run the real shell script in self-test mode against fixture
+config.txt files. Self-test mode never touches a real boot partition;
+``$BOOT_CONFIG`` is the fixture path and the mount/sync calls are stubbed
+inside the script. This lets us drive the script identically to how it
+runs on the camera, without root or hardware.
+
+Invariants under test:
+
+1. Script is idempotent against any input — a second run leaves the file
+   byte-identical to the first run's output.
+2. Clean auto-detect is the default — produces a single
+   ``camera_auto_detect=1`` line and no explicit dtoverlay.
+3. The "stale duplicate" state observed live on .115 (leading-whitespace
+   ``camera_auto_detect=0`` + ``dtoverlay=ov5647`` from RPI_EXTRA_CONFIG,
+   plus bare duplicates appended by the original script) heals in a
+   single run.
+4. Already-correct state is a no-op (file unchanged on disk; the script
+   detects the cmp-equal case before remounting).
+5. ``/data/config/camera-sensor`` override pins the requested sensor
+   when the file contains a recognised name; ignored otherwise.
+6. Other dtoverlay lines (vc4-fkms-v3d, act-led, ...) are preserved.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "ensure-camera-overlay.sh"
+)
+
+
+def _run(
+    config_path: Path, override_path: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the script in self-test mode against the given fixture."""
+    env = os.environ.copy()
+    env["HM_OVERRIDE_FILE"] = str(override_path) if override_path else "/dev/null"
+    return subprocess.run(
+        ["sh", str(SCRIPT_PATH), "--self-test", str(config_path)],
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write(path: Path, content: str) -> None:
+    """Write fixture content with LF line endings on every platform.
+
+    Default ``write_text`` translates ``\\n`` to ``os.linesep`` on Windows,
+    which would inject ``\\r\\n`` into the fixture and make awk see literal
+    CR characters. The script ships LF-only because the camera runs Linux,
+    so the test must mirror that.
+    """
+    text = textwrap.dedent(content).lstrip("\n")
+    path.write_bytes(text.encode("utf-8"))
+
+
+def _read(path: Path) -> str:
+    return path.read_bytes().decode("utf-8")
+
+
+# Fixture A — clean image just out of bitbake. The Yocto-baked
+# RPI_EXTRA_CONFIG already produced a leading-whitespace block.
+FIXTURE_CLEAN_YOCTO_BAKE = """
+    # Some unrelated boot config
+    enable_uart=1
+    dtoverlay=vc4-fkms-v3d
+
+     camera_auto_detect=0
+     dtoverlay=ov5647
+
+    # have a properly sized image
+    disable_overscan=1
+"""
+
+# Fixture B — .115-style stale state: leading-ws block from the OLD Yocto
+# bake (before this PR), plus bare duplicates appended by the OLD
+# ensure-camera-overlay.sh when its grep failed to match the leading-ws
+# variant.
+FIXTURE_STALE_DUPLICATES = """
+    enable_uart=1
+    dtoverlay=vc4-fkms-v3d
+
+     camera_auto_detect=0
+     dtoverlay=ov5647
+
+    # have a properly sized image
+    disable_overscan=1
+    dtparam=audio=on
+
+    # Camera sensor (added by ensure-camera-overlay)
+    camera_auto_detect=0
+    dtoverlay=ov5647
+"""
+
+# Fixture C — already-correct state (post-fix file produced by this script
+# on a previous boot). Running the script must not change the file.
+FIXTURE_ALREADY_CORRECT = """
+    enable_uart=1
+    dtoverlay=vc4-fkms-v3d
+    disable_overscan=1
+    dtparam=audio=on
+
+    # Camera sensor (managed by ensure-camera-overlay)
+    camera_auto_detect=1
+"""
+
+# Fixture D — hand-patched state from this session's manual validation:
+# the auto-detect line is bare (no leading ws) and the original
+# dtoverlay=ov5647 lines have been commented out with a "disabled" marker.
+FIXTURE_HAND_PATCHED = """
+    enable_uart=1
+    dtoverlay=vc4-fkms-v3d
+
+    # camera_auto_detect=0  # disabled 2026-04-25T09:46Z for OV5647 auto-detect test
+    # dtoverlay=ov5647  # disabled 2026-04-25T09:46Z for OV5647 auto-detect test
+
+    disable_overscan=1
+    dtparam=audio=on
+
+    # Camera sensor (added by ensure-camera-overlay)
+    camera_auto_detect=1
+    #dtoverlay=ov5647  # disabled 2026-04-25T09:46Z for OV5647 auto-detect test
+"""
+
+
+class TestAutoDetect:
+    def test_clean_yocto_bake_collapses_to_canonical_block(
+        self, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_CLEAN_YOCTO_BAKE)
+        _run(cfg)
+        out = _read(cfg)
+        # No active OV5647 or auto_detect=0 line anywhere.
+        assert not any(
+            line.lstrip().startswith("dtoverlay=ov5647") for line in out.splitlines()
+        ), out
+        assert not any(
+            line.lstrip().startswith("camera_auto_detect=0")
+            for line in out.splitlines()
+        ), out
+        # Exactly one auto_detect=1.
+        assert (
+            sum(
+                1
+                for line in out.splitlines()
+                if line.lstrip().startswith("camera_auto_detect=1")
+            )
+            == 1
+        ), out
+        # Unrelated overlays preserved.
+        assert "dtoverlay=vc4-fkms-v3d" in out
+        assert "enable_uart=1" in out
+        assert "disable_overscan=1" in out
+
+    def test_stale_duplicates_heal_in_one_run(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_STALE_DUPLICATES)
+        _run(cfg)
+        out = _read(cfg)
+        assert " dtoverlay=ov5647" not in out
+        assert "dtoverlay=ov5647" not in out
+        assert " camera_auto_detect=0" not in out
+        # Old "added by" header is removed; new "managed by" header is added.
+        assert "added by ensure-camera-overlay" not in out
+        assert "managed by ensure-camera-overlay" in out
+        assert (
+            sum(
+                1 for line in out.splitlines() if line.strip() == "camera_auto_detect=1"
+            )
+            == 1
+        )
+
+    def test_hand_patched_state_collapses_cleanly(self, tmp_path: Path) -> None:
+        """The hand-patched state from manual validation should normalise
+        to the canonical managed block — disabled-marker comments dropped,
+        single auto_detect=1, no orphan disabled-OV5647 lines."""
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_HAND_PATCHED)
+        _run(cfg)
+        out = _read(cfg)
+        assert "disabled 2026-04-25" not in out
+        assert "managed by ensure-camera-overlay" in out
+        assert (
+            sum(
+                1 for line in out.splitlines() if line.strip() == "camera_auto_detect=1"
+            )
+            == 1
+        )
+
+    def test_idempotent_second_run_is_byte_identical(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_STALE_DUPLICATES)
+        _run(cfg)
+        first = _read(cfg)
+        _run(cfg)
+        second = _read(cfg)
+        assert first == second
+
+    def test_already_correct_state_is_noop(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_ALREADY_CORRECT)
+        before = _read(cfg)
+        before_mtime = cfg.stat().st_mtime_ns
+        result = _run(cfg)
+        after = _read(cfg)
+        assert before == after
+        # Stdout reports the no-change branch.
+        assert "no changes" in result.stdout
+        # mtime unchanged confirms cmp-equal short-circuit fired.
+        assert cfg.stat().st_mtime_ns == before_mtime
+
+
+class TestSensorOverride:
+    @pytest.mark.parametrize("sensor", ["ov5647", "imx219", "imx477", "imx708"])
+    def test_override_pins_explicit_sensor(self, tmp_path: Path, sensor: str) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_CLEAN_YOCTO_BAKE)
+        override = tmp_path / "camera-sensor"
+        override.write_text(sensor + "\n")
+        _run(cfg, override_path=override)
+        out = _read(cfg)
+        # Override turns auto_detect off and pins the named overlay.
+        assert "camera_auto_detect=0" in out
+        assert "camera_auto_detect=1" not in out
+        assert f"dtoverlay={sensor}" in out
+        # No competing sensor overlays.
+        for other in ("ov5647", "imx219", "imx477", "imx708"):
+            if other == sensor:
+                continue
+            assert f"dtoverlay={other}" not in out
+
+    def test_override_handles_whitespace_and_case(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_CLEAN_YOCTO_BAKE)
+        override = tmp_path / "camera-sensor"
+        override.write_text("  IMX219  \n")
+        _run(cfg, override_path=override)
+        out = _read(cfg)
+        assert "dtoverlay=imx219" in out
+        assert "camera_auto_detect=0" in out
+
+    def test_unknown_override_falls_back_to_auto_detect(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_CLEAN_YOCTO_BAKE)
+        override = tmp_path / "camera-sensor"
+        override.write_text("totally-bogus-sensor\n")
+        result = _run(cfg, override_path=override)
+        out = _read(cfg)
+        assert "camera_auto_detect=1" in out
+        assert "dtoverlay=ov5647" not in out
+        # Warning emitted on stderr.
+        assert "ignoring unrecognised override" in result.stderr
+
+    def test_empty_override_falls_back_to_auto_detect(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_CLEAN_YOCTO_BAKE)
+        override = tmp_path / "camera-sensor"
+        override.write_text("\n")
+        _run(cfg, override_path=override)
+        out = _read(cfg)
+        assert "camera_auto_detect=1" in out
+        assert "dtoverlay=ov5647" not in out
+
+    def test_override_idempotent(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.txt"
+        _write(cfg, FIXTURE_STALE_DUPLICATES)
+        override = tmp_path / "camera-sensor"
+        override.write_text("imx219\n")
+        _run(cfg, override_path=override)
+        first = _read(cfg)
+        _run(cfg, override_path=override)
+        second = _read(cfg)
+        assert first == second

--- a/meta-home-monitor/conf/machine/home-monitor-camera.conf
+++ b/meta-home-monitor/conf/machine/home-monitor-camera.conf
@@ -1,37 +1,43 @@
 #@TYPE: Machine
 #@NAME: Home Monitor Camera (Raspberry Pi Zero 2 W)
-#@DESCRIPTION: Home Monitor camera machine based on raspberrypi0-2w-64, \
-#shipping overlays for the PiHut ZeroCam (OV5647 — default) and \
-#Raspberry Pi Camera Module 2 (IMX219). Other Pi cameras are also \
-#supported at boot time by editing /boot/config.txt.
+#@DESCRIPTION: Home Monitor camera machine based on raspberrypi0-2w-64. \
+#The Pi firmware detects the connected sensor at boot via i2c probe \
+#and loads the matching overlay automatically. All Pi-officially- \
+#supported sensors that ship with overlays in meta-raspberrypi work \
+#out of the box (OV5647 / IMX219 / IMX477 / IMX708) — no rebuild on \
+#sensor swap.
 
 require conf/machine/raspberrypi0-2w-64.conf
 
-# --- Device-tree overlays shipped in the image ---------------------
+# --- Device-tree overlays shipped in the boot partition ------------
 #
-# Both sensor overlays are baked into the boot partition so switching
-# cameras is a one-line edit of /boot/config.txt — no OTA + no rebuild.
-# meta-raspberrypi's default set already includes all of these, so the
-# :append is a belt-and-braces pin.
+# meta-raspberrypi already installs all of these by default; the
+# :append below is a belt-and-braces pin so a future change to the
+# upstream overlay set cannot silently drop one we rely on.
+#
+# Adding a new sensor to this list does NOT require rebuilding the
+# kernel — the .dtbo files are loaded by the firmware at boot, after
+# the SoC has identified which sensor is on the CSI ribbon.
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
     overlays/ov5647.dtbo \
     overlays/imx219.dtbo \
+    overlays/imx477.dtbo \
+    overlays/imx708.dtbo \
     "
 
-# --- Default camera: OV5647 (PiHut ZeroCam) ------------------------
+# --- Sensor selection: firmware auto-detect ------------------------
 #
-# PiHut ZeroCam usually ships without the camera EEPROM that Pi firmware
-# needs for auto-detection, so we pin the overlay explicitly. For a Pi
-# Camera Module 2 (IMX219) or 3 (IMX708), the operator edits
-# /boot/config.txt on the SD card (or over SSH) and changes the
-# dtoverlay line:
+# `camera_auto_detect=1` tells the Pi firmware to probe the CSI bus
+# at boot and load the matching overlay. This works for both EEPROM-
+# carrying boards (Camera Module 2/3, HQ) and the EEPROM-less PiHut
+# ZeroCam (OV5647) — the firmware also performs an i2c chip-id scan
+# at known sensor addresses and recognises the OV5647 even without
+# its EEPROM.
 #
-#   dtoverlay=ov5647    # default — PiHut ZeroCam
-#   dtoverlay=imx219    # Raspberry Pi Camera Module 2
-#   dtoverlay=imx708    # Raspberry Pi Camera Module 3
-#
-# Setting `camera_auto_detect=1` would skip the explicit overlay and
-# let the firmware probe the CSI EEPROM, but that fails for EEPROM-less
-# boards (the common OV5647 case), so we leave auto-detect off and
-# pick the sensor explicitly.
-RPI_EXTRA_CONFIG += " \n camera_auto_detect=0 \n dtoverlay=ov5647 \n "
+# An explicit override is available at runtime: drop a sensor name
+# into /data/config/camera-sensor (one of: ov5647, imx219, imx477,
+# imx708) and ensure-camera-overlay.service will pin that overlay
+# on the next boot. Useful for bring-up, weird ribbons, or a sensor
+# whose auto-detect path has not yet been validated. The file lives
+# on /data so it survives OTAs by design.
+RPI_EXTRA_CONFIG += " \n camera_auto_detect=1 \n "


### PR DESCRIPTION
## Goal

Multi-sensor camera support, Phase 0 of #173. Switch the camera image from hardcoded `dtoverlay=ov5647` to firmware-driven `camera_auto_detect=1`, and rewrite the boot-time reconciler so it can heal `/boot/config.txt` from any older state — critical because SWUpdate's rootfs-only OTA can never overwrite the boot partition on existing field cameras.

## Change summary

- `meta-home-monitor/conf/machine/home-monitor-camera.conf`
  - `RPI_EXTRA_CONFIG` → `camera_auto_detect=1`, no explicit `dtoverlay`.
  - Overlays list expanded to ship `ov5647`, `imx219`, `imx477`, `imx708` (`imx219`/`imx708` already there from PR #92, plus `imx477`/`imx708` newly added). meta-raspberrypi defaults already include all of these — the `:append` is a belt-and-braces pin.
  - Comment block rewritten to reflect auto-detect as the primary path; documents the new `/data/config/camera-sensor` opt-in override.
- `app/camera/config/ensure-camera-overlay.sh` — full rewrite. Idempotent reconciler: strips any active or stale `camera_auto_detect=N` / `dtoverlay=<known-sensor>` lines (handles both leading-whitespace `RPI_EXTRA_CONFIG`-bake variant and bare variant from the prior script), re-emits a single canonical managed block, only touches `/boot` if an actual diff is needed. Honours `/data/config/camera-sensor` as an opt-in pin when present.
- `app/camera/tests/integration/test_ensure_camera_overlay.py` — 13 new tests across four fixtures (clean Yocto bake, .115-style stale duplicates, this-session's hand-patched state, already-correct), idempotency invariant on repeated runs, and parameterised override tests for all four supported sensors. Uses a `--self-test` mode in the script that swaps fixture paths and stubs mount/sync so the test can drive the real script without root or hardware.

## Test plan

Local:
- `python -m pytest app/camera/tests/integration/test_ensure_camera_overlay.py -v` → 13/13 pass.
- `python -m pytest app/camera/tests/unit/ app/camera/tests/integration/test_ensure_camera_overlay.py --no-cov -q` → 390/390 pass (no regression).
- `bash -n app/camera/config/ensure-camera-overlay.sh` → syntax OK.

CI must pass:
- `ruff check .` and `ruff format --check .` (already run locally; clean).
- Camera pytest with coverage gate ≥80%.
- Shell lint (`shellcheck`) on the rewritten script.
- `bitbake -p` parse-validation (CI's Yocto check).

Verification on hardware (post-merge, in the OTA + per-camera verify phase of #173):
- Build new camera image; OTA to .186, .115, .148.
- `systemctl unmask ensure-camera-overlay.service` per camera (currently masked from the manual validation phase).
- Confirm dmesg shows correct sensor probe per camera (`imx219@10` on .186/.115, `ov5647@36` on .148).
- Confirm `libcamera-hello --list-cameras` enumerates the right sensor.
- Confirm camera-streamer healthy, server heartbeats HTTP 200.

## Deployment impact

- **Image rebuild required.** Both the machine conf change (regenerates `/boot/config.txt`) and the script change (rootfs file) ship via Yocto.
- **Existing cameras have `ensure-camera-overlay.service` masked** from the manual P3 validation in #173. After OTA, run `systemctl unmask ensure-camera-overlay.service` per camera to re-enable. The rewritten script is idempotent and safe.
- **Backups exist**: every camera has `/data/config.txt.bak-pre-imx219` from the manual patch, so one-command rollback is `cp /data/config.txt.bak-pre-imx219 /boot/config.txt`.
- **No server-side impact**, no API contract change in this PR.
- **Camera-streamer Python untouched** in this PR — that's P1.1.

## Doc impact

- Machine conf comment block updated in-tree.
- Parent issue #173 holds the full multi-PR context (acceptance criteria, validation evidence from manual three-camera test, full file impact list, dashboard / server work scoped for follow-up PRs).

## Why option (b), not retiring the script

Keeping a script is load-bearing because of OTA semantics: SWUpdate only writes rootfs partitions. Cameras updated from the current `1.3.0`/`1.3.1` images carry their existing `/boot/config.txt` forever — which has `camera_auto_detect=0` + `dtoverlay=ov5647` baked in. Without this script, those cameras would never benefit from the new auto-detect policy. The script makes first-boot-post-OTA reconcile the boot partition.

The leading-whitespace stale-state observed live on `.115` (both the Yocto-baked `RPI_EXTRA_CONFIG` literal-newline variant AND the bare appended variant on the same image) is reproduced as `FIXTURE_STALE_DUPLICATES` in the test suite to prevent regression.

Refs: #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
