### PR TITLE
feat(server): persist + expose per-camera sensor capabilities

### DIFF
--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -70,6 +70,16 @@ class Camera:
     hardware_ok: bool = True
     hardware_error: str = ""
     hardware_faults: list[dict] = field(default_factory=list)
+    # Camera sensor identity + supported modes — populated from the
+    # heartbeat payload's ``capabilities`` block (#173). Cameras on
+    # firmware older than the multi-sensor change don't include the
+    # block; those records keep ``sensor_model=""`` and an empty
+    # ``sensor_modes`` list and the dashboard falls back to the legacy
+    # preset dropdown for them. Each mode is a dict with integer
+    # ``width``, ``height`` and float ``max_fps``.
+    sensor_model: str = ""
+    sensor_modes: list[dict] = field(default_factory=list)
+    sensor_detection_method: str = ""
 
 
 @dataclass

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -18,7 +18,21 @@ from datetime import UTC, datetime
 log = logging.getLogger("monitor.camera_service")
 
 VALID_RECORDING_MODES = {"off", "continuous", "schedule", "motion"}
+
+# Legacy resolution allowlist used when the camera has not yet reported
+# its sensor capabilities (cameras on pre-#173 firmware, or a fresh pair
+# whose first heartbeat hasn't landed). Once a camera reports its real
+# ``sensor_modes`` via heartbeat, validation uses those instead and this
+# preset becomes a fallback.
 VALID_RESOLUTIONS = {"720p", "1080p"}
+
+# Lowercase libcamera model strings the multi-sensor work supports.
+# Mirrors `KNOWN_SENSOR_MODES` in the camera-side `sensor_info` module.
+KNOWN_SENSORS = ("ov5647", "imx219", "imx477", "imx708")
+
+# Cap on persisted sensor_modes list length — defends against a malformed
+# camera heartbeat trying to inflate the cameras.json store.
+MAX_SENSOR_MODES = 32
 VALID_SCHEDULE_DAYS = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"}
 _TIME_RE = re.compile(r"^\d{2}:\d{2}$")
 
@@ -215,6 +229,12 @@ class CameraService:
                 # Structured faults (ADR-0023). Kept alongside the
                 # flat legacy fields until all consumers migrate.
                 "hardware_faults": list(getattr(c, "hardware_faults", []) or []),
+                # Sensor capabilities (#173) — empty for cameras still
+                # on pre-multi-sensor firmware. Dashboard falls back
+                # to the legacy preset dropdown when ``sensor_modes``
+                # is empty.
+                "sensor_model": getattr(c, "sensor_model", "") or "",
+                "sensor_modes": list(getattr(c, "sensor_modes", []) or []),
             }
             if admin_view:
                 # Admin-only fields: network topology + health metrics
@@ -254,6 +274,12 @@ class CameraService:
             "vflip": camera.vflip,
             "motion_sensitivity": getattr(camera, "motion_sensitivity", 5),
             "config_sync": camera.config_sync,
