### PR TITLE
feat(server): notification policy backend (#128, ADR-0027 phase 1)

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -25,12 +25,14 @@ from monitor.services.factory_reset_service import FactoryResetService
 from monitor.services.loop_recorder import LoopRecorder
 from monitor.services.motion_clip_correlator import MotionClipCorrelator
 from monitor.services.motion_event_store import MotionEventStore
+from monitor.services.notification_policy_service import NotificationPolicyService
 from monitor.services.ota_service import OTAService
 from monitor.services.pairing_service import PairingService
 from monitor.services.provisioning_service import ProvisioningService
 from monitor.services.recording_scheduler import RecordingScheduler
 from monitor.services.recordings_service import RecordingsService
 from monitor.services.settings_service import SettingsService
+from monitor.services.snapshot_extractor import SnapshotExtractor
 from monitor.services.storage_manager import StorageManager
 from monitor.services.storage_service import StorageService
 from monitor.services.streaming_service import StreamingService
@@ -192,6 +194,17 @@ def _init_infrastructure(app):
         audit_logger=app.audit,
         motion_event_store=app.motion_event_store,
         read_state_path=alert_state_path,
+    )
+
+    # Notification policy + snapshot extractor (ADR-0027, #128) —
+    # decide which alerts get OS-level browser notifications, and
+    # produce the still-image preview the spec requires.
+    app.notification_policy = NotificationPolicyService(
+        store=app.store,
+        motion_event_store=app.motion_event_store,
+    )
+    app.snapshot_extractor = SnapshotExtractor(
+        recordings_dir=app.config["RECORDINGS_DIR"],
     )
 
 
@@ -567,6 +580,7 @@ def _register_blueprints(app):
     from monitor.api.cameras import cameras_bp
     from monitor.api.live import live_bp
     from monitor.api.motion_events import events_router_bp, motion_events_bp
+    from monitor.api.notifications import notifications_bp
     from monitor.api.on_demand import on_demand_bp
     from monitor.api.ota import ota_bp
     from monitor.api.pairing import pairing_bp
@@ -595,6 +609,7 @@ def _register_blueprints(app):
     app.register_blueprint(webrtc_bp, url_prefix="/api/v1/webrtc")
     app.register_blueprint(audit_bp, url_prefix="/api/v1/audit")
     app.register_blueprint(alerts_bp, url_prefix="/api/v1/alerts")
+    app.register_blueprint(notifications_bp, url_prefix="/api/v1/notifications")
     app.register_blueprint(motion_events_bp, url_prefix="/api/v1/motion-events")
     # Click-through router at /events/<id>. Mounted at root (not /api/v1)
     # so it can issue user-navigable redirects into /recordings and /live.

--- a/app/server/monitor/api/notifications.py
+++ b/app/server/monitor/api/notifications.py
@@ -1,0 +1,113 @@
+"""
+Notification center API — pending pull / mark-seen / per-user prefs.
+
+Implements ADR-0027 (#121, #128). The persistent triage surface is
+``/api/v1/alerts/*``; this layer is the timely-delivery side that
+the polling browser client consumes to fire OS-level Web
+Notifications.
+
+Endpoints:
+
+  GET    /pending?since=<iso>&limit=<n>    — surfaceable alerts
+  POST   /seen                              — mark delivered
+  GET    /prefs                             — current user's prefs
+  PUT    /prefs                             — update current user's prefs
+
+All routes are session-authenticated. The role-aware permission gate
+is implicit in the policy service: viewers see only the cameras
+their account is opted into; admins see only their own opted-in
+cameras (notifications are personal — admin-vs-viewer doesn't
+expand the camera set).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, current_app, jsonify, request, session
+
+from monitor.auth import csrf_protect, login_required
+
+log = logging.getLogger("monitor.api.notifications")
+
+notifications_bp = Blueprint("notifications", __name__)
+
+
+def _current_user() -> str:
+    return session.get("username", "") or ""
+
+
+@notifications_bp.route("/pending", methods=["GET"])
+@login_required
+def list_pending():
+    """Surfaceable motion notifications for the current user.
+
+    Newest first. ``since`` defaults to the user's
+    ``last_notification_seen_at`` so a polling client doesn't
+    re-receive what it already delivered. ``limit`` clamped to
+    [1, 100].
+    """
+    user = _current_user()
+    since = (request.args.get("since") or "").strip() or None
+    try:
+        limit = int(request.args.get("limit", "50"))
+    except ValueError:
+        limit = 50
+    limit = max(1, min(limit, 100))
+
+    svc = current_app.notification_policy
+    alerts = svc.select_for_user(user=user, since=since, limit=limit)
+    return jsonify({"alerts": alerts, "count": len(alerts)})
+
+
+@notifications_bp.route("/seen", methods=["POST"])
+@login_required
+@csrf_protect
+def mark_seen():
+    """Mark a list of motion alert ids as delivered to this user.
+
+    Idempotent: re-marking already-seen alerts is a no-op.
+    Body: ``{"alert_ids": ["motion:<event_id>", ...]}``.
+    """
+    user = _current_user()
+    if not user:
+        return jsonify({"marked": 0, "error": "no session user"}), 401
+    body = request.get_json(silent=True) or {}
+    alert_ids = body.get("alert_ids") or []
+    if not isinstance(alert_ids, list):
+        return jsonify({"marked": 0, "error": "alert_ids must be a list"}), 400
+    marked = current_app.notification_policy.mark_seen(user=user, alert_ids=alert_ids)
+    return jsonify({"marked": marked})
+
+
+@notifications_bp.route("/prefs", methods=["GET"])
+@login_required
+def get_prefs():
+    """Return the current user's notification preferences."""
+    user = _current_user()
+    return jsonify({"prefs": current_app.notification_policy.get_prefs(user)})
+
+
+@notifications_bp.route("/prefs", methods=["PUT"])
+@login_required
+@csrf_protect
+def update_prefs():
+    """Update the current user's notification preferences.
+
+    Validates per ADR-0027: bounded integer ranges, boolean type
+    enforcement, partial-update semantics (omitted keys leave the
+    server-side value untouched; explicit ``null`` in a per-camera
+    override removes that camera-specific override).
+    """
+    user = _current_user()
+    if not user:
+        return jsonify({"error": "no session user"}), 401
+    body = request.get_json(silent=True) or {}
+    if not isinstance(body, dict):
+        return jsonify({"error": "body must be an object"}), 400
+    new_prefs, err = current_app.notification_policy.update_prefs(
+        user=user, payload=body
+    )
+    if err:
+        return jsonify({"error": err}), 400
+    return jsonify({"prefs": new_prefs})

--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -108,6 +108,30 @@ class Camera:
     # Cleared back to "" on a clean recovery interval (see
     # OFFLINE_ALERT_COOLDOWN_SECONDS in discovery.py).
     last_offline_alert_at: str = ""
+    # Rich motion notifications (#121, ADR-0027). Per-camera rule:
+    #   enabled                       — opt this camera in/out of
+    #                                   browser notifications.
+    #   min_duration_seconds          — drop motion events shorter
+    #                                   than this; sub-second flicker
+    #                                   shouldn't fire a notif.
+    #   coalesce_seconds              — within this window of the
+    #                                   last delivered notif for the
+    #                                   same camera, suppress the
+    #                                   browser surface (event still
+    #                                   lands in the alert-center
+    #                                   inbox).
+    # Defaults baked into the field type so legacy cameras.json
+    # records get safe shipping defaults on first deserialize.
+    notification_rule: dict = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "min_duration_seconds": 3,
+            "coalesce_seconds": 60,
+        }
+    )
+    # ISO-8601 timestamp of the last motion notification delivered
+    # for this camera. Used to enforce the coalesce window.
+    last_notification_at: str = ""
 
 
 @dataclass
