### PR TITLE
feat(server): rich-motion-notifications frontend (#129, ADR-0027 phase 2)

### DIFF
--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -335,6 +335,18 @@ class CameraService:
                 "offline_alerts_enabled": bool(
                     getattr(c, "offline_alerts_enabled", True)
                 ),
+                # #129 — surface the per-camera notification rule so
+                # the Notifications tab can render the camera-defaults
+                # editor (admin) and the per-user override panel (all).
+                # Default rule for legacy records (#128).
+                "notification_rule": dict(
+                    getattr(c, "notification_rule", None)
+                    or {
+                        "enabled": True,
+                        "min_duration_seconds": 3,
+                        "coalesce_seconds": 60,
+                    }
+                ),
             }
             if admin_view:
                 # Admin-only fields: network topology + health metrics
@@ -745,6 +757,10 @@ class CameraService:
             "image_quality",
             # #136 per-camera offline alert toggle
             "offline_alerts_enabled",
+            # #129 per-camera notification rule (ADR-0027). Admins
+            # set the camera-level baseline; per-user overrides live
+            # in user.notification_prefs.cameras{}.
+            "notification_rule",
         }
         unknown = set(data.keys()) - allowed
         if unknown:
@@ -754,6 +770,23 @@ class CameraService:
             data["offline_alerts_enabled"], bool
         ):
             return "offline_alerts_enabled must be a boolean"
+
+        if "notification_rule" in data:
+            rule = data["notification_rule"]
+            if not isinstance(rule, dict):
+                return "notification_rule must be an object"
+            if "enabled" in rule and not isinstance(rule["enabled"], bool):
+                return "notification_rule.enabled must be a boolean"
+            for k, lo, hi in (
+                ("min_duration_seconds", 1, 60),
+                ("coalesce_seconds", 10, 600),
+            ):
+                if k in rule:
+                    v = rule[k]
+                    if not isinstance(v, int) or isinstance(v, bool):
+                        return f"notification_rule.{k} must be an integer"
+                    if v < lo or v > hi:
+                        return f"notification_rule.{k} must be {lo}..{hi}"
 
         if (
             "recording_mode" in data

--- a/app/server/monitor/templates/base.html
+++ b/app/server/monitor/templates/base.html
@@ -252,6 +252,98 @@
         setInterval(poll, 30 * 1000);
     })();
     </script>
