### PR TITLE
docs(recording-scheduler): correct stale module docstring on motion mode

### DIFF
--- a/app/server/monitor/services/recording_scheduler.py
+++ b/app/server/monitor/services/recording_scheduler.py
@@ -6,7 +6,13 @@ Policy (per tick, per camera):
     mode == "off"         → recorder stopped.
     mode == "continuous"  → recorder running while camera is paired.
     mode == "schedule"    → recorder running iff now-in-window(schedule, now).
-    mode == "motion"      → treated as "off" (reserved for future motion ADR).
+    mode == "motion"      → recorder running iff a motion event is currently
+                            in progress, OR within `motion_post_roll_seconds`
+                            of its end. Requires a `motion_event_store` to be
+                            wired in (see ADR-0021); without one, motion mode
+                            silently evaluates to False — the same fail-safe
+                            pre-Phase-4 behaviour the docstring used to claim
+                            was the permanent design.
 
 When turning a recorder on, the scheduler also asks the camera to start
 streaming (if `desired_stream_state == "stopped"`), persists the new


### PR DESCRIPTION
## Summary

Cleanup item flagged in the self-review of PR #202 (motion-mode pre-roll exec plan).

The module docstring at the top of `app/server/monitor/services/recording_scheduler.py` still claimed:

> `mode == "motion"  → treated as "off" (reserved for future motion ADR).`

This has been wrong since **ADR-0021** (camera-side motion detection) shipped. The actual code at lines 207–220 of the same file already evaluates motion mode via `motion_event_store.is_camera_active(post_roll_seconds=...)`. The risk of leaving the docstring stale is real: a future agent reading the policy block as ground truth could "fix" the working code back to the no-op described.

Replaces the stale line with an accurate paragraph that names the actual behaviour, including the fail-safe "no event store wired in → silent False" branch so the optionality remains visible.

## Self-review

- One concern, doc-only edit. No code paths touched.
- The new docstring stays consistent with the docstring on `evaluate_recording()` further down (lines 196–200) — they now describe the same thing.
- ADR-0021 is the cited authority; consistent with how other docstrings in this file reference ADRs.
- Behaviour unchanged. No tests added because nothing executable changed; existing `test_recording_scheduler.py` tests already cover the motion-mode path.

## Test plan

- [x] `pre-commit run --files app/server/monitor/services/recording_scheduler.py` — passed (ruff, ruff format, validate-ai-repo-setup, check-doc-links)
- [ ] CI on this PR (will watch and merge with `--admin` after green per standing instruction)

## Deployment impact

**None.** Comment-only change. No image rebuild, no behavior change, no test impact.

## Doc impact

This **is** the doc impact. ADR-0021's "Open items" section will be updated separately when the pre-roll work in PR #202's plan flips its feature flag default-on (Phase 4).