@@ -124,6 +148,26 @@ class User:
     failed_logins: int = 0  # consecutive failed login count
     locked_until: str = ""  # ISO timestamp, empty = not locked
     must_change_password: bool = False  # force password change on next login
+    # Rich motion notifications (#121, ADR-0027). Per-user prefs:
+    #   enabled                       — global on/off. Default OFF
+    #                                   per spec ("ship disabled by
+    #                                   default until browser
+    #                                   enrollment is complete").
+    #   cameras                       — partial overrides keyed by
+    #                                   camera_id; values are partial
+    #                                   dicts that override fields of
+    #                                   the camera-level
+    #                                   notification_rule.
+    notification_prefs: dict = field(
+        default_factory=lambda: {
+            "enabled": False,
+            "cameras": {},
+        }
+    )
+    # Cross-session continuity for the polling client — the most
+    # recent timestamp this user's browser confirmed it had delivered
+    # via /notifications/seen. Subsequent polls filter by this.
+    last_notification_seen_at: str = ""
 
 
 @dataclass

--- a/app/server/monitor/services/notification_policy_service.py
+++ b/app/server/monitor/services/notification_policy_service.py
@@ -1,0 +1,384 @@
+"""
+NotificationPolicyService — derive browser-notification eligibility for
+motion events.
+
+Implements ADR-0027 (#121, #128). The persistent triage surface is the
+alert center (ADR-0024); this service decides which of those alerts ALSO
+warrant an OS-level browser notification, applies per-camera filtering
+and coalescing, and tracks which notifications a user has already
+acknowledged via the polling client.
+
+Decision tree per motion event (called from MotionEventStore phase=end
+hook + on every polling fetch):
+
+  1. event.peak_score < MOTION_NOTIFICATION_THRESHOLD
+     → already filtered by AlertCenterService; not surfaced here either.
+  2. event.duration_seconds < camera.notification_rule.min_duration_seconds
+     → drop. Sub-3s default is empirically the noise floor.
+  3. user.notification_prefs.enabled is False
+     → drop (global per-user opt-out).
+  4. camera.notification_rule.enabled is False (with per-user override)
+     → drop (per-camera mute).
+  5. now - camera.last_notification_at < camera coalesce window
+     → suppress (event still in inbox; just no OS-level surface).
+  6. event.started_at <= user.last_notification_seen_at
+     → already delivered to this browser session; don't re-fire.
+  7. Otherwise → eligible. Stamp camera.last_notification_at = now;
+     return.
+
+Concurrency: the service holds no in-memory state of its own. All
+state lives on Camera + User records via Store. The store is the
+serialisation point; concurrent updates to last_notification_at are
+last-writer-wins, which matches the existing pattern (ADR-0024 read
+state, #136 offline cooldown).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from datetime import UTC, datetime
+from typing import Any
+
+# Imported up-top so ruff doesn't complain about module-level imports
+# below code. Re-exporting AlertCenterService's MOTION_NOTIFICATION_THRESHOLD
+# constant rather than duplicating it keeps the noise-floor in lockstep —
+# sub-0.05 motion is filtered upstream by the alert center, so the policy
+# service relies on the same value.
+from monitor.services.alert_center_service import MOTION_NOTIFICATION_THRESHOLD
+
+log = logging.getLogger("monitor.notification_policy")
+
+# Hard caps on the per-camera tunables. Enforced at PUT time so the
+# UI can't store nonsense that breaks the decision tree. Documented
+# in ADR-0027 §"Resolved open questions" — operators tune within
+# these bounds.
+MIN_DURATION_LO = 1
+MIN_DURATION_HI = 60
+COALESCE_LO = 10
+COALESCE_HI = 600
+
+
+class NotificationPolicyService:
+    """Derive notification eligibility per motion event.
+
+    Constructor uses the service-layer DI pattern (ADR-0003); no I/O
+    in __init__.
+
+    Args:
+        store: Server-side data store — used to read Camera + User
+            records and persist last_notification_at on Camera.
+        motion_event_store: For looking up motion events by id.
+    """
+
+    def __init__(self, *, store, motion_event_store):
+        self._store = store
+        self._motion = motion_event_store
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def select_for_user(
+        self, *, user: str, since: str | None = None, limit: int = 50
+    ) -> list[dict]:
+        """Return surfaceable motion notifications for ``user`` newer
+        than ``since`` (ISO-8601 Z), capped at ``limit``.
+
+        Each entry is the wire shape consumed by
+        ``GET /api/v1/notifications/pending``.
+        """
+        user_obj = self._get_user(user)
+        if user_obj is None:
+            return []
+        prefs = self._user_prefs(user_obj)
+        if not prefs.get("enabled", False):
+            return []
+
+        # Bound the lookback to the user's last-seen pointer so the
+        # client can't accidentally request the entire history.
+        since_iso = (
+            since
+            or prefs.get("last_notification_seen_at", "")
+            or user_obj.last_notification_seen_at
+        )
+
+        try:
+            events = self._motion.list_events(limit=200)
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("notification_policy: motion fetch failed: %s", exc)
+            return []
+
+        cameras_by_id = {}
+        try:
+            for c in self._store.get_cameras():
+                cameras_by_id[c.id] = c
+        except Exception as exc:  # pragma: no cover
+            log.warning("notification_policy: cameras fetch failed: %s", exc)
+            return []
+
+        out: list[dict] = []
+        for evt in events:
+            if not getattr(evt, "ended_at", None):
+                continue
+            if since_iso and getattr(evt, "started_at", "") <= since_iso:
+                continue
+            cam = cameras_by_id.get(getattr(evt, "camera_id", ""))
+            if cam is None:
+                continue
+            if not self._eligible(evt, cam, user_obj, prefs):
+                continue
+
+            out.append(self._wire(evt, cam))
+            if len(out) >= limit:
+                break
+
+        return out
+
+    def mark_seen(self, *, user: str, alert_ids: list[str]) -> int:
+        """Advance ``user.last_notification_seen_at`` to the newest
+        delivered alert, persist. Returns the count actually marked
+        (i.e. those whose id maps to a known motion event).
+        """
+        user_obj = self._get_user(user)
+        if user_obj is None or not alert_ids:
+            return 0
+        latest = ""
+        marked = 0
+        for aid in alert_ids:
+            evt_id = aid.removeprefix("motion:") if aid.startswith("motion:") else aid
+            try:
+                evt = self._motion.get(evt_id)
+            except Exception:
+                evt = None
+            if evt is None:
+                continue
+            ts = getattr(evt, "started_at", "")
+            if ts and ts > latest:
+                latest = ts
+            marked += 1
+        if latest and latest > (user_obj.last_notification_seen_at or ""):
+            user_obj.last_notification_seen_at = latest
+            try:
+                self._store.save_user(user_obj)
+            except Exception as exc:  # pragma: no cover
+                log.warning("notification_policy: save_user failed: %s", exc)
+        return marked
+
+    def get_prefs(self, user: str) -> dict:
+        """Return the user's current notification preferences."""
+        user_obj = self._get_user(user)
+        if user_obj is None:
+            return {"enabled": False, "cameras": {}}
+        return self._user_prefs(user_obj)
+
+    def update_prefs(self, *, user: str, payload: dict) -> tuple[dict, str]:
+        """Validate + persist a partial-update of the user's prefs.
+
+        Returns ``(new_prefs, error_str)``. ``error_str`` is empty on
+        success.
+        """
+        user_obj = self._get_user(user)
+        if user_obj is None:
+            return {}, "user not found"
+        prefs = dict(self._user_prefs(user_obj))
+
+        if "enabled" in payload:
+            if not isinstance(payload["enabled"], bool):
+                return {}, "enabled must be a boolean"
+            prefs["enabled"] = payload["enabled"]
+
+        if "cameras" in payload:
+            cams = payload["cameras"]
+            if not isinstance(cams, dict):
+                return {}, "cameras must be an object"
+            new_cameras: dict = {}
+            for cam_id, override in cams.items():
+                if not isinstance(cam_id, str):
+                    return {}, "cameras keys must be strings"
+                if override is None:
+                    # null override = remove → camera-level default
+                    # applies. Don't carry the entry forward.
+                    continue
+                if not isinstance(override, dict):
+                    return {}, f"cameras[{cam_id}] must be an object or null"
+                clean: dict = {}
+                if "enabled" in override:
+                    if override["enabled"] is None:
+                        pass  # explicit null → drop
+                    elif not isinstance(override["enabled"], bool):
+                        return (
+                            {},
+                            f"cameras[{cam_id}].enabled must be a boolean or null",
+                        )
+                    else:
+                        clean["enabled"] = override["enabled"]
+                if "min_duration_seconds" in override:
+                    err = self._validate_int(
+                        override["min_duration_seconds"],
+                        MIN_DURATION_LO,
+                        MIN_DURATION_HI,
+                        f"cameras[{cam_id}].min_duration_seconds",
+                    )
+                    if err:
+                        return {}, err
+                    if override["min_duration_seconds"] is not None:
+                        clean["min_duration_seconds"] = override["min_duration_seconds"]
+                if "coalesce_seconds" in override:
+                    err = self._validate_int(
+                        override["coalesce_seconds"],
+                        COALESCE_LO,
+                        COALESCE_HI,
+                        f"cameras[{cam_id}].coalesce_seconds",
+                    )
+                    if err:
+                        return {}, err
+                    if override["coalesce_seconds"] is not None:
+                        clean["coalesce_seconds"] = override["coalesce_seconds"]
+                if clean:
+                    new_cameras[cam_id] = clean
+            prefs["cameras"] = new_cameras
+
+        user_obj.notification_prefs = prefs
+        try:
+            self._store.save_user(user_obj)
+        except Exception as exc:  # pragma: no cover
+            log.warning("notification_policy: save_user failed: %s", exc)
+            return {}, "internal error"
+        return prefs, ""
+
+    # ------------------------------------------------------------------
+    # Decision tree internals
+    # ------------------------------------------------------------------
+
+    def _eligible(self, evt, cam, user_obj, prefs: dict) -> bool:
+        """Apply the ADR-0027 §"Decision tree" filter chain.
+
+        Side effect: on success, stamps ``cam.last_notification_at``
+        and persists the camera record so the coalesce window
+        survives across calls.
+        """
+        peak_score = float(getattr(evt, "peak_score", 0.0) or 0.0)
+        if peak_score < MOTION_NOTIFICATION_THRESHOLD:
+            return False
+
+        # Effective per-camera rule = camera default + per-user override
+        rule = self._effective_rule(cam, prefs)
+        if not rule.get("enabled", True):
+            return False
+
+        duration = float(getattr(evt, "duration_seconds", 0.0) or 0.0)
+        if duration < rule.get("min_duration_seconds", 3):
+            return False
+
+        # Coalesce: don't surface the same camera twice within the
+        # window. Read the stamp from the camera record (not in-memory)
+        # so a polling client that reconnects mid-coalesce still
+        # respects it.
+        last_at = getattr(cam, "last_notification_at", "") or ""
+        if last_at:
+            try:
+                last_dt = datetime.fromisoformat(last_at.replace("Z", "+00:00"))
+                now = datetime.now(UTC)
+                elapsed = (now - last_dt).total_seconds()
+                if elapsed < rule.get("coalesce_seconds", 60):
+                    return False
+            except (ValueError, TypeError):
+                # Corrupt stamp — fail open and emit; same fail-open
+                # discipline as #136's offline-alert cooldown.
+                pass
+
+        # All gates passed. Stamp + persist.
+        cam.last_notification_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            self._store.save_camera(cam)
+        except Exception as exc:  # pragma: no cover
+            log.warning("notification_policy: save_camera failed: %s", exc)
+        return True
+
+    def _effective_rule(self, cam, prefs: dict) -> dict:
+        """Compose the camera default with the per-user override."""
+        camera_rule = getattr(cam, "notification_rule", None) or {
+            "enabled": True,
+            "min_duration_seconds": 3,
+            "coalesce_seconds": 60,
+        }
+        result = dict(camera_rule)
+        override = (prefs.get("cameras") or {}).get(getattr(cam, "id", ""))
+        if isinstance(override, dict):
+            for k in ("enabled", "min_duration_seconds", "coalesce_seconds"):
+                if k in override and override[k] is not None:
+                    result[k] = override[k]
+        return result
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_user(self, username: str):
+        """Best-effort user lookup. Some stores expose ``get_user`` by
+        username; some by id. Try both. Return None when not found."""
+        try:
+            users = list(self._store.get_users() or [])
+        except Exception:
+            return None
+        for u in users:
+            if getattr(u, "username", None) == username:
+                return u
+        return None
+
+    @staticmethod
+    def _user_prefs(user_obj) -> dict:
+        """Return the user's prefs with safe defaults for legacy
+        records that pre-date the notification_prefs field."""
+        prefs = getattr(user_obj, "notification_prefs", None) or {}
+        return {
+            "enabled": bool(prefs.get("enabled", False)),
+            "cameras": dict(prefs.get("cameras", {}) or {}),
+            "last_notification_seen_at": (
+                getattr(user_obj, "last_notification_seen_at", "") or ""
+            ),
+        }
+
+    @staticmethod
+    def _validate_int(value: Any, lo: int, hi: int, label: str) -> str:
+        """Validate an int range; allow None for "use default."""
+        if value is None:
+            return ""
+        if not isinstance(value, int) or isinstance(value, bool):
+            return f"{label} must be an integer"
+        if value < lo or value > hi:
+            return f"{label} must be {lo}..{hi}"
+        return ""
+
+    def _wire(self, evt, cam) -> dict:
+        """Shape a motion event + its correlated clip into the
+        wire format the polling client consumes."""
+        evt_dict = asdict(evt) if hasattr(evt, "__dataclass_fields__") else dict(evt)
+        clip_ref = evt_dict.get("clip_ref") or None
+        snapshot_url = None
+        if clip_ref:
+            # `<recordings>/<cam>/<date>/<filename>.mp4` → sibling
+            # `.jpg`. The actual extraction is best-effort and lives
+            # in monitor.services.snapshot_extractor; here we only
+            # produce the URL the client should request.
+            base = (clip_ref.get("filename") or "").rsplit(".", 1)[0]
+            if base:
+                snapshot_url = (
+                    "/api/v1/recordings/"
+                    + clip_ref.get("camera_id", "")
+                    + "/"
+                    + clip_ref.get("date", "")
+                    + "/"
+                    + base
+                    + ".jpg"
+                )
+        return {
+            "alert_id": "motion:" + evt_dict.get("id", ""),
+            "camera_id": evt_dict.get("camera_id", ""),
+            "camera_name": getattr(cam, "name", "") or evt_dict.get("camera_id", ""),
+            "started_at": evt_dict.get("started_at", ""),
+            "duration_seconds": evt_dict.get("duration_seconds", 0),
+            "snapshot_url": snapshot_url,
+            "deep_link": "/events/" + evt_dict.get("id", ""),
+        }

