### PR TITLE
chore(security): always sign SWU bundles (dev + prod) + AI security-posture rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to RPi Home Monitor are documented here.
 
 ## [Unreleased]
 
-(Nothing yet — next release will land here.)
+### Security
+- **SWU signing now enforced on dev builds for parity with prod** — distro default is `SWUPDATE_SIGNING ?= "1"`; `config/{rpi4b,zero2w}/local.conf` no longer override it to `"0"`; `scripts/build.sh` always passes `--sign`. Both dev and prod images now ship `/etc/swupdate-public.crt` + `/etc/swupdate-enforce` and accept only CMS-signed `.swu` bundles. The dev-vs-prod axis is now strictly debug-tweaks + dev tools — not the signing layer. Tests the signing workflow on dev hardware before promotion to prod and removes the "dev accepts anything" footgun. ADR-0014 updated with the new policy.
+- **AI execution rules: "never propose weakening security"** — new section in `docs/ai/execution-rules.md` codifying the rule that AI agents must refuse insecure shortcuts (injecting authorized_keys, disabling signing, adding debug-tweaks to prod, bypassing CSRF/mTLS/signatures, etc.) and propose secure alternatives instead. Triggered by an actual instance of the agent suggesting a security-weakening "convenience option" during 1.4.0 OTA validation.
 
 ## [1.4.0] — 2026-04-25
 

--- a/config/rpi4b/local.conf
+++ b/config/rpi4b/local.conf
@@ -30,7 +30,8 @@ MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-rpidistro-bcm43455"
 KERNEL_IMAGETYPE = "Image"
 
 # --- OTA signing (ADR-0014) ---
-# "0" = dev: CONFIG_SIGNED_IMAGES disabled, unsigned bundles accepted (default)
-# "1" = prod: CONFIG_SIGNED_IMAGES enabled, bundles must be signed with
-#             ~/.monitor-keys/ota-signing.key (run ./scripts/generate-ota-keys.sh first)
-SWUPDATE_SIGNING = "0"
+# Distro default is SWUPDATE_SIGNING="1" (enforced everywhere — dev and prod
+# both ship with CONFIG_SIGNED_IMAGES=y). Override here only for one-off
+# unsigned experiments; otherwise leave the distro default.
+# Run ./scripts/generate-ota-keys.sh once per developer to populate
+# ~/.monitor-keys/ota-signing.{key,crt} before the first build.

--- a/config/rpi4b/local.conf.prod
+++ b/config/rpi4b/local.conf.prod
@@ -20,8 +20,9 @@ require local.conf
 # Production overrides
 # -------------------
 
-# OTA signing (ADR-0014) — CONFIG_SIGNED_IMAGES enabled.
-# With this set, the image ships /etc/swupdate-enforce and rejects
-# any unsigned .swu at install time. build-swu.sh --sign must be
-# used for bundles targeting this image.
+# OTA signing — handled by the distro default (SWUPDATE_SIGNING="1")
+# for both dev and prod since 1.4.1. Listed here for documentation
+# only; the assignment below is redundant with the distro default but
+# kept explicit so prod builds always self-document their signing
+# posture even if a future distro change weakens the default.
 SWUPDATE_SIGNING = "1"

--- a/config/zero2w/local.conf
+++ b/config/zero2w/local.conf
@@ -30,7 +30,8 @@ MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-rpidistro-bcm43436s"
 KERNEL_IMAGETYPE = "Image"
 
 # --- OTA signing (ADR-0014) ---
-# "0" = dev: CONFIG_SIGNED_IMAGES disabled, unsigned bundles accepted (default)
-# "1" = prod: CONFIG_SIGNED_IMAGES enabled, bundles must be signed with
-#             ~/.monitor-keys/ota-signing.key (run ./scripts/generate-ota-keys.sh first)
-SWUPDATE_SIGNING = "0"
+# Distro default is SWUPDATE_SIGNING="1" (enforced everywhere — dev and prod
+# both ship with CONFIG_SIGNED_IMAGES=y). Override here only for one-off
+# unsigned experiments; otherwise leave the distro default.
+# Run ./scripts/generate-ota-keys.sh once per developer to populate
+# ~/.monitor-keys/ota-signing.{key,crt} before the first build.

--- a/config/zero2w/local.conf.prod
+++ b/config/zero2w/local.conf.prod
@@ -20,8 +20,9 @@ require local.conf
 # Production overrides
 # -------------------
 
-# OTA signing (ADR-0014) — CONFIG_SIGNED_IMAGES enabled.
-# With this set, the image ships /etc/swupdate-enforce and rejects
-# any unsigned .swu at install time. build-swu.sh --sign must be
-# used for bundles targeting this image.
+# OTA signing — handled by the distro default (SWUPDATE_SIGNING="1")
+# for both dev and prod since 1.4.1. Listed here for documentation
+# only; the assignment below is redundant with the distro default but
+# kept explicit so prod builds always self-document their signing
+# posture even if a future distro change weakens the default.
 SWUPDATE_SIGNING = "1"

