### PR TITLE
fix(camera-service): fps cap is now per-resolution, not global (#207)

### DIFF
--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -719,12 +719,49 @@ class CameraService:
             fps = data["fps"]
             if not isinstance(fps, int) or fps < 1:
                 return "fps must be a positive integer"
-            # Per-camera fps cap when the sensor's modes are known.
-            # Otherwise fall back to the legacy 1-30 bound.
+            # Per-(width, height) fps cap when the sensor's modes are
+            # known. Pre-#207 this used the global max across all modes,
+            # which let invalid combos through — e.g. an OV5647 1296x972
+            # tops out at ~43 fps but 1920x1080 caps at 30, and the
+            # global-max check accepted fps=43 with width=1920+height=1080
+            # because 43 was a valid number for *some* mode. The camera
+            # then rejected the pushed config and config_sync stuck on
+            # "pending" forever. Match the camera-side
+            # ControlHandler._validate_params() behaviour: cap by the
+            # specific (w, h) the user is selecting.
             if sensor_modes:
-                fps_max = max(int(m["max_fps"]) for m in sensor_modes if "max_fps" in m)
-                if fps > fps_max:
-                    return f"fps must be 1-{fps_max} for this sensor"
+                target_w = data.get(
+                    "width", camera.width if camera is not None else None
+                )
+                target_h = data.get(
+                    "height", camera.height if camera is not None else None
+                )
+                # Find the mode that matches the requested resolution.
+                # If we can't (e.g. user picked an invalid pair — the
+                # resolution check at line ~749 will catch it), fall
+                # back to the global max so we don't double-error on the
+                # same condition.
+                pair_max = None
+                for m in sensor_modes:
+                    if (
+                        int(m.get("width", 0)) == target_w
+                        and int(m.get("height", 0)) == target_h
+                        and "max_fps" in m
+                    ):
+                        pair_max = int(m["max_fps"])
+                        break
+                if pair_max is not None:
+                    if fps > pair_max:
+                        return (
+                            f"fps must be 1-{pair_max} for "
+                            f"{target_w}x{target_h} on this sensor"
+                        )
+                else:
+                    fps_max = max(
+                        int(m["max_fps"]) for m in sensor_modes if "max_fps" in m
+                    )
+                    if fps > fps_max:
+                        return f"fps must be 1-{fps_max} for this sensor"
             elif fps > 30:
                 return "fps must be an integer between 1 and 30"
 

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -1060,7 +1060,14 @@ class TestPerCameraValidation:
         err, code = svc.update("cam-001", {"width": 1920, "height": 1080, "fps": 47})
         assert code == 200, err
 
-    def test_ov5647_camera_rejects_47fps(self):
+    def test_ov5647_camera_rejects_47fps_at_1080p(self):
+        """Updated for #207 — fps cap is now per-resolution.
+
+        Pre-#207 the cap was the global max across all modes (43),
+        so fps=47 at any resolution returned the global error.
+        Post-#207 the cap is the max for the *selected* (w, h), so
+        fps=47 at 1920x1080 returns the 1080p-specific cap (30).
+        """
         svc, _ = self._service_with_camera(
             sensor_model="ov5647",
             sensor_modes=[
@@ -1070,7 +1077,86 @@ class TestPerCameraValidation:
         )
         err, code = svc.update("cam-001", {"width": 1920, "height": 1080, "fps": 47})
         assert code == 400
-        assert "must be 1-43" in err  # max across modes is 43
+        assert "1-30" in err
+        assert "1920x1080" in err
+
+    def test_ov5647_rejects_43fps_at_1080p_when_only_lower_res_supports_it(self):
+        """Regression for #207 — exact issue repro.
+
+        OV5647 modes: 1296x972 caps at 43; 1920x1080 caps at 30.
+        Pre-fix: fps=43 at 1080p was accepted because 43 is a valid
+        max for *some* mode (1296x972). Post-fix: rejected because the
+        cap belongs to the (1920, 1080) pair specifically.
+        """
+        svc, _ = self._service_with_camera(
+            sensor_model="ov5647",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 30.0},
+                {"width": 1296, "height": 972, "max_fps": 43.0},
+            ],
+        )
+        err, code = svc.update("cam-001", {"width": 1920, "height": 1080, "fps": 43})
+        assert code == 400
+        assert "1-30" in err
+
+    def test_ov5647_accepts_43fps_at_1296x972(self):
+        """Companion to the rejection test — same fps, lower res, OK.
+
+        Confirms the per-pair lookup actually picks up the right mode
+        rather than always falling back to a global value.
+        """
+        svc, _ = self._service_with_camera(
+            sensor_model="ov5647",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 30.0},
+                {"width": 1296, "height": 972, "max_fps": 43.0},
+            ],
+        )
+        err, code = svc.update("cam-001", {"width": 1296, "height": 972, "fps": 43})
+        assert code == 200, err
+
+    def test_fps_alone_uses_camera_current_resolution(self):
+        """When only fps is being changed, the cap comes from the
+        camera's currently-saved (width, height), not from any
+        arbitrary mode in the list.
+
+        OV5647 saved at 1920x1080. User PUTs only fps=43. Must reject
+        — 1080p tops out at 30 — even though 43 would be valid for
+        1296x972 if they were also changing the resolution.
+        """
+        svc, _ = self._service_with_camera(
+            width=1920,
+            height=1080,
+            sensor_model="ov5647",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 30.0},
+                {"width": 1296, "height": 972, "max_fps": 43.0},
+            ],
+        )
+        err, code = svc.update("cam-001", {"fps": 43})
+        assert code == 400
+        assert "1-30" in err
+        assert "1920x1080" in err
+
+    def test_fps_check_with_invalid_resolution_falls_back_to_global_cap(self):
+        """If the requested (w, h) isn't in sensor_modes at all, we
+        can't compute a per-pair cap — fall back to the global max so
+        we don't reject the FPS for the wrong reason. The invalid
+        resolution itself is rejected by the later (w, h) pair check.
+        """
+        svc, _ = self._service_with_camera(
+            sensor_model="ov5647",
+            sensor_modes=[
+                {"width": 1920, "height": 1080, "max_fps": 30.0},
+                {"width": 1296, "height": 972, "max_fps": 43.0},
+            ],
+        )
+        # 9999x9999 isn't a valid mode — the (w, h) check will reject
+        # this PUT, but it should reject for resolution, not for fps.
+        err, code = svc.update("cam-001", {"width": 9999, "height": 9999, "fps": 40})
+        assert code == 400
+        # Resolution rejection — not the fps one
+        assert "not supported by sensor" in err
 
     def test_pre_173_camera_keeps_legacy_30fps_cap(self):
         svc, _ = self._service_with_camera(sensor_model="", sensor_modes=[])