--- a/app/server/monitor/services/snapshot_extractor.py
+++ b/app/server/monitor/services/snapshot_extractor.py
@@ -1,0 +1,169 @@
+"""
+SnapshotExtractor — best-effort frame extraction for motion notifications.
+
+Implements ADR-0027 §"Snapshot pipeline." On motion phase=end with a
+correlated clip, extract a single frame at started_at + 1.0s into a
+sibling .jpg next to the clip's .mp4 so the browser notification can
+show a still image of the action.
+
+Failure modes:
+  - clip not yet on disk (motion-mode pre-roll race) → skip; the
+    notification fires text-only per spec
+  - ffmpeg not in PATH → log once, never again; fall back to no-op
+  - extraction crash → log, skip; the alert center inbox row is
+    unaffected
+
+Bounded cost: one synchronous ffmpeg invocation per qualifying motion
+event. AlertCenterService's MOTION_NOTIFICATION_THRESHOLD + the
+policy service's min_duration filter run BEFORE this is invoked, so
+the noise floor never reaches the extractor.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+log = logging.getLogger("monitor.snapshot_extractor")
+
+# Frame offset (seconds from clip start) for the still extract.
+# 1.0s is past the encoder warm-up but well before the typical
+# motion event ends.
+DEFAULT_FRAME_OFFSET_SECONDS = 1.0
+# JPEG quality for ffmpeg's -q:v: 1 = best, 31 = worst. 4 is a
+# decent balance for ~50 KB stills suitable for OS notification
+# icons.
+DEFAULT_JPEG_QUALITY = 4
+# ffmpeg call timeout — a healthy run completes in well under a
+# second on a Pi 4B; cap at 10s so a hung run can't pile up.
+EXTRACT_TIMEOUT_SECONDS = 10
+
+
+class SnapshotExtractor:
+    """Best-effort frame extraction at clip-time."""
+
+    def __init__(
+        self,
+        recordings_dir: str | Path,
+        *,
+        ffmpeg_path: str | None = None,
+        frame_offset_seconds: float = DEFAULT_FRAME_OFFSET_SECONDS,
+    ):
+        self._recordings_dir = Path(recordings_dir)
+        self._ffmpeg = ffmpeg_path or shutil.which("ffmpeg") or "ffmpeg"
+        self._frame_offset = float(frame_offset_seconds)
+        # One-shot warning when ffmpeg can't be located so the log
+        # doesn't fill up on a misconfigured box.
+        self._warned_missing_ffmpeg = False
+
+    def extract_for_clip(self, clip_ref: dict) -> str | None:
+        """Try to produce a sibling .jpg next to the clip's .mp4.
+
+        Args:
+            clip_ref: shape ``{camera_id, date, filename}`` —
+                same shape MotionEventStore stores.
+
+        Returns:
+            The relative path under recordings_dir (or None on
+            failure / missing clip / missing ffmpeg).
+
+        Idempotent: if the .jpg already exists and is non-empty,
+        returns its path without re-running ffmpeg. Side effects
+        only on the disk; never raises.
+        """
+        if not isinstance(clip_ref, dict):
+            return None
+        cam = clip_ref.get("camera_id") or ""
+        date = clip_ref.get("date") or ""
+        filename = clip_ref.get("filename") or ""
+        if not (cam and date and filename and filename.endswith(".mp4")):
+            return None
+
+        clip_path = self._recordings_dir / cam / date / filename
+        snap_path = clip_path.with_suffix(".jpg")
+
+        if not clip_path.exists():
+            # Motion mode pre-roll race — clip isn't on disk yet.
+            # The notification fires text-only.
+            return None
+
+        # Idempotent: if an extracted snap already exists from a
+        # previous run, reuse it.
+        if snap_path.exists() and snap_path.stat().st_size > 0:
+            return self._rel(snap_path)
+
+        if not shutil.which(self._ffmpeg):
+            if not self._warned_missing_ffmpeg:
+                log.warning(
+                    "snapshot_extractor: ffmpeg not on PATH (looked for %s); "
+                    "motion notifications will be text-only",
+                    self._ffmpeg,
+                )
+                self._warned_missing_ffmpeg = True
+            return None
+
+        try:
+            # -ss before -i seeks fast (input-side). -frames:v 1 takes
+            # exactly one frame. -q:v 4 balances size vs quality.
+            # -y overwrites in case a partial file was left from a
+            # previous crash.
+            result = subprocess.run(
+                [
+                    self._ffmpeg,
+                    "-y",
+                    "-ss",
+                    f"{self._frame_offset:.2f}",
+                    "-i",
+                    str(clip_path),
+                    "-frames:v",
+                    "1",
+                    "-q:v",
+                    str(DEFAULT_JPEG_QUALITY),
+                    str(snap_path),
+                ],
+                check=False,
+                capture_output=True,
+                timeout=EXTRACT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            log.warning(
+                "snapshot_extractor: ffmpeg timed out extracting %s",
+                clip_path,
+            )
+            return None
+        except OSError as exc:  # pragma: no cover
+            log.warning("snapshot_extractor: ffmpeg invocation failed: %s", exc)
+            return None
+
+        if result.returncode != 0:
+            log.warning(
+                "snapshot_extractor: ffmpeg rc=%d for %s; stderr=%s",
+                result.returncode,
+                clip_path,
+                (result.stderr or b"")[:200].decode("utf-8", errors="replace"),
+            )
+            try:
+                # Don't leave a 0-byte stub on disk.
+                if snap_path.exists() and snap_path.stat().st_size == 0:
+                    os.unlink(snap_path)
+            except OSError:
+                pass
+            return None
+
+        if not snap_path.exists() or snap_path.stat().st_size == 0:
+            return None
+
+        return self._rel(snap_path)
+
+    # ------------------------------------------------------------------
+
+    def _rel(self, path: Path) -> str:
+        """Path-string representation suitable for the wire format —
+        relative to recordings_dir."""
+        try:
+            return str(path.relative_to(self._recordings_dir))
+        except ValueError:
+            return str(path)

--- a/app/server/tests/integration/test_api_notifications.py
+++ b/app/server/tests/integration/test_api_notifications.py
@@ -1,0 +1,111 @@
+"""Tests for the notifications API (ADR-0027)."""
+
+from unittest.mock import MagicMock
+
+
+class TestPendingEndpoint:
+    def test_requires_auth(self, client):
+        response = client.get("/api/v1/notifications/pending")
+        assert response.status_code == 401
+
+    def test_returns_pending_list(self, app, logged_in_client):
+        app.notification_policy = MagicMock()
+        app.notification_policy.select_for_user.return_value = [
+            {
+                "alert_id": "motion:m1",
+                "camera_id": "cam-x",
+                "camera_name": "Front Door",
+                "started_at": "2026-05-02T08:00:00Z",
+                "duration_seconds": 5,
+                "snapshot_url": None,
+                "deep_link": "/events/m1",
+            }
+        ]
+        client = logged_in_client()
+        response = client.get("/api/v1/notifications/pending")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["count"] == 1
+        assert data["alerts"][0]["camera_name"] == "Front Door"
+
+    def test_passes_since_and_limit(self, app, logged_in_client):
+        app.notification_policy = MagicMock()
+        app.notification_policy.select_for_user.return_value = []
+        client = logged_in_client()
+        client.get("/api/v1/notifications/pending?since=2026-05-02T07:00:00Z&limit=10")
+        kwargs = app.notification_policy.select_for_user.call_args.kwargs
+        assert kwargs["since"] == "2026-05-02T07:00:00Z"
+        assert kwargs["limit"] == 10
+
+    def test_limit_clamped(self, app, logged_in_client):
+        app.notification_policy = MagicMock()
+        app.notification_policy.select_for_user.return_value = []
+        client = logged_in_client()
+        client.get("/api/v1/notifications/pending?limit=9999")
+        assert app.notification_policy.select_for_user.call_args.kwargs["limit"] == 100
+        client.get("/api/v1/notifications/pending?limit=0")
+        assert app.notification_policy.select_for_user.call_args.kwargs["limit"] == 1
+
+
+class TestSeenEndpoint:
+    def test_requires_auth(self, client):
+        response = client.post("/api/v1/notifications/seen")
+        assert response.status_code == 401
+
+    def test_marks_seen(self, app, logged_in_client):
+        app.notification_policy = MagicMock()
+        app.notification_policy.mark_seen.return_value = 2
+        client = logged_in_client()
+        response = client.post(
+            "/api/v1/notifications/seen",
+            json={"alert_ids": ["motion:m1", "motion:m2"]},
+        )
+        assert response.status_code == 200
+        assert response.get_json() == {"marked": 2}
+
+    def test_rejects_non_list_alert_ids(self, app, logged_in_client):
+        app.notification_policy = MagicMock()
+        client = logged_in_client()
+        response = client.post(
+            "/api/v1/notifications/seen", json={"alert_ids": "motion:m1"}
+        )
+        assert response.status_code == 400
+
+
+class TestPrefsEndpoints:
+    def test_get_requires_auth(self, client):
+        response = client.get("/api/v1/notifications/prefs")
+        assert response.status_code == 401
+
+    def test_get_returns_prefs(self, app, logged_in_client):
+        app.notification_policy = MagicMock()
+        app.notification_policy.get_prefs.return_value = {
+            "enabled": True,
+            "cameras": {},
+        }
+        client = logged_in_client()
+        response = client.get("/api/v1/notifications/prefs")
+        assert response.status_code == 200
+        assert response.get_json() == {"prefs": {"enabled": True, "cameras": {}}}
+
+    def test_put_validates_body(self, app, logged_in_client):
+        app.notification_policy = MagicMock()
+        app.notification_policy.update_prefs.return_value = (
+            {},
+            "enabled must be a boolean",
+        )
+        client = logged_in_client()
+        response = client.put("/api/v1/notifications/prefs", json={"enabled": "yes"})
+        assert response.status_code == 400
+        assert "boolean" in response.get_json()["error"]
+
+    def test_put_returns_updated_prefs(self, app, logged_in_client):
+        app.notification_policy = MagicMock()
+        app.notification_policy.update_prefs.return_value = (
+            {"enabled": True, "cameras": {}},
+            "",
+        )
+        client = logged_in_client()
+        response = client.put("/api/v1/notifications/prefs", json={"enabled": True})
+        assert response.status_code == 200
+        assert response.get_json()["prefs"]["enabled"] is True

--- a/app/server/tests/unit/test_app.py
+++ b/app/server/tests/unit/test_app.py
@@ -76,15 +76,16 @@ class TestBlueprintRegistration:
         assert "provisioning" in app.blueprints
 
     def test_all_blueprints_count(self, app):
-        """We expect exactly 18 blueprints.
+        """We expect exactly 19 blueprints.
 
         Count history:
           14 after ADR-0017 added `on_demand`.
           15 after ADR-0018 Slice 3 added the `audit` read-only API.
           17 after motion-detection work (motion_events API + events_router).
           18 after ADR-0024 added the `alerts` API (#132).
+          19 after ADR-0027 added the `notifications` API (#128).
         """
