### PR TITLE
[codex] Fix camera pending replay and FPS validation

### DIFF
--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -43,8 +43,8 @@ _TIME_RE = re.compile(r"^\d{2}:\d{2}$")
 # - Injection via shell-unsafe characters
 _CAMERA_ID_RE = re.compile(r"^cam-[a-z0-9]{1,48}$")
 
-# Stream parameters that should be pushed to the camera (ADR-0015)
-STREAM_PARAMS = {
+# Stream parameters that should be pushed to the camera (ADR-0015).
+STREAM_PARAM_FIELDS = (
     "width",
     "height",
     "fps",
@@ -64,6 +64,22 @@ STREAM_PARAMS = {
     # JSON-encoded value via the existing control channel; camera
     # decodes and applies via Picamera2.set_controls.
     "image_quality",
+)
+STREAM_PARAMS = set(STREAM_PARAM_FIELDS)
+
+STREAM_PARAM_DEFAULTS = {
+    "width": 1920,
+    "height": 1080,
+    "fps": 25,
+    "bitrate": 4000000,
+    "h264_profile": "high",
+    "keyframe_interval": 30,
+    "rotation": 0,
+    "hflip": False,
+    "vflip": False,
+    "motion_sensitivity": 5,
+    "recording_motion_enabled": False,
+    "image_quality": {},
 }
 
 
@@ -85,6 +101,34 @@ def _translate_stream_params_for_wire(params: dict) -> dict:
     if "recording_motion_enabled" in translated:
         translated["motion_detection"] = translated.pop("recording_motion_enabled")
     return translated
+
+
+def _stream_params_from_camera(camera) -> dict:
+    """Return the full server-side stream config for replay to a camera."""
+    params = {}
+    for key in STREAM_PARAM_FIELDS:
+        value = getattr(camera, key, STREAM_PARAM_DEFAULTS[key])
+        if key == "image_quality" and isinstance(value, dict):
+            value = dict(value)
+        params[key] = value
+    return params
+
+
+def _sensor_mode_max_fps(sensor_modes: list[dict]) -> dict[tuple[int, int], int]:
+    """Map each reported sensor resolution to its highest supported fps."""
+    max_by_resolution: dict[tuple[int, int], int] = {}
+    for mode in sensor_modes:
+        try:
+            width = int(mode["width"])
+            height = int(mode["height"])
+            max_fps = int(mode["max_fps"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if width <= 0 or height <= 0 or max_fps <= 0:
+            continue
+        key = (width, height)
+        max_by_resolution[key] = max(max_by_resolution.get(key, 0), max_fps)
+    return max_by_resolution
 
 
 def _validate_image_quality(payload: dict, camera) -> str:
@@ -596,17 +640,9 @@ class CameraService:
         # If we have a pending config push, include it in the response
         response: dict = {"ok": True}
         if had_pending:
-            response["pending_config"] = {
-                "width": camera.width,
-                "height": camera.height,
-                "fps": camera.fps,
-                "bitrate": camera.bitrate,
-                "h264_profile": camera.h264_profile,
-                "keyframe_interval": camera.keyframe_interval,
-                "rotation": camera.rotation,
-                "hflip": camera.hflip,
-                "vflip": camera.vflip,
-            }
+            response["pending_config"] = _translate_stream_params_for_wire(
+                _stream_params_from_camera(camera)
+            )
 
         return response, "", 200
 
@@ -679,6 +715,7 @@ class CameraService:
         sensor_modes: list[dict] = []
         if camera is not None:
             sensor_modes = list(getattr(camera, "sensor_modes", []) or [])
+        sensor_mode_fps = _sensor_mode_max_fps(sensor_modes)
         allowed = {
             "name",
             "location",
@@ -721,11 +758,7 @@ class CameraService:
                 return "fps must be a positive integer"
             # Per-camera fps cap when the sensor's modes are known.
             # Otherwise fall back to the legacy 1-30 bound.
-            if sensor_modes:
-                fps_max = max(int(m["max_fps"]) for m in sensor_modes if "max_fps" in m)
-                if fps > fps_max:
-                    return f"fps must be 1-{fps_max} for this sensor"
-            elif fps > 30:
+            if not sensor_mode_fps and fps > 30:
                 return "fps must be an integer between 1 and 30"
 
         if "name" in data:
@@ -746,15 +779,24 @@ class CameraService:
         # Per-camera (width, height) pair check — only when the sensor's
         # modes have been reported. The pair must be one of the modes
         # the camera advertised. Skipped silently for pre-#173 cameras.
-        if sensor_modes and ("width" in data or "height" in data):
-            current_w = camera.width if camera is not None else None
-            current_h = camera.height if camera is not None else None
-            w = data.get("width", current_w)
-            h = data.get("height", current_h)
-            valid_pairs = {(int(m["width"]), int(m["height"])) for m in sensor_modes}
-            if (w, h) not in valid_pairs:
-                pretty = ", ".join(f"{pw}x{ph}" for pw, ph in sorted(valid_pairs))
-                return f"resolution {w}x{h} not supported by sensor (valid: {pretty})"
+        current_w = camera.width if camera is not None else None
+        current_h = camera.height if camera is not None else None
+        w = data.get("width", current_w)
+        h = data.get("height", current_h)
+
+        if (
+            sensor_mode_fps
+            and ("width" in data or "height" in data)
+            and (w, h) not in sensor_mode_fps
+        ):
+            pretty = ", ".join(f"{pw}x{ph}" for pw, ph in sorted(sensor_mode_fps))
+            return f"resolution {w}x{h} not supported by sensor (valid: {pretty})"
+
+        if sensor_mode_fps and ("fps" in data or "width" in data or "height" in data):
+            fps = data.get("fps", camera.fps if camera is not None else None)
+            fps_max = sensor_mode_fps.get((w, h))
+            if fps_max is not None and fps > fps_max:
+                return f"fps must be 1-{fps_max} for {w}x{h}"
 
         if "bitrate" in data:
             br = data["bitrate"]

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -40,6 +40,9 @@ def _make_camera(**overrides):
         "recording_schedule": [],
         "recording_motion_enabled": False,
         "desired_stream_state": "stopped",
+        "motion_sensitivity": 5,
+        "image_controls": {},
+        "image_quality": {},
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -819,6 +822,25 @@ class TestAcceptHeartbeat:
         assert "pending_config" in response
         assert response["pending_config"]["fps"] == 30
 
+    def test_pending_config_replays_all_camera_control_fields(self):
+        """Offline updates must replay the same fields direct pushes send."""
+        cam = _make_camera(
+            config_sync="pending",
+            motion_sensitivity=8,
+            recording_motion_enabled=True,
+            image_quality={"Sharpness": 1.5},
+        )
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        response, _, code = svc.accept_heartbeat("cam-001", self._basic_payload())
+        assert code == 200
+        pending = response["pending_config"]
+        assert pending["motion_sensitivity"] == 8
+        assert pending["motion_detection"] is True
+        assert pending["image_quality"] == {"Sharpness": 1.5}
+        assert "recording_motion_enabled" not in pending
+
     def test_no_pending_config_when_synced(self):
         cam = _make_camera(config_sync="synced")
         store = MagicMock()
@@ -1060,7 +1082,7 @@ class TestPerCameraValidation:
         err, code = svc.update("cam-001", {"width": 1920, "height": 1080, "fps": 47})
         assert code == 200, err
 
-    def test_ov5647_camera_rejects_47fps(self):
+    def test_ov5647_camera_rejects_fps_above_selected_mode_cap(self):
         svc, _ = self._service_with_camera(
             sensor_model="ov5647",
             sensor_modes=[
@@ -1068,9 +1090,20 @@ class TestPerCameraValidation:
                 {"width": 1296, "height": 972, "max_fps": 43.0},
             ],
         )
-        err, code = svc.update("cam-001", {"width": 1920, "height": 1080, "fps": 47})
+        err, code = svc.update("cam-001", {"width": 1920, "height": 1080, "fps": 43})
         assert code == 400
-        assert "must be 1-43" in err  # max across modes is 43
+        assert "must be 1-30 for 1920x1080" in err
+
+    def test_ov5647_camera_accepts_high_fps_on_matching_mode(self):
+        svc, _ = self._service_with_camera(
+            sensor_model="ov5647",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 30.0},
+                {"width": 1296, "height": 972, "max_fps": 43.0},
+            ],
+        )
+        err, code = svc.update("cam-001", {"width": 1296, "height": 972, "fps": 43})
+        assert code == 200, err
 
     def test_pre_173_camera_keeps_legacy_30fps_cap(self):
         svc, _ = self._service_with_camera(sensor_model="", sensor_modes=[])


### PR DESCRIPTION
﻿## Summary

- replay the full camera-applied stream/control payload when `config_sync` is pending
- reuse the existing server-to-camera wire translation so pending `recording_motion_enabled` becomes `motion_detection`
- validate FPS against the selected/current sensor mode instead of the global max across all modes
- add regressions for offline pending replay and mode-specific FPS caps

## Root Cause

The heartbeat pending replay path had drifted from `STREAM_PARAMS` and still listed only the older stream fields by hand. Separately, server-side FPS validation used the highest FPS from any reported mode, which let invalid resolution/FPS pairs through before the camera-side validator rejected them.

## Validation

- `pytest app/server/tests/unit/test_camera_service.py -q`
- `pytest app/server/tests/ -q` (`1721 passed`)
- `ruff check .`
- `ruff format --check .`
