### PR TITLE
feat(server): review queue — sort=importance for the alert center (#144)

### DIFF
--- a/app/server/monitor/api/alerts.py
+++ b/app/server/monitor/api/alerts.py
@@ -21,6 +21,12 @@ Query params on GET / and POST /mark-all-read (both share the filter set):
   unread_only  — "1" / "true" / etc. (GET only)
   limit        — 1..200, default 50 (GET only)
   before       — ISO-8601 timestamp; only alerts strictly older
+  sort         — "timestamp" (default) | "importance"   (GET only)
+                 Importance order is the review queue per
+                 docs/specs/r1-review-queue.md (#144): severity DESC,
+                 timestamp DESC. Combine with unread_only=1 for the
+                 triage view — operator scans most-important
+                 unread items first.
 """
 
 from __future__ import annotations
@@ -70,6 +76,12 @@ def list_alerts():
     severity = (request.args.get("severity") or "").strip() or None
     unread_only = _truthy(request.args.get("unread_only"))
     before = (request.args.get("before") or "").strip() or None
+    sort = (request.args.get("sort") or "timestamp").strip()
+    # Defensive: only accept the documented values. An unknown sort
+    # token falls through to the default rather than 400-erroring —
+    # query-string typos shouldn't surface as broken pages.
+    if sort not in ("timestamp", "importance"):
+        sort = "timestamp"
 
     try:
         limit = int(request.args.get("limit", "50"))
@@ -86,6 +98,7 @@ def list_alerts():
         unread_only=unread_only,
         limit=limit,
         before=before,
+        sort=sort,
     )
     unread_count = svc.unread_count(user=user, role=role)
 

--- a/app/server/monitor/services/alert_center_service.py
+++ b/app/server/monitor/services/alert_center_service.py
@@ -183,14 +183,23 @@ class AlertCenterService:
         unread_only: bool = False,
         limit: int = 50,
         before: str | None = None,
+        sort: str = "timestamp",
     ) -> list[dict]:
-        """Return alerts visible to ``(user, role)``, newest first.
+        """Return alerts visible to ``(user, role)``, ordered per ``sort``.
 
         Filters and the role-aware permission gate are applied
         server-side. The dashboard / inbox UI may not bypass these
         by sending a different role string — Flask's session/role
         machinery (``admin_required`` / ``login_required``) is the
         binding source of truth at the API layer.
+
+        Sort modes (#144 review queue):
+          ``"timestamp"`` — newest first (default, the inbox view).
+          ``"importance"`` — severity DESC, then timestamp DESC.
+                             This is the *review queue* ordering: the
+                             operator scans the most important
+                             unread items first per the
+                             ``r1-review-queue.md`` spec.
         """
         alerts = self._compute_alerts(role=role)
         alerts = self._apply_read_state(alerts, user=user)
@@ -207,9 +216,16 @@ class AlertCenterService:
         if before:
             alerts = [a for a in alerts if a.timestamp < before]
 
-        # Sort by timestamp descending. A stable sort means same-second
-        # alerts keep source-derived insertion order.
-        alerts.sort(key=lambda a: a.timestamp, reverse=True)
+        if sort == "importance":
+            # Sort by severity rank DESC, then timestamp DESC. A stable
+            # sort means same-rank alerts keep their relative
+            # newest-first order.
+            alerts.sort(key=lambda a: a.timestamp, reverse=True)
+            alerts.sort(key=lambda a: _SEVERITY_ORDER.get(a.severity, 0), reverse=True)
+        else:
+            # Default: newest first. Stable sort preserves source-
+            # derived insertion order on same-second alerts.
+            alerts.sort(key=lambda a: a.timestamp, reverse=True)
 
         if limit > 0:
             alerts = alerts[:limit]

--- a/app/server/monitor/templates/alerts.html
+++ b/app/server/monitor/templates/alerts.html
@@ -41,6 +41,16 @@
         Unread only
     </label>
 
+    <span class="text-small text-muted" style="margin-left:16px;">Sort:</span>
+    <button class="btn btn--secondary btn--small"
+            :class="{'btn--active': sortMode === 'timestamp'}"
+            @click="setSort('timestamp')"
+            title="Newest first">Newest</button>
+    <button class="btn btn--secondary btn--small"
+            :class="{'btn--active': sortMode === 'importance'}"
+            @click="setSort('importance')"
+            title="Review queue: severity first, then newest (per docs/specs/r1-review-queue.md)">Review queue</button>
+
     <span style="flex:1;"></span>
 
     <button class="btn btn--secondary btn--small"
@@ -131,6 +141,7 @@ function alertsPage() {
         filterSource: '',     // '' | 'fault' | 'audit' | 'motion'
         filterSeverity: '',   // '' | 'warning' | 'error' | 'critical'
         filterUnreadOnly: false,
+        sortMode: 'timestamp', // 'timestamp' | 'importance' (#144 review queue)
 
         // Inline action state
         markingId: '',
@@ -151,6 +162,13 @@ function alertsPage() {
             this.reload();
         },
 
+        setSort(mode) {
+            // Idempotent — clicking the active sort button re-applies it
+            // rather than toggling off (alerts always have *some* order).
+            this.sortMode = mode === 'importance' ? 'importance' : 'timestamp';
+            this.reload();
+        },
+
         async reload() {
             this.loading = true;
             this.loadError = '';
@@ -158,6 +176,9 @@ function alertsPage() {
             if (this.filterSource) qs.set('source', this.filterSource);
             if (this.filterSeverity) qs.set('severity', this.filterSeverity);
             if (this.filterUnreadOnly) qs.set('unread_only', '1');
+            // sort=timestamp is the API default; only send when non-default
+            // so the URL stays clean for the common path.
+            if (this.sortMode === 'importance') qs.set('sort', 'importance');
             qs.set('limit', '100');
 
             try {

--- a/app/server/tests/integration/test_api_alerts.py
+++ b/app/server/tests/integration/test_api_alerts.py
@@ -61,6 +61,39 @@ class TestListAlertsEndpoint:
         assert kwargs["limit"] == 10
         assert kwargs["before"] == "2026-04-30T00:00:00Z"
 
+    def test_sort_importance_passed_through(self, app, logged_in_client):
+        """#144 review queue — `sort=importance` reaches the service
+        layer."""
+        app.alert_center = MagicMock()
+        app.alert_center.list_alerts.return_value = []
+        app.alert_center.unread_count.return_value = 0
+        client = logged_in_client()
+        client.get("/api/v1/alerts/?sort=importance")
+        kwargs = app.alert_center.list_alerts.call_args.kwargs
+        assert kwargs["sort"] == "importance"
+
+    def test_sort_default_is_timestamp(self, app, logged_in_client):
+        """Backwards-compat — clients that don't pass sort still get
+        the inbox newest-first ordering."""
+        app.alert_center = MagicMock()
+        app.alert_center.list_alerts.return_value = []
+        app.alert_center.unread_count.return_value = 0
+        client = logged_in_client()
+        client.get("/api/v1/alerts/")
+        kwargs = app.alert_center.list_alerts.call_args.kwargs
+        assert kwargs["sort"] == "timestamp"
+
+    def test_sort_unknown_falls_back_to_default(self, app, logged_in_client):
+        """Defensive — a garbage sort= value mustn't 400 the page
+        for the user; treat it as the default."""
+        app.alert_center = MagicMock()
+        app.alert_center.list_alerts.return_value = []
+        app.alert_center.unread_count.return_value = 0
+        client = logged_in_client()
+        client.get("/api/v1/alerts/?sort=alphabetical")
+        kwargs = app.alert_center.list_alerts.call_args.kwargs
+        assert kwargs["sort"] == "timestamp"
+
     def test_limit_clamped(self, app, logged_in_client):
         app.alert_center = MagicMock()
         app.alert_center.list_alerts.return_value = []

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -228,6 +228,25 @@ class TestAlertCenterUI:
         # hard-coded URL. Pin that the template uses :href="alert.deep_link".
         assert ':href="alert.deep_link"' in body
 
+    def test_alerts_page_has_review_queue_sort_toggle(self, client):
+        """#144 review queue — the alerts page exposes the
+        importance-sort mode as a "Review queue" button alongside
+        "Newest". Pin both the chip text and the API parameter name
+        so a future "tidy-up" doesn't quietly drop the wiring.
+        """
+        with client.session_transaction() as sess:
+            sess["user_id"] = "user-001"
+            sess["username"] = "admin"
+            sess["role"] = "admin"
+        response = client.get("/alerts")
+        body = response.get_data(as_text=True)
+        assert ">Review queue<" in body
+        assert ">Newest<" in body
+        # API parameter wiring — sort=importance reaches the backend.
+        assert "sort=importance" in body or "'sort'" in body
+        # Alpine state tracks the current mode.
+        assert "sortMode" in body
+
 
 class TestDashboardSensorAwareSettings:
     """The Camera Settings modal builds its resolution dropdown from

--- a/app/server/tests/unit/test_svc_alert_center.py
+++ b/app/server/tests/unit/test_svc_alert_center.py
@@ -387,6 +387,138 @@ class TestSorting:
         assert [a["id"] for a in result] == ["motion:mot-new", "motion:mot-old"]
 
 
+class TestImportanceSort:
+    """#144 review queue — `sort=importance` orders by severity DESC,
+    then timestamp DESC. Combined with `unread_only=1` this is the
+    triage view: operator scans most-important unread items first
+    per `r1-review-queue.md`.
+    """
+
+    def _three_severity_setup(self, tmp_path):
+        """Build a fixture covering info, warning, error, critical
+        across the three sources so importance can be unambiguously
+        verified.
+
+        Timestamps deliberately ordered so a pure newest-first sort
+        would put info NEWEST → confirms importance sort is winning,
+        not just stability.
+        """
+        cameras = [
+            _FakeCamera(
+                id="cam-d8ee",
+                hardware_faults=[
+                    # Critical fault, OLDEST timestamp
+                    {
+                        "code": "cert_revoked",
+                        "severity": "critical",
+                        "message": "cert",
+                        "opened_at": "2026-04-30T07:00:00Z",
+                    },
+                    # Warning fault, mid timestamp
+                    {
+                        "code": "h264",
+                        "severity": "warning",
+                        "message": "h264",
+                        "opened_at": "2026-04-30T08:00:00Z",
+                    },
+                ],
+            )
+        ]
+        # Audit error event, newer than the warning, older than the
+        # info motion below.
+        audit_events = [
+            {
+                "timestamp": "2026-04-30T08:30:00Z",
+                "event": "OTA_FAILED",
+                "user": "admin",
+                "ip": "",
+                "detail": "verify failed",
+            }
+        ]
+        # info-severity motion, NEWEST timestamp — proves importance
+        # sort beats timestamp sort.
+        motion_events = [
+            _FakeMotionEvent(
+                id="mot-1",
+                camera_id="cam-d8ee",
+                started_at="2026-04-30T09:00:00Z",
+                ended_at="2026-04-30T09:00:02Z",
+                peak_score=0.07,  # below 0.10 → info severity
+            )
+        ]
+        return _make_service(
+            tmp_path,
+            cameras=cameras,
+            audit_events=audit_events,
+            motion_events=motion_events,
+        )
+
+    def test_importance_sort_orders_by_severity_first(self, tmp_path):
+        svc = self._three_severity_setup(tmp_path)
+        result = svc.list_alerts(user="alice", role="admin", sort="importance")
+        severities = [a["severity"] for a in result]
+        # Expected order: critical, error, warning, info
+        rank_order = ["critical", "error", "warning", "info"]
+        # Verify the severities are in non-increasing rank order
+        ranks = [rank_order.index(s) for s in severities]
+        assert ranks == sorted(ranks)
+        # And the FIRST item is the critical one (the test would pass
+        # with all-info too without this anchor)
+        assert severities[0] == "critical"
+
+    def test_importance_sort_breaks_ties_with_timestamp_desc(self, tmp_path):
+        """Two same-severity alerts: newer one first. Stability
+        guarantees the (severity, -ts) compound order matches what
+        the spec asks for ('rank... using shared importance rules')."""
+        cameras = [
+            _FakeCamera(
+                id="cam-1",
+                hardware_faults=[
+                    {
+                        "code": "older",
+                        "severity": "error",
+                        "message": "older",
+                        "opened_at": "2026-04-30T07:00:00Z",
+                    },
+                    {
+                        "code": "newer",
+                        "severity": "error",
+                        "message": "newer",
+                        "opened_at": "2026-04-30T09:00:00Z",
+                    },
+                ],
+            )
+        ]
+        svc = _make_service(tmp_path, cameras=cameras)
+        result = svc.list_alerts(user="alice", role="admin", sort="importance")
+        ids = [a["id"] for a in result]
+        assert ids == ["fault:cam-1:newer", "fault:cam-1:older"]
+
+    def test_default_sort_unchanged_when_no_sort_param(self, tmp_path):
+        """Backwards-compat regression — clients that don't pass
+        sort= still get the inbox newest-first ordering. The default
+        kwarg path matches the pre-#144 shape."""
+        svc = self._three_severity_setup(tmp_path)
+        result = svc.list_alerts(user="alice", role="admin")
+        timestamps = [a["timestamp"] for a in result]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    def test_importance_sort_combines_with_unread_only(self, tmp_path):
+        """The "review queue" is `sort=importance + unread_only=1`.
+        Verify both filters compose."""
+        svc = self._three_severity_setup(tmp_path)
+        # Mark the critical one as read; review queue should now
+        # surface error first.
+        svc.mark_read(user="alice", alert_id="fault:cam-d8ee:cert_revoked")
+        result = svc.list_alerts(
+            user="alice", role="admin", sort="importance", unread_only=True
+        )
+        assert all(not a["is_read"] for a in result)
+        # First item in the unread-importance view is now the error,
+        # not the critical (which was marked read).
+        assert result[0]["severity"] == "error"
+
+
 class TestFilters:
     def _two_camera_setup(self, tmp_path):
         cameras = [


### PR DESCRIPTION
## Summary

Closes #144. Backend slice for the Review queue feature spec (`r1-review-queue.md`).

**The alert center already IS the surface the spec describes.** What was missing per the acceptance criteria: *"ordered or grouped consistently using shared importance rules."*

This PR adds an `importance`-sort mode (severity DESC, timestamp DESC) to the existing alert center. The "review queue" is `/alerts?sort=importance&unread_only=1` — same alerts, different ordering. No new persistent surface, no duplicate template.

## Why one chip, not a separate page

Spec §"Technical Approach" — *"deep-link into existing event/clip views rather than duplicating playback code."* The same logic applies to the queue itself. Two parallel surfaces would mean two implementations of the same source of truth. The chip is the lightest embodiment of *"review surface optimised for triage"*.

## Files

| File | Change |
|---|---|
| `monitor/services/alert_center_service.py` | New `sort` kwarg on `list_alerts()`; severity-DESC compound sort when `sort="importance"` |
| `monitor/api/alerts.py` | `?sort=` query param parsing (unknown values fall through to default — query typos shouldn't 400) |
| `monitor/templates/alerts.html` | "Newest" / "Review queue" chip pair, Alpine `sortMode` state |
| `tests/unit/test_svc_alert_center.py` | 4 new tests (`TestImportanceSort`) |
| `tests/integration/test_api_alerts.py` | 3 new tests (sort pass-through, default, fallback) |
| `tests/integration/test_views.py` | 1 new structural-anchor test |

## Self-review

- **One concern**: importance-ordering for the existing alert center.
- **Backwards compatible**: `sort` kwarg defaults to `"timestamp"`; every caller that doesn't pass it gets the existing inbox shape.
- **Defensive**: API parses unknown sort values down to `"timestamp"` rather than rejecting — same hardening pattern as #148's read-state defaults.
- **No new dependencies**, no new persistent state, no new files.
- **Test coverage**: severity-first ordering verified with a fixture covering all four severity levels arranged in *anti-importance* timestamp order, so a stable timestamp sort would put info first — confirms importance is winning, not just lucky.

## Test plan

- [x] `pytest app/server/tests/unit/test_svc_alert_center.py app/server/tests/integration/test_api_alerts.py app/server/tests/integration/test_views.py` — 89 passed
- [x] `pre-commit run --files <touched>` — ruff + format + validators all green
- [ ] CI on this PR — will watch and `--admin` merge once green per standing instruction
- [ ] After merge: SSH-deploy 3 files (alert_center_service.py, api/alerts.py, templates/alerts.html), restart monitor.service, verify by hitting `/alerts` from authed browser and toggling "Review queue".

## Deployment impact

Server-only, app code. Same `/opt/monitor/monitor/` deploy path. No camera-side changes. Three files (two service modules + one template). Service restart picks them up.

## Doc impact

None on this PR. ADR-0024 already established the alert center as the inbox surface; this extends its ordering. CHANGELOG entry will land with the release.