--- a/docs/adr/0014-swupdate-signing-dev-prod.md
+++ b/docs/adr/0014-swupdate-signing-dev-prod.md
@@ -1,6 +1,6 @@
-# ADR-0014: Disable OTA Bundle Signing for Dev Builds
+# ADR-0014: OTA Bundle Signing Policy
 
-**Status:** Accepted
+**Status:** Accepted (revised 2026-04-26 — see "Update — 1.4.1: signing always-on")
 **Date:** 2026-04-13
 
 ## Context
@@ -96,3 +96,40 @@ Detached signatures for non-SWUpdate artifacts can still use different tooling, 
 **Always enable signing, commit a "dev" cert+key to the repo:** The key would be public (anyone could sign malicious bundles for dev devices). Violates the principle of never committing private keys. Rejected.
 
 **Single defconfig with signing disabled permanently:** Would require re-enabling for prod builds via a manual local.conf change with no guardrails. Using `SWUPDATE_SIGNING` is explicit and self-documenting. Rejected.
+
+## Update — 1.4.1: signing always-on
+
+The original split (dev unsigned / prod signed) created an asymmetry that
+the team paid for during 1.4.0 hardware validation: a dev SWU could not
+be installed on a prod-flashed device, and a prod SWU could not be
+exercised on a dev-flashed device without a parallel signing rehearsal.
+Worse, "unsigned dev images" trained reviewers to think of signing as a
+"prod-only thing" — which is the wrong intuition. Signing is a security
+control; it should be the default.
+
+As of 1.4.1, the policy is **signing always-on**. Both dev and prod
+builds:
+
+- compile swupdate with `CONFIG_SIGNED_IMAGES=y` and `CONFIG_SIGALG_CMS=y`
+- ship `/etc/swupdate-public.crt` and `/etc/swupdate-enforce`
+- accept only CMS-signed `.swu` bundles at install time
+
+The only meaningful axis between dev and prod images is now
+`debug-tweaks` + dev tools (gdb, strace, tcpdump, root SSH). Signing,
+auth, hardening posture are identical.
+
+Concretely:
+
+- Distro default flipped to `SWUPDATE_SIGNING ?= "1"` in
+  `meta-home-monitor/conf/distro/home-monitor.conf`.
+- `config/{rpi4b,zero2w}/local.conf` no longer set `SWUPDATE_SIGNING="0"`.
+  The distro default applies.
+- `scripts/build.sh` auto-applies `--sign` to every target (not just
+  `*-prod`).
+- The dev/prod naming on `local.conf.prod` is preserved for clarity but
+  the signing line in `local.conf.prod` is now redundant with the distro
+  default.
+
+The original "Negative" point — "Dev images accept unsigned bundles" —
+no longer applies. Dev developers must run `generate-ota-keys.sh` once
+the same as prod operators do; the cost is small and well-contained.

--- a/docs/ai/execution-rules.md
+++ b/docs/ai/execution-rules.md
@@ -85,3 +85,37 @@ Never reintroduce any CLI, SSH, or pre-auth recovery mechanism that resets the
 sole admin account. That direction is closed by product decision and documented
 in `docs/admin-recovery.md`, `docs/adr/0022-no-backdoors.md`, and
 `docs/exec-plans/auth-recovery.md`.
+
+## Security Posture Rule — never propose weakening security
+
+**Rule:** Never propose weakening security as a workaround or convenience. If
+a workflow requires bypassing or weakening signing, auth, hardening, or any
+other security control, **refuse and propose a secure alternative**. Don't
+soft-pedal it as "if you want to..." — call it what it is and don't offer it
+as an option.
+
+Examples of things to never propose:
+
+- Injecting authorized_keys / passwords into prod images for "convenience"
+- Disabling signing enforcement to install unsigned bundles
+- Adding `debug-tweaks` to prod (or any equivalent broadens-attack-surface
+  feature)
+- Suggesting `--privileged` containers as a shortcut
+- Proposing "just SSH in" instead of fixing the proper user-facing path
+- Bypassing CSRF, mTLS, or signature checks "for testing"
+- Adding open ports, removing firewall rules, disabling SELinux/AppArmor
+- Anything that makes prod look like dev for ergonomic reasons
+
+Instead, always:
+
+- Make the secure path THE path.
+- If the secure path is too painful, fix the path, not the security.
+- Surface that the user wants to do something insecure, refuse, propose the
+  secure approach.
+- Treat security regressions in proposals the same as other regressions —
+  block them.
+
+This rule applies whether or not the user explicitly asked for the insecure
+shortcut. "User asked me to" is not a defence. Propose the secure path; if
+the user still wants the insecure one, escalate visibly (commit message,
+ADR, or a refusal back to the user) rather than land it quietly.