+
+    <script>
+    // Browser notifications poller (#129, ADR-0027). Same 30s
+    // cadence as the bell badge so we don't double the request
+    // rate. Fires `new Notification(...)` for surfaceable motion
+    // alerts the user opted into and that this browser hasn't
+    // already delivered. Web Notifications API only — no service
+    // worker, no Web Push, no cloud relay (per ADR-0027 §"Why not
+    // Web Push").
+    //
+    // Permission state is the gate: if the user hasn't granted it,
+    // we skip the fetch entirely (no point fetching what we can't
+    // surface). The Settings → Notifications panel is where the
+    // request is made.
+    (function() {
+        if (typeof Notification === 'undefined') return;
+
+        function poll() {
+            if (Notification.permission !== 'granted') return;
+
+            fetch('/api/v1/notifications/pending', {
+                credentials: 'same-origin',
+                cache: 'no-store',
+            })
+                .then(function(r) {
+                    return r.ok ? r.json() : null;
+                })
+                .then(function(d) {
+                    if (!d || !Array.isArray(d.alerts) || d.alerts.length === 0) return;
+                    var ids = [];
+                    d.alerts.forEach(function(n) {
+                        try {
+                            var note = new Notification('Motion: ' + (n.camera_name || n.camera_id), {
+                                body: humaniseTime(n.started_at) + ' · ' +
+                                      (n.duration_seconds || '?') + 's',
+                                // Snapshot URL falls back to the project
+                                // logo when ffmpeg couldn't extract one
+                                // (motion-mode pre-roll race per ADR-0027).
+                                icon: n.snapshot_url || '/static/images/logo.svg',
+                                // OS-level dedupe: same alert_id replaces
+                                // any pending notification with this tag.
+                                tag: n.alert_id,
+                            });
+                            // Click → land on the event detail.
+                            note.onclick = function() {
+                                window.focus();
+                                if (n.deep_link) window.location.href = n.deep_link;
+                                note.close();
+                            };
+                            ids.push(n.alert_id);
+                        } catch (e) {
+                            // Some browsers throw on Notification ctor
+                            // when the page is hidden + the user agent
+                            // is being conservative. Skip silently — the
+                            // alert is still in the inbox.
+                        }
+                    });
+                    if (ids.length) {
+                        // Tell the server this browser delivered them
+                        // so subsequent polls don't re-fire.
+                        var csrfToken = (document.cookie.match(/csrf_token=([^;]+)/) || [])[1];
+                        fetch('/api/v1/notifications/seen', {
+                            method: 'POST',
+                            credentials: 'same-origin',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-Token': csrfToken || '',
+                            },
+                            body: JSON.stringify({ alert_ids: ids }),
+                        }).catch(function() { /* best-effort */ });
+                    }
+                })
+                .catch(function() { /* polling is best-effort */ });
+        }
+
+        function humaniseTime(iso) {
+            if (!iso) return '';
+            var t = new Date(iso).getTime();
+            if (isNaN(t)) return iso;
+            var elapsed = (Date.now() - t) / 1000;
+            if (elapsed < 60) return 'just now';
+            if (elapsed < 3600) return Math.floor(elapsed / 60) + 'm ago';
+            return Math.floor(elapsed / 3600) + 'h ago';
+        }
+
+        // Same 30s cadence as the bell badge. Stagger the FIRST
+        // call by 5s so the dashboard render isn't competing with
+        // an extra fetch on first paint.
+        setTimeout(poll, 5 * 1000);
+        setInterval(poll, 30 * 1000);
+    })();
+    </script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -7,19 +7,28 @@
 <h1 class="page-title">Settings</h1>
 
 <!-- Settings Tab Bar -->