### PR DESCRIPTION
## Summary

Closes #207.

`CameraService._validate_update()` computed the fps cap as `max(max_fps for mode in sensor_modes)` — the **global** max across every advertised mode. The camera-side validator (`ControlHandler._validate_params`) caps fps **per (width, height) pair**. Two ends of the wire disagreed.

OV5647 modes: `1296x972 @ 43 fps`, `1920x1080 @ 30 fps`.
- Pre-fix: PUT `{width: 1920, height: 1080, fps: 43}` → 200, `config_sync=pending` → camera rejects on push → dashboard stuck.
- Post-fix: same PUT → 400 *"fps must be 1-30 for 1920x1080 on this sensor"*.

## Fix

Match the camera-side rule: when sensor_modes are known, find the mode matching the requested `(width, height)` pair (taken from `data` if being changed, else from the `camera`'s current values) and cap fps against that mode's `max_fps`. Error message names the resolution so the constraint is obvious.

Edge cases:

| Case | Behaviour |
|---|---|
| fps-only PUT (no width/height in data) | Cap from camera's *current* (w, h). Test: `test_fps_alone_uses_camera_current_resolution`. |
| Requested (w, h) not in sensor_modes | Fall back to global max for fps; the existing (w, h) pair check at L~749 then rejects on resolution. Test: `test_fps_check_with_invalid_resolution_falls_back_to_global_cap`. |
| Pre-#173 cameras (empty sensor_modes) | Legacy 1–30 fallback preserved. Existing test still passes. |

## Self-review

- **One concern**: per-resolution fps cap. Same shape edit, no API change, no new dependencies.
- **Test churn is minimal**: I had to update one existing test (`test_ov5647_camera_rejects_47fps`) because its assertion was on the **old** error message — that test now correctly asserts the new per-resolution message. I renamed it to `_at_1080p` and pinned both the cap (`1-30`) and the resolution (`1920x1080`) so a future regression on either is loud.
- **Validation is strictly tighter**: pre-existing PUTs that *should have failed* will now correctly fail. No legitimate request shape is rejected that wasn't before.
- **No deploy risk**: pure server Python, same `/opt/monitor/monitor/services/camera_service.py` path the alert-center deploy used. Service restart picks it up.

## Test plan

- [x] `pytest app/server/tests/unit/test_camera_service.py` — 87 passed (83 prior + 4 new)
- [x] `pre-commit run --files <touched>` — ruff + format + validators all green
- [ ] CI on this PR — will watch and `--admin` merge once green per standing instruction
- [ ] After merge: SSH-deploy `monitor/services/camera_service.py` to the live server (same one-file deploy path), restart service, verify with a PUT to `/api/v1/cameras/<id>` carrying an over-spec fps that the new error fires.

## Deployment impact

Server-only, app code. Pure validation tightening — no schema changes, no new endpoints, no existing user behaviour change for valid requests.

## Doc impact

None. Bug + fix captured in commit message + test docstrings.