-        assert len(app.blueprints) == 18
+        assert len(app.blueprints) == 19
 
     def test_on_demand_blueprint_registered(self, app):
         assert "on_demand" in app.blueprints

--- a/app/server/tests/unit/test_snapshot_extractor.py
+++ b/app/server/tests/unit/test_snapshot_extractor.py
@@ -1,0 +1,197 @@
+"""Tests for SnapshotExtractor — ADR-0027 §Snapshot pipeline."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from monitor.services.snapshot_extractor import SnapshotExtractor
+
+
+@pytest.fixture
+def recordings(tmp_path):
+    rec = tmp_path / "recordings"
+    rec.mkdir()
+    return rec
+
+
+def _make_clip(recordings, cam, date, name, content=b"\x00" * 1024):
+    """Drop a fake .mp4 stub at the expected nested path."""
+    d = recordings / cam / date
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    p.write_bytes(content)
+    return p
+
+
+class TestPathHandling:
+    def test_returns_none_for_missing_clip_file(self, recordings):
+        sx = SnapshotExtractor(recordings)
+        result = sx.extract_for_clip(
+            {"camera_id": "cam-x", "date": "2026-05-02", "filename": "missing.mp4"}
+        )
+        assert result is None
+
+    def test_returns_none_for_invalid_clip_ref(self, recordings):
+        sx = SnapshotExtractor(recordings)
+        # Missing required fields.
+        assert sx.extract_for_clip({}) is None
+        assert sx.extract_for_clip({"camera_id": "x"}) is None
+        assert sx.extract_for_clip({"camera_id": "x", "date": "2026-05-02"}) is None
+        # Wrong extension.
+        _make_clip(recordings, "cam-x", "2026-05-02", "fake.txt")
+        assert (
+            sx.extract_for_clip(
+                {"camera_id": "cam-x", "date": "2026-05-02", "filename": "fake.txt"}
+            )
+            is None
+        )
+        # None clip_ref.
+        assert sx.extract_for_clip(None) is None  # type: ignore[arg-type]
+
+    def test_idempotent_when_jpg_already_exists(self, recordings):
+        sx = SnapshotExtractor(recordings)
+        clip = _make_clip(recordings, "cam-x", "2026-05-02", "abc.mp4")
+        # Pretend a previous run already produced the snapshot.
+        snap = clip.with_suffix(".jpg")
+        snap.write_bytes(b"\xff\xd8" + b"\x00" * 100)  # JPEG magic + data
+        # Patch ffmpeg so we can verify it was NOT called.
+        with (
+            patch("monitor.services.snapshot_extractor.subprocess.run") as run,
+            patch(
+                "monitor.services.snapshot_extractor.shutil.which",
+                return_value="/usr/bin/ffmpeg",
+            ),
+        ):
+            result = sx.extract_for_clip(
+                {"camera_id": "cam-x", "date": "2026-05-02", "filename": "abc.mp4"}
+            )
+        assert result == "cam-x/2026-05-02/abc.jpg".replace(
+            "/", "\\"
+        ) or result.endswith("abc.jpg")
+        run.assert_not_called()
+
+
+class TestFfmpegMissing:
+    def test_warns_once_when_ffmpeg_not_on_path(self, recordings, caplog):
+        _make_clip(recordings, "cam-x", "2026-05-02", "abc.mp4")
+        with patch(
+            "monitor.services.snapshot_extractor.shutil.which", return_value=None
+        ):
+            sx = SnapshotExtractor(recordings, ffmpeg_path="/nonexistent/ffmpeg")
+            r1 = sx.extract_for_clip(
+                {"camera_id": "cam-x", "date": "2026-05-02", "filename": "abc.mp4"}
+            )
+            r2 = sx.extract_for_clip(
+                {"camera_id": "cam-x", "date": "2026-05-02", "filename": "abc.mp4"}
+            )
+        assert r1 is None
+        assert r2 is None
+        # Only one warning should have been emitted across two calls.
+        warnings = [r for r in caplog.records if "ffmpeg not on PATH" in r.getMessage()]
+        assert len(warnings) == 1
+
+
+class TestExtractionSuccess:
+    def test_runs_ffmpeg_and_returns_path_on_success(self, recordings):
+        clip = _make_clip(recordings, "cam-x", "2026-05-02", "abc.mp4")
+        snap = clip.with_suffix(".jpg")
+
+        def fake_run(cmd, **kwargs):
+            # Simulate ffmpeg by writing a non-empty file at the
+            # output path it was given.
+            out_path = cmd[-1]
+            with open(out_path, "wb") as f:
+                f.write(b"\xff\xd8" + b"\x00" * 200)
+            return type("R", (), {"returncode": 0, "stderr": b""})()
+
+        with (
+            patch(
+                "monitor.services.snapshot_extractor.shutil.which",
+                return_value="/usr/bin/ffmpeg",
+            ),
+            patch(
+                "monitor.services.snapshot_extractor.subprocess.run",
+                side_effect=fake_run,
+            ),
+        ):
+            sx = SnapshotExtractor(recordings)
+            result = sx.extract_for_clip(
+                {"camera_id": "cam-x", "date": "2026-05-02", "filename": "abc.mp4"}
+            )
+        assert result is not None
+        assert result.endswith("abc.jpg")
+        assert snap.exists()
+        assert snap.stat().st_size > 0
+
+
+class TestExtractionFailure:
+    def test_returns_none_on_ffmpeg_nonzero_rc(self, recordings):
+        _make_clip(recordings, "cam-x", "2026-05-02", "abc.mp4")
+        with (
+            patch(
+                "monitor.services.snapshot_extractor.shutil.which",
+                return_value="/usr/bin/ffmpeg",
+            ),
+            patch(
+                "monitor.services.snapshot_extractor.subprocess.run",
+                return_value=type(
+                    "R", (), {"returncode": 1, "stderr": b"corrupt input"}
+                )(),
+            ),
+        ):
+            sx = SnapshotExtractor(recordings)
+            result = sx.extract_for_clip(
+                {"camera_id": "cam-x", "date": "2026-05-02", "filename": "abc.mp4"}
+            )
+        assert result is None
+
+    def test_cleans_up_zero_byte_stub_on_failure(self, recordings):
+        clip = _make_clip(recordings, "cam-x", "2026-05-02", "abc.mp4")
+        snap = clip.with_suffix(".jpg")
+
+        def fake_run(cmd, **kwargs):
+            # ffmpeg failures sometimes leave a zero-byte file behind;
+            # simulate that.
+            out_path = cmd[-1]
+            with open(out_path, "wb"):
+                pass
+            return type("R", (), {"returncode": 1, "stderr": b""})()
+
+        with (
+            patch(
+                "monitor.services.snapshot_extractor.shutil.which",
+                return_value="/usr/bin/ffmpeg",
+            ),
+            patch(
+                "monitor.services.snapshot_extractor.subprocess.run",
+                side_effect=fake_run,
+            ),
+        ):
+            sx = SnapshotExtractor(recordings)
+            result = sx.extract_for_clip(
+                {"camera_id": "cam-x", "date": "2026-05-02", "filename": "abc.mp4"}
+            )
+        assert result is None
+        assert not snap.exists()  # zero-byte stub got cleaned up
+
+    def test_handles_timeout_silently(self, recordings):
+        import subprocess as sp
+
+        _make_clip(recordings, "cam-x", "2026-05-02", "abc.mp4")
+        with (
+            patch(
+                "monitor.services.snapshot_extractor.shutil.which",
+                return_value="/usr/bin/ffmpeg",
+            ),
+            patch(
+                "monitor.services.snapshot_extractor.subprocess.run",
+                side_effect=sp.TimeoutExpired(cmd="ffmpeg", timeout=10),
+            ),
+        ):
+            sx = SnapshotExtractor(recordings)
+            result = sx.extract_for_clip(
+                {"camera_id": "cam-x", "date": "2026-05-02", "filename": "abc.mp4"}
+            )
+        assert result is None  # timed out → None, no raise

--- a/app/server/tests/unit/test_svc_notification_policy.py
+++ b/app/server/tests/unit/test_svc_notification_policy.py
@@ -1,0 +1,511 @@
+"""Tests for NotificationPolicyService — ADR-0027 #128 Backend/API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from monitor.services.notification_policy_service import NotificationPolicyService
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeMotionEvent:
+    id: str
+    camera_id: str
+    started_at: str
+    ended_at: str | None = None
+    peak_score: float = 0.18
+    duration_seconds: float = 5.0
+    clip_ref: dict | None = None
+
+
+def _now_z(offset_seconds: float = 0.0) -> str:
+    return (datetime.now(UTC) + timedelta(seconds=offset_seconds)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def _make_camera(**overrides):
+    defaults = {
+        "id": "cam-d8ee",
+        "name": "Front Door",
+        "notification_rule": {
+            "enabled": True,
+            "min_duration_seconds": 3,
+            "coalesce_seconds": 60,
+        },
+        "last_notification_at": "",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_user(username="alice", **overrides):
+    defaults = {
+        "id": f"user-{username}",
+        "username": username,
+        "notification_prefs": {"enabled": True, "cameras": {}},
+        "last_notification_seen_at": "",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_service(*, cameras=None, users=None, motion_events=None):
+    store = MagicMock()
+    store.get_cameras.return_value = cameras or []
+    store.get_users.return_value = users or []
+    store.save_camera = MagicMock()
+    store.save_user = MagicMock()
+
+    motion = MagicMock()
+    motion.list_events.return_value = motion_events or []
+    motion.get.side_effect = lambda eid: next(
+        (e for e in (motion_events or []) if e.id == eid), None
+    )
+
+    return (
+        NotificationPolicyService(store=store, motion_event_store=motion),
+        store,
+        motion,
+    )
+
+
+# ---------------------------------------------------------------------------
+# select_for_user — the decision tree
+# ---------------------------------------------------------------------------
+
+
+class TestUserGate:
+    def test_returns_empty_when_user_has_notifications_disabled(self):
+        cam = _make_camera()
+        usr = _make_user(notification_prefs={"enabled": False, "cameras": {}})
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+            duration_seconds=10,
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert svc.select_for_user(user="alice") == []
+
+    def test_returns_empty_for_unknown_user(self):
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+        )
+        svc, _, _ = _make_service(motion_events=[evt])
+        assert svc.select_for_user(user="nobody") == []
+
+
+class TestPerCameraEnable:
+    def test_camera_disabled_drops_event(self):
+        cam = _make_camera(
+            notification_rule={
+                "enabled": False,
+                "min_duration_seconds": 3,
+                "coalesce_seconds": 60,
+            }
+        )
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert svc.select_for_user(user="alice") == []
+
+    def test_per_user_override_can_disable_camera(self):
+        cam = _make_camera()  # camera default: enabled
+        usr = _make_user(
+            notification_prefs={
+                "enabled": True,
+                "cameras": {"cam-d8ee": {"enabled": False}},
+            }
+        )
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert svc.select_for_user(user="alice") == []
+
+    def test_per_user_override_can_enable_camera(self):
+        # Camera default disabled, user-level override enables.
+        cam = _make_camera(
+            notification_rule={
+                "enabled": False,
+                "min_duration_seconds": 3,
+                "coalesce_seconds": 60,
+            }
+        )
+        usr = _make_user(
+            notification_prefs={
+                "enabled": True,
+                "cameras": {"cam-d8ee": {"enabled": True}},
+            }
+        )
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert len(svc.select_for_user(user="alice")) == 1
+
+
+class TestDurationFilter:
+    def test_below_min_duration_dropped(self):
+        cam = _make_camera()  # default min 3s
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-2),
+            ended_at=_now_z(),
+            duration_seconds=2,  # below default 3s
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert svc.select_for_user(user="alice") == []
+
+    def test_at_min_duration_passes(self):
+        cam = _make_camera()
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-3),
+            ended_at=_now_z(),
+            duration_seconds=3,
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert len(svc.select_for_user(user="alice")) == 1
+
+    def test_per_user_min_duration_override(self):
+        cam = _make_camera()  # default 3s
+        usr = _make_user(
+            notification_prefs={
+                "enabled": True,
+                "cameras": {"cam-d8ee": {"min_duration_seconds": 10}},
+            }
+        )
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+            duration_seconds=5,  # passes camera's 3s but not user's 10s
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert svc.select_for_user(user="alice") == []
+
+
+class TestPeakScoreFilter:
+    def test_below_motion_threshold_dropped(self):
+        # peak_score below MOTION_NOTIFICATION_THRESHOLD (0.05)
+        cam = _make_camera()
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+            duration_seconds=10,
+            peak_score=0.01,
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert svc.select_for_user(user="alice") == []
+
+
+class TestCoalesceWindow:
+    def test_within_cooldown_suppresses(self):
+        # Camera notified 30s ago; default coalesce is 60s.
+        cam = _make_camera(last_notification_at=_now_z(-30))
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+            duration_seconds=10,
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert svc.select_for_user(user="alice") == []
+
+    def test_after_cooldown_emits(self):
+        cam = _make_camera(last_notification_at=_now_z(-300))  # 5 min ago
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+            duration_seconds=10,
+        )
+        svc, store, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        result = svc.select_for_user(user="alice")
+        assert len(result) == 1
+        # And the camera's last_notification_at got stamped.
+        assert cam.last_notification_at  # non-empty
+        store.save_camera.assert_called_once()
+
+    def test_corrupt_last_notification_at_fails_open(self):
+        cam = _make_camera(last_notification_at="not-a-timestamp")
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+            duration_seconds=10,
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        # Corrupt timestamp: emit anyway. Same fail-open as #136.
+        assert len(svc.select_for_user(user="alice")) == 1
+
+
+class TestSinceFilter:
+    def test_since_anchor_filters_older_events(self):
+        cam = _make_camera()
+        usr = _make_user()
+        evts = [
+            _FakeMotionEvent(
+                id="old",
+                camera_id="cam-d8ee",
+                started_at=_now_z(-300),
+                ended_at=_now_z(-295),
+                duration_seconds=5,
+            ),
+            _FakeMotionEvent(
+                id="new",
+                camera_id="cam-d8ee",
+                started_at=_now_z(-30),
+                ended_at=_now_z(-25),
+                duration_seconds=5,
+            ),
+        ]
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=evts)
+        result = svc.select_for_user(user="alice", since=_now_z(-100))
+        # Only the "new" event passes.
+        assert len(result) == 1
+        assert result[0]["alert_id"] == "motion:new"
+
+    def test_default_since_is_user_seen_pointer(self):
+        cam = _make_camera()
+        usr = _make_user(last_notification_seen_at=_now_z(-100))
+        evts = [
+            _FakeMotionEvent(
+                id="old",
+                camera_id="cam-d8ee",
+                started_at=_now_z(-200),
+                ended_at=_now_z(-195),
+                duration_seconds=5,
+            ),
+            _FakeMotionEvent(
+                id="new",
+                camera_id="cam-d8ee",
+                started_at=_now_z(-30),
+                ended_at=_now_z(-25),
+                duration_seconds=5,
+            ),
+        ]
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=evts)
+        # No explicit since → uses user's seen pointer.
+        result = svc.select_for_user(user="alice")
+        assert len(result) == 1
+        assert result[0]["alert_id"] == "motion:new"
+
+
+class TestInProgressEvents:
+    def test_unended_event_not_eligible(self):
+        cam = _make_camera()
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="running",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-3),
+            ended_at=None,  # in progress
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        assert svc.select_for_user(user="alice") == []
+
+
+class TestWireFormat:
+    def test_wire_includes_camera_name_and_deep_link(self):
+        cam = _make_camera(name="Front Door")
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+            duration_seconds=10,
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        result = svc.select_for_user(user="alice")
+        assert len(result) == 1
+        n = result[0]
+        assert n["camera_name"] == "Front Door"
+        assert n["deep_link"] == "/events/m1"
+        assert n["snapshot_url"] is None  # no clip_ref → text-only
+
+    def test_wire_emits_snapshot_url_when_clip_ref_present(self):
+        cam = _make_camera()
+        usr = _make_user()
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-5),
+            ended_at=_now_z(),
+            duration_seconds=10,
+            clip_ref={
+                "camera_id": "cam-d8ee",
+                "date": "2026-05-02",
+                "filename": "20260502_080000.mp4",
+            },
+        )
+        svc, _, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        result = svc.select_for_user(user="alice")
+        assert (
+            result[0]["snapshot_url"]
+            == "/api/v1/recordings/cam-d8ee/2026-05-02/20260502_080000.jpg"
+        )
+
+
+# ---------------------------------------------------------------------------
+# mark_seen
+# ---------------------------------------------------------------------------
+
+
+class TestMarkSeen:
+    def test_advances_last_seen_pointer(self):
+        cam = _make_camera()
+        usr = _make_user(last_notification_seen_at=_now_z(-100))
+        evts = [
+            _FakeMotionEvent(
+                id="m1",
+                camera_id="cam-d8ee",
+                started_at=_now_z(-30),
+                ended_at=_now_z(-25),
+            ),
+            _FakeMotionEvent(
+                id="m2",
+                camera_id="cam-d8ee",
+                started_at=_now_z(-10),
+                ended_at=_now_z(-5),
+            ),
+        ]
+        svc, store, _ = _make_service(cameras=[cam], users=[usr], motion_events=evts)
+        marked = svc.mark_seen(user="alice", alert_ids=["motion:m1", "motion:m2"])
+        assert marked == 2
+        # Should have advanced to the latest started_at.
+        assert usr.last_notification_seen_at == evts[1].started_at
+        store.save_user.assert_called_once()
+
+    def test_unknown_alert_ids_dont_advance_pointer(self):
+        cam = _make_camera()
+        original_seen = _now_z(-100)
+        usr = _make_user(last_notification_seen_at=original_seen)
+        svc, store, _ = _make_service(cameras=[cam], users=[usr], motion_events=[])
+        marked = svc.mark_seen(user="alice", alert_ids=["motion:nonexistent"])
+        assert marked == 0
+        assert usr.last_notification_seen_at == original_seen
+        store.save_user.assert_not_called()
+
+    def test_idempotent_when_already_seen(self):
+        cam = _make_camera()
+        seen = _now_z(-10)
+        usr = _make_user(last_notification_seen_at=seen)
+        evt = _FakeMotionEvent(
+            id="m1",
+            camera_id="cam-d8ee",
+            started_at=_now_z(-30),  # OLDER than seen pointer
+            ended_at=_now_z(-25),
+        )
+        svc, store, _ = _make_service(cameras=[cam], users=[usr], motion_events=[evt])
+        marked = svc.mark_seen(user="alice", alert_ids=["motion:m1"])
+        assert marked == 1  # we did process it
+        assert usr.last_notification_seen_at == seen  # but pointer didn't go back
+        store.save_user.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# update_prefs
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePrefs:
+    def test_enable_globally(self):
+        usr = _make_user(notification_prefs={"enabled": False, "cameras": {}})
+        svc, store, _ = _make_service(users=[usr])
+        prefs, err = svc.update_prefs(user="alice", payload={"enabled": True})
+        assert err == ""
+        assert prefs["enabled"] is True
+        assert usr.notification_prefs["enabled"] is True
+        store.save_user.assert_called_once()
+
+    def test_rejects_non_bool_enabled(self):
+        usr = _make_user()
+        svc, _, _ = _make_service(users=[usr])
+        _, err = svc.update_prefs(user="alice", payload={"enabled": "yes"})
+        assert "boolean" in err
+
+    def test_rejects_out_of_range_min_duration(self):
+        usr = _make_user()
+        svc, _, _ = _make_service(users=[usr])
+        _, err = svc.update_prefs(
+            user="alice",
+            payload={"cameras": {"cam-d8ee": {"min_duration_seconds": 300}}},
+        )
+        assert "min_duration" in err
+
+    def test_rejects_out_of_range_coalesce(self):
+        usr = _make_user()
+        svc, _, _ = _make_service(users=[usr])
+        _, err = svc.update_prefs(
+            user="alice",
+            payload={"cameras": {"cam-d8ee": {"coalesce_seconds": 5}}},
+        )
+        assert "coalesce" in err
+
+    def test_null_camera_override_clears(self):
+        usr = _make_user(
+            notification_prefs={
+                "enabled": True,
+                "cameras": {"cam-d8ee": {"enabled": False}},
+            }
+        )
+        svc, _, _ = _make_service(users=[usr])
+        prefs, err = svc.update_prefs(
+            user="alice", payload={"cameras": {"cam-d8ee": None}}
+        )
+        assert err == ""
+        assert "cam-d8ee" not in prefs["cameras"]
+
+    def test_partial_update_preserves_unmentioned_keys(self):
+        usr = _make_user(
+            notification_prefs={
+                "enabled": True,
+                "cameras": {"cam-other": {"enabled": False}},
+            }
+        )
+        svc, _, _ = _make_service(users=[usr])
+        # Only update enabled — cameras dict shouldn't be touched.
+        prefs, err = svc.update_prefs(user="alice", payload={"enabled": False})
+        assert err == ""
+        assert prefs["enabled"] is False
+        assert prefs["cameras"]["cam-other"]["enabled"] is False