+            # Sensor capabilities (#173). Empty for pre-multi-sensor
+            # firmware; dashboard falls back to the legacy preset.
+            "sensor_model": getattr(camera, "sensor_model", "") or "",
+            "sensor_modes": list(getattr(camera, "sensor_modes", []) or []),
+            "sensor_detection_method": getattr(camera, "sensor_detection_method", "")
+            or "",
         }, ""
 
     def confirm(
@@ -316,8 +342,10 @@ class CameraService:
         if not data:
             return "JSON body required", 400
 
-        # Validate fields
-        error = self._validate_update(data)
+        # Validate fields. Pass the live camera record so per-camera
+        # sensor capabilities tighten the resolution / fps checks
+        # beyond the legacy preset bounds.
+        error = self._validate_update(data, camera=camera)
         if error:
             return error, 400
 
@@ -434,6 +462,37 @@ class CameraService:
         if fw and isinstance(fw, str):
             camera.firmware_version = fw
 
+        # Sensor capabilities — populated by the camera-side detection
+        # layer (#173). Cameras on older firmware omit the key entirely
+        # and the existing record is left untouched.
+        caps = data.get("capabilities")
+        if isinstance(caps, dict):
+            sensor_model = caps.get("sensor_model")
+            if sensor_model is None:
+                # Detected-but-unknown sensor: clear any previous value.
+                camera.sensor_model = ""
+            elif isinstance(sensor_model, str):
+                camera.sensor_model = sensor_model.strip().lower()[:32]
+            modes = caps.get("sensor_modes")
+            if isinstance(modes, list):
+                accepted_modes: list[dict] = []
+                for raw_mode in modes[:MAX_SENSOR_MODES]:
+                    if not isinstance(raw_mode, dict):
+                        continue
+                    try:
+                        w = int(raw_mode["width"])
+                        h = int(raw_mode["height"])
+                        f = float(raw_mode["max_fps"])
+                    except (KeyError, TypeError, ValueError):
+                        continue
+                    if w <= 0 or h <= 0 or f <= 0 or f > 240:
+                        continue
+                    accepted_modes.append({"width": w, "height": h, "max_fps": f})
+                camera.sensor_modes = accepted_modes
+            method = caps.get("detection_method")
+            if isinstance(method, str):
+                camera.sensor_detection_method = method[:32]
+
         # Capture sync state before touching stream params.
         # If config_sync is "pending" the server has unsent changes — keep them
         # and tell the camera via pending_config instead of overwriting with its
@@ -533,8 +592,20 @@ class CameraService:
 
         return "", 200
 
-    def _validate_update(self, data: dict) -> str:
-        """Validate camera update fields. Returns error string or empty."""
+    def _validate_update(self, data: dict, camera=None) -> str:
+        """Validate camera update fields. Returns error string or empty.
+
+        When ``camera`` is provided and has reported its sensor
+        capabilities (#173), per-camera ``sensor_modes`` tighten the
+        resolution / fps checks: a camera with an IMX219 accepts
+        3280x2464, an OV5647 doesn't, etc. Without ``camera`` (or with
+        an empty modes list — pre-#173 firmware), validation falls back
+        to the legacy preset bounds (fps 1-30, resolution from
+        ``VALID_RESOLUTIONS``).
+        """
+        sensor_modes: list[dict] = []
+        if camera is not None:
+            sensor_modes = list(getattr(camera, "sensor_modes", []) or [])
         allowed = {
             "name",
             "location",
@@ -571,7 +642,15 @@ class CameraService:
 
         if "fps" in data:
             fps = data["fps"]
-            if not isinstance(fps, int) or fps < 1 or fps > 30:
+            if not isinstance(fps, int) or fps < 1:
+                return "fps must be a positive integer"
+            # Per-camera fps cap when the sensor's modes are known.
+            # Otherwise fall back to the legacy 1-30 bound.
+            if sensor_modes:
+                fps_max = max(int(m["max_fps"]) for m in sensor_modes if "max_fps" in m)
+                if fps > fps_max:
+                    return f"fps must be 1-{fps_max} for this sensor"
+            elif fps > 30:
                 return "fps must be an integer between 1 and 30"
 
         if "name" in data:
@@ -588,6 +667,19 @@ class CameraService:
             not isinstance(data["height"], int) or data["height"] < 1
         ):
             return "height must be a positive integer"
+
+        # Per-camera (width, height) pair check — only when the sensor's
+        # modes have been reported. The pair must be one of the modes
+        # the camera advertised. Skipped silently for pre-#173 cameras.
+        if sensor_modes and ("width" in data or "height" in data):
+            current_w = camera.width if camera is not None else None
+            current_h = camera.height if camera is not None else None
+            w = data.get("width", current_w)
+            h = data.get("height", current_h)
+            valid_pairs = {(int(m["width"]), int(m["height"])) for m in sensor_modes}
+            if (w, h) not in valid_pairs:
+                pretty = ", ".join(f"{pw}x{ph}" for pw, ph in sorted(valid_pairs))
+                return f"resolution {w}x{h} not supported by sensor (valid: {pretty})"
 
         if "bitrate" in data:
             br = data["bitrate"]

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -154,6 +154,14 @@ CAMERA_LIST_FIELDS_ADMIN = {
     # Structured fault list per ADR-0023 — [{code, severity, message,
     # hint, context}]. Empty list when healthy. Not admin-gated.
     "hardware_faults",
+    # Sensor identity + supported modes (#173). Populated from the
+    # camera-side capability detection layer via heartbeat.
+    # ``sensor_model`` is a lowercase libcamera string ("imx219",
+    # "ov5647", ...) or empty for cameras still on pre-#173 firmware.
+    # ``sensor_modes`` is a list of {width, height, max_fps} dicts —
+    # empty until the first heartbeat carries the capabilities block.
+    "sensor_model",
+    "sensor_modes",
 }
 
 # Viewers see a subset — no IP (network topology) or health metrics (occupancy risk)

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -879,3 +879,201 @@ class TestAcceptHeartbeat:
         _, error, code = svc.accept_heartbeat("cam-001", payload)
         assert code == 200
         assert not error
+
+
+# --- Sensor capabilities (#173) ---
+
+
+class TestSensorCapabilitiesIngestion:
+    """The camera-side heartbeat embeds a ``capabilities`` block carrying
+    sensor identity + supported modes (#173). The service persists the
+    block on the Camera record so the dashboard can render per-camera
+    Settings dropdowns and so future updates can be validated against
+    the live sensor's actual mode list."""
+
+    def _capabilities_payload(self, **overrides):
+        return {
+            "streaming": False,
+            "cpu_temp": 40.0,
+            "memory_percent": 30,
+            "uptime_seconds": 100,
+            "capabilities": {
+                "sensor_model": "imx219",
+                "sensor_modes": [
+                    {"width": 640, "height": 480, "max_fps": 58.0},
+                    {"width": 1640, "height": 1232, "max_fps": 41.0},
+                    {"width": 1920, "height": 1080, "max_fps": 47.0},
+                    {"width": 3280, "height": 2464, "max_fps": 21.0},
+                ],
+                "detection_method": "picamera2",
+                **overrides,
+            },
+        }
+
+    def test_persists_imx219_capabilities(self):
+        cam = _make_camera(sensor_model="", sensor_modes=[])
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat("cam-001", self._capabilities_payload())
+        assert cam.sensor_model == "imx219"
+        assert {(m["width"], m["height"]) for m in cam.sensor_modes} == {
+            (640, 480),
+            (1640, 1232),
+            (1920, 1080),
+            (3280, 2464),
+        }
+        assert cam.sensor_detection_method == "picamera2"
+
+    def test_lowercases_and_trims_sensor_model(self):
+        cam = _make_camera(sensor_model="")
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat(
+            "cam-001",
+            self._capabilities_payload(sensor_model="  IMX219  "),
+        )
+        assert cam.sensor_model == "imx219"
+
+    def test_drops_garbage_modes(self):
+        cam = _make_camera(sensor_model="", sensor_modes=[])
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat(
+            "cam-001",
+            self._capabilities_payload(
+                sensor_modes=[
+                    {"width": 1920, "height": 1080, "max_fps": 30.0},  # ok
+                    {"width": "bad", "height": 1080, "max_fps": 30.0},  # type
+                    {"width": -1, "height": 1080, "max_fps": 30.0},  # neg
+                    {"height": 1080, "max_fps": 30.0},  # missing width
+                    {"width": 1920, "height": 1080, "max_fps": 9999.0},  # absurd
+                    "not a dict",
+                ]
+            ),
+        )
+        # Only the one well-formed entry survives.
+        assert len(cam.sensor_modes) == 1
+        assert cam.sensor_modes[0]["width"] == 1920
+
+    def test_caps_persisted_modes_at_max(self):
+        cam = _make_camera(sensor_model="", sensor_modes=[])
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        # Hand-craft a payload with way more modes than we accept.
+        from monitor.services.camera_service import MAX_SENSOR_MODES
+
+        modes = [
+            {"width": 640 + i, "height": 480, "max_fps": 30.0}
+            for i in range(MAX_SENSOR_MODES + 5)
+        ]
+        svc.accept_heartbeat(
+            "cam-001",
+            self._capabilities_payload(sensor_modes=modes),
+        )
+        assert len(cam.sensor_modes) == MAX_SENSOR_MODES
+
+    def test_unknown_capabilities_block_is_ignored(self):
+        """Garbage shape under ``capabilities`` does not crash or
+        clobber the existing record."""
+        cam = _make_camera(sensor_model="ov5647", sensor_modes=[{"a": 1}])
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat(
+            "cam-001",
+            {
+                "streaming": False,
+                "capabilities": "not-a-dict",
+            },
+        )
+        assert cam.sensor_model == "ov5647"
+        assert cam.sensor_modes == [{"a": 1}]
+
+    def test_pre_173_payload_leaves_record_untouched(self):
+        """Cameras on older firmware omit ``capabilities`` entirely.
+        The existing sensor fields on the record must not be cleared."""
+        cam = _make_camera(
+            sensor_model="ov5647",
+            sensor_modes=[{"width": 1920, "height": 1080, "max_fps": 30.0}],
+        )
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        svc.accept_heartbeat(
+            "cam-001",
+            {
+                "streaming": False,
+                "cpu_temp": 40.0,
+                "memory_percent": 30,
+                "uptime_seconds": 100,
+            },
+        )
+        assert cam.sensor_model == "ov5647"
+        assert cam.sensor_modes == [{"width": 1920, "height": 1080, "max_fps": 30.0}]
+
+
+class TestPerCameraValidation:
+    """Update validation respects each camera's reported sensor modes
+    when available, falling back to the legacy preset bounds for
+    pre-#173 cameras."""
+
+    def _service_with_camera(self, **overrides):
+        cam = _make_camera(**overrides)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        return CameraService(store), cam
+
+    def test_imx219_camera_accepts_3280x2464(self):
+        svc, _ = self._service_with_camera(
+            sensor_model="imx219",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 47.0},
+                {"width": 3280, "height": 2464, "max_fps": 21.0},
+            ],
+        )
+        err, code = svc.update("cam-001", {"width": 3280, "height": 2464, "fps": 21})
+        assert code == 200, err
+
+    def test_ov5647_camera_rejects_imx219_resolution(self):
+        svc, _ = self._service_with_camera(
+            sensor_model="ov5647",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 30.0},
+                {"width": 2592, "height": 1944, "max_fps": 15.0},
+            ],
+        )
+        err, code = svc.update("cam-001", {"width": 3280, "height": 2464})
+        assert code == 400
+        assert "not supported by sensor" in err
+
+    def test_imx219_camera_accepts_47fps_at_1080p(self):
+        svc, _ = self._service_with_camera(
+            sensor_model="imx219",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 47.0},
+            ],
+        )
+        err, code = svc.update("cam-001", {"width": 1920, "height": 1080, "fps": 47})
+        assert code == 200, err
+
+    def test_ov5647_camera_rejects_47fps(self):
+        svc, _ = self._service_with_camera(
+            sensor_model="ov5647",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 30.0},
+                {"width": 1296, "height": 972, "max_fps": 43.0},
+            ],
+        )
+        err, code = svc.update("cam-001", {"width": 1920, "height": 1080, "fps": 47})
+        assert code == 400
+        assert "must be 1-43" in err  # max across modes is 43
+
+    def test_pre_173_camera_keeps_legacy_30fps_cap(self):
+        svc, _ = self._service_with_camera(sensor_model="", sensor_modes=[])
+        err, code = svc.update("cam-001", {"fps": 47})
+        assert code == 400
+        assert "1 and 30" in err


