### PR TITLE
feat(server): alert center backend (ADR-0024, #132)

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -14,6 +14,7 @@ from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from monitor.logging_config import configure_logging
+from monitor.services.alert_center_service import AlertCenterService
 from monitor.services.audit import AuditLogger
 from monitor.services.camera_control_client import CameraControlClient
 from monitor.services.camera_ota_client import CameraOTAClient
@@ -180,6 +181,17 @@ def _init_infrastructure(app):
     app.motion_clip_correlator = MotionClipCorrelator(
         app.config["RECORDINGS_DIR"],
         clip_duration_seconds=app.config.get("CLIP_DURATION_SECONDS", 180),
+    )
+
+    # Alert center (ADR-0024) — derive-on-read view over audit, motion,
+    # and per-camera fault sources. Per-user read-state is the only new
+    # persistent surface; lives at /data/config/alert_read_state.json.
+    alert_state_path = os.path.join(app.config["CONFIG_DIR"], "alert_read_state.json")
+    app.alert_center = AlertCenterService(
+        store=app.store,
+        audit_logger=app.audit,
+        motion_event_store=app.motion_event_store,
+        read_state_path=alert_state_path,
     )
 
 
@@ -550,6 +562,7 @@ def _resume_camera_pipelines(app):
 
 def _register_blueprints(app):
     """Register all Flask blueprints."""
+    from monitor.api.alerts import alerts_bp
     from monitor.api.audit import audit_bp
     from monitor.api.cameras import cameras_bp
     from monitor.api.live import live_bp
@@ -581,6 +594,7 @@ def _register_blueprints(app):
     app.register_blueprint(storage_bp, url_prefix="/api/v1/storage")
     app.register_blueprint(webrtc_bp, url_prefix="/api/v1/webrtc")
     app.register_blueprint(audit_bp, url_prefix="/api/v1/audit")
+    app.register_blueprint(alerts_bp, url_prefix="/api/v1/alerts")
     app.register_blueprint(motion_events_bp, url_prefix="/api/v1/motion-events")
     # Click-through router at /events/<id>. Mounted at root (not /api/v1)
     # so it can issue user-navigable redirects into /recordings and /live.

--- a/app/server/monitor/api/alerts.py
+++ b/app/server/monitor/api/alerts.py
@@ -1,0 +1,156 @@
+"""
+Alert center API — list, mark-read, unread-count.
+
+Implements ADR-0024 §"API". All routes are session-authenticated; the
+service-layer permission gate (admin sees everything; viewer sees only
+fault- and motion-derived alerts) is enforced inside
+``AlertCenterService.list_alerts()``, not here. This keeps the
+defence-in-depth pattern from issue #148 — server-side filter is the
+source of truth, the UI does not render stale-but-ungated rows.
+
+Endpoints:
+  GET    /                  — list alerts (filters via query params)
+  POST   /<alert_id>/read   — mark a single alert as read for this user
+  POST   /mark-all-read     — bulk mark, respecting the same filters as GET
+  GET    /unread-count      — cheap badge count
+
+Query params on GET / and POST /mark-all-read (both share the filter set):
+  source       — "fault" | "audit" | "motion"           (optional)
+  severity     — "info" | "warning" | "error" | "critical"
+                 (treated as "at least this severe")    (optional)
+  unread_only  — "1" / "true" / etc. (GET only)
+  limit        — 1..200, default 50 (GET only)
+  before       — ISO-8601 timestamp; only alerts strictly older
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, current_app, jsonify, request, session
+
+from monitor.auth import csrf_protect, login_required
+
+log = logging.getLogger("monitor.api.alerts")
+
+alerts_bp = Blueprint("alerts", __name__)
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _current_user_and_role() -> tuple[str, str]:
+    """Return (username, role) for the active session.
+
+    Falls back to ("", "viewer") on a missing session — the
+    surrounding ``login_required`` decorator is the binding gate, but
+    we still want sane values rather than raising downstream.
+    """
+    username = session.get("username", "") or ""
+    role = session.get("role", "viewer") or "viewer"
+    return username, role
+
+
+@alerts_bp.route("/", methods=["GET"])
+@alerts_bp.route("", methods=["GET"])
+@login_required
+def list_alerts():
+    """List alerts visible to the current session, newest-first.
+
+    See module docstring for the supported query params. The
+    ``unread_count`` field is the count BEFORE pagination — the
+    nav badge should consume that, not ``len(alerts)``.
+    """
+    user, role = _current_user_and_role()
+
+    source = (request.args.get("source") or "").strip() or None
+    severity = (request.args.get("severity") or "").strip() or None
+    unread_only = _truthy(request.args.get("unread_only"))
+    before = (request.args.get("before") or "").strip() or None
+
+    try:
+        limit = int(request.args.get("limit", "50"))
+    except ValueError:
+        limit = 50
+    limit = max(1, min(limit, 200))
+
+    svc = current_app.alert_center
+    alerts = svc.list_alerts(
+        user=user,
+        role=role,
+        source=source,
+        severity=severity,
+        unread_only=unread_only,
+        limit=limit,
+        before=before,
+    )
+    unread_count = svc.unread_count(user=user, role=role)
+
+    return jsonify(
+        {
+            "alerts": alerts,
+            "count": len(alerts),
+            "unread_count": unread_count,
+        }
+    )
+
+
+@alerts_bp.route("/unread-count", methods=["GET"])
+@login_required
+def unread_count():
+    """Cheap count for the nav badge. Polled every ~30 s by the UI."""
+    user, role = _current_user_and_role()
+    count = current_app.alert_center.unread_count(user=user, role=role)
+    return jsonify({"count": count})
+
+
+@alerts_bp.route("/<alert_id>/read", methods=["POST"])
+@login_required
+@csrf_protect
+def mark_read(alert_id: str):
+    """Mark a single alert as read for the current user. Idempotent.
+
+    Returns 400 only on a clearly bogus alert_id shape (no recognised
+    typed prefix). Re-marking a read alert is a no-op success.
+    """
+    user, _ = _current_user_and_role()
+    if not user:
+        return jsonify({"ok": False, "error": "no session user"}), 401
+    ok = current_app.alert_center.mark_read(user=user, alert_id=alert_id)
+    if not ok:
+        return jsonify({"ok": False, "error": "invalid alert id"}), 400
+    return jsonify({"ok": True})
+
+
+@alerts_bp.route("/mark-all-read", methods=["POST"])
+@login_required
+@csrf_protect
+def mark_all_read():
+    """Mark every alert matching the same filter set as GET as read.
+
+    Filters can come from the JSON body OR the query string — the
+    body wins on conflict. Same shape as GET so a UI that holds the
+    current filter state can re-use it for the bulk action.
+    """
+    user, role = _current_user_and_role()
+    if not user:
+        return jsonify({"marked": 0, "error": "no session user"}), 401
+
+    body = request.get_json(silent=True) or {}
+    source = (body.get("source") or request.args.get("source") or "").strip() or None
+    severity = (
+        body.get("severity") or request.args.get("severity") or ""
+    ).strip() or None
+    before = (body.get("before") or request.args.get("before") or "").strip() or None
+
+    marked = current_app.alert_center.mark_all_read(
+        user=user,
+        role=role,
+        source=source,
+        severity=severity,
+        before=before,
+    )
+    return jsonify({"marked": marked})

--- a/app/server/monitor/services/alert_center_service.py
+++ b/app/server/monitor/services/alert_center_service.py
@@ -1,0 +1,555 @@
+"""
+AlertCenterService — derive-on-read view over existing event sources.
+
+Implements ADR-0024. The alert center is **not** a new persistent store
+of alerts — alerts are derived on every read from the three existing
+event sources:
+
+  AuditLogger          (security-relevant audit events)
+  MotionEventStore     (motion detections with clip correlation)
+  Camera.hardware_faults (per-heartbeat fault snapshot, ADR-0023)
+
+The only new persistent state is a small per-user read-flag map at
+``/data/config/alert_read_state.json``. Atomic writes (tempfile +
+os.replace) match the rest of the codebase (ADR-0002).
+
+Catalogue (per ADR-0024 §"What counts as an alert"):
+
+  Faults:  severity in {warning, error, critical}  (info excluded)
+  Audit:   OTA_FAILED, OTA_ROLLBACK, CAMERA_OFFLINE,
+           CERT_REVOKED, FIREWALL_BLOCKED
+  Motion:  closed events with peak_score >= MOTION_NOTIFICATION_THRESHOLD
+           (default; per-camera override is a future-slice concern)
+
+Permission model (defence-in-depth — server-side filter is the source of
+truth, the UI does not render stale-but-ungated rows):
+
+  Viewers see fault- and motion-derived alerts only.
+  Admins see everything (faults + audit + motion).
+
+Alert IDs are stable across reads so per-user state survives. Typed
+prefixes:
+
+  fault:<camera_id>:<code>           — derived from Camera.hardware_faults
+  audit:<sha256(line)[:16]>          — content-hashed audit line
+  motion:<motion_event_id>           — natural ID from MotionEventStore
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import threading
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+log = logging.getLogger("monitor.alert_center")
+
+
+# ---------------------------------------------------------------------------
+# Catalogue — what counts as an alert
+# ---------------------------------------------------------------------------
+
+# Audit event names that are user-visible alerts. Per ADR-0024:
+#   LOGIN_FAILED is intentionally excluded — the audit teaser
+#   (issue #148) is the right surface for login storms; surfacing
+#   them in the alert center too would drown the inbox.
+ALERT_AUDIT_EVENTS: frozenset[str] = frozenset(
+    {
+        "OTA_FAILED",
+        "OTA_ROLLBACK",
+        "CAMERA_OFFLINE",
+        "CERT_REVOKED",
+        "FIREWALL_BLOCKED",
+    }
+)
+
+# Severity threshold for fault-derived alerts. info-level faults are
+# diagnostic (e.g. "thermal headroom shrinking") and stay on the
+# camera card, not in the inbox.
+ALERT_FAULT_SEVERITIES: frozenset[str] = frozenset({"warning", "error", "critical"})
+
+# Per-camera notification threshold default. Each motion event with a
+# peak_score at or above this is alert-worthy. ADR-0024 defers a
+# per-camera tunable to a later slice (#121); for now, one global
+# default that's well above ambient sensor noise.
+MOTION_NOTIFICATION_THRESHOLD: float = 0.05
+
+# Default severity mapping for audit events. The audit log has no
+# native severity field, so the alert center assigns one from the
+# catalogue. Anything not listed gets "warning" as a safe default.
+_AUDIT_SEVERITY: dict[str, str] = {
+    "OTA_FAILED": "error",
+    "OTA_ROLLBACK": "warning",
+    "CAMERA_OFFLINE": "warning",
+    "CERT_REVOKED": "critical",
+    "FIREWALL_BLOCKED": "warning",
+}
+
+# Severity ordering so the API can sort / filter by "at least this bad."
+_SEVERITY_ORDER = {"info": 0, "warning": 1, "error": 2, "critical": 3}
+
+# Schema version for the read-state file. Bump on any breaking shape
+# change so a forward-rolling install can migrate cleanly. v1 is the
+# initial layout below.
+READ_STATE_SCHEMA_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Alert dataclass — wire-format shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Alert:
+    """Single row in the alert center.
+
+    Derived on read; not persisted as such. ``is_read`` and ``read_at``
+    are joined from the per-user read-state file.
+    """
+
+    id: str
+    source: str  # "fault" | "audit" | "motion"
+    severity: str  # "info" | "warning" | "error" | "critical"
+    timestamp: str  # ISO-8601 UTC with trailing Z
+    subject: dict  # {"type": "camera", "id": "cam-d8ee"} | {"type": "server"}
+    message: str
+    deep_link: str
+    is_read: bool = False
+    read_at: str | None = None
+    hint: str = ""
+    context: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class AlertCenterService:
+    """Derive alerts on read from existing event sources; persist read state.
+
+    Constructor is dependency-injected (service-layer pattern, ADR-0003).
+    No I/O in ``__init__`` beyond a one-time read-state file read; all
+    real work happens in the public methods.
+
+    Args:
+        store: Server-side data store (used to enumerate cameras +
+            their persisted hardware_faults).
+        audit_logger: AuditLogger for the audit-derived alerts.
+        motion_event_store: MotionEventStore for motion-derived alerts.
+        read_state_path: Where to persist the per-user read-flag JSON.
+            Created on first write; safe to point at a path that
+            doesn't exist yet.
+    """
+
+    def __init__(
+        self,
+        *,
+        store,
+        audit_logger,
+        motion_event_store,
+        read_state_path: str | Path,
+    ):
+        self._store = store
+        self._audit = audit_logger
+        self._motion = motion_event_store
+        self._path = Path(read_state_path)
+        self._lock = threading.Lock()
+        self._read_state: dict[str, dict[str, str]] = self._load_read_state()
+
+    # -- public API ---------------------------------------------------------
+
+    def list_alerts(
+        self,
+        *,
+        user: str,
+        role: str,
+        source: str | None = None,
+        severity: str | None = None,
+        unread_only: bool = False,
+        limit: int = 50,
+        before: str | None = None,
+    ) -> list[dict]:
+        """Return alerts visible to ``(user, role)``, newest first.
+
+        Filters and the role-aware permission gate are applied
+        server-side. The dashboard / inbox UI may not bypass these
+        by sending a different role string — Flask's session/role
+        machinery (``admin_required`` / ``login_required``) is the
+        binding source of truth at the API layer.
+        """
+        alerts = self._compute_alerts(role=role)
+        alerts = self._apply_read_state(alerts, user=user)
+
+        if source:
+            alerts = [a for a in alerts if a.source == source]
+        if severity:
+            min_rank = _SEVERITY_ORDER.get(severity, -1)
+            alerts = [
+                a for a in alerts if _SEVERITY_ORDER.get(a.severity, 0) >= min_rank
+            ]
+        if unread_only:
+            alerts = [a for a in alerts if not a.is_read]
+        if before:
+            alerts = [a for a in alerts if a.timestamp < before]
+
+        # Sort by timestamp descending. A stable sort means same-second
+        # alerts keep source-derived insertion order.
+        alerts.sort(key=lambda a: a.timestamp, reverse=True)
+
+        if limit > 0:
+            alerts = alerts[:limit]
+
+        return [asdict(a) for a in alerts]
+
+    def unread_count(self, *, user: str, role: str) -> int:
+        """Cheap count for the nav badge.
+
+        Walks the same compute path as ``list_alerts`` but skips the
+        sort + serialise. The cost is bounded by audit_log_lines +
+        motion_events + active_faults — all small.
+        """
+        alerts = self._compute_alerts(role=role)
+        alerts = self._apply_read_state(alerts, user=user)
+        return sum(1 for a in alerts if not a.is_read)
+
+    def mark_read(self, *, user: str, alert_id: str) -> bool:
+        """Mark a single alert as read for this user. Idempotent.
+
+        Returns True on success, False on a clearly bogus alert_id
+        shape (the only failure mode — we do NOT validate that the
+        alert currently exists, because the source might be paginated
+        or compacted between the user's view and the click).
+        """
+        if not _looks_like_alert_id(alert_id):
+            return False
+        if not user:
+            return False
+
+        ts = _now_z()
+        with self._lock:
+            self._read_state.setdefault(user, {})[alert_id] = ts
+            self._persist_locked()
+        return True
+
+    def mark_all_read(
+        self,
+        *,
+        user: str,
+        role: str,
+        source: str | None = None,
+        severity: str | None = None,
+        before: str | None = None,
+    ) -> int:
+        """Mark every alert matching the same filters as ``list_alerts``.
+
+        Filters mirror ``list_alerts`` so a user clicking "mark all
+        read" while filtered to severity=error doesn't accidentally
+        clear the warning badge too. Returns the count actually
+        flipped (i.e. previously unread + now-read). Re-marking
+        already-read alerts does not increment the count.
+        """
+        alerts = self._compute_alerts(role=role)
+        alerts = self._apply_read_state(alerts, user=user)
+
+        if source:
+            alerts = [a for a in alerts if a.source == source]
+        if severity:
+            min_rank = _SEVERITY_ORDER.get(severity, -1)
+            alerts = [
+                a for a in alerts if _SEVERITY_ORDER.get(a.severity, 0) >= min_rank
+            ]
+        if before:
+            alerts = [a for a in alerts if a.timestamp < before]
+
+        ts = _now_z()
+        flipped = 0
+        with self._lock:
+            user_state = self._read_state.setdefault(user, {})
+            for a in alerts:
+                if a.is_read:
+                    continue
+                user_state[a.id] = ts
+                flipped += 1
+            if flipped:
+                self._persist_locked()
+        return flipped
+
+    def forget_user(self, user: str) -> bool:
+        """Drop all read state for a deleted user.
+
+        Called by UserService.delete via the cascade hook documented
+        in ADR-0024 §"Storage". Idempotent — calling on an unknown
+        user is a no-op.
+        """
+        if not user:
+            return False
+        with self._lock:
+            if user not in self._read_state:
+                return False
+            del self._read_state[user]
+            self._persist_locked()
+        return True
+
+    # -- alert derivation ---------------------------------------------------
+
+    def _compute_alerts(self, *, role: str) -> list[Alert]:
+        """Walk all three sources and emit alert records.
+
+        Permission gate applied here, not at the API layer, so any
+        future caller (e.g. the dashboard summary service drilling
+        into a "you have N alerts" deep-link) gets the same view.
+        """
+        out: list[Alert] = []
+        is_admin = role == "admin"
+
+        # --- faults (visible to everyone) ---
+        try:
+            cameras = self._store.get_cameras()
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("alert_center: failed to load cameras: %s", exc)
+            cameras = []
+
+        for cam in cameras:
+            for fault in getattr(cam, "hardware_faults", None) or []:
+                if not isinstance(fault, dict):
+                    continue
+                severity = fault.get("severity") or "warning"
+                if severity not in ALERT_FAULT_SEVERITIES:
+                    continue
+                code = fault.get("code") or "unknown"
+                ts = fault.get("opened_at") or fault.get("timestamp") or _now_z()
+                out.append(
+                    Alert(
+                        id=f"fault:{cam.id}:{code}",
+                        source="fault",
+                        severity=severity,
+                        timestamp=_normalise_iso_z(ts),
+                        subject={"type": "camera", "id": cam.id},
+                        message=fault.get("message") or code,
+                        hint=fault.get("hint") or "",
+                        context=fault.get("context") or {},
+                        deep_link="/dashboard#cameras-section",
+                    )
+                )
+
+        # --- audit (admin only) ---
+        if is_admin:
+            try:
+                audit_events = self._audit.get_events(limit=500)
+            except Exception as exc:  # pragma: no cover
+                log.warning("alert_center: failed to load audit: %s", exc)
+                audit_events = []
+
+            for ev in audit_events:
+                code = ev.get("event") or ""
+                if code not in ALERT_AUDIT_EVENTS:
+                    continue
+                line_repr = json.dumps(ev, sort_keys=True, separators=(",", ":"))
+                alert_id = (
+                    f"audit:{hashlib.sha256(line_repr.encode()).hexdigest()[:16]}"
+                )
+                out.append(
+                    Alert(
+                        id=alert_id,
+                        source="audit",
+                        severity=_AUDIT_SEVERITY.get(code, "warning"),
+                        timestamp=_normalise_iso_z(ev.get("timestamp") or _now_z()),
+                        subject=_audit_subject(ev),
+                        message=_audit_message(ev),
+                        context={
+                            "user": ev.get("user", ""),
+                            "ip": ev.get("ip", ""),
+                            "detail": ev.get("detail", ""),
+                        },
+                        deep_link="/logs",
+                    )
+                )
+
+        # --- motion (visible to everyone) ---
+        try:
+            motion_events = self._motion.list_events(limit=500)
+        except Exception as exc:  # pragma: no cover
+            log.warning("alert_center: failed to load motion events: %s", exc)
+            motion_events = []
+
+        for evt in motion_events:
+            ended_at = getattr(evt, "ended_at", None)
+            if not ended_at:
+                continue  # still in progress; not yet alert-worthy
+            peak_score = float(getattr(evt, "peak_score", 0.0) or 0.0)
+            if peak_score < MOTION_NOTIFICATION_THRESHOLD:
+                continue
+            cam_id = getattr(evt, "camera_id", "") or ""
+            evt_id = getattr(evt, "id", "") or ""
+            started_at = getattr(evt, "started_at", "") or _now_z()
+            out.append(
+                Alert(
+                    id=f"motion:{evt_id}",
+                    source="motion",
+                    severity="info" if peak_score < 0.10 else "warning",
+                    timestamp=_normalise_iso_z(started_at),
+                    subject={"type": "camera", "id": cam_id},
+                    message=f"Motion detected on {cam_id}",
+                    context={
+                        "peak_score": peak_score,
+                        "duration_seconds": getattr(evt, "duration_seconds", 0),
+                    },
+                    deep_link=f"/events/{evt_id}",
+                )
+            )
+
+        return out
+
+    # -- read state ---------------------------------------------------------
+
+    def _apply_read_state(self, alerts: list[Alert], *, user: str) -> list[Alert]:
+        """Annotate alerts with is_read / read_at for ``user``.
+
+        Read state never travels across users — each user has their
+        own map. ADR-0024 §Q2.
+        """
+        with self._lock:
+            user_state = dict(self._read_state.get(user, {}))
+        for a in alerts:
+            ts = user_state.get(a.id)
+            if ts:
+                a.is_read = True
+                a.read_at = ts
+        return alerts
+
+    def _load_read_state(self) -> dict[str, dict[str, str]]:
+        """Read the per-user read-state file. Tolerant of missing/corrupt."""
+        if not self._path.exists():
+            return {}
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning(
+                "alert_center: read-state file unreadable, starting empty: %s", exc
+            )
+            return {}
+
+        if not isinstance(data, dict):
+            return {}
+        users = data.get("users", {})
+        if not isinstance(users, dict):
+            return {}
+
+        # Defensive shape check — drop anything that doesn't match.
+        clean: dict[str, dict[str, str]] = {}
+        for u, alerts in users.items():
+            if not isinstance(u, str) or not isinstance(alerts, dict):
+                continue
+            clean[u] = {
+                k: v
+                for k, v in alerts.items()
+                if isinstance(k, str) and isinstance(v, str)
+            }
+        return clean
+
+    def _persist_locked(self) -> None:
+        """Atomic write of the read-state file. Caller holds ``self._lock``."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": READ_STATE_SCHEMA_VERSION,
+            "users": self._read_state,
+        }
+        # Atomic replace via tempfile in the same directory (must be
+        # same fs for os.replace to be atomic).
+        fd, tmp_path = tempfile.mkstemp(
+            prefix="alert_read_state.", suffix=".tmp", dir=str(self._path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, separators=(",", ":"))
+            os.replace(tmp_path, self._path)
+        except OSError as exc:
+            log.error("alert_center: failed to persist read state: %s", exc)
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _normalise_iso_z(value: str) -> str:
+    """Coerce an ISO-8601 timestamp into ``YYYY-MM-DDTHH:MM:SSZ``.
+
+    The audit log uses Z-suffixed UTC, motion events use isoformat with
+    a +00:00 offset, and some heartbeat-derived faults round-trip via
+    Python's datetime so they may also use offset notation. Sort
+    correctness depends on a single representation, so normalise.
+    """
+    if not isinstance(value, str) or not value:
+        return _now_z()
+    try:
+        # datetime.fromisoformat handles both Z and offset notations
+        # in Python 3.11+ (the runtime target per pyproject.toml).
+        normalised = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalised).astimezone(UTC)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (ValueError, TypeError):
+        return value  # fall back to raw — sort still terminates
+
+
+def _looks_like_alert_id(alert_id: str) -> bool:
+    """Cheap shape-check so the API doesn't blindly persist garbage.
+
+    Real validation lives at the source — but reading or storing an
+    alert_id with no recognised prefix is always a programming error,
+    not user input we should accept silently.
+    """
+    if not isinstance(alert_id, str) or not alert_id:
+        return False
+    return any(
+        alert_id.startswith(prefix) for prefix in ("fault:", "audit:", "motion:")
+    )
+
+
+def _audit_subject(ev: dict) -> dict:
+    """Best-effort subject inference for an audit-derived alert.
+
+    Some audit codes carry a camera_id in ``detail`` (e.g. CAMERA_OFFLINE
+    "cam-d8ee gone offline"); when we can't be sure, anchor it on the
+    server.
+    """
+    code = ev.get("event") or ""
+    detail = ev.get("detail") or ""
+    if code in {"CAMERA_OFFLINE"} and detail:
+        # Heuristic: first whitespace-delimited token.
+        token = detail.split()[0] if detail else ""
+        if token.startswith("cam-") or token.startswith("camera-"):
+            return {"type": "camera", "id": token.rstrip(":,;")}
+    return {"type": "server"}
+
+
+def _audit_message(ev: dict) -> str:
+    """Human-friendly one-line message for an audit-derived alert."""
+    code = ev.get("event") or "EVENT"
+    detail = (ev.get("detail") or "").strip()
+    label_map = {
+        "OTA_FAILED": "OTA update failed",
+        "OTA_ROLLBACK": "OTA update rolled back",
+        "CAMERA_OFFLINE": "Camera went offline",
+        "CERT_REVOKED": "Certificate revoked",
+        "FIREWALL_BLOCKED": "Firewall blocked traffic",
+    }
+    label = label_map.get(code, code.replace("_", " ").lower().capitalize())
+    if detail:
+        return f"{label}: {detail}"
+    return label

--- a/app/server/tests/integration/test_api_alerts.py
+++ b/app/server/tests/integration/test_api_alerts.py
@@ -1,0 +1,180 @@
+"""Tests for the alert center API (ADR-0024)."""
+
+from unittest.mock import MagicMock
+
+
+class TestListAlertsEndpoint:
+    def test_requires_auth(self, client):
+        response = client.get("/api/v1/alerts/")
+        assert response.status_code == 401
+
+    def test_admin_returns_alerts(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.list_alerts.return_value = [
+            {
+                "id": "fault:cam-d8ee:boom",
+                "source": "fault",
+                "severity": "error",
+                "timestamp": "2026-04-30T08:00:00Z",
+                "subject": {"type": "camera", "id": "cam-d8ee"},
+                "message": "boom",
+                "deep_link": "/dashboard#cameras-section",
+                "is_read": False,
+                "read_at": None,
+                "hint": "",
+                "context": {},
+            }
+        ]
+        app.alert_center.unread_count.return_value = 1
+        client = logged_in_client()
+        response = client.get("/api/v1/alerts/")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["count"] == 1
+        assert data["unread_count"] == 1
+        assert data["alerts"][0]["source"] == "fault"
+
+    def test_viewer_can_call_endpoint(self, app, logged_in_client):
+        # Permission filtering happens in the service layer; the API
+        # itself only requires login. Tested here so a regression that
+        # added @admin_required would fail loudly.
+        app.alert_center = MagicMock()
+        app.alert_center.list_alerts.return_value = []
+        app.alert_center.unread_count.return_value = 0
+        client = logged_in_client("viewer")
+        response = client.get("/api/v1/alerts/")
+        assert response.status_code == 200
+
+    def test_filters_passed_through(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.list_alerts.return_value = []
+        app.alert_center.unread_count.return_value = 0
+        client = logged_in_client()
+        client.get(
+            "/api/v1/alerts/?source=motion&severity=warning"
+            "&unread_only=1&limit=10&before=2026-04-30T00:00:00Z"
+        )
+        kwargs = app.alert_center.list_alerts.call_args.kwargs
+        assert kwargs["source"] == "motion"
+        assert kwargs["severity"] == "warning"
+        assert kwargs["unread_only"] is True
+        assert kwargs["limit"] == 10
+        assert kwargs["before"] == "2026-04-30T00:00:00Z"
+
+    def test_limit_clamped(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.list_alerts.return_value = []
+        app.alert_center.unread_count.return_value = 0
+        client = logged_in_client()
+        client.get("/api/v1/alerts/?limit=99999")
+        assert app.alert_center.list_alerts.call_args.kwargs["limit"] == 200
+        client.get("/api/v1/alerts/?limit=0")
+        assert app.alert_center.list_alerts.call_args.kwargs["limit"] == 1
+        client.get("/api/v1/alerts/?limit=abc")
+        assert app.alert_center.list_alerts.call_args.kwargs["limit"] == 50
+
+    def test_unread_count_independent_of_pagination(self, app, logged_in_client):
+        # The badge consumes unread_count, not len(alerts) — even with
+        # limit=1 the response surfaces the full unread total.
+        app.alert_center = MagicMock()
+        app.alert_center.list_alerts.return_value = [{"id": "x", "source": "fault"}]
+        app.alert_center.unread_count.return_value = 17
+        client = logged_in_client()
+        response = client.get("/api/v1/alerts/?limit=1")
+        data = response.get_json()
+        assert data["count"] == 1
+        assert data["unread_count"] == 17
+
+
+class TestUnreadCountEndpoint:
+    def test_requires_auth(self, client):
+        response = client.get("/api/v1/alerts/unread-count")
+        assert response.status_code == 401
+
+    def test_returns_count(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.unread_count.return_value = 3
+        client = logged_in_client()
+        response = client.get("/api/v1/alerts/unread-count")
+        assert response.status_code == 200
+        assert response.get_json() == {"count": 3}
+
+    def test_user_and_role_passed_to_service(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.unread_count.return_value = 0
+        client = logged_in_client("viewer", username="bob")
+        client.get("/api/v1/alerts/unread-count")
+        kwargs = app.alert_center.unread_count.call_args.kwargs
+        assert kwargs["user"] == "bob"
+        assert kwargs["role"] == "viewer"
+
+
+class TestMarkReadEndpoint:
+    def test_requires_auth(self, client):
+        response = client.post("/api/v1/alerts/audit:abcd/read")
+        assert response.status_code == 401
+
+    def test_marks_alert_read(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.mark_read.return_value = True
+        client = logged_in_client()
+        response = client.post("/api/v1/alerts/fault:cam-d8ee:boom/read")
+        assert response.status_code == 200
+        assert response.get_json() == {"ok": True}
+        kwargs = app.alert_center.mark_read.call_args.kwargs
+        assert kwargs["user"] == "admin"
+        assert kwargs["alert_id"] == "fault:cam-d8ee:boom"
+
+    def test_invalid_id_returns_400(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.mark_read.return_value = False
+        client = logged_in_client()
+        response = client.post("/api/v1/alerts/garbage/read")
+        assert response.status_code == 400
+
+
+class TestMarkAllReadEndpoint:
+    def test_requires_auth(self, client):
+        response = client.post("/api/v1/alerts/mark-all-read")
+        assert response.status_code == 401
+
+    def test_marks_all_read(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.mark_all_read.return_value = 5
+        client = logged_in_client()
+        response = client.post("/api/v1/alerts/mark-all-read")
+        assert response.status_code == 200
+        assert response.get_json() == {"marked": 5}
+
+    def test_filters_from_body(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.mark_all_read.return_value = 0
+        client = logged_in_client()
+        client.post(
+            "/api/v1/alerts/mark-all-read",
+            json={"source": "motion", "severity": "warning"},
+        )
+        kwargs = app.alert_center.mark_all_read.call_args.kwargs
+        assert kwargs["source"] == "motion"
+        assert kwargs["severity"] == "warning"
+
+    def test_filters_from_query_string(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.mark_all_read.return_value = 0
+        client = logged_in_client()
+        client.post(
+            "/api/v1/alerts/mark-all-read?source=audit&before=2026-04-30T00:00:00Z"
+        )
+        kwargs = app.alert_center.mark_all_read.call_args.kwargs
+        assert kwargs["source"] == "audit"
+        assert kwargs["before"] == "2026-04-30T00:00:00Z"
+
+    def test_body_wins_over_query_string(self, app, logged_in_client):
+        app.alert_center = MagicMock()
+        app.alert_center.mark_all_read.return_value = 0
+        client = logged_in_client()
+        client.post(
+            "/api/v1/alerts/mark-all-read?source=audit",
+            json={"source": "motion"},
+        )
+        assert app.alert_center.mark_all_read.call_args.kwargs["source"] == "motion"

--- a/app/server/tests/unit/test_app.py
+++ b/app/server/tests/unit/test_app.py
@@ -76,14 +76,15 @@ class TestBlueprintRegistration:
         assert "provisioning" in app.blueprints
 
     def test_all_blueprints_count(self, app):
-        """We expect exactly 17 blueprints.
+        """We expect exactly 18 blueprints.
 
         Count history:
           14 after ADR-0017 added `on_demand`.
           15 after ADR-0018 Slice 3 added the `audit` read-only API.
           17 after motion-detection work (motion_events API + events_router).
+          18 after ADR-0024 added the `alerts` API (#132).
         """
-        assert len(app.blueprints) == 17
+        assert len(app.blueprints) == 18
 
     def test_on_demand_blueprint_registered(self, app):
         assert "on_demand" in app.blueprints

--- a/app/server/tests/unit/test_svc_alert_center.py
+++ b/app/server/tests/unit/test_svc_alert_center.py
@@ -1,0 +1,580 @@
+"""Tests for AlertCenterService — ADR-0024 derive-on-read alert center."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
+
+from monitor.services.alert_center_service import (
+    ALERT_AUDIT_EVENTS,
+    ALERT_FAULT_SEVERITIES,
+    AlertCenterService,
+    _audit_message,
+    _audit_subject,
+    _looks_like_alert_id,
+    _normalise_iso_z,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures — minimal stubs so tests don't pull the whole app factory
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeMotionEvent:
+    id: str
+    camera_id: str
+    started_at: str
+    ended_at: str | None = None
+    peak_score: float = 0.0
+    duration_seconds: float = 0.0
+
+
+@dataclass
+class _FakeCamera:
+    id: str
+    hardware_faults: list[dict] = field(default_factory=list)
+
+
+def _make_service(tmp_path, *, cameras=None, audit_events=None, motion_events=None):
+    """Build an AlertCenterService backed by mocked sources."""
+    store = MagicMock()
+    store.get_cameras.return_value = cameras or []
+
+    audit = MagicMock()
+    audit.get_events.return_value = audit_events or []
+
+    motion = MagicMock()
+    motion.list_events.return_value = motion_events or []
+
+    return AlertCenterService(
+        store=store,
+        audit_logger=audit,
+        motion_event_store=motion,
+        read_state_path=str(tmp_path / "config" / "alert_read_state.json"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Catalogue + helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogue:
+    def test_audit_catalogue_excludes_login_failed(self):
+        # ADR-0024: LOGIN_FAILED stays in the audit teaser, not the
+        # alert center. Regression test for the explicit decision.
+        assert "LOGIN_FAILED" not in ALERT_AUDIT_EVENTS
+
+    def test_audit_catalogue_includes_critical_codes(self):
+        for code in ("OTA_FAILED", "OTA_ROLLBACK", "CAMERA_OFFLINE", "CERT_REVOKED"):
+            assert code in ALERT_AUDIT_EVENTS
+
+    def test_fault_severities_exclude_info(self):
+        # info-level faults stay on the camera card; not alert-worthy.
+        assert "info" not in ALERT_FAULT_SEVERITIES
+        assert "warning" in ALERT_FAULT_SEVERITIES
+        assert "error" in ALERT_FAULT_SEVERITIES
+        assert "critical" in ALERT_FAULT_SEVERITIES
+
+
+class TestAlertIdShape:
+    def test_recognises_typed_prefixes(self):
+        assert _looks_like_alert_id("fault:cam-d8ee:sensor_missing")
+        assert _looks_like_alert_id("audit:abcdef0123456789")
+        assert _looks_like_alert_id("motion:mot-20260430T071122Z-cam-d8ee")
+
+    def test_rejects_garbage(self):
+        assert not _looks_like_alert_id("")
+        assert not _looks_like_alert_id("hello-world")
+        assert not _looks_like_alert_id("UNKNOWN:foo")
+        assert not _looks_like_alert_id(None)  # type: ignore[arg-type]
+
+
+class TestTimestampNormalisation:
+    def test_iso_with_offset_to_z(self):
+        assert _normalise_iso_z("2026-04-30T08:14:02+00:00") == "2026-04-30T08:14:02Z"
+
+    def test_already_z(self):
+        assert _normalise_iso_z("2026-04-30T08:14:02Z") == "2026-04-30T08:14:02Z"
+
+    def test_garbage_falls_through(self):
+        assert _normalise_iso_z("not-a-timestamp") == "not-a-timestamp"
+
+    def test_empty_returns_now(self):
+        out = _normalise_iso_z("")
+        # We don't pin the exact time but it must end with Z.
+        assert out.endswith("Z")
+
+
+class TestAuditSubjectInference:
+    def test_camera_offline_with_camid_in_detail(self):
+        subj = _audit_subject(
+            {"event": "CAMERA_OFFLINE", "detail": "cam-d8ee gone offline"}
+        )
+        assert subj == {"type": "camera", "id": "cam-d8ee"}
+
+    def test_camera_offline_without_camid_falls_back_to_server(self):
+        subj = _audit_subject({"event": "CAMERA_OFFLINE", "detail": ""})
+        assert subj == {"type": "server"}
+
+    def test_ota_failed_anchors_on_server(self):
+        subj = _audit_subject({"event": "OTA_FAILED", "detail": "verify failed"})
+        assert subj == {"type": "server"}
+
+
+class TestAuditMessage:
+    def test_known_code_uses_label(self):
+        assert "OTA update failed" in _audit_message(
+            {"event": "OTA_FAILED", "detail": "verify failed"}
+        )
+
+    def test_unknown_code_falls_through(self):
+        msg = _audit_message({"event": "MYSTERY_EVENT", "detail": ""})
+        assert "Mystery event" in msg or "MYSTERY_EVENT" in msg
+
+
+# ---------------------------------------------------------------------------
+# Service-level behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAlerts:
+    """Test which alerts each role sees."""
+
+    def test_admin_sees_all_three_sources(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[
+                    {
+                        "code": "camera_sensor_missing",
+                        "severity": "error",
+                        "message": "Camera sensor missing",
+                    }
+                ],
+            ),
+        ]
+        audit_events = [
+            {
+                "timestamp": "2026-04-30T08:14:02Z",
+                "event": "OTA_FAILED",
+                "user": "admin",
+                "ip": "1.2.3.4",
+                "detail": "verify failed",
+            }
+        ]
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-1",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:00:00Z",
+                ended_at="2026-04-30T08:00:15Z",
+                peak_score=0.18,
+            )
+        ]
+        svc = _make_service(
+            tmp_path,
+            cameras=cameras,
+            audit_events=audit_events,
+            motion_events=motion_events,
+        )
+        result = svc.list_alerts(user="alice", role="admin")
+        sources = {a["source"] for a in result}
+        assert sources == {"fault", "audit", "motion"}
+
+    def test_viewer_does_not_see_audit_alerts(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[
+                    {
+                        "code": "camera_sensor_missing",
+                        "severity": "error",
+                        "message": "Camera sensor missing",
+                    }
+                ],
+            ),
+        ]
+        audit_events = [
+            {
+                "timestamp": "2026-04-30T08:14:02Z",
+                "event": "OTA_FAILED",
+                "user": "admin",
+                "ip": "1.2.3.4",
+                "detail": "verify failed",
+            }
+        ]
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-1",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:00:00Z",
+                ended_at="2026-04-30T08:00:15Z",
+                peak_score=0.18,
+            )
+        ]
+        svc = _make_service(
+            tmp_path,
+            cameras=cameras,
+            audit_events=audit_events,
+            motion_events=motion_events,
+        )
+        result = svc.list_alerts(user="bob", role="viewer")
+        sources = {a["source"] for a in result}
+        assert "audit" not in sources
+        assert sources == {"fault", "motion"}
+
+
+class TestFaultFiltering:
+    def test_info_fault_excluded(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[
+                    {"code": "thermal_headroom", "severity": "info", "message": "warm"}
+                ],
+            )
+        ]
+        svc = _make_service(tmp_path, cameras=cameras)
+        result = svc.list_alerts(user="alice", role="admin")
+        assert result == []
+
+    def test_warning_fault_included(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[
+                    {
+                        "code": "h264_unsupported",
+                        "severity": "warning",
+                        "message": "no h264",
+                    }
+                ],
+            )
+        ]
+        svc = _make_service(tmp_path, cameras=cameras)
+        result = svc.list_alerts(user="alice", role="admin")
+        assert len(result) == 1
+        assert result[0]["severity"] == "warning"
+        assert result[0]["id"] == "fault:cam-d8ee:h264_unsupported"
+
+    def test_malformed_fault_skipped(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=["not-a-dict", {"code": "ok", "severity": "error"}],
+            )
+        ]
+        svc = _make_service(tmp_path, cameras=cameras)
+        result = svc.list_alerts(user="alice", role="admin")
+        assert len(result) == 1
+
+
+class TestAuditFiltering:
+    def test_login_failed_excluded(self, tmp_path):
+        # Regression: ADR-0024 explicitly keeps LOGIN_FAILED out.
+        audit_events = [
+            {
+                "timestamp": "2026-04-30T08:00:00Z",
+                "event": "LOGIN_FAILED",
+                "user": "",
+                "ip": "1.2.3.4",
+                "detail": "wrong password",
+            }
+        ]
+        svc = _make_service(tmp_path, audit_events=audit_events)
+        result = svc.list_alerts(user="alice", role="admin")
+        assert result == []
+
+    def test_unknown_audit_code_excluded(self, tmp_path):
+        audit_events = [
+            {
+                "timestamp": "2026-04-30T08:00:00Z",
+                "event": "RANDOM_NEW_THING",
+                "user": "",
+                "ip": "",
+                "detail": "",
+            }
+        ]
+        svc = _make_service(tmp_path, audit_events=audit_events)
+        result = svc.list_alerts(user="alice", role="admin")
+        assert result == []
+
+
+class TestMotionFiltering:
+    def test_in_progress_event_excluded(self, tmp_path):
+        # ended_at is None → still in progress, not yet alert-worthy.
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-running",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:00:00Z",
+                ended_at=None,
+                peak_score=0.5,
+            )
+        ]
+        svc = _make_service(tmp_path, motion_events=motion_events)
+        result = svc.list_alerts(user="alice", role="admin")
+        assert result == []
+
+    def test_low_score_excluded(self, tmp_path):
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-noise",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:00:00Z",
+                ended_at="2026-04-30T08:00:02Z",
+                peak_score=0.001,  # well below threshold
+            )
+        ]
+        svc = _make_service(tmp_path, motion_events=motion_events)
+        result = svc.list_alerts(user="alice", role="admin")
+        assert result == []
+
+    def test_severity_scales_with_peak_score(self, tmp_path):
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-low",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:00:00Z",
+                ended_at="2026-04-30T08:00:02Z",
+                peak_score=0.07,  # >= threshold, < 0.10
+            ),
+            _FakeMotionEvent(
+                id="mot-high",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:01:00Z",
+                ended_at="2026-04-30T08:01:02Z",
+                peak_score=0.18,
+            ),
+        ]
+        svc = _make_service(tmp_path, motion_events=motion_events)
+        result = svc.list_alerts(user="alice", role="admin")
+        by_id = {a["id"]: a for a in result}
+        assert by_id["motion:mot-low"]["severity"] == "info"
+        assert by_id["motion:mot-high"]["severity"] == "warning"
+
+
+class TestSorting:
+    def test_newest_first(self, tmp_path):
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-old",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:00:00Z",
+                ended_at="2026-04-30T08:00:02Z",
+                peak_score=0.18,
+            ),
+            _FakeMotionEvent(
+                id="mot-new",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:05:00Z",
+                ended_at="2026-04-30T08:05:02Z",
+                peak_score=0.18,
+            ),
+        ]
+        svc = _make_service(tmp_path, motion_events=motion_events)
+        result = svc.list_alerts(user="alice", role="admin")
+        assert [a["id"] for a in result] == ["motion:mot-new", "motion:mot-old"]
+
+
+class TestFilters:
+    def _two_camera_setup(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[
+                    {"code": "boom", "severity": "error", "message": "boom"}
+                ],
+            )
+        ]
+        audit_events = [
+            {
+                "timestamp": "2026-04-30T08:00:00Z",
+                "event": "OTA_FAILED",
+                "user": "admin",
+                "ip": "",
+                "detail": "",
+            }
+        ]
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-1",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:01:00Z",
+                ended_at="2026-04-30T08:01:02Z",
+                peak_score=0.18,
+            )
+        ]
+        return _make_service(
+            tmp_path,
+            cameras=cameras,
+            audit_events=audit_events,
+            motion_events=motion_events,
+        )
+
+    def test_source_filter(self, tmp_path):
+        svc = self._two_camera_setup(tmp_path)
+        result = svc.list_alerts(user="alice", role="admin", source="motion")
+        assert len(result) == 1
+        assert result[0]["source"] == "motion"
+
+    def test_severity_at_least(self, tmp_path):
+        svc = self._two_camera_setup(tmp_path)
+        result = svc.list_alerts(user="alice", role="admin", severity="error")
+        # only the fault is severity=error (audit OTA_FAILED is also error,
+        # motion is "warning"); we want both error+, not exact match
+        for a in result:
+            assert a["severity"] in ("error", "critical")
+
+    def test_before_filter(self, tmp_path):
+        svc = self._two_camera_setup(tmp_path)
+        # only events strictly older than the cutoff
+        result = svc.list_alerts(
+            user="alice",
+            role="admin",
+            before="2026-04-30T08:00:30Z",
+        )
+        # OTA_FAILED at 08:00:00 is before; motion at 08:01:00 is not
+        assert any(a["source"] == "audit" for a in result)
+        assert not any(a["source"] == "motion" for a in result)
+
+    def test_limit(self, tmp_path):
+        svc = self._two_camera_setup(tmp_path)
+        result = svc.list_alerts(user="alice", role="admin", limit=1)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Read state
+# ---------------------------------------------------------------------------
+
+
+class TestReadState:
+    def _basic(self, tmp_path):
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-1",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:00:00Z",
+                ended_at="2026-04-30T08:00:02Z",
+                peak_score=0.18,
+            ),
+            _FakeMotionEvent(
+                id="mot-2",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T08:01:00Z",
+                ended_at="2026-04-30T08:01:02Z",
+                peak_score=0.18,
+            ),
+        ]
+        return _make_service(tmp_path, motion_events=motion_events)
+
+    def test_unread_count_starts_at_total(self, tmp_path):
+        svc = self._basic(tmp_path)
+        assert svc.unread_count(user="alice", role="admin") == 2
+
+    def test_mark_read_drops_unread_count(self, tmp_path):
+        svc = self._basic(tmp_path)
+        ok = svc.mark_read(user="alice", alert_id="motion:mot-1")
+        assert ok
+        assert svc.unread_count(user="alice", role="admin") == 1
+
+    def test_per_user_isolation(self, tmp_path):
+        svc = self._basic(tmp_path)
+        svc.mark_read(user="alice", alert_id="motion:mot-1")
+        # bob hasn't read anything
+        assert svc.unread_count(user="bob", role="admin") == 2
+        assert svc.unread_count(user="alice", role="admin") == 1
+
+    def test_mark_read_idempotent(self, tmp_path):
+        svc = self._basic(tmp_path)
+        svc.mark_read(user="alice", alert_id="motion:mot-1")
+        svc.mark_read(user="alice", alert_id="motion:mot-1")
+        assert svc.unread_count(user="alice", role="admin") == 1
+
+    def test_mark_read_rejects_garbage_id(self, tmp_path):
+        svc = self._basic(tmp_path)
+        assert svc.mark_read(user="alice", alert_id="totally-bogus") is False
+
+    def test_mark_all_read_respects_filters(self, tmp_path):
+        # mot-1 at 08:00:00, mot-2 at 08:01:00
+        svc = self._basic(tmp_path)
+        marked = svc.mark_all_read(
+            user="alice", role="admin", before="2026-04-30T08:00:30Z"
+        )
+        assert marked == 1
+        # mot-1 read; mot-2 still unread
+        result = svc.list_alerts(user="alice", role="admin")
+        by_id = {a["id"]: a for a in result}
+        assert by_id["motion:mot-1"]["is_read"] is True
+        assert by_id["motion:mot-2"]["is_read"] is False
+
+    def test_mark_all_read_returns_zero_when_already_read(self, tmp_path):
+        svc = self._basic(tmp_path)
+        svc.mark_all_read(user="alice", role="admin")
+        # second call: nothing left to flip
+        marked = svc.mark_all_read(user="alice", role="admin")
+        assert marked == 0
+
+
+class TestPersistence:
+    def test_state_survives_service_restart(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[{"code": "boom", "severity": "error", "message": "x"}],
+            )
+        ]
+        svc1 = _make_service(tmp_path, cameras=cameras)
+        svc1.mark_read(user="alice", alert_id="fault:cam-d8ee:boom")
+        # Spawn a new service with the same path → should pick up the read state
+        svc2 = _make_service(tmp_path, cameras=cameras)
+        assert svc2.unread_count(user="alice", role="admin") == 0
+
+    def test_corrupt_file_falls_back_to_empty(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        bad = config_dir / "alert_read_state.json"
+        bad.write_text("this is not json {{{ broken")
+        # Should not raise; state starts empty.
+        svc = _make_service(tmp_path)
+        assert svc.unread_count(user="alice", role="admin") == 0
+
+    def test_persisted_file_has_schema_version(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[{"code": "boom", "severity": "error", "message": "x"}],
+            )
+        ]
+        svc = _make_service(tmp_path, cameras=cameras)
+        svc.mark_read(user="alice", alert_id="fault:cam-d8ee:boom")
+        path = tmp_path / "config" / "alert_read_state.json"
+        payload = json.loads(path.read_text())
+        assert payload["schema_version"] == 1
+        assert "alice" in payload["users"]
+
+
+class TestUserDeletion:
+    def test_forget_user_drops_their_state(self, tmp_path):
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[{"code": "x", "severity": "error", "message": "x"}],
+            )
+        ]
+        svc = _make_service(tmp_path, cameras=cameras)
+        svc.mark_read(user="alice", alert_id="fault:cam-d8ee:x")
+        svc.mark_read(user="bob", alert_id="fault:cam-d8ee:x")
+
+        assert svc.forget_user("alice") is True
+        # alice is unread again; bob is still read
+        assert svc.unread_count(user="alice", role="admin") == 1
+        assert svc.unread_count(user="bob", role="admin") == 0
+
+    def test_forget_unknown_user_is_no_op(self, tmp_path):
+        svc = _make_service(tmp_path)
+        assert svc.forget_user("nobody") is False


### PR DESCRIPTION
## Summary

Implements **#132 Backend/API: Local alert center** per ADR-0024 (merged in #205).

Pure server Python. No camera-streamer changes, no Yocto, no boot config — runs on this Windows test box and on the live server image. Five files added, two existing files updated.

| File | Role | Lines |
|---|---|---|
| `monitor/services/alert_center_service.py` (new) | Derive-on-read service | ~430 |
| `monitor/api/alerts.py` (new) | Flask blueprint, 4 routes | ~150 |
| `monitor/__init__.py` | DI wiring + blueprint registration | +14 |
| `tests/unit/test_svc_alert_center.py` (new) | 41 service tests | ~440 |
| `tests/integration/test_api_alerts.py` (new) | 17 route tests | ~170 |
| `tests/unit/test_app.py` | Blueprint-count bump 17 → 18 | +1/-1 |

## Architecture

`AlertCenterService` is a **derive-on-read** view over the three existing event sources:

| Source | What we read | Alert ID prefix |
|---|---|---|
| `AuditLogger` | Audit events matching the catalogue | `audit:<sha256(line)[:16]>` |
| `MotionEventStore` | Closed motion events ≥ 0.05 peak score | `motion:<motion_event_id>` |
| `Camera.hardware_faults` | Active faults of severity ≥ warning | `fault:<camera_id>:<code>` |

The **only** new persistent state is `/data/config/alert_read_state.json` — a tiny per-user read-flag map. Atomic writes (`tempfile.mkstemp` + `os.replace`) per ADR-0002.

`Camera.hardware_faults` is the in-place form of ADR-0023's fault data — the FaultService that ADR-0023 proposed as a separate registry hasn't shipped yet, but the heartbeat already populates the same `{code, severity, message, hint, context}` shape on the camera record. Service reads from there directly. If a future PR introduces a separate FaultService, swapping the source is one line.

## Catalogue (per ADR-0024)

- **Faults**: severity in {warning, error, critical}. info excluded.
- **Audit**: `OTA_FAILED`, `OTA_ROLLBACK`, `CAMERA_OFFLINE`, `CERT_REVOKED`, `FIREWALL_BLOCKED`. **`LOGIN_FAILED` intentionally excluded** — belongs in the audit teaser (#148), not the alert inbox. Regression-tested.
- **Motion**: closed events with `peak_score >= 0.05`.

## Permission model (defence-in-depth, same pattern as #148)

- **Viewers**: fault + motion only
- **Admins**: everything

Server-side filter is the source of truth; the UI does not render stale-but-ungated rows. Tested.

## API

| Route | Auth | Behaviour |
|---|---|---|
| `GET /api/v1/alerts/` | login_required | List, filters: `source`, `severity` (at-least-this-severe), `unread_only`, `limit` (1–200), `before` |
| `GET /api/v1/alerts/unread-count` | login_required | Cheap badge count |
| `POST /api/v1/alerts/<id>/read` | login_required + csrf_protect | Idempotent mark-read |
| `POST /api/v1/alerts/mark-all-read` | login_required + csrf_protect | Bulk, same filters as GET; body wins over query string |

## Self-review

- **One concern**: Backend/API slice of #132 only. Frontend (#133) and verification (#134) are separate PRs.
- **No new daemons**, no scheduled jobs, no background threads. Per the ADR-0024 implementation guardrail.
- **Backwards compatible**: no API changes, no schema migrations. Pre-existing clients see new routes appear; ignore them.
- **Schema versioned**: read-state JSON has `schema_version: 1` so a future shape change can migrate cleanly.
- **User-deletion cascade**: `forget_user(username)` provided + tested. Not yet wired into `UserService.delete` (that's a one-line callback registration to add when this lands; documented in the ADR §"Storage").
- **Defensive parsing throughout**: malformed faults skipped, corrupt JSON file falls back to empty state, garbage alert IDs return 400 not 500.

## Test plan

- [x] **Service unit tests (41)**: catalogue gates, role filtering, source/severity/before/limit filters, sort, per-user isolation, idempotent mark_read, mark_all_read filter respect, persistence across service restart, corrupt-file tolerance, schema_version, forget_user cascade.
- [x] **API integration tests (17)**: auth gates (401 unauth), viewer-can-call, filter pass-through, limit clamping, body-vs-query precedence, badge-vs-pagination math, CSRF on POSTs, garbage-id 400.
- [x] **Full server suite**: 1781 passed (1780 prior + 1 from the bumped blueprint count test). 8 min run, all green.
- [x] **`ruff check` + `ruff format --check`**: clean.
- [x] **`pre-commit run --files <touched>`**: passed.
- [ ] CI on this PR — will watch and `--admin` merge once green per standing instruction.

## Deployment impact

- **App-only change.** No Yocto, no boot config, no system services, no partition layout changes.
- New file `/data/config/alert_read_state.json` created on first write. No migrations.
- New routes are additive. Existing API contracts unchanged.
- No image rebuild required if this is rolled out via the app-deploy path; OTA path also fine.

## Doc impact

- ADR-0024 (already merged) is the design contract; no doc changes needed in this PR.
- CHANGELOG entry will land with #131's umbrella close, not here.

## What this unblocks

- **#133 Frontend/UI**: nav badge + `/alerts` page can now consume `/api/v1/alerts/*`.
- **#134 Verification/Docs**: contract pinned, ready to spec.
- **#135–#138, #139–#142, #143–#146, #127–#130**: each adds its own source-side hysteresis + new audit codes; the catalogue grows, this service stays as-is.