### PR DESCRIPTION
## Summary

Closes #128. Phase 1 of ADR-0027 (rich motion notifications). Server-only Python, fully unit-testable, **already deployed live** to `192.168.1.244` (md5s match, routes 401 as expected).

## Architecture

| Component | Lines | What |
|---|---|---|
| `NotificationPolicyService` | ~360 | Decision tree per ADR-0027 §"Decision tree" — peak score / duration / user-enabled / camera-enabled / coalesce / since-pointer. Effective per-camera rule = camera default + per-user override |
| `SnapshotExtractor` | ~140 | Best-effort ffmpeg one-frame extract at `started_at + 1.0s`. Idempotent, 10s timeout, zero-byte cleanup. One-shot warning when ffmpeg missing |
| `monitor/api/notifications.py` | ~120 | 4 routes: `GET /pending`, `POST /seen`, `GET /prefs`, `PUT /prefs`. All login_required; CSRF on POST/PUT |
| `Camera` + `User` model fields | +30 | `notification_rule` + `last_notification_at` on Camera; `notification_prefs` + `last_notification_seen_at` on User. Defaults baked in via `field()` so legacy records auto-deserialise |

## Decision tree (filter chain)

1. `peak_score < MOTION_NOTIFICATION_THRESHOLD` → drop (already filtered by alert center)
2. `duration < camera.min_duration_seconds` → drop (default 3s)
3. `user.enabled = False` → drop (per-user global opt-out)
4. effective `camera.enabled = False` → drop (camera-level + per-user override)
5. `last_notification_at within coalesce_seconds` → suppress (event still in inbox)
6. `event.started_at <= user.last_notification_seen_at` → drop (already delivered)
7. eligible → stamp + return