### PR DESCRIPTION
## Goal

Server-side half of multi-sensor support (#173). Persist the per-camera `capabilities` block from #175's heartbeat payload, expose it on the camera-info APIs the dashboard reads, and use it to validate resolution/fps updates against each camera's actual sensor modes (so an IMX219 camera accepts 3280×2464 and 47 fps at 1080p; an OV5647 rejects both).

## Change summary

- **`app/server/monitor/models.py`** — three new fields on `Camera`: `sensor_model: str`, `sensor_modes: list[dict]`, `sensor_detection_method: str`. All default to empty so pre-#175 cameras load with the legacy preset behaviour.
- **`app/server/monitor/services/camera_service.py`**
  - `accept_heartbeat`: parses `data.get("capabilities")` defensively. Lowercases + strips the model; per-entry rejects malformed `sensor_modes` (non-dict, missing keys, non-numeric, absurd ranges) without dropping the whole block; clamps to `MAX_SENSOR_MODES = 32` entries; pre-#175 heartbeats (no `capabilities` key) leave existing fields untouched.
  - `list_cameras` + `get_camera_status`: include the new fields.
  - `_validate_update`: when `sensor_modes` is populated, validates `width`/`height`/`fps` against the per-camera mode list. Falls back to the legacy 720p/1080p + 1-30 fps preset when empty.
- **`app/server/tests/unit/test_camera_service.py`** — two new test classes (11 tests total) covering capability ingestion (happy path, normalisation, garbage rejection, cap, non-clobber, pre-#175 untouched) and per-camera validation (IMX219 vs OV5647 acceptance/rejection, legacy fallback).

## Test plan

- `python -m pytest app/server/tests/unit/ app/server/tests/integration/ --no-cov -q` → **1504/1504 pass** (+11 new).
- `ruff check app/server/` clean; `ruff format` no diffs.
- CI: server unit + integration + contract + coverage ≥85%.

Hardware verification (post-merge with the camera image OTA):
- After OTA, server's `/api/v1/cameras/<id>/status` for `.186` should return `sensor_model: "imx219"` with the IMX219 mode list including 3280×2464.
- Same endpoint for `.148` should return `sensor_model: "ov5647"` with modes capped at 2592×1944.
- Dashboard PUT `/api/v1/cameras/<id>` with `width=3280, height=2464` succeeds for `.186` and fails for `.148` with `"resolution 3280x2464 not supported by sensor (valid: ...)"`.

## Deployment impact

- **Server-only deploy.** No camera image rebuild for this PR; camera-side capability emission landed in #175.
- **No service restart required** beyond the standard `systemctl restart monitor`.
- **API contract is purely additive.** New fields on `/api/v1/cameras` + `/api/v1/cameras/<id>/status`; new optional `capabilities` block accepted on heartbeats. Old dashboards see the new fields as extra JSON keys and ignore them; old cameras simply don't populate the fields.
- **No data migration needed.** Existing `/data/config/cameras.json` records load with empty defaults; the next heartbeat from each camera populates the fields.

## Doc impact

- New module-level docstring on the validation/sensor constants documents the legacy fallback.
- Parent issue #173 captures the cross-PR context.

Refs: #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