-<div class="settings-tabs" x-show="isAdmin">
-    <button class="settings-tab" :class="{ active: tab === 'system' }" @click="tab = 'system'">System</button>
-    <button class="settings-tab" :class="{ active: tab === 'network' }" @click="tab = 'network'">Network</button>
-    <button class="settings-tab" :class="{ active: tab === 'tailscale' }" @click="tab = 'tailscale'">Tailscale</button>
-    <button class="settings-tab" :class="{ active: tab === 'users' }" @click="tab = 'users'">Users</button>
-    <button class="settings-tab" :class="{ active: tab === 'recording' }" @click="tab = 'recording'">Recording</button>
-    <button class="settings-tab" :class="{ active: tab === 'storage' }" @click="tab = 'storage'">Storage</button>
-    <button class="settings-tab" :class="{ active: tab === 'updates' }" @click="tab = 'updates'; loadOtaStatus()">Updates</button>
+<div class="settings-tabs">
+    <!-- Admin-only configuration tabs. Viewers don't see these — they
+         get the Notifications tab below as their only Settings
+         surface (their own per-user prefs are personal, not system). -->
+    <template x-if="isAdmin">
+        <span style="display:contents;">
+            <button class="settings-tab" :class="{ active: tab === 'system' }" @click="tab = 'system'">System</button>
+            <button class="settings-tab" :class="{ active: tab === 'network' }" @click="tab = 'network'">Network</button>
+            <button class="settings-tab" :class="{ active: tab === 'tailscale' }" @click="tab = 'tailscale'">Tailscale</button>
+            <button class="settings-tab" :class="{ active: tab === 'users' }" @click="tab = 'users'">Users</button>
+            <button class="settings-tab" :class="{ active: tab === 'recording' }" @click="tab = 'recording'">Recording</button>
+            <button class="settings-tab" :class="{ active: tab === 'storage' }" @click="tab = 'storage'">Storage</button>
+            <button class="settings-tab" :class="{ active: tab === 'updates' }" @click="tab = 'updates'; loadOtaStatus()">Updates</button>
+        </span>
+    </template>
+    <!-- Notifications tab is per-user — visible to admins AND viewers
+         (#129, ADR-0027). Each user manages their own browser-
+         notification opt-in here; admins additionally see the
+         camera-level defaults inside the panel. -->
+    <button class="settings-tab" :class="{ active: tab === 'notifications' }" @click="tab = 'notifications'; loadNotificationPrefs()">Notifications</button>
     <!-- ADR-0025: "Security" tab retired. Audit-log management
-         (open + clear) lives at /logs itself — the contextually
-         correct surface ("you decide to clear while looking at
-         the log, not while configuring the system"). -->
-
+         (open + clear) lives at /logs itself. -->
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════
@@ -950,7 +959,135 @@
 <!-- ═══════════════════════════════════════════════════════════
      NON-ADMIN: System Info + Change Password only
      ��═════════════════════════════════════════════════��════════ -->
-<div x-show="!isAdmin" x-cloak>
+<!-- ═══════════════════════════════════════════════════════════
+     NOTIFICATIONS TAB (visible to admin + viewer — #129, ADR-0027)
+     -----------------------------------------------------------
+     Per-user controls (everyone). Per-camera defaults gated by
+     isAdmin inside the panel — viewers can override defaults for
+     themselves but can't change the camera-level baseline.
+     ═══════════════════════════════════════════════════════════ -->
+<div x-show="tab === 'notifications'" x-cloak>
+    <div class="settings-section">
+        <div class="settings-section__title">Browser notifications</div>
+        <div class="card">
+            <p class="text-small text-muted" style="margin:0 0 var(--space-3) 0;">
+                Get a desktop notification when motion is detected on a camera you opted into.
+                Notifications fire while a Home Monitor tab is open in this browser.
+                Unread items are always visible in the
+                <a href="/alerts">alert center</a> — these are just the
+                ones the system surfaces immediately.
+            </p>
+
+            <div class="info-row">
+                <span class="info-row__label">Browser permission</span>
+                <span class="info-row__value">
+                    <span x-show="notify.permission === 'granted'" class="text-success">Granted</span>
+                    <span x-show="notify.permission === 'denied'" class="text-danger">Denied — re-enable in your browser's site settings</span>
+                    <span x-show="notify.permission === 'default'" class="text-muted">Not requested</span>
+                    <span x-show="notify.permission === 'unsupported'" class="text-muted">Not supported on this browser</span>
+                    <button class="btn btn--secondary btn--small"
+                            x-show="notify.permission === 'default'"
+                            @click="requestNotificationPermission()"
+                            style="margin-left:var(--space-2);">Request permission</button>
+                </span>
+            </div>
+
+            <div class="info-row" style="border-bottom:none;">
+                <span class="info-row__label">Notify me</span>
+                <span class="info-row__value">
+                    <label style="display:inline-flex; align-items:center; gap:8px; cursor:pointer;">
+                        <input type="checkbox"
+                               x-model="notify.prefs.enabled"
+                               @change="saveNotificationPrefs()">
+                        <span x-text="notify.prefs.enabled ? 'On' : 'Off'"
+                              :class="notify.prefs.enabled ? 'text-success' : 'text-muted'"></span>
+                    </label>
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <div class="settings-section" x-show="notify.prefs.enabled && notify.cameras.length > 0">
+        <div class="settings-section__title">Per-camera</div>
+        <div class="card">
+            <p class="text-small text-muted" style="margin:0 0 var(--space-3) 0;">
+                Mute notifications for individual cameras without affecting other users.
+                Defaults come from the camera's setting (admin-managed) below.
+            </p>
+            <template x-for="cam in notify.cameras" :key="cam.id">
+                <div class="info-row">
+                    <span class="info-row__label">
+                        <span x-text="cam.name || cam.id"></span>
+                        <span class="text-small text-muted" x-show="cam.location" x-text="' · ' + cam.location"></span>
+                    </span>
+                    <span class="info-row__value">
+                        <label style="display:inline-flex; align-items:center; gap:8px; cursor:pointer;">
+                            <input type="checkbox"
+                                   :checked="effectiveCameraEnabled(cam)"
+                                   @change="setCameraOverride(cam.id, 'enabled', $event.target.checked)">
+                            <span x-text="effectiveCameraEnabled(cam) ? 'On' : 'Off'"
+                                  :class="effectiveCameraEnabled(cam) ? 'text-success' : 'text-muted'"></span>
+                        </label>
+                    </span>
+                </div>
+            </template>
+        </div>
+    </div>
+
+    <div class="settings-section" x-show="notify.permission === 'granted' && notify.prefs.enabled">
+        <div class="settings-section__title">Test</div>
+        <div class="card">
+            <p class="text-small text-muted" style="margin:0 0 var(--space-3) 0;">
+                Fire a synthetic notification so you can verify your browser's look-and-feel
+                before relying on it for real motion events.
+            </p>
+            <button class="btn btn--secondary" @click="fireTestNotification()">Send a test notification</button>
+        </div>
+    </div>
+
+    <div class="settings-section" x-show="isAdmin && notify.cameras.length > 0">
+        <div class="settings-section__title">Camera defaults <span class="text-small text-muted">(admin)</span></div>
+        <div class="card">
+            <p class="text-small text-muted" style="margin:0 0 var(--space-3) 0;">
+                Default notification rule for each camera. Anyone can override above for themselves;
+                this is the baseline.
+            </p>
+            <template x-for="cam in notify.cameras" :key="cam.id">
+                <div class="info-row" style="display:block;">
+                    <div style="display:flex; justify-content:space-between; align-items:center;">
+                        <span class="info-row__label">
+                            <strong x-text="cam.name || cam.id"></strong>
+                        </span>
+                        <label class="text-small" style="display:inline-flex; align-items:center; gap:6px; cursor:pointer;">
+                            <input type="checkbox"
+                                   :checked="cam.notification_rule && cam.notification_rule.enabled !== false"
+                                   @change="setCameraDefault(cam.id, 'enabled', $event.target.checked)">
+                            <span>Allow notifications</span>
+                        </label>
+                    </div>
+                    <div style="display:flex; gap:var(--space-3); margin-top:var(--space-2); flex-wrap:wrap;">
+                        <label class="text-small" style="flex:1; min-width:140px;">
+                            Min duration (s)
+                            <input type="number" min="1" max="60"
+                                   class="form-input"
+                                   :value="(cam.notification_rule && cam.notification_rule.min_duration_seconds) || 3"
+                                   @change="setCameraDefault(cam.id, 'min_duration_seconds', parseInt($event.target.value))">
+                        </label>
+                        <label class="text-small" style="flex:1; min-width:140px;">
+                            Coalesce (s)
+                            <input type="number" min="10" max="600"
+                                   class="form-input"
+                                   :value="(cam.notification_rule && cam.notification_rule.coalesce_seconds) || 60"
+                                   @change="setCameraDefault(cam.id, 'coalesce_seconds', parseInt($event.target.value))">
+                        </label>
+                    </div>
+                </div>
+            </template>
+        </div>
+    </div>
+</div>
+
+<div x-show="!isAdmin && tab !== 'notifications'" x-cloak>
     <div class="settings-section">
         <div class="settings-section__title">System Info</div>
         <div class="card">
@@ -2049,6 +2186,136 @@ function settingsPage() {
         /* ADR-0025: audit-log management methods retired from
            settings.html entirely. The clear-log action now lives
            on /logs (logs.html) where it's contextually correct. */
+
+        /* === Browser notifications (#129, ADR-0027) === */
+
+        /* Alpine state for the Notifications tab. Loaded lazily on
+           first tab activation; subsequent visits reuse cached
+           state. Two-way bound to the form controls.
+             permission: live read-only mirror of the browser's
+               Notification.permission state (granted/denied/default
+               or 'unsupported' if the API is missing — old browsers
+               or non-secure contexts).
+             prefs: per-user preferences from /notifications/prefs.
+             cameras: full camera list from /api/v1/cameras (with
+               admin-only fields stripped for viewers, per the
+               existing API contract). Used to render per-camera
+               override rows + admin's camera-defaults section. */
+        notify: { permission: 'default', prefs: { enabled: false, cameras: {} }, cameras: [] },
+
+        async loadNotificationPrefs() {
+            // Resolve current permission state. The Notifications API
+            // is window-scoped, so this works without any granted
+            // capability — just reads the user's existing answer.
+            this.notify.permission =
+                (typeof Notification === 'undefined') ? 'unsupported' : Notification.permission;
+            try {
+                var resp = await window.HM.api.get('/api/v1/notifications/prefs');
+                this.notify.prefs = (resp && resp.prefs) || { enabled: false, cameras: {} };
+            } catch(e) {
+                this.notify.prefs = { enabled: false, cameras: {} };
+            }
+            try {
+                var cams = await window.HM.api.get('/api/v1/cameras');
+                this.notify.cameras = Array.isArray(cams) ? cams : [];
+            } catch(e) {
+                this.notify.cameras = [];
+            }
+        },
+
+        async requestNotificationPermission() {
+            if (typeof Notification === 'undefined') {
+                this.notify.permission = 'unsupported';
+                return;
+            }
+            try {
+                var p = await Notification.requestPermission();
+                this.notify.permission = p;
+                if (p === 'granted') {
+                    window.HM.toast('Notifications enabled', 'success');
+                } else if (p === 'denied') {
+                    window.HM.toast('Notifications denied — check your browser site settings', 'error');
+                }
+            } catch(e) {
+                // Some browsers throw rather than rejecting; treat as denied.
+                this.notify.permission = 'denied';
+            }
+        },
+
+        async saveNotificationPrefs() {
+            try {
+                var resp = await window.HM.api.put(
+                    '/api/v1/notifications/prefs',
+                    { enabled: !!this.notify.prefs.enabled }
+                );
+                this.notify.prefs = (resp && resp.prefs) || this.notify.prefs;
+            } catch(e) {
+                window.HM.toast(e.message || 'Failed to save', 'error');
+            }
+        },
+
+        /* Per-user override of the camera-level rule. The effective
+           value is `camera.notification_rule[field]` unless the user
+           has set their own override in `prefs.cameras[cam_id]`. */
+        effectiveCameraEnabled(cam) {
+            var override = (this.notify.prefs.cameras || {})[cam.id];
+            if (override && typeof override.enabled === 'boolean') return override.enabled;
+            var camRule = cam.notification_rule || {};
+            return camRule.enabled !== false;  // default true
+        },
+
+        async setCameraOverride(camId, field, value) {
+            var cams = Object.assign({}, this.notify.prefs.cameras || {});
+            var entry = Object.assign({}, cams[camId] || {});
+            entry[field] = value;
+            cams[camId] = entry;
+            try {
+                var resp = await window.HM.api.put(
+                    '/api/v1/notifications/prefs',
+                    { cameras: cams }
+                );
+                this.notify.prefs = (resp && resp.prefs) || this.notify.prefs;
+            } catch(e) {
+                window.HM.toast(e.message || 'Failed to save', 'error');
+                // Re-load to show server's truth.
+                this.loadNotificationPrefs();
+            }
+        },
+
+        /* Camera-level default rule edit (admin only). Pushes the
+           change through PUT /api/v1/cameras/<id> which already
+           accepts `notification_rule` per the model. */
+        async setCameraDefault(camId, field, value) {
+            var cam = this.notify.cameras.find(function(c) { return c.id === camId; });
+            if (!cam) return;
+            var rule = Object.assign(
+                { enabled: true, min_duration_seconds: 3, coalesce_seconds: 60 },
+                cam.notification_rule || {}
+            );
+            rule[field] = value;
+            try {
+                await window.HM.api.put(
+                    '/api/v1/cameras/' + encodeURIComponent(camId),
+                    { notification_rule: rule }
+                );
+                cam.notification_rule = rule;
+            } catch(e) {
+                window.HM.toast(e.message || 'Failed to save', 'error');
+                this.loadNotificationPrefs();
+            }
+        },
+
+        fireTestNotification() {
+            if (typeof Notification === 'undefined' || Notification.permission !== 'granted') {
+                window.HM.toast('Notifications are not currently allowed', 'error');
+                return;
+            }
+            new Notification('Home Monitor', {
+                body: 'Test notification — your setup is working.',
+                icon: '/static/images/logo.svg',
+                tag: 'home-monitor-test',
+            });
+        },
     };
 }
 </script>

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -177,6 +177,11 @@ CAMERA_LIST_FIELDS_ADMIN = {
     # the dashboard's offline indicator is unaffected. Surfaced so
     # the Camera Settings modal can render the toggle.
     "offline_alerts_enabled",
+    # Per-camera notification rule (#129 / ADR-0027). Dict with
+    # {enabled, min_duration_seconds, coalesce_seconds}. The
+    # camera-level baseline; per-user overrides live separately
+    # in user.notification_prefs.cameras{}.
+    "notification_rule",
 }
 
 # Viewers see a subset — no IP (network topology) or health metrics (occupancy risk)

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -172,6 +172,75 @@ class TestAlertCenterUI:
         with open(stamp, "w") as f:
             f.write("done")
 
+    def test_settings_notifications_tab_visible_to_admin(self, client):
+        """ADR-0027 / #129 — Settings has a Notifications tab in
+        the admin tab bar. Pin both the button and the tab body
+        gate so a future "tidy-up" can't quietly drop them.
+        """
+        with client.session_transaction() as sess:
+            sess["user_id"] = "user-001"
+            sess["username"] = "admin"
+            sess["role"] = "admin"
+        response = client.get("/settings")
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # Tab button.
+        assert "tab === 'notifications'" in body
+        assert "Notifications</button>" in body or "Notifications<" in body
+        # Tab body has the per-user controls.
+        assert "Browser notifications" in body
+        assert "Notify me" in body
+        # Permission state surfaced.
+        assert "notify.permission === 'granted'" in body
+        assert "notify.permission === 'denied'" in body
+        # Test-notification button.
+        assert "fireTestNotification()" in body
+        # Camera defaults section is admin-only.
+        assert "isAdmin && notify.cameras.length" in body
+
+    def test_settings_notifications_tab_visible_to_viewer(self, client):
+        """Notifications are personal — viewers can manage their
+        own prefs even though they don't see the admin tab bar.
+        Pin that the panel renders for non-admin too.
+        """
+        with client.session_transaction() as sess:
+            sess["user_id"] = "user-002"
+            sess["username"] = "bob"
+            sess["role"] = "viewer"
+        response = client.get("/settings")
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # Tab button is in the always-visible part of the tab bar
+        # (the admin-only template-block excludes it). The tab body
+        # is gated by tab=='notifications', not by isAdmin, so it
+        # appears for the viewer when they click the button.
+        assert "Notifications</button>" in body or "Notifications<" in body
+        # Per-camera defaults section IS admin-only — verify it's
+        # gated.
+        assert 'x-show="isAdmin && notify.cameras.length' in body
+
+    def test_base_html_polls_notifications_pending(self, client):
+        """The polling-and-fire-Notification logic must be wired
+        in base.html so the bell-badge poller's neighbour fires
+        OS-level notifications when permission is granted. Pin the
+        fetch URL + the gate.
+        """
+        with client.session_transaction() as sess:
+            sess["user_id"] = "user-001"
+            sess["username"] = "admin"
+            sess["role"] = "admin"
+        # Any authed page renders base.html — use dashboard.
+        response = client.get("/dashboard")
+        body = response.get_data(as_text=True)
+        # Permission gate (skip fetch entirely if not granted).
+        assert "Notification.permission !== 'granted'" in body
+        # Fetch URL.
+        assert "/api/v1/notifications/pending" in body
+        # OS-level dedupe via tag.
+        assert "tag: n.alert_id" in body
+        # Mark-seen round trip so the same alert doesn't re-fire.
+        assert "/api/v1/notifications/seen" in body
+
     def test_dashboard_camera_cards_have_id_anchors(self, client):
         """The Tier-1 status strip's deep_link is `/dashboard#camera-<id>`
         (per system_summary_service._cameras). For that link to actually


### PR DESCRIPTION
## Summary

Closes #129. Phase 2 of ADR-0027 (rich motion notifications). Already deployed live to `192.168.1.244`.

| Surface | Visible to | What |
|---|---|---|
| **Settings → Notifications tab** | Admins + viewers | Permission state, per-user on/off, per-camera overrides, test-notification button. Camera defaults section gated to admins only inside the panel |
| **base.html polling loop** | All authed pages | Polls `/api/v1/notifications/pending` every 30s alongside the bell-badge poll, fires `new Notification(...)` with snapshot/icon, OS-level dedupe via `tag: alert_id`, click → deep_link, marks-seen on the server so re-poll doesn't refire |

## UX decisions

- **Notifications are personal**, not system. The tab is visible to both admins and viewers — viewers manage their own opt-in without admin permission. Other Settings tabs (System / Network / Tailscale / Users / Recording / Storage / Updates) stay admin-only.
- **Camera defaults editor lives in the Notifications panel**, not the Camera Settings modal. The camera-level rule is the *baseline* from which per-user overrides derive — keeping it next to the per-user controls makes the relationship visible.
- **Permission gate is the first decision**. We don't fetch `/pending` at all unless `Notification.permission === 'granted'` — saves polling cost for users who haven't opted in.
- **Snapshot fallback to logo**. ADR-0027 §"Snapshot pipeline" text-only fallback when ffmpeg can't extract.
- **Existing viewer fallback respected**. `<div x-show="!isAdmin && tab !== 'notifications'">` keeps System Info + Change Password visible by default, hides it when the user clicks the Notifications tab.

## Files

| File | Change |
|---|---|
| `monitor/templates/settings.html` | New Notifications tab body + Alpine state (`notify`, `loadNotificationPrefs`, `saveNotificationPrefs`, `setCameraOverride`, `setCameraDefault`, `requestNotificationPermission`, `effectiveCameraEnabled`, `fireTestNotification`); tab bar restructured so Notifications shows for everyone |
| `monitor/templates/base.html` | Polling loop that fires `new Notification(...)` |
| `monitor/services/camera_service.py` | Accept `notification_rule` on PUT (with bool/int range validation); include in GET response |
| `tests/contracts/test_api_contracts.py` | New field added to expected camera response shape |
| `tests/integration/test_views.py` | 3 new structural-anchor tests (admin tab, viewer tab, base.html polling) |

## Self-review

- **Server-side validation**: bool + int-range checks on `notification_rule` (1–60 / 10–600 per ADR-0027). Regression-pinned by the contract test addition.
- **Backwards compatible**: legacy cameras.json records get safe defaults via `field(default_factory=lambda: ...)` on the dataclass — same pattern as #136.
- **No new daemons**, no service workers, no Web Push, no cloud relay. Per ADR-0027.
- **CSRF on `/seen` POST** uses the existing `csrf_token` cookie pattern (read in JS, sent as header).
- **Polling defers 5s on first call** so the dashboard's initial render isn't competing with an extra fetch.

## Test plan

- [x] `pytest test_views.py + contracts/ + test_camera_service.py` — **278 passed**
- [x] `pre-commit` — green
- [x] **Already deployed live** on `192.168.1.244`. Service active, routes 401 (auth-gated), settings page renders. The browser-side functionality (permission grant, real Notification firing) is the cross-browser verification work for #130 — exercise with hand-wave at `.148`'s ZeroCam from a real browser tab.

## Deployment impact

Server-only, app code. Three files. Same `/opt/monitor/monitor/` deploy path. No new persistent surfaces — Camera + User dataclass fields default-deserialise.

## Doc impact

None on this PR. ADR-0027 is the contract; the in-template help text describes the UX. CHANGELOG entry will land with the release.