### PR TITLE
feat(server): camera-settings toggle for offline alerts (#137)

### DIFF
--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -327,6 +327,12 @@ class CameraService:
                 "image_quality": dict(getattr(c, "image_quality", {}) or {}),
                 "encoder_max_pixels": int(getattr(c, "encoder_max_pixels", 0) or 0),
                 "board_name": getattr(c, "board_name", "") or "",
+                # #137 — surface the per-camera offline-alert mute so
+                # the dashboard's Camera Settings modal can render the
+                # toggle. Default True for legacy records (#136).
+                "offline_alerts_enabled": bool(
+                    getattr(c, "offline_alerts_enabled", True)
+                ),
             }
             if admin_view:
                 # Admin-only fields: network topology + health metrics

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -490,6 +490,26 @@
                         Recent Events feed (ADR-0021).
                     </div>
                 </div>
+                <!-- Per-camera offline-alert mute (#136 + #137). Backend
+                     field offline_alerts_enabled; default true. Status
+                     still flips to "offline" on the dashboard when this
+                     camera goes silent — only the alert-center inbox
+                     emission is gated. Tooltip on the label explains
+                     the maintenance-mode use case so an operator
+                     doesn't permanently mute by mistake. -->
+                <div class="form-group">
+                    <label style="display:flex; align-items:center; gap:8px; cursor:pointer;"
+                           title="Alert when this camera stops responding. Turn off to silence the inbox during maintenance — the dashboard offline indicator is unaffected.">
+                        <input type="checkbox" x-model="editForm.offline_alerts_enabled">
+                        <span>Offline alerts</span>
+                    </label>
+                    <div class="text-small text-muted" style="margin-top:4px;">
+                        Surface a CAMERA_OFFLINE entry in the alert center
+                        when this camera misses heartbeats. Off silences
+                        the inbox; the offline indicator on the dashboard
+                        is unaffected.
+                    </div>
+                </div>
                 <div class="form-group" :style="editForm.recording_motion_enabled ? '' : 'opacity:0.45; pointer-events:none;'">
                     <label style="display:flex; align-items:baseline; justify-content:space-between;">
                         <span>Motion sensitivity</span>
@@ -1206,6 +1226,14 @@ function dashboardPage() {
                 // /data/config default (ADR-0021).
                 motion_sensitivity: (typeof cam.motion_sensitivity === 'number')
                     ? cam.motion_sensitivity : 5,
+                // #137 — per-camera mute for the alert-center offline
+                // emission. Backend field offline_alerts_enabled defaults
+                // True (safe-by-default for a security product). A
+                // pre-#136 cameras.json record loads with `undefined`
+                // here; treat that as True so the operator's first
+                // legitimate offline event still alerts.
+                offline_alerts_enabled: (typeof cam.offline_alerts_enabled === 'boolean')
+                    ? cam.offline_alerts_enabled : true,
                 resolutionOptions: options,
                 maxFps: this._maxFpsFor(options, pickedRes),
                 // Sensor identity (#173). Empty when the camera hasn't
@@ -1295,6 +1323,8 @@ function dashboardPage() {
                 recording_motion_enabled: Boolean(this.editForm.recording_motion_enabled),
                 motion_sensitivity: Math.max(1, Math.min(10,
                     parseInt(this.editForm.motion_sensitivity) || 5)),
+                // #137 — round-trip the per-camera offline-alert mute.
+                offline_alerts_enabled: Boolean(this.editForm.offline_alerts_enabled),
                 // #182 — only customised image-quality keys travel
                 // (defaults are inferred from the camera's catalogue
                 // and don't need to be persisted).

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -172,6 +172,11 @@ CAMERA_LIST_FIELDS_ADMIN = {
     "image_quality",
     "encoder_max_pixels",
     "board_name",
+    # Per-camera offline-alert mute (#136 + #137). Boolean; default
+    # True. Server-side gate for the alert-center inbox emission;
+    # the dashboard's offline indicator is unaffected. Surfaced so
+    # the Camera Settings modal can render the toggle.
+    "offline_alerts_enabled",
 }
 
 # Viewers see a subset — no IP (network topology) or health metrics (occupancy risk)

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -228,6 +228,27 @@ class TestAlertCenterUI:
         # hard-coded URL. Pin that the template uses :href="alert.deep_link".
         assert ':href="alert.deep_link"' in body
 
+    def test_dashboard_camera_settings_has_offline_alerts_toggle(self, client):
+        """#137 — Camera Settings modal exposes a toggle for the
+        per-camera offline_alerts_enabled flag added in #136.
+        Pin both the visible label and the Alpine binding so a future
+        refactor that quietly drops the toggle fails loudly.
+        """
+        with client.session_transaction() as sess:
+            sess["user_id"] = "user-001"
+            sess["username"] = "admin"
+            sess["role"] = "admin"
+        response = client.get("/dashboard")
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # Toggle row label.
+        assert ">Offline alerts<" in body
+        # Bound to editForm.
+        assert 'x-model="editForm.offline_alerts_enabled"' in body
+        # Initial-state and save-payload wiring.
+        assert "offline_alerts_enabled: (typeof cam.offline_alerts_enabled" in body
+        assert "Boolean(this.editForm.offline_alerts_enabled)" in body
+
     def test_alerts_page_has_review_queue_sort_toggle(self, client):
         """#144 review queue — the alerts page exposes the
         importance-sort mode as a "Review queue" button alongside

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -98,6 +98,32 @@ class TestListCameras:
         result = svc.list_cameras()
         assert "rtsp_url" not in result[0]
 
+    def test_includes_offline_alerts_enabled_in_serialisation(self):
+        """#137 — the dashboard's Camera Settings modal needs the
+        per-camera offline-alert mute in the GET payload to render
+        the toggle's initial state correctly. Default True for
+        legacy records that pre-date #136.
+        """
+        cam = _make_camera(offline_alerts_enabled=False)
+        store = MagicMock()
+        store.get_cameras.return_value = [cam]
+        svc = CameraService(store)
+        result = svc.list_cameras()
+        assert result[0]["offline_alerts_enabled"] is False
+
+    def test_offline_alerts_enabled_defaults_true_for_legacy_record(self):
+        """A SimpleNamespace without the field at all (older
+        cameras.json on disk) must round-trip as True so the operator
+        gets the safe default behaviour."""
+        cam = _make_camera()
+        if hasattr(cam, "offline_alerts_enabled"):
+            delattr(cam, "offline_alerts_enabled")
+        store = MagicMock()
+        store.get_cameras.return_value = [cam]
+        svc = CameraService(store)
+        result = svc.list_cameras()
+        assert result[0]["offline_alerts_enabled"] is True
+
 
 class TestAddCamera:
     """Test registering a new pending camera."""


### PR DESCRIPTION
## Summary

Closes #137. Frontend slice for the camera offline-alerts feature.

The Backend/API in #136 already added `Camera.offline_alerts_enabled` (default True) and `PUT /api/v1/cameras/<id>` accepts it. This PR completes the operator-facing path: the dashboard Camera Settings modal now shows an **Offline alerts** toggle so operators can mute the inbox for known-flaky / under-maintenance cameras without losing the visual offline indicator on the dashboard.

## Files

| File | Change |
|---|---|
| `monitor/templates/dashboard.html` | New form-group row with checkbox + help text + tooltip; `editForm` initial-state + save-payload wiring |
| `monitor/services/camera_service.py` | `list_cameras()` response now includes `offline_alerts_enabled` (default True for legacy records) |
| `tests/integration/test_views.py` | Structural-anchor test pinning the label + Alpine binding + wiring |
| `tests/unit/test_camera_service.py` | 2 new tests for the new serialisation field |

## Self-review

- **One concern**: surfacing the per-camera mute toggle. Backend already shipped + deployed in #136.
- **Help text + tooltip make the maintenance use-case clear** so operators don't accidentally permanently mute. The label reinforces "the dashboard offline indicator is unaffected" — only the alert center is gated.
- **Defensive defaults**: legacy cameras.json records (pre-#136) lacking the field load as True (safe-by-default for a security product). Tested.
- **No new dependencies**, no new persistent state, no new endpoints.

## Test plan

- [x] `pytest app/server/tests/integration/test_views.py app/server/tests/unit/test_camera_service.py` — 113 passed
- [x] `pre-commit run --files <touched>` — ruff + format + validators all green
- [ ] CI on this PR — will watch and `--admin` merge once green per standing instruction
- [ ] After merge: SSH-deploy 2 files (`dashboard.html`, `camera_service.py`), restart `monitor.service`, manually verify the toggle appears in the Camera Settings modal of the live dashboard.

## Deployment impact

Server-only, app code. Same `/opt/monitor/monitor/` deploy path. Two files. Service restart picks them up.

## Doc impact

None beyond the in-template help text. Spec at `docs/specs/r1-camera-offline-alerts.md` is the contract.