### PR TITLE
feat(dashboard): per-camera Settings dropdown driven by sensor capabilities

### DIFF
--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -406,12 +406,29 @@
                     <input type="text" class="form-input" x-model="editForm.location"
                            maxlength="64" placeholder="e.g. Porch (optional)">
                 </div>
+                <!-- Sensor label — rendered from the camera's reported
+                     ``capabilities`` block (#173). Empty for cameras still
+                     on pre-multi-sensor firmware; the dropdown falls back
+                     to the legacy preset in that case. -->
+                <div class="form-group" x-show="editForm.sensorLabel">
+                    <label>Sensor</label>
+                    <div class="form-input" style="background: var(--surface-muted, #f5f5f5); color: var(--text-muted, #555); cursor: default;"
+                         x-text="editForm.sensorLabel"></div>
+                </div>
+                <!-- Mismatch banner — fires when the camera's saved
+                     resolution is no longer in its current sensor's
+                     mode list (e.g. the user swapped from IMX219 back
+                     to OV5647 with a saved 3280x2464). -->
+                <div class="alert alert-warning" x-show="editForm.resolutionMismatch" style="margin-bottom: 1rem;">
+                    <strong>Saved resolution unavailable on this sensor.</strong>
+                    <span x-text="editForm.resolutionMismatchHint"></span>
+                </div>
                 <div class="form-group">
                     <label>Resolution</label>
                     <select class="form-input" x-model="editForm.resolution" @change="onResolutionChange()">
-                        <option value="640x480">640x480 (max 58 fps)</option>
-                        <option value="1296x972">1296x972 (max 43 fps)</option>
-                        <option value="1920x1080">1920x1080 (max 30 fps)</option>
+                        <template x-for="opt in editForm.resolutionOptions" :key="opt.value">
+                            <option :value="opt.value" x-text="opt.label"></option>
+                        </template>
                     </select>
                 </div>
                 <div class="form-group">
@@ -904,17 +921,82 @@ function dashboardPage() {
         },
 
         // --- Stream Settings (ADR-0015) ---
-        _resMaxFps: { '640x480': 58, '1296x972': 43, '1920x1080': 30 },
+
+        // Legacy fallback dropdown options + max-fps map. Used when the
+        // camera hasn't reported its sensor capabilities yet (pre-#173
+        // firmware, or fresh pair before the first heartbeat).
+        _legacyResolutionOptions: [
+            { value: '640x480',   label: '640x480 (max 58 fps)',  width: 640,  height: 480,  max_fps: 58 },
+            { value: '1296x972',  label: '1296x972 (max 43 fps)', width: 1296, height: 972,  max_fps: 43 },
+            { value: '1920x1080', label: '1920x1080 (max 30 fps)', width: 1920, height: 1080, max_fps: 30 },
+        ],
+
+        // Build the dropdown option list for ONE camera from its
+        // reported sensor_modes (#173). Each camera gets its own list,
+        // so an IMX219 shows 3280x2464 and an OV5647 stops at 2592x1944.
+        _resolutionOptionsFor(cam) {
+            var modes = (cam && Array.isArray(cam.sensor_modes)) ? cam.sensor_modes : [];
+            if (!modes.length) {
+                return this._legacyResolutionOptions.slice();
+            }
+            // Sort by pixel count so the dropdown is small-to-large.
+            var sorted = modes.slice().sort(function(a, b) {
+                return (a.width * a.height) - (b.width * b.height);
+            });
+            return sorted.map(function(m) {
+                var fps = Math.round(Number(m.max_fps) || 0);
+                return {
+                    value: m.width + 'x' + m.height,
+                    label: m.width + 'x' + m.height + ' (max ' + fps + ' fps)',
+                    width: m.width,
+                    height: m.height,
+                    max_fps: fps,
+                };
+            });
+        },
+
+        // Look up max fps for a resolution string in a given options list.
+        _maxFpsFor(options, resKey) {
+            for (var i = 0; i < options.length; i++) {
+                if (options[i].value === resKey) {
+                    return options[i].max_fps;
+                }
+            }
+            return 30;
+        },
 
         openStreamSettings(cam) {
             this.editCam = cam;
             var resKey = cam.width + 'x' + cam.height;
+            var options = this._resolutionOptionsFor(cam);
+            // If the camera's saved resolution isn't in the current
+            // sensor's mode list (e.g. the user swapped sensors and
+            // the saved 3280x2464 is now invalid), pick the closest
+            // smaller mode and warn the operator.
+            var savedInModes = options.some(function(o) { return o.value === resKey; });
+            var mismatch = !savedInModes && options.length > 0;
+            var clampTarget = options.length ? options[options.length - 1] : null;
+            // When the saved value is too big, clamp DOWN to the largest
+            // mode the new sensor supports. When it's too small (rare —
+            // sensor downgrade), use the smallest. Pick the largest
+            // available mode that does not exceed the saved width so the
+            // user stays close to what they had.
+            if (mismatch && options.length) {
+                var keep = null;
+                for (var i = 0; i < options.length; i++) {
+                    if (options[i].width <= cam.width && options[i].height <= cam.height) {
+                        keep = options[i];
+                    }
+                }
+                clampTarget = keep || options[options.length - 1];
+            }
+            var pickedRes = mismatch ? clampTarget.value : resKey;
             this.editForm = {
                 // Issue #156 — name + location editable in the same modal.
                 name: cam.name || '',
                 location: cam.location || '',
-                resolution: resKey,
-                fps: cam.fps,
+                resolution: pickedRes,
+                fps: mismatch ? Math.min(cam.fps, clampTarget.max_fps) : cam.fps,
                 bitrateMbps: (cam.bitrate / 1000000),
                 h264_profile: cam.h264_profile || 'high',
                 keyframe_interval: cam.keyframe_interval || 30,
@@ -932,7 +1014,23 @@ function dashboardPage() {
                 // /data/config default (ADR-0021).
                 motion_sensitivity: (typeof cam.motion_sensitivity === 'number')
                     ? cam.motion_sensitivity : 5,
-                maxFps: this._resMaxFps[resKey] || 30,
+                resolutionOptions: options,
+                maxFps: this._maxFpsFor(options, pickedRes),
+                // Sensor identity (#173). Empty when the camera hasn't
+                // reported caps yet — Alpine x-show hides the row.
+                sensorLabel: cam.sensor_model
+                    ? (cam.sensor_model.toUpperCase()
+                       + (cam.sensor_modes && cam.sensor_modes.length
+                          ? ' (' + cam.sensor_modes.length + ' modes available)'
+                          : ''))
+                    : '',
+                resolutionMismatch: mismatch,
+                resolutionMismatchHint: mismatch
+                    ? ('Saved was ' + resKey + ' (' + cam.fps + ' fps); '
+                       + 'switched to ' + clampTarget.value
+                       + ' which is the closest mode this sensor supports. '
+                       + 'Adjust below and click Save to apply.')
+                    : '',
             };
             this.streamSaveMsg = '';
         },
@@ -952,7 +1050,13 @@ function dashboardPage() {
         },
 
         onResolutionChange() {
-            this.editForm.maxFps = this._resMaxFps[this.editForm.resolution] || 30;
+            // Look up the new max fps from THIS camera's options list,
+            // not a global preset — different sensors have different
+            // ceilings (#173).
+            this.editForm.maxFps = this._maxFpsFor(
+                this.editForm.resolutionOptions || [],
+                this.editForm.resolution
+            );
             if (this.editForm.fps > this.editForm.maxFps) {
                 this.editForm.fps = this.editForm.maxFps;
             }

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -131,3 +131,42 @@ class TestProtectedPages:
             sess["role"] = "admin"
         response = client.get("/settings")
         assert response.status_code == 200
+
+
+class TestDashboardSensorAwareSettings:
+    """The Camera Settings modal builds its resolution dropdown from
+    each camera's reported sensor_modes (#173) rather than a global
+    hardcoded list. This regression test pins the template-side
+    structure so a future "tidy-up" doesn't quietly delete the
+    dynamic rendering and snap us back to OV5647-only modes."""
+
+    @pytest.fixture(autouse=True)
+    def setup_done(self, app):
+        stamp = os.path.join(app.config["DATA_DIR"], ".setup-done")
+        with open(stamp, "w") as f:
+            f.write("done")
+
+    def test_dashboard_renders_dynamic_resolution_template(self, client):
+        with client.session_transaction() as sess:
+            sess["user_id"] = "user-001"
+            sess["username"] = "admin"
+            sess["role"] = "admin"
+        response = client.get("/dashboard")
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # New dynamic dropdown markup is present.
+        assert 'x-for="opt in editForm.resolutionOptions"' in body
+        assert ':value="opt.value"' in body
+        # Sensor label row is present (hidden when empty).
+        assert "editForm.sensorLabel" in body
+        # Mismatch banner is present.
+        assert "editForm.resolutionMismatch" in body
+        # Legacy hardcoded ``_resMaxFps`` map MUST be gone — its presence
+        # would mean the per-camera lookup got reverted.
+        assert "_resMaxFps:" not in body, (
+            "Legacy hardcoded _resMaxFps map reappeared — multi-sensor "
+            "support regressed (see #173 / P1.3)."
+        )
+        # Sensor-aware helper is the new source of truth.
+        assert "_resolutionOptionsFor" in body
+        assert "_legacyResolutionOptions" in body


### PR DESCRIPTION
## Goal

Dashboard half of multi-sensor support (#173). The Camera Settings modal renders its resolution dropdown from each camera's reported `sensor_modes` (per #176's API), so two cameras with two different sensors render two different option lists on the same Settings page. IMX219 shows 3280×2464 / 1920×1080@47 / etc.; OV5647 caps at 2592×1944 / 1920×1080@30.

## Change summary

**`app/server/monitor/templates/dashboard.html`**
- Resolution `<select>` rendered with Alpine `<template x-for>` over `editForm.resolutionOptions` instead of three hardcoded `<option>` elements.
- New "Sensor" row above the dropdown displays the live sensor model + mode count ("IMX219 (4 modes available)"). Hidden via `x-show` for cameras still on pre-#175 firmware that haven't reported caps yet.
- Mismatch banner above the dropdown fires when the camera's saved resolution is no longer in its current sensor's mode list (e.g. user swapped IMX219 → OV5647 with saved 3280×2464). Explains what the system did automatically and prompts to review + Save.
- New JS helpers `_resolutionOptionsFor(cam)` and `_maxFpsFor(opts, resKey)` build the per-camera option list (sorted small→large by pixel count) and look up max fps. Pure functions on the Alpine component.
- `openStreamSettings(cam)` rewritten to read `cam.sensor_modes` / `cam.sensor_model`, build the options, detect mismatch, pick the largest supported mode ≤ saved as the clamp target, populate the form.
- `onResolutionChange()` now consults the per-camera options list, not a global preset.
- `_legacyResolutionOptions` keeps the old static list as the fallback for cameras without reported caps. Backward compatible — pre-#175 cameras render the modal exactly as before.
- The hardcoded `_resMaxFps` map is **gone**.

**`app/server/tests/integration/test_views.py`**
- New `TestDashboardSensorAwareSettings` class with one regression test that pins the template structure: asserts the Alpine `x-for`, sensor-label row, mismatch banner are present, and the legacy `_resMaxFps:` map is gone (its return would mean someone reverted the per-camera lookup).

## Test plan

- `pytest app/server/tests/integration/test_views.py --no-cov -q` → **16/16 pass** (was 15; +1 new).
- `ruff check app/server/` clean; `ruff format` clean after run.
- CI: server unit + integration + browser-E2E + coverage ≥85%.

Hardware verification (post-merge with #176 deployed and the camera image OTA):
- Dashboard for `.186` IMX219: Settings shows "Sensor: IMX219 (4 modes available)" and the dropdown lists 640×480, 1640×1232, 1920×1080, 3280×2464.
- Dashboard for `.148` OV5647: Settings shows "Sensor: OV5647 (4 modes available)" and the dropdown lists 640×480, 1296×972, 1920×1080, 2592×1944.
- Save the IMX219 to 3280×2464 → persists, reload shows it.
- Imagine sensor swap: save OV5647 with 3280×2464 (impossible to reach this state from a real swap, but if a record drifts) → mismatch banner fires + clamps to 2592×1944.

## Deployment impact

- **Server-only deploy** (no camera image rebuild for this PR).
- Operators viewing the dashboard see the new Settings layout immediately. Cameras still on pre-#175 firmware show the legacy preset dropdown. After #173's camera OTA lands and a heartbeat lands, the dynamic path kicks in automatically.
- API contract unchanged.

## Doc impact

- Inline comments in dashboard.html describe the dynamic-options flow.
- Parent issue #173 captures the cross-PR context.

## Why no JS unit tests

The dashboard has no Selenium/Playwright/Jest infrastructure today (confirmed via codebase scan). Adding a JS test framework purely for one new function set is out of scope for this PR. The new template-rendering integration test pins the structure server-side; full functional coverage will come during hardware verification in #173's deployment phase.

Refs: #173, depends on #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