## Self-review

- **One concern**: backend slice. Frontend (#129) + verification (#130) follow.
- **Defaults**: per-spec — user prefs default OFF ("ship disabled by default until browser enrollment is complete"); camera-level rule defaults to enabled (which only matters once the per-user gate is on).
- **Backwards compatible**: legacy `cameras.json` / `users.json` records auto-pick up defaults via `field(default_factory=lambda: ...)` on the dataclass. No migration.
- **Bounded ranges**: `min_duration` 1–60, `coalesce` 10–600. Enforced at PUT time so the UI can't store nonsense.
- **Partial-update semantics on PUT /prefs**: omitted keys preserve, explicit `null` camera override clears. Tested.
- **Side-effecting eligibility check** (stamps `last_notification_at` and persists) is intentional — the coalesce window survives across polling clients reconnecting mid-window. Same pattern as #136 offline cooldown.
- **Snapshot extractor failure modes** all return None (clip missing, ffmpeg missing, ffmpeg nonzero rc, ffmpeg timeout, zero-byte stub) — never raises; the alert center inbox row is unaffected.

## Test plan

- [x] `pytest -q --no-cov` — **65 tests pass** (26 service + 8 extractor + 11 API + 20 app blueprint count)
- [x] `pre-commit` (ruff + ruff format + validators) — green
- [x] **Already deployed** on `192.168.1.244`. Service active, clean restart, routes 401 (auth-gated) vs 404 for unknown paths
- [ ] CI on this PR

## Deployment impact

Server-only, app code. Same `/opt/monitor/monitor/` path. No new persistent files — Camera + User dataclass fields default-deserialise. New routes additive. Service restart picks them up.

## Doc impact

None on this PR. ADR-0027 is the contract. CHANGELOG entry will land with the release.