--- a/meta-home-monitor/conf/distro/home-monitor.conf
+++ b/meta-home-monitor/conf/distro/home-monitor.conf
@@ -62,6 +62,19 @@ LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch commercial"
 # No debug tweaks by default — dev images add them explicitly
 EXTRA_IMAGE_FEATURES ?= ""
 
+# --- OTA signing posture (ADR-0014) ---
+# Distro-wide default: every image (dev and prod) is built with
+# CONFIG_SIGNED_IMAGES=y and ships /etc/swupdate-public.crt plus
+# /etc/swupdate-enforce. The dev-vs-prod axis is debug-tweaks +
+# debug tools — NOT the signing-enforcement layer. This means the
+# signing workflow is exercised on dev hardware before promotion
+# to prod, and there is no "dev images accept anything" footgun.
+#
+# An individual build can still opt out with `SWUPDATE_SIGNING = "0"`
+# in local.conf for one-off experiments, but that is a deliberate
+# policy override, not the default.
+SWUPDATE_SIGNING ?= "1"
+
 # --- Build reproducibility ---
 INHERIT += "create-spdx"
 INHERIT += "rm_work"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,9 +36,12 @@ for arg in "$@"; do
         *)        echo "Unknown flag: $arg" >&2; exit 1 ;;
     esac
 done
-case "$TARGET" in
-    *-prod) [ -z "$SIGN_SWU" ] && SIGN_SWU="--sign" ;;
-esac
+# SWU bundles are always signed since 1.4.1 — the distro sets
+# SWUPDATE_SIGNING="1" for every image (dev and prod), so a dev
+# image will refuse an unsigned bundle just like prod does. The
+# only difference between dev and prod builds is debug-tweaks +
+# tools, NOT the signing layer. See ADR-0014.
+[ -z "$SIGN_SWU" ] && SIGN_SWU="--sign"
 
 KEY_DIR="${KEY_DIR:-$HOME/.monitor-keys}"
 LOCAL_OTA_CERT="$KEY_DIR/ota-signing.crt"


### PR DESCRIPTION
## Summary

Two coupled policy changes for 1.4.1.

### 1. SWU signing always-on (dev + prod parity)

Before: dev images were built with \`SWUPDATE_SIGNING=0\` (CONFIG_SIGNED_IMAGES disabled, daemon accepts anything). Prod images had \`SWUPDATE_SIGNING=1\`. This split caused real pain during 1.4.0 hardware validation:

- A dev SWU couldn't be installed on a prod-flashed device (CMS verify failure at the swupdate binary level).
- A prod SWU couldn't be exercised on a dev-flashed device without parallel signing rehearsal.
- Reviewers were trained to think of signing as "a prod-only thing", which is the wrong intuition.

After: every image (dev and prod) ships with \`CONFIG_SIGNED_IMAGES=y\`, \`/etc/swupdate-public.crt\`, and \`/etc/swupdate-enforce\`. Both dev and prod refuse unsigned bundles. The dev-vs-prod axis is now strictly **debug-tweaks + dev tools**, not the signing layer.

Concrete diff:
- \`meta-home-monitor/conf/distro/home-monitor.conf\` — \`SWUPDATE_SIGNING ?= \"1\"\` (distro default)
- \`config/{rpi4b,zero2w}/local.conf\` — drop the \`SWUPDATE_SIGNING=\"0\"\` override
- \`config/{rpi4b,zero2w}/local.conf.prod\` — keep the \`=\"1\"\` line for self-documentation only (now redundant with distro default)
- \`scripts/build.sh\` — always set \`SIGN_SWU=\"--sign\"\`, not just for \`*-prod\`
- \`docs/adr/0014-swupdate-signing-dev-prod.md\` — title + status updated, "Update — 1.4.1: signing always-on" section appended

### 2. AI execution rule: never propose weakening security

New "Security Posture Rule" section in \`docs/ai/execution-rules.md\`. Filed because during 1.4.0 hardware validation the AI agent suggested a security-weakening shortcut ("inject root authorized_keys into prod for hot-deploy convenience"). The rule explicitly blocks that class of proposal:

- Refuse insecure shortcuts; propose secure alternatives instead
- "User asked me to" is not a defence
- Make the secure path THE path; if the secure path is too painful, fix the path, not the security
- Examples: don't inject authorized_keys, don't disable signing, don't add debug-tweaks to prod, don't bypass CSRF/mTLS/signatures, etc.

## Test plan

- [x] No unit/integration tests touch SWUPDATE_SIGNING — it's a build-time variable. Verification is at the build artefact layer.
- [ ] Build dev image on the GCloud yocto VM with cleansstate on swupdate + image recipes; confirm \`/etc/swupdate-public.crt\` + \`/etc/swupdate-enforce\` ship in the dev rootfs.
- [ ] Build dev SWU; confirm \`sw-description.sig\` is present in the cpio.
- [ ] \`openssl cms -verify\` against the dev SWU's sig — must pass.
- [ ] CHANGELOG entry under [Unreleased] documents the change.

These verification steps will be run as part of the 1.4.1 release cut on the build VM, on top of this PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)