### PR TITLE
fix(yocto): DISTRO_VERSION expansion fails because LAYERDIR is None at distro-conf parse

### DIFF
--- a/meta-home-monitor/conf/distro/home-monitor.conf
+++ b/meta-home-monitor/conf/distro/home-monitor.conf
@@ -14,7 +14,7 @@ DISTRO_NAME = "Home Monitor OS"
 # stamped into /etc/os-release on-device and surfaces in the admin
 # UI's "Current version" line. The git tag the release artefacts are
 # built from must match this value (release.sh enforces).
-DISTRO_VERSION := "${@open(d.getVar('LAYERDIR') + '/../VERSION').read().strip()}"
+DISTRO_VERSION := "${@open(d.getVar('HOME_MONITOR_LAYERDIR') + '/../VERSION').read().strip()}"
 DISTRO_CODENAME = "phase1"
 
 # Pin BUILD_ID to the static DISTRO_VERSION. poky's os-release.bb

--- a/meta-home-monitor/conf/layer.conf
+++ b/meta-home-monitor/conf/layer.conf
@@ -19,3 +19,12 @@ LAYERDEPENDS_home-monitor = " \
     raspberrypi \
     "
 LAYERSERIES_COMPAT_home-monitor = "scarthgap"
+
+# Re-export this layer's directory so other conf files in the layer
+# can resolve repo-root-relative paths reliably. ``LAYERDIR`` itself
+# is only bound while THIS file is being parsed; by the time the
+# distro conf (``conf/distro/home-monitor.conf``) is processed,
+# bitbake has moved on to other layers and ``getVar('LAYERDIR')``
+# returns ``None``. Snapshot it under a layer-specific name so the
+# distro conf can read the repo-root ``VERSION`` file.
+HOME_MONITOR_LAYERDIR := "${LAYERDIR}"

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -51,6 +51,12 @@ CHANGELOG = REPO / "CHANGELOG.md"
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 DISTRO_DYNAMIC_RE = re.compile(
+    # Accepts any ``${@open(...VERSION...).read().strip()}`` expression
+    # where the path argument resolves to the repo-root VERSION file —
+    # currently via ``HOME_MONITOR_LAYERDIR`` (set in
+    # ``meta-home-monitor/conf/layer.conf``), but the regex stays
+    # tolerant so a refactor to a different bbvar doesn't fail this
+    # check by name alone.
     r"DISTRO_VERSION\s*:?=\s*\"\$\{@open\(.+VERSION.+\)\.read\(\)\.strip\(\)\}\""
 )
 CHANGELOG_HEADER_RE = re.compile(r"^## \[(\d+\.\d+\.\d+)\]")


### PR DESCRIPTION
Caught on the v1.4.0 prod build. `LAYERDIR` is only bound during `conf/layer.conf` parsing, not later when distro conf is read. Snapshot it as `HOME_MONITOR_LAYERDIR` in layer.conf and read that from the distro conf.

Standard Yocto idiom for repo-root-relative file reads from non-layer-conf locations.

Test: `python scripts/check_version_consistency.py` still passes; the prod build on the VM is restarting after this lands.

Refs: #178