### PR TITLE
fix(camera-service): replay every STREAM_PARAMS field on pending heartbeat (#206)

### DIFF
--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -593,20 +593,25 @@ class CameraService:
                 f"camera {camera_id} reconnected via heartbeat",
             )
 
-        # If we have a pending config push, include it in the response
+        # If we have a pending config push, include it in the response.
+        #
+        # Build the replay payload from ``STREAM_PARAMS`` (the same set
+        # the direct push at update() uses) and apply the same wire
+        # translation. Hand-written subset here used to omit
+        # motion_sensitivity, recording_motion_enabled, and image_quality
+        # — fields added after the original 9-key snapshot — so any
+        # offline update of those settings stayed pending forever
+        # (#206). The fix routes both paths through the same source of
+        # truth so a future field added to STREAM_PARAMS is automatically
+        # replayed on reconnect.
         response: dict = {"ok": True}
         if had_pending:
-            response["pending_config"] = {
-                "width": camera.width,
-                "height": camera.height,
-                "fps": camera.fps,
-                "bitrate": camera.bitrate,
-                "h264_profile": camera.h264_profile,
-                "keyframe_interval": camera.keyframe_interval,
-                "rotation": camera.rotation,
-                "hflip": camera.hflip,
-                "vflip": camera.vflip,
+            replay = {
+                key: getattr(camera, key)
+                for key in STREAM_PARAMS
+                if hasattr(camera, key)
             }
+            response["pending_config"] = _translate_stream_params_for_wire(replay)
 
         return response, "", 200
 

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -828,6 +828,76 @@ class TestAcceptHeartbeat:
         assert code == 200
         assert "pending_config" not in response
 
+    def test_pending_config_replays_motion_and_image_quality_fields(self):
+        """Regression for #206 — pending replay omits new STREAM_PARAMS fields.
+
+        Pre-fix the replay payload was a hard-coded 9-key dict that
+        only covered the original stream block (width/height/fps/
+        bitrate/h264_profile/keyframe_interval/rotation/hflip/vflip).
+        motion_sensitivity, recording_motion_enabled, and image_quality
+        — added in #173/#182 — were never replayed, so an admin who
+        toggled motion or tuned image quality while the camera was
+        offline saw the dashboard show the new values forever while
+        the device kept running the old ones.
+
+        Fix: route both the direct push and the heartbeat replay
+        through the same STREAM_PARAMS + _translate_stream_params_for_wire
+        machinery. Future fields added to STREAM_PARAMS now replay
+        automatically with no further code changes.
+        """
+        cam = _make_camera(
+            config_sync="pending",
+            motion_sensitivity=7,
+            recording_motion_enabled=True,
+            image_quality={"Sharpness": 1.5, "Contrast": 1.2},
+        )
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        response, _, code = svc.accept_heartbeat("cam-001", self._basic_payload())
+        assert code == 200
+
+        replay = response["pending_config"]
+        # Old fields still there (no regression on the original path)
+        assert replay["fps"] == cam.fps
+        assert replay["width"] == cam.width
+        assert replay["height"] == cam.height
+        # New fields now replayed
+        assert replay["motion_sensitivity"] == 7
+        assert replay["image_quality"] == {"Sharpness": 1.5, "Contrast": 1.2}
+        # And the wire translation matches the direct-push path:
+        # recording_motion_enabled → motion_detection
+        assert "recording_motion_enabled" not in replay
+        assert replay["motion_detection"] is True
+
+    def test_pending_config_replay_skips_missing_attributes(self):
+        """Pre-#173 firmware-shaped Camera records (no image_quality
+        attribute at all) must not crash the replay path.
+
+        STREAM_PARAMS may grow ahead of older persisted records; the
+        replay builder has to skip attributes the dataclass instance
+        doesn't carry rather than raising AttributeError on every
+        offline reconnect.
+        """
+        cam = _make_camera(config_sync="pending")
+        # Simulate an older Camera record by deleting newer attributes
+        # that may not exist on disk.
+        for missing in ("image_quality", "motion_sensitivity"):
+            if hasattr(cam, missing):
+                delattr(cam, missing)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        response, _, code = svc.accept_heartbeat("cam-001", self._basic_payload())
+        assert code == 200
+        replay = response["pending_config"]
+        # Original fields still replay even when newer ones are absent
+        assert "fps" in replay
+        assert "width" in replay
+        # Missing attrs are silently dropped, not raised
+        assert "image_quality" not in replay
+        assert "motion_sensitivity" not in replay
+
     def test_logs_camera_online_audit_when_was_offline(self):
         cam = _make_camera(status="offline")
         store = MagicMock()


### PR DESCRIPTION
## Summary

Closes #206.

`CameraService.accept_heartbeat()` had two divergent paths for pushing config to a camera:

1. **Direct push** (online camera, in `update()`): iterates `STREAM_PARAMS`, applies `_translate_stream_params_for_wire`, sends to camera.
2. **Pending replay** (camera reconnects after offline update): hard-coded 9-key payload — `width / height / fps / bitrate / h264_profile / keyframe_interval / rotation / hflip / vflip`.

When `motion_sensitivity`, `recording_motion_enabled`, and `image_quality` joined `STREAM_PARAMS` in #173 and #182, only the direct push picked them up. The replay path was never updated. So:

- Server stores the new value. `config_sync = pending`.
- Camera reconnects. Heartbeat returns the old 9-key replay.
- Camera applies the 9 fields. Motion + Image Quality changes silently dropped.
- Dashboard shows desired; device runs prior. Visible in the post-#182 Image Quality panel as "I changed Sharpness on the offline camera and nothing happened."

## Fix

One change in `accept_heartbeat`: build the replay from `STREAM_PARAMS` and route through `_translate_stream_params_for_wire`. Same source of truth as the direct push. Future fields added to `STREAM_PARAMS` replay automatically — no further code changes needed.

`hasattr(camera, key)` guard so older `Camera` records (predating any given `STREAM_PARAMS` addition) don't raise `AttributeError` on reconnect.

## Self-review

- **One concern**: pending-config replay correctness. Same shape edit, no new dependencies, no API change.
- **Backward compatible**: cameras still on older firmware that don't recognise the new keys ignore them per the existing wire contract — the camera-streamer's `set_config` upper-cases keys and stores them; unread keys are dropped silently. Verified by inspection of `camera_streamer/control.py:set_config`.
- **No deploy risk**: pure server Python, lands on the same `/opt/monitor/monitor/services/camera_service.py` path as the alert center deploy. Service restart picks it up.
- **Tests cover the regression** + the older-record edge case I introduced with the `hasattr` guard.

## Test plan

- [x] `pytest app/server/tests/unit/test_camera_service.py` — 85 passed (83 prior + 2 new)
- [x] `pre-commit run --files <touched>` — ruff + format + doc-links + validators all green
- [ ] CI on this PR — will watch and `--admin` merge once green per standing instruction
- [ ] After merge: SSH-deploy `monitor/services/camera_service.py` to `192.168.1.244` (same path as #208 deploy: `/opt/monitor/monitor/services/`), restart `monitor.service`, verify heartbeat path with the new fields by running an offline-update repro on a real camera

## Deployment impact

Server-only, app code. No schema changes, no migrations, no new endpoints. Existing cameras + dashboards see no API surface change.

## Doc impact

None. Bug + fix are captured in the commit message + test docstrings.