### PR TITLE
feat(versioning): /etc/os-release VERSION_ID is the image-side SSOT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
           python scripts/ai/check_doc_links.py
           python scripts/ai/check_shell_scripts.py
           python scripts/check_version_consistency.py
+          python scripts/check_versioning_design.py
 
   pre-commit:
     name: Pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to RPi Home Monitor are documented here.
 
 ## [Unreleased]
 
-(Nothing yet — next release will land here.)
+### Fixed
+- **Camera and server now report the actual release version on fresh-flashed images.** Previously both surfaces (camera local status page and server dashboard `firmware_version`) read `/etc/sw-versions`, which shipped hardcoded as `home-monitor 1.0.0` from `meta-home-monitor/recipes-core/sw-versions/files/sw-versions` and was only updated by SWUpdate's post-install hook during OTA. A freshly flashed prod card therefore reported `1.0.0` no matter what release it was actually running. End-to-end fix:
+  - The sw-versions Yocto recipe is now templated: `do_install` writes `home-monitor ${DISTRO_VERSION}` at build time. The static baseline file is deleted.
+  - A shared `release_version()` helper lands in `app/shared/release_version/` (canonical) plus identical copies in `camera_streamer/release_version.py` and `monitor/release_version.py`. The helper reads `/etc/os-release VERSION_ID` (the standard Linux convention, already templated correctly) and is lazy-cached.
+  - `heartbeat.py` and `status_server.py` (camera) and `settings_service.py` + `api/ota.py` + `api/system.py` (server) now route through the helper.
+  - Seven new CI guards in `scripts/check_versioning_design.py` lock the contract: templated recipe, byte-identical helper copies, no app-code reads of `/etc/sw-versions`, no app-code reads of `/etc/os-release` outside the helper, `@@VERSION@@` placeholder in SWU templates, semver tag validity, VERSION ↔ CHANGELOG match.
+  - Design lives in `docs/architecture/versioning.md` and is now linked from `docs/ai/index.md` so future agents pick it up.
 
 ## [1.4.2] — 2026-04-26
 

--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -100,21 +100,23 @@ def _get_memory_percent() -> int:
 
 
 def _get_firmware_version() -> str:
-    """Read the first version string from ``/etc/sw-versions``.
+    """Return the product release version for inclusion in heartbeats.
 
-    The file is written by SWUpdate post-install and lists
-    ``<component> <version>`` pairs. Callers tolerate an empty return
-    (missing file, unreadable, bad format) by reporting ``""``.
+    Thin wrapper over the shared ``release_version()`` helper, which
+    reads ``/etc/os-release VERSION_ID``. Pre-1.4.3 this function
+    read ``/etc/sw-versions`` directly, but that file ships
+    hard-coded ``home-monitor 1.0.0`` on fresh-flashed images and
+    only got rewritten by an OTA post-install hook — meaning every
+    fresh prod card heartbeated the wrong version until its first
+    OTA. See ``docs/architecture/versioning.md`` for the migration.
+
+    Empty string on parse failure preserves the legacy contract:
+    the server records ``""`` and the dashboard renders it as
+    ``unknown`` rather than crashing.
     """
-    try:
-        with open("/etc/sw-versions") as f:
-            for line in f:
-                parts = line.strip().split()
-                if len(parts) >= 2:
-                    return parts[1]
-    except OSError:
-        pass
-    return ""
+    from camera_streamer.release_version import release_version
+
+    return release_version()
 
 
 def _get_cpu_temp(thermal_path: str | None) -> float:

--- a/app/camera/camera_streamer/release_version.py
+++ b/app/camera/camera_streamer/release_version.py
@@ -1,0 +1,101 @@
+"""Single image-side release-version helper for camera + server.
+
+Both Yocto recipes (camera-streamer, monitor-server) copy this file
+into their own package's namespace at build time:
+
+  /opt/camera/camera_streamer/release_version.py    (camera image)
+  /opt/monitor/monitor/release_version.py            (server image)
+
+Source of truth: this single file. The CI guard
+``scripts/check_versioning_design.py`` asserts both recipes install
+it from the canonical location and that no second copy with diverged
+content exists.
+
+The runtime read path is intentionally minimal:
+
+  /etc/os-release VERSION_ID
+        ↑   (templated by Yocto's os-release.bbappend from
+            ${DISTRO_VERSION}, which itself reads the repo-root
+            ``VERSION`` file at build time)
+
+This is the image-side single source of truth chosen in
+``docs/architecture/versioning.md`` §C. Older images shipped a
+hardcoded ``/etc/sw-versions`` and got it wrong on every
+fresh-flashed prod card; this helper points at the right file.
+
+The function is module-level so the same import works in both
+``camera_streamer`` and ``monitor`` packages with no plumbing.
+The result is cached on first read — release version doesn't change
+during a process lifetime, and the file is on the rootfs (no IO
+hit worth re-paying on every heartbeat).
+
+Reset behaviour: ``_clear_cache()`` is exposed for tests and for
+SIGHUP/reload paths if any caller eventually wants to refresh
+without restarting the process. Production code should not call it.
+"""
+
+from __future__ import annotations
+
+import threading
+
+__all__ = ["_clear_cache", "release_version"]
+
+_OS_RELEASE_PATH = "/etc/os-release"
+_KEY = "VERSION_ID"
+
+_lock = threading.Lock()
+_cached: str | None = None
+
+
+def _parse(path: str) -> str:
+    """Parse os-release(5) and return the value of ``VERSION_ID``.
+
+    os-release has a deceptively simple shell-assignment grammar:
+    ``KEY=value`` per line, value may be quoted with single or double
+    quotes. We don't honour escape sequences (the file is generated
+    by Yocto, never hand-edited; values are trivially ASCII).
+    Returns empty string on any failure so callers can render
+    ``"unknown"`` instead of crashing.
+    """
+    try:
+        with open(path, encoding="ascii", errors="replace") as f:
+            for line in f:
+                key, sep, value = line.strip().partition("=")
+                if not sep or key != _KEY:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                    value = value[1:-1]
+                return value
+    except OSError:
+        return ""
+    return ""
+
+
+def release_version(os_release_path: str | None = None) -> str:
+    """Return the product release version (e.g. ``"1.4.3"``).
+
+    Reads ``/etc/os-release VERSION_ID`` once and caches the result.
+    Returns an empty string when the file is missing or malformed —
+    callers display ``"unknown"`` rather than failing loudly, mirroring
+    the older ``_get_firmware_version`` semantics this replaces.
+
+    Tests pass an explicit path to bypass the cache.
+    """
+    global _cached
+    if os_release_path is not None:
+        # Test mode — uncached read against an explicit path.
+        return _parse(os_release_path)
+    if _cached is not None:
+        return _cached
+    with _lock:
+        if _cached is None:
+            _cached = _parse(_OS_RELEASE_PATH)
+    return _cached
+
+
+def _clear_cache() -> None:
+    """Reset the cached value. For tests and SIGHUP-style reloads."""
+    global _cached
+    with _lock:
+        _cached = None

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -231,23 +231,19 @@ def _get_cpu_temp(thermal_path=None):
         return 0.0
 
 
-def _get_firmware_version(sw_versions_path="/etc/sw-versions"):
-    """Read the camera firmware version from /etc/sw-versions.
+def _get_firmware_version(sw_versions_path=None):
+    """Return the product release version for the local status page.
 
-    SWUpdate records each installed bundle as "<component> <version>"
-    lines. The camera image ships only the "home-monitor" row (or
-    "home-camera"); we return the version string from the first line,
-    or empty if nothing is readable.
+    Thin wrapper over the shared ``release_version()`` helper
+    (``/etc/os-release VERSION_ID``). The legacy ``sw_versions_path``
+    parameter is kept for source-level backward compatibility with
+    any out-of-tree caller and is now silently ignored — the
+    helper always reads ``/etc/os-release``. See
+    ``docs/architecture/versioning.md`` for the migration rationale.
     """
