### PR TITLE
fix(recipe): release_version.py install path bug — broke v1.4.3 build

### DIFF
--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -69,7 +69,8 @@ do_install() {
     # Shared release_version helper (single source of truth in
     # app/shared/release_version/; identical copy installed in the
     # monitor-server image). See docs/architecture/versioning.md.
-    install -m 0644 ${WORKDIR}/release_version.py \
+    # The file:// fetcher preserves the subdir name under WORKDIR.
+    install -m 0644 ${WORKDIR}/release_version/release_version.py \
         ${D}/opt/camera/camera_streamer/release_version.py
 
     # Default config (copied to /data on first boot)

--- a/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
+++ b/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
@@ -64,7 +64,8 @@ do_install() {
     # Shared release_version helper (single source of truth in
     # app/shared/release_version/; identical copy installed in the
     # camera-streamer image). See docs/architecture/versioning.md.
-    install -m 0644 ${WORKDIR}/release_version.py \
+    # The file:// fetcher preserves the subdir name under WORKDIR.
+    install -m 0644 ${WORKDIR}/release_version/release_version.py \
         ${D}/opt/monitor/monitor/release_version.py
 
     # Create data directories (will be on /data partition in production)


### PR DESCRIPTION
Yocto's file:// fetcher preserves subdir structure under ${WORKDIR}. The install path didn't account for that, breaking monitor-server do_install during the v1.4.3 build. One-line fix in each of the two recipes.