### PR TITLE
fix(dashboard): Tier-1 status strip click now scrolls to the offline camera

### DIFF
--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -256,11 +256,17 @@ class SystemSummaryService:
             ],
         }
         # Deep-link to the first offline or faulted camera if any,
-        # else the dashboard itself.
-        link = "/"
+        # else the dashboard itself. Use the explicit `/dashboard`
+        # path (not `/`) — the index route 302s to /dashboard which
+        # drops the URL fragment, so `/#camera-X` ends up on
+        # /dashboard with no anchor and the click does nothing.
+        # Pairs with the camera-card `id="camera-<id>"` anchor in
+        # dashboard.html so same-page clicks scroll cleanly without
+        # a navigation round-trip.
+        link = "/dashboard"
         first_problem = offline[0] if offline else (faulted[0] if faulted else None)
         if first_problem is not None:
-            link = "/#camera-" + getattr(first_problem, "id", "")
+            link = "/dashboard#camera-" + getattr(first_problem, "id", "")
         return worst, detail, link
 
     # -- storage ------------------------------------------------------------

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -223,7 +223,10 @@
         </div>
     </template>
     <template x-for="cam in pairedCameras" :key="cam.id">
-        <div class="card camera-card" :data-cam-id="cam.id">
+        <div class="card camera-card"
+             :id="'camera-' + cam.id"
+             :data-cam-id="cam.id"
+             style="scroll-margin-top:80px;">
             <div class="camera-card__info" @click="cam.status === 'online' && (window.location.href = '/live?camera=' + encodeURIComponent(cam.id))" :style="cam.status === 'online' ? 'cursor:pointer' : ''">
                 <div class="camera-card__name" x-text="cam.name || cam.id"></div>
                 <div class="camera-card__location" x-text="cam.location || 'No location set'"></div>

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -172,6 +172,26 @@ class TestAlertCenterUI:
         with open(stamp, "w") as f:
             f.write("done")
 
+    def test_dashboard_camera_cards_have_id_anchors(self, client):
+        """The Tier-1 status strip's deep_link is `/dashboard#camera-<id>`
+        (per system_summary_service._cameras). For that link to actually
+        scroll to the offending card on click, each paired-camera card
+        must carry `id="camera-<id>"`. Regression test for the live
+        "click does nothing" bug — without the binding the anchor doesn't
+        exist and the click silently does nothing.
+        """
+        with client.session_transaction() as sess:
+            sess["user_id"] = "user-001"
+            sess["username"] = "admin"
+            sess["role"] = "admin"
+        response = client.get("/dashboard")
+        body = response.get_data(as_text=True)
+        # Alpine binding that emits the per-camera id.
+        assert ":id=\"'camera-' + cam.id\"" in body
+        # scroll-margin-top so the scrolled-to card doesn't jam against
+        # the top-bar (~70px tall + a comfortable gap).
+        assert "scroll-margin-top" in body
+
     def test_dashboard_does_not_render_audit_teaser(self, client):
         """ADR-0025 — the dashboard's audit teaser (admin-only,
         5-row mini-log) was retired in favour of the bell badge →

--- a/app/server/tests/unit/test_svc_system_summary.py
+++ b/app/server/tests/unit/test_svc_system_summary.py
@@ -176,7 +176,13 @@ class TestCameraStateTransitions:
         out = svc.compute_summary()
         assert out["state"] == "amber"
         assert "offline" in out["summary"].lower()
-        assert out["deep_link"].startswith("/")
+        # Deep-link points at /dashboard with the camera id as fragment
+        # so clicking the status strip on the dashboard scrolls to
+        # the offending card without round-tripping through `/` (which
+        # 302s and drops the fragment). Regression for the
+        # "click does nothing" bug reported live.
+        assert out["deep_link"].startswith("/dashboard#camera-")
+        assert cam.id in out["deep_link"]
 
     def test_long_offline_is_red(self):
         cam = _cam(


### PR DESCRIPTION
## Summary

Reported live: clicking the Tier-1 status strip ("Front Door is offline") did nothing.

Two root causes combined:

1. `system_summary_service._cameras()` emitted `deep_link = "/#camera-<id>"`. The index route `/` 302s to `/dashboard`, **dropping the URL fragment**. So the click landed on `/dashboard` with no anchor — silently no-op.

2. Even if the fragment had survived, no `id="camera-<id>"` anchor existed on individual paired-camera cards. The grid had `id="cameras-grid"` and the heading had `id="cameras-section"` but per-card anchors were missing.

## Fix

| File | Change |
|---|---|
| `system_summary_service.py` | `link = "/dashboard#camera-..."` — full path, not `/`. Same-page hash-only navigation; no round-trip, no fragment loss. |
| `dashboard.html` | Each paired-camera card now carries `:id="'camera-' + cam.id"` + `scroll-margin-top:80px` so it doesn't jam against the top-bar after scroll. |

## Why this is a child PR of #218

This is stacked on top of `feat/ia-consolidation` because the dashboard.html on `main` doesn't yet have the IA consolidation changes — branching from main and pushing this fix would revert the audit-teaser removal. Once #218 merges, retargeting this PR to main is a one-click rebase.

## Test plan

- [x] `pytest app/server/tests/unit/test_svc_system_summary.py app/server/tests/integration/test_views.py` — 50 passed
- [x] `pre-commit run --files <touched>` — green
- [x] **Deployed live** to `192.168.1.244`; md5s match. Hard-refresh and click the offline strip — scrolls cleanly to the camera card.

Two regression tests:
- `test_recently_offline_is_amber` now asserts the `/dashboard#camera-<id>` shape (catches the bare-fragment regression).
- `test_dashboard_camera_cards_have_id_anchors` pins both the Alpine binding and the scroll-margin-top so a future refactor that drops them fails loudly.

## Deployment impact

Server-only, app code. Two files. No schema, no API change, no role-gate change.

## Doc impact

None beyond test docstrings.