-    try:
-        with open(sw_versions_path) as f:
-            for line in f:
-                parts = line.strip().split()
-                if len(parts) >= 2:
-                    return parts[1]
-    except OSError:
-        pass
-    return ""
+    from camera_streamer.release_version import release_version
+
+    return release_version()
 
 
 def _get_uptime():

--- a/app/camera/tests/unit/test_release_version.py
+++ b/app/camera/tests/unit/test_release_version.py
@@ -1,0 +1,138 @@
+"""Unit tests for the camera-side release_version() helper.
+
+The helper is the single image-side SSOT for the product release
+version (per docs/architecture/versioning.md §C). Server has a
+byte-identical copy under monitor.release_version; the static
+guard scripts/check_versioning_design.py asserts they don't
+diverge.
+
+These tests exercise parsing — quoted/unquoted, missing files,
+malformed lines, the cache, and the reset hatch.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from camera_streamer import release_version as rv_module
+from camera_streamer.release_version import (
+    _clear_cache,
+    release_version,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    _clear_cache()
+    yield
+    _clear_cache()
+
+
+def _write(p: Path, contents: str) -> Path:
+    p.write_text(textwrap.dedent(contents).lstrip("\n"), encoding="utf-8")
+    return p
+
+
+class TestParse:
+    def test_double_quoted_value(self, tmp_path):
+        p = _write(
+            tmp_path / "os-release",
+            """
+            NAME="Home Monitor OS"
+            VERSION_ID="1.4.3"
+            PRETTY_NAME="Home Monitor OS 1.4.3"
+            """,
+        )
+        assert release_version(str(p)) == "1.4.3"
+
+    def test_single_quoted_value(self, tmp_path):
+        p = _write(tmp_path / "os-release", "VERSION_ID='1.4.3'\n")
+        assert release_version(str(p)) == "1.4.3"
+
+    def test_unquoted_value(self, tmp_path):
+        # os-release(5) allows unquoted values for ASCII-only strings.
+        p = _write(tmp_path / "os-release", "VERSION_ID=1.4.3\n")
+        assert release_version(str(p)) == "1.4.3"
+
+    def test_pre_release_suffix(self, tmp_path):
+        p = _write(tmp_path / "os-release", 'VERSION_ID="1.5.0-rc1"\n')
+        assert release_version(str(p)) == "1.5.0-rc1"
+
+    def test_missing_file(self, tmp_path):
+        # Returns "" rather than raising — callers render "unknown".
+        assert release_version(str(tmp_path / "does-not-exist")) == ""
+
+    def test_missing_version_id_field(self, tmp_path):
+        p = _write(tmp_path / "os-release", 'NAME="Other"\n')
+        assert release_version(str(p)) == ""
+
+    def test_blank_lines_and_comments_tolerated(self, tmp_path):
+        p = _write(
+            tmp_path / "os-release",
+            """
+
+            # this is a comment
+            NAME="Home Monitor OS"
+
+            VERSION_ID="1.4.3"
+            """,
+        )
+        assert release_version(str(p)) == "1.4.3"
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        # Line without `=` shouldn't crash the parser.
+        p = _write(
+            tmp_path / "os-release",
+            """
+            this is not a valid line
+            VERSION_ID="1.4.3"
+            another bad line
+            """,
+        )
+        assert release_version(str(p)) == "1.4.3"
+
+    def test_first_match_wins(self, tmp_path):
+        # If somehow VERSION_ID appears twice, return the first.
+        p = _write(
+            tmp_path / "os-release",
+            """
+            VERSION_ID="1.4.3"
+            VERSION_ID="should-be-ignored"
+            """,
+        )
+        assert release_version(str(p)) == "1.4.3"
+
+
+class TestCache:
+    def test_cached_after_first_real_read(self, tmp_path, monkeypatch):
+        """release_version() with no path arg uses the cache + module
+        constant. Patch the constant to point at a tmp file, call
+        once, mutate the file, call again — cached value persists."""
+        p = _write(tmp_path / "os-release", 'VERSION_ID="1.4.3"\n')
+        monkeypatch.setattr(rv_module, "_OS_RELEASE_PATH", str(p))
+        first = release_version()
+        assert first == "1.4.3"
+
+        # Mutate file under us; cache should hide the change.
+        p.write_text('VERSION_ID="9.9.9"\n', encoding="utf-8")
+        assert release_version() == "1.4.3"
+
+    def test_clear_cache_lets_a_fresh_read_through(self, tmp_path, monkeypatch):
+        p = _write(tmp_path / "os-release", 'VERSION_ID="1.4.3"\n')
+        monkeypatch.setattr(rv_module, "_OS_RELEASE_PATH", str(p))
+        assert release_version() == "1.4.3"
+        p.write_text('VERSION_ID="9.9.9"\n', encoding="utf-8")
+        _clear_cache()
+        assert release_version() == "9.9.9"
+
+    def test_explicit_path_bypasses_cache(self, tmp_path):
+        a = _write(tmp_path / "a", 'VERSION_ID="1.0.0"\n')
+        b = _write(tmp_path / "b", 'VERSION_ID="2.0.0"\n')
+        # Explicit-path mode is uncached on purpose so tests can
+        # interleave reads against different files in one run.
+        assert release_version(str(a)) == "1.0.0"
+        assert release_version(str(b)) == "2.0.0"
+        assert release_version(str(a)) == "1.0.0"

--- a/app/server/monitor/api/ota.py
+++ b/app/server/monitor/api/ota.py
@@ -60,13 +60,17 @@ def _latest_camera_bundle(ota, camera_id):
 @login_required
 def get_status():
     """Get OTA update status for server + all cameras."""
-    settings = current_app.store.get_settings()
     cameras = current_app.store.get_cameras()
     ota = current_app.ota_service
 
+    # Live read from /etc/os-release VERSION_ID, not the persisted
+    # Settings.firmware_version (which is legacy plumbing — see
+    # docs/architecture/versioning.md §C).
+    from monitor.release_version import release_version
+
     result = {
         "server": {
-            "current_version": settings.firmware_version,
+            "current_version": release_version(),
             **ota.get_status("server"),
         },
         "cameras": [],

--- a/app/server/monitor/api/system.py
+++ b/app/server/monitor/api/system.py
@@ -100,10 +100,18 @@ def info():
     settings = current_app.store.get_settings()
     uptime = get_uptime()
     os_info = _read_os_release()
+    # Live read of release version from /etc/os-release via the shared
+    # helper — the persisted Settings.firmware_version is legacy plumbing
+    # (see docs/architecture/versioning.md §C). Note: we already parse
+    # /etc/os-release locally in this module via _read_os_release(); we
+    # still defer to the helper to keep ONE read path and ONE caching
+    # policy across the codebase.
+    from monitor.release_version import release_version
+
     return jsonify(
         {
             "hostname": settings.hostname,
-            "firmware_version": settings.firmware_version,
+            "firmware_version": release_version(),
             "uptime": uptime,
             "os_name": os_info.get("PRETTY_NAME", "Unknown"),
             "os_version": os_info.get("VERSION_ID", ""),

--- a/app/server/monitor/release_version.py
+++ b/app/server/monitor/release_version.py
@@ -1,0 +1,101 @@
+"""Single image-side release-version helper for camera + server.
+
+Both Yocto recipes (camera-streamer, monitor-server) copy this file
+into their own package's namespace at build time:
+
+  /opt/camera/camera_streamer/release_version.py    (camera image)
+  /opt/monitor/monitor/release_version.py            (server image)
+
+Source of truth: this single file. The CI guard
+``scripts/check_versioning_design.py`` asserts both recipes install
+it from the canonical location and that no second copy with diverged
+content exists.
+
+The runtime read path is intentionally minimal:
+
+  /etc/os-release VERSION_ID
+        ↑   (templated by Yocto's os-release.bbappend from
+            ${DISTRO_VERSION}, which itself reads the repo-root
+            ``VERSION`` file at build time)
+
+This is the image-side single source of truth chosen in
+``docs/architecture/versioning.md`` §C. Older images shipped a
+hardcoded ``/etc/sw-versions`` and got it wrong on every
+fresh-flashed prod card; this helper points at the right file.
+
+The function is module-level so the same import works in both
+``camera_streamer`` and ``monitor`` packages with no plumbing.
+The result is cached on first read — release version doesn't change
+during a process lifetime, and the file is on the rootfs (no IO
+hit worth re-paying on every heartbeat).
+
+Reset behaviour: ``_clear_cache()`` is exposed for tests and for
+SIGHUP/reload paths if any caller eventually wants to refresh
+without restarting the process. Production code should not call it.
+"""
+
+from __future__ import annotations
+
+import threading
+
+__all__ = ["_clear_cache", "release_version"]
+
+_OS_RELEASE_PATH = "/etc/os-release"
+_KEY = "VERSION_ID"
+
+_lock = threading.Lock()
+_cached: str | None = None
+
+
+def _parse(path: str) -> str:
+    """Parse os-release(5) and return the value of ``VERSION_ID``.
+
+    os-release has a deceptively simple shell-assignment grammar:
+    ``KEY=value`` per line, value may be quoted with single or double
+    quotes. We don't honour escape sequences (the file is generated
+    by Yocto, never hand-edited; values are trivially ASCII).
+    Returns empty string on any failure so callers can render
+    ``"unknown"`` instead of crashing.
+    """
+    try:
+        with open(path, encoding="ascii", errors="replace") as f:
+            for line in f:
+                key, sep, value = line.strip().partition("=")
+                if not sep or key != _KEY:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                    value = value[1:-1]
+                return value
+    except OSError:
+        return ""
+    return ""
+
+
+def release_version(os_release_path: str | None = None) -> str:
+    """Return the product release version (e.g. ``"1.4.3"``).
+
+    Reads ``/etc/os-release VERSION_ID`` once and caches the result.
+    Returns an empty string when the file is missing or malformed —
+    callers display ``"unknown"`` rather than failing loudly, mirroring
+    the older ``_get_firmware_version`` semantics this replaces.
+
+    Tests pass an explicit path to bypass the cache.
+    """
+    global _cached
+    if os_release_path is not None:
+        # Test mode — uncached read against an explicit path.
+        return _parse(os_release_path)
+    if _cached is not None:
+        return _cached
+    with _lock:
+        if _cached is None:
+            _cached = _parse(_OS_RELEASE_PATH)
+    return _cached
+
+
+def _clear_cache() -> None:
+    """Reset the cached value. For tests and SIGHUP-style reloads."""
+    global _cached
+    with _lock:
+        _cached = None

--- a/app/server/monitor/services/settings_service.py
+++ b/app/server/monitor/services/settings_service.py
@@ -18,6 +18,19 @@ from flask import current_app
 
 log = logging.getLogger("monitor.services.settings_service")
 
+
+def _live_firmware_version() -> str:
+    """Read the live release version from /etc/os-release.
+
+    Defers the import so unit tests that don't ship the helper on
+    PYTHONPATH still load this module. The helper itself is
+    lazy-cached so repeated calls are essentially free.
+    """
+    from monitor.release_version import release_version
+
+    return release_version()
+
+
 UPDATABLE_FIELDS = {
     "timezone",
     "ntp_mode",
@@ -54,7 +67,13 @@ class SettingsService:
             "session_timeout_minutes": settings.session_timeout_minutes,
             "hostname": settings.hostname,
             "setup_completed": settings.setup_completed,
-            "firmware_version": settings.firmware_version,
+            # Always serve the live release version from /etc/os-release
+            # (via the shared release_version() helper) rather than the
+            # persisted Settings.firmware_version field. The persisted
+            # field is legacy plumbing kept for store-schema stability;
+            # the truth lives in /etc/os-release per
+            # docs/architecture/versioning.md §C.
+            "firmware_version": _live_firmware_version(),
             "tailscale_enabled": settings.tailscale_enabled,
             "tailscale_auto_connect": settings.tailscale_auto_connect,
             "tailscale_accept_routes": settings.tailscale_accept_routes,

--- a/app/server/tests/integration/test_api_ota.py
+++ b/app/server/tests/integration/test_api_ota.py
@@ -24,7 +24,15 @@ class TestOTAStatus:
         assert response.status_code == 200
         data = response.get_json()
         assert "server" in data
-        assert data["server"]["current_version"] == "1.0.0"
+        # Per docs/architecture/versioning.md §C, current_version reads
+        # /etc/os-release VERSION_ID via release_version(). On a CI
+        # runner with no os-release present (or with the host's own
+        # os-release that doesn't carry our VERSION_ID), the helper
+        # returns "" — that's the documented fail-safe. The test only
+        # cares that the field exists and is a string; the live value
+        # comes from the device at runtime.
+        assert "current_version" in data["server"]
+        assert isinstance(data["server"]["current_version"], str)
         assert "cameras" in data
 
     def test_includes_camera_status(self, app, logged_in_client):

--- a/app/server/tests/integration/test_api_settings.py
+++ b/app/server/tests/integration/test_api_settings.py
@@ -20,7 +20,10 @@ class TestGetSettings:
         assert data["clip_duration_seconds"] == 180
         assert data["session_timeout_minutes"] == 30
         assert data["storage_threshold_percent"] == 90
-        assert data["firmware_version"] == "1.0.0"
+        # firmware_version is a live read of /etc/os-release VERSION_ID
+        # via release_version() since 1.4.3 (docs/architecture/versioning.md).
+        # Empty string on CI runners; only assert it's a string.
+        assert isinstance(data["firmware_version"], str)
         assert data["setup_completed"] is False
 
     def test_viewer_can_read_settings(self, logged_in_client):

--- a/app/server/tests/integration/test_api_system.py
+++ b/app/server/tests/integration/test_api_system.py
@@ -55,7 +55,10 @@ class TestInfoEndpoint:
         assert response.status_code == 200
         data = response.get_json()
         assert data["hostname"] == "home-monitor"
-        assert data["firmware_version"] == "1.0.0"
+        # firmware_version is a live read of /etc/os-release VERSION_ID
+        # via release_version() since 1.4.3 (docs/architecture/versioning.md).
+        # Empty string on CI runners; only assert it's a string.
+        assert isinstance(data["firmware_version"], str)
         assert data["uptime"]["seconds"] == 7200
 
 

--- a/app/server/tests/unit/test_settings_service.py
+++ b/app/server/tests/unit/test_settings_service.py
@@ -52,7 +52,13 @@ class TestGetSettings:
         assert result["session_timeout_minutes"] == 30
         assert result["hostname"] == "homemonitor"
         assert result["setup_completed"] is False
-        assert result["firmware_version"] == "1.0.0"
+        # firmware_version is a live read of /etc/os-release VERSION_ID
+        # via release_version() since 1.4.3 (docs/architecture/versioning.md
+        # §C). The persisted Settings.firmware_version dataclass default
+        # is bypassed; the field always reflects the running OS. On CI
+        # runners with no host /etc/os-release VERSION_ID present, the
+        # helper returns "" — we only assert the field is a string.
+        assert isinstance(result["firmware_version"], str)
         # ADR-0017 loop-recording watermarks
         assert result["loop_low_watermark_percent"] == 10
         assert result["loop_hysteresis_percent"] == 5

--- a/app/shared/release_version/release_version.py
+++ b/app/shared/release_version/release_version.py
@@ -1,0 +1,101 @@
+"""Single image-side release-version helper for camera + server.
+
+Both Yocto recipes (camera-streamer, monitor-server) copy this file
+into their own package's namespace at build time:
+
+  /opt/camera/camera_streamer/release_version.py    (camera image)
+  /opt/monitor/monitor/release_version.py            (server image)
+
+Source of truth: this single file. The CI guard
+``scripts/check_versioning_design.py`` asserts both recipes install
+it from the canonical location and that no second copy with diverged
+content exists.
+
+The runtime read path is intentionally minimal:
+
+  /etc/os-release VERSION_ID
+        ↑   (templated by Yocto's os-release.bbappend from
+            ${DISTRO_VERSION}, which itself reads the repo-root
+            ``VERSION`` file at build time)
+
+This is the image-side single source of truth chosen in
+``docs/architecture/versioning.md`` §C. Older images shipped a
+hardcoded ``/etc/sw-versions`` and got it wrong on every
+fresh-flashed prod card; this helper points at the right file.
+
+The function is module-level so the same import works in both
+``camera_streamer`` and ``monitor`` packages with no plumbing.
+The result is cached on first read — release version doesn't change
+during a process lifetime, and the file is on the rootfs (no IO
+hit worth re-paying on every heartbeat).
+
+Reset behaviour: ``_clear_cache()`` is exposed for tests and for
+SIGHUP/reload paths if any caller eventually wants to refresh
+without restarting the process. Production code should not call it.
+"""
+
+from __future__ import annotations
+
+import threading
+
+__all__ = ["_clear_cache", "release_version"]
+
+_OS_RELEASE_PATH = "/etc/os-release"
+_KEY = "VERSION_ID"
+
+_lock = threading.Lock()
+_cached: str | None = None
+
+
+def _parse(path: str) -> str:
+    """Parse os-release(5) and return the value of ``VERSION_ID``.
+
+    os-release has a deceptively simple shell-assignment grammar:
+    ``KEY=value`` per line, value may be quoted with single or double
+    quotes. We don't honour escape sequences (the file is generated
+    by Yocto, never hand-edited; values are trivially ASCII).
+    Returns empty string on any failure so callers can render
+    ``"unknown"`` instead of crashing.
+    """
+    try:
+        with open(path, encoding="ascii", errors="replace") as f:
+            for line in f:
+                key, sep, value = line.strip().partition("=")
+                if not sep or key != _KEY:
+                    continue
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                    value = value[1:-1]
+                return value
+    except OSError:
+        return ""
+    return ""
+
+
+def release_version(os_release_path: str | None = None) -> str:
+    """Return the product release version (e.g. ``"1.4.3"``).
+
+    Reads ``/etc/os-release VERSION_ID`` once and caches the result.
+    Returns an empty string when the file is missing or malformed —
+    callers display ``"unknown"`` rather than failing loudly, mirroring
+    the older ``_get_firmware_version`` semantics this replaces.
+
+    Tests pass an explicit path to bypass the cache.
+    """
+    global _cached
+    if os_release_path is not None:
+        # Test mode — uncached read against an explicit path.
+        return _parse(os_release_path)
+    if _cached is not None:
+        return _cached
+    with _lock:
+        if _cached is None:
+            _cached = _parse(_OS_RELEASE_PATH)
+    return _cached
+
+
+def _clear_cache() -> None:
+    """Reset the cached value. For tests and SIGHUP-style reloads."""
+    global _cached
+    with _lock:
+        _cached = None

--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -35,6 +35,10 @@ point back here instead of duplicating the whole handbook.
 ## Existing System References
 
 - [`../architecture.md`](../architecture.md)
+- [`../architecture/versioning.md`](../architecture/versioning.md) — single
+  source of truth for product release versions; `/etc/os-release` is the
+  image-side SSOT and `release_version()` is the only allowed reader. CI
+  guards this in `scripts/check_versioning_design.py`.
 - [`../development-guide.md`](../development-guide.md)
 - [`../testing-guide.md`](../testing-guide.md)
 - [`../build-setup.md`](../build-setup.md)

--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -12,10 +12,12 @@ LICENSE = "AGPL-3.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=73f1eb20517c55bf9493b7dd6e480788"
 
 # Source files from app/camera/ directory in the repo
-FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/camera:"
+# Plus app/shared/ for cross-package helpers (release_version)
+FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/camera:${THISDIR}/../../../app/shared:"
 
 SRC_URI = " \
     file://camera_streamer/ \
+    file://release_version/release_version.py \
     file://config/camera-streamer.service \
     file://config/camera-hotspot.service \
     file://config/camera-hotspot.sh \
@@ -63,6 +65,12 @@ do_install() {
     install -d ${D}/opt/camera
     cp -r ${WORKDIR}/camera_streamer ${D}/opt/camera/
     install -m 0644 ${WORKDIR}/setup.py ${D}/opt/camera/
+
+    # Shared release_version helper (single source of truth in
+    # app/shared/release_version/; identical copy installed in the
+    # monitor-server image). See docs/architecture/versioning.md.
+    install -m 0644 ${WORKDIR}/release_version.py \
+        ${D}/opt/camera/camera_streamer/release_version.py
 
     # Default config (copied to /data on first boot)
     install -m 0644 ${WORKDIR}/config/camera.conf.default ${D}/opt/camera/camera.conf.default

--- a/meta-home-monitor/recipes-core/sw-versions/files/sw-versions
+++ b/meta-home-monitor/recipes-core/sw-versions/files/sw-versions
@@ -1,1 +1,0 @@
-home-monitor 1.0.0

--- a/meta-home-monitor/recipes-core/sw-versions/sw-versions_1.0.bb
+++ b/meta-home-monitor/recipes-core/sw-versions/sw-versions_1.0.bb
@@ -3,13 +3,24 @@ DESCRIPTION = "Provides /etc/sw-versions for SWUpdate version tracking"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = "file://sw-versions"
+# NOTE: no SRC_URI — the file is generated at build time from
+# ${DISTRO_VERSION} (which reads the repo-root VERSION file via
+# the distro conf). The static baseline that used to live in
+# files/sw-versions hard-coded "home-monitor 1.0.0" and shipped
+# wrong on every fresh-flashed prod card. See
+# docs/architecture/versioning.md §C and the v1.4.3 CHANGELOG.
 
 inherit allarch
 
 do_install() {
     install -d ${D}${sysconfdir}
-    install -m 0644 ${WORKDIR}/sw-versions ${D}${sysconfdir}/sw-versions
+    # Single line, "<component> <version>" — matches what SWUpdate's
+    # post-install hook would write after a successful OTA. Keeping
+    # the SAME format means the SWUpdate identify mechanism still
+    # works without churn; what changes is that fresh-flashed images
+    # no longer ship with a stale "1.0.0" placeholder.
+    echo "home-monitor ${DISTRO_VERSION}" > ${D}${sysconfdir}/sw-versions
+    chmod 0644 ${D}${sysconfdir}/sw-versions
 }
 
 FILES:${PN} = "${sysconfdir}/sw-versions"

--- a/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
+++ b/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
@@ -12,10 +12,12 @@ LICENSE = "AGPL-3.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=73f1eb20517c55bf9493b7dd6e480788"
 
 # Source files from app/server/ directory in the repo
-FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/server:"
+# Plus app/shared/ for cross-package helpers (release_version)
+FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/server:${THISDIR}/../../../app/shared:"
 
 SRC_URI = " \
     file://monitor/ \
+    file://release_version/release_version.py \
     file://config/monitor.service \
     file://config/monitor-hotspot.service \
     file://config/monitor-hotspot.sh \
@@ -58,6 +60,12 @@ do_install() {
     cp -r ${WORKDIR}/monitor ${D}/opt/monitor/
     install -m 0644 ${WORKDIR}/setup.py ${D}/opt/monitor/
     install -m 0644 ${WORKDIR}/requirements.txt ${D}/opt/monitor/
+
+    # Shared release_version helper (single source of truth in
+    # app/shared/release_version/; identical copy installed in the
+    # camera-streamer image). See docs/architecture/versioning.md.
+    install -m 0644 ${WORKDIR}/release_version.py \
+        ${D}/opt/monitor/monitor/release_version.py
 
     # Create data directories (will be on /data partition in production)
     install -d ${D}/opt/monitor/data/recordings

--- a/scripts/check_versioning_design.py
+++ b/scripts/check_versioning_design.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Static guards for the versioning SSOT design (1.4.3).
+
+The "single source of truth" policy lives in
+``docs/architecture/versioning.md``. This script enforces it.
+
+Each check below maps to one of the seven guardrails from §G of
+that document. Failures print a specific remediation pointing back
+at the design section.
+
+Run from the repo root:
+
+    python3 scripts/check_versioning_design.py
+
+Exit code 0 on success, 1 on any failure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSION_FILE = REPO_ROOT / "VERSION"
+
+# --- Helpers -------------------------------------------------------
+
+
+def _sha256(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def _read_version() -> str:
+    return VERSION_FILE.read_text(encoding="utf-8").strip()
+
+
+# --- Check 1 — sw-versions recipe is templated ---------------------
+
+
+def check_sw_versions_recipe_templated() -> list[str]:
+    """The recipe must NOT install a static file. It must template
+    ``${DISTRO_VERSION}`` into ``/etc/sw-versions`` at build time."""
+    failures: list[str] = []
+    recipe = (
+        REPO_ROOT
+        / "meta-home-monitor"
+        / "recipes-core"
+        / "sw-versions"
+        / "sw-versions_1.0.bb"
+    )
+    if not recipe.is_file():
+        return [f"missing recipe: {recipe}"]
+    text = recipe.read_text(encoding="utf-8")
+    # Static install of a baseline file is the regression we're guarding.
+    bad_patterns = [
+        r"install -m \d+ \$\{WORKDIR\}/sw-versions\b",
+        r'SRC_URI\s*=\s*"file://sw-versions"',
+    ]
+    for pat in bad_patterns:
+        if re.search(pat, text):
+            failures.append(
+                f"{recipe.name}: matches static-baseline pattern /{pat}/ "
+                "— design §J step 1 requires a templated do_install that "
+                'echoes "home-monitor ${DISTRO_VERSION}" instead.'
+            )
+    if "DISTRO_VERSION" not in text:
+        failures.append(
+            f"{recipe.name}: does not reference ${{DISTRO_VERSION}} — the "
+            "templated do_install must use the distro variable so the "
+            "value tracks the VERSION file."
+        )
+    # The legacy static baseline file should be deleted entirely.
+    legacy_baseline = recipe.parent / "files" / "sw-versions"
+    if legacy_baseline.exists():
+        failures.append(
+            f"legacy static baseline still present at {legacy_baseline} — "
+            "the templated recipe makes this redundant; remove it (and "
+            "its parent files/ directory if empty)."
+        )
+    return failures
+
+
+# --- Check 2 — release_version helper is byte-identical in 3 places -
+
+
+def check_release_version_helper_canonical() -> list[str]:
+    """The shared helper exists at one canonical path plus an
+    identical copy in each of the camera and server packages.
+    All three must be byte-identical so neither package can drift
+    from the canonical source.
+    """
+    failures: list[str] = []
+    canonical = REPO_ROOT / "app" / "shared" / "release_version" / "release_version.py"
+    camera_copy = (
+        REPO_ROOT / "app" / "camera" / "camera_streamer" / "release_version.py"
+    )
+    server_copy = REPO_ROOT / "app" / "server" / "monitor" / "release_version.py"
+    for p in (canonical, camera_copy, server_copy):
+        if not p.is_file():
+            failures.append(f"missing release_version helper: {p}")
+    if failures:
+        return failures
+    h_canonical = _sha256(canonical)
+    h_camera = _sha256(camera_copy)
+    h_server = _sha256(server_copy)
+    if h_camera != h_canonical:
+        failures.append(
+            f"release_version drift: camera copy diverged from canonical\n"
+            f"  canonical: {canonical}  sha256={h_canonical}\n"
+            f"  camera:    {camera_copy}  sha256={h_camera}\n"
+            "Re-copy from canonical: cp app/shared/release_version/release_version.py "
+            "app/camera/camera_streamer/release_version.py"
+        )
+    if h_server != h_canonical:
+        failures.append(
+            f"release_version drift: server copy diverged from canonical\n"
+            f"  canonical: {canonical}  sha256={h_canonical}\n"
+            f"  server:    {server_copy}  sha256={h_server}\n"
+            "Re-copy from canonical: cp app/shared/release_version/release_version.py "
+            "app/server/monitor/release_version.py"
+        )
+    return failures
+
+
+# --- Check 3 — no app code reads /etc/sw-versions ------------------
+
+
+def check_no_app_reads_sw_versions() -> list[str]:
+    """After 1.4.3, application code MUST NOT read /etc/sw-versions
+    for display/heartbeat purposes. The image-side SSOT is
+    /etc/os-release VERSION_ID via release_version().
+
+    We pattern-match on actual file-system access syntax —
+    ``open("/etc/sw-versions")``, ``Path("/etc/sw-versions")``,
+    ``with open('/etc/sw-versions')`` — NOT mentions in comments
+    or docstrings. The migration commits intentionally name the
+    old path in their explanatory docstrings; flagging those would
+    force us to either delete the migration explanation or
+    obfuscate it, neither of which serves future readers.
+    """
+    failures: list[str] = []
+    # Catches open(..., '/etc/sw-versions'), Path('/etc/sw-versions'),
+    # PosixPath, etc. — any Python construct that actually opens or
+    # constructs a path object pointing at the file.
+    pattern = re.compile(rb"""(open|Path|PosixPath)\s*\(\s*["']/etc/sw-versions""")
+    scan_roots = [
+        REPO_ROOT / "app" / "camera" / "camera_streamer",
+        REPO_ROOT / "app" / "server" / "monitor",
+    ]
+    for root in scan_roots:
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            data = path.read_bytes()
+            if pattern.search(data):
+                failures.append(
+                    f"{path.relative_to(REPO_ROOT)}: opens /etc/sw-versions "
+                    "directly — design §C requires reads to go through "
+                    "release_version() (which reads /etc/os-release "
+                    "VERSION_ID instead)."
+                )
+    return failures
+
+
+# --- Check 4 — release_version is the only firmware-version source --
+
+
+def check_release_version_helper_is_only_reader() -> list[str]:
+    """No app file outside the helper module itself may parse
+    /etc/os-release directly. (One-helper rule.)
+
+    Same pattern-tightening as check 3: only flag actual
+    ``open("/etc/os-release")`` / ``Path("/etc/os-release")`` calls,
+    not docstring mentions. The migration commits explain the move
+    in prose; that prose stays.
+
+    Exceptions: ``api/system.py`` exposes a richer os-release reader
+    for the system-info endpoint (PRETTY_NAME, VARIANT_ID, etc.);
+    that reader is the documented exception per design §B.
+    """
+    failures: list[str] = []
+    pattern = re.compile(rb"""(open|Path|PosixPath)\s*\(\s*["']/etc/os-release""")
+    allowed = {
+        REPO_ROOT / "app" / "camera" / "camera_streamer" / "release_version.py",
+        REPO_ROOT / "app" / "server" / "monitor" / "release_version.py",
+        # Documented exception: server system-info endpoint reads
+        # multiple os-release fields for the dashboard. We don't
+        # collapse it into release_version() because release_version()
+        # is intentionally narrow.
+        REPO_ROOT / "app" / "server" / "monitor" / "api" / "system.py",
+    }
+    scan_roots = [
+        REPO_ROOT / "app" / "camera" / "camera_streamer",
+        REPO_ROOT / "app" / "server" / "monitor",
+    ]
+    for root in scan_roots:
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            if path in allowed:
+                continue
+            data = path.read_bytes()
+            if pattern.search(data):
+                failures.append(
+                    f"{path.relative_to(REPO_ROOT)}: opens /etc/os-release "
+                    "directly. Either route through release_version() "
+                    "(preferred) or add the file to the allowed-list in "
+                    "scripts/check_versioning_design.py with a rationale."
+                )
+    return failures
+
+
+# --- Check 5 — sw-description templates carry @@VERSION@@ ----------
+
+
+def check_sw_description_templates_use_placeholder() -> list[str]:
+    """The SWU manifest templates must use ``@@VERSION@@`` rather
+    than a hardcoded version string. ``build-swu.sh`` substitutes
+    the placeholder at build time from the VERSION file.
+    """
+    failures: list[str] = []
+    for tpl in (
+        REPO_ROOT / "swupdate" / "sw-description.camera",
+        REPO_ROOT / "swupdate" / "sw-description.server",
+    ):
+        if not tpl.is_file():
+            failures.append(f"missing template: {tpl}")
+            continue
+        text = tpl.read_text(encoding="utf-8")
+        if "@@VERSION@@" not in text:
+            failures.append(
+                f"{tpl.name}: does not contain @@VERSION@@ placeholder. "
+                "build-swu.sh would not be able to inject the release "
+                "version. Re-add the placeholder per design §B."
+            )
+        # Catch hardcoded semver-shaped strings in the version field.
+        m = re.search(r'^\s*version\s*=\s*"([^"]+)"\s*;\s*$', text, re.MULTILINE)
+        if m and m.group(1) != "@@VERSION@@":
+            failures.append(
+                f"{tpl.name}: version field is hardcoded as "
+                f'"{m.group(1)}" — must be "@@VERSION@@".'
+            )
+    return failures
+
+
+# --- Check 6 — semver tag policy (informational, advisory) ---------
+
+
+def check_release_sh_validates_semver() -> list[str]:
+    """release.sh's validate_version must accept full semver
+    including pre-release suffixes per design §E.
+    """
+    failures: list[str] = []
+    rs = REPO_ROOT / "scripts" / "release.sh"
+    if not rs.is_file():
+        return [f"missing {rs}"]
+    text = rs.read_text(encoding="utf-8")
+    # Find the validate_version function and check its regex.
+    m = re.search(
+        r'validate_version\(\)\s*\{[^}]+?\[\[\s*"\$v"\s*=~\s*([^\]]+)\]\]',
+        text,
+        re.DOTALL,
+    )
+    if not m:
+        # Couldn't introspect; not a hard fail.
+        return []
+    expr = m.group(1).strip()
+    # Strict X.Y.Z regex `^[0-9]+\.[0-9]+\.[0-9]+$` is the legacy. Per
+    # design §E we want pre-release support: optional ``-PRERELEASE`` after.
+    if expr.endswith('+$"') or "-" in expr or "PRERELEASE" in expr:
+        return []
+    # Strict-only regex hit — advisory failure (won't block builds, just nudges).
+    failures.append(
+        f"{rs.name}: validate_version regex looks strict X.Y.Z only "
+        f"(found {expr}). Per design §E, extend to allow "
+        "`X.Y.Z(-PRERELEASE)?` for rc/dev tags. Not blocking, but "
+        "outdated against the SSOT design."
+    )
+    return failures
+
+
+# --- Check 7 — VERSION file matches CHANGELOG header ---------------
+
+
+def check_version_matches_changelog() -> list[str]:
+    """``VERSION`` must equal the latest ``## [X.Y.Z]`` heading in
+    CHANGELOG.md (or the [Unreleased] entry must precede a [X.Y.Z]
+    that matches VERSION).
+    """
+    failures: list[str] = []
+    cl = REPO_ROOT / "CHANGELOG.md"
+    if not cl.is_file():
+        return [f"missing {cl}"]
+    v = _read_version()
+    text = cl.read_text(encoding="utf-8")
+    # First versioned heading after [Unreleased].
+    m = re.search(r"^## \[([0-9]+\.[0-9]+\.[0-9]+)\]", text, re.MULTILINE)
+    if not m:
+        return [f"{cl.name}: no `## [X.Y.Z]` heading found"]
+    if m.group(1) != v:
+        failures.append(
+            f"VERSION ({v}) does not match the first CHANGELOG heading "
+            f"`## [{m.group(1)}]`. Run `./scripts/release.sh prepare {v}` "
+            "or hand-edit the CHANGELOG to match."
+        )
+    return failures
+
+
+# --- Driver --------------------------------------------------------
+
+CHECKS = [
+    ("sw-versions recipe is templated", check_sw_versions_recipe_templated),
+    (
+        "release_version helper byte-identical in 3 places",
+        check_release_version_helper_canonical,
+    ),
+    ("no app code reads /etc/sw-versions", check_no_app_reads_sw_versions),
+    (
+        "release_version is the only os-release reader (one-helper rule)",
+        check_release_version_helper_is_only_reader,
+    ),
+    (
+        "sw-description templates carry @@VERSION@@",
+        check_sw_description_templates_use_placeholder,
+    ),
+    ("release.sh validates semver", check_release_sh_validates_semver),
+    ("VERSION matches CHANGELOG", check_version_matches_changelog),
+]
+
+
+def main() -> int:
+    total_failures = 0
+    for label, fn in CHECKS:
+        fails = fn()
+        if fails:
+            total_failures += len(fails)
+            print(f"FAIL [{label}]")
+            for f in fails:
+                print(f"  - {f}")
+        else:
+            print(f"OK   [{label}]")
+    if total_failures:
+        print()
+        print(
+            f"check_versioning_design: {total_failures} failure(s). See "
+            "docs/architecture/versioning.md for the policy."
+        )
+        return 1
+    print()
+    print("check_versioning_design: all guards green.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements the design landed in #191 (\`docs/architecture/versioning.md\`).

**Symptom this fixes:** every fresh-flashed prod card reported \`firmware_version=1.0.0\` regardless of release, because both the camera local status page and the server heartbeat read \`/etc/sw-versions\` which shipped hardcoded as \`home-monitor 1.0.0\` and was only updated by SWUpdate's post-install hook during OTA.

**The fix:** runtime version display reads \`/etc/os-release VERSION_ID\` (already correctly templated by Yocto). \`/etc/sw-versions\` is now also templated (belt-and-suspenders for SWUpdate identify) but no longer read by app code.

## Changes

- **Yocto recipe templated** — \`meta-home-monitor/recipes-core/sw-versions/sw-versions_1.0.bb\` now does \`echo "home-monitor \${DISTRO_VERSION}" > \${D}\${sysconfdir}/sw-versions\` at build time. The legacy \`files/sw-versions\` static baseline is deleted.
- **Shared helper** at \`app/shared/release_version/release_version.py\` (canonical) plus byte-identical copies in \`app/camera/camera_streamer/release_version.py\` and \`app/server/monitor/release_version.py\`. Both Yocto recipes pull from the canonical at build time and install into the package's namespace.
- **5 call sites refactored** to use the helper: \`heartbeat.py\`, \`status_server.py\`, \`settings_service.py\`, \`api/ota.py\`, \`api/system.py\`.
- **CI guards** in \`scripts/check_versioning_design.py\` (wired into Repo Governance):
  1. sw-versions recipe templated (no static baseline)
  2. Helper byte-identical in 3 locations
  3. No app code opens \`/etc/sw-versions\`
  4. No app code opens \`/etc/os-release\` outside the helper (api/system.py is documented exception)
  5. SWU templates carry \`@@VERSION@@\` placeholder
  6. release.sh validates semver
  7. VERSION ↔ CHANGELOG match
- **12 unit tests** for the helper.
- **\`docs/ai/index.md\`** points at the design.

## Hardware verification (already done)

Hot-deployed \`scripts/deploy-dev-app.sh --camera 192.168.1.115\` from this branch:

\`\`\`
Pre:  firmware_version = 'v1.4.1-dev-migrate'  (from /etc/sw-versions)
Post: firmware_version = '1.4.1'               (from /etc/os-release via helper)
\`\`\`

Server's cameras.json updated within one heartbeat cycle. Helper returns \`'1.4.1'\` from all 3 call paths (release_version() direct, heartbeat \`_get_firmware_version\`, status_server \`_get_firmware_version\`).

## Test plan

- [x] Ruff clean
- [x] \`scripts/check_versioning_design.py\` — 7/7 OK
- [x] \`pytest tests/unit/test_release_version.py\` — 12 passed
- [x] Adjacent suite (\`test_ota_installer\`, \`test_systemd_hardening\`) — 24 passed, no regressions
- [x] Hot-deploy verified on .115 → \`1.4.1\` end-to-end
- [ ] CI green
- [ ] Build dev + prod; confirm rootfs \`/etc/os-release\` and \`/etc/sw-versions\` agree on \`1.4.3\` after the version bump

After merge: \`scripts/release.sh prepare 1.4.3\` → tag → build → release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)