### PR TITLE
fix(camera): verify avahi-publish stayed alive after launch (#198)

### DIFF
--- a/app/camera/camera_streamer/discovery.py
+++ b/app/camera/camera_streamer/discovery.py
@@ -13,10 +13,22 @@ TXT records:
   paired   = true/false
 
 Uses avahi-publish-service which is part of avahi-daemon package.
+
+Readiness contract (issue #198): ``avahi-publish-*`` exits with a
+non-zero return code immediately if avahi-daemon is not yet available
+on the bus, or if the publication is rejected (duplicate name,
+malformed TXT, etc.). Without a brief post-launch readiness check,
+``Popen`` returns successfully and the service believes it is
+advertising while in reality nothing reaches the wire — the exact
+"silent green" failure mode operators reported on cold boot. We poll
+``process.poll()`` for a short window after launch and surface any
+immediate failure (with the child's stderr) instead of pretending all
+is well.
 """
 
 import logging
 import subprocess
+import time
 
 from camera_streamer import wifi
 
@@ -30,6 +42,18 @@ VERSION = "1.0.0"
 class DiscoveryService:
     """Advertise camera via mDNS/Avahi for server auto-discovery."""
 
+    # Total wall-time we wait for an avahi-publish-* helper to confirm
+    # it didn't immediately exit. avahi's failure modes (bus not ready,
+    # duplicate name, bad TXT) all produce an exit within tens of
+    # milliseconds, so 500 ms is comfortably above the noise floor.
+    # Tests override this to 0.0 (see camera test conftest) so the suite
+    # does not pay a half-second per start() call.
+    PUBLISH_READINESS_TIMEOUT_SECONDS = 0.5
+    # Cadence of poll() checks within the readiness window. Smaller than
+    # the timeout so we detect failures quickly without burning a CPU
+    # core on a tight loop.
+    PUBLISH_READINESS_POLL_INTERVAL = 0.05
+
     def __init__(self, config, pairing_manager=None):
         self._config = config
         self._pairing = pairing_manager
@@ -42,7 +66,14 @@ class DiscoveryService:
         return self._process is not None and self._process.poll() is None
 
     def start(self):
-        """Start mDNS advertisement."""
+        """Start mDNS advertisement.
+
+        After spawning the avahi-publish helper we briefly verify the
+        process is still alive — the helper exits immediately if
+        avahi-daemon isn't ready or the publication is rejected, and
+        we'd otherwise log "advertisement started" while nothing was
+        on the wire. See module docstring (issue #198).
+        """
         if self._running:
             return
 
@@ -75,19 +106,32 @@ class DiscoveryService:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
             )
-            log.info(
-                "mDNS advertisement started: %s %s port %d",
-                service_name,
-                SERVICE_TYPE,
-                SERVICE_PORT,
-            )
-            self._start_host_advertisement()
         except FileNotFoundError:
             log.error("avahi-publish-service not found — mDNS disabled")
             self._running = False
+            self._process = None
+            return
         except OSError as e:
             log.error("Failed to start mDNS: %s", e)
             self._running = False
+            self._process = None
+            return
+
+        if not self._verify_publish_alive(self._process, "service"):
+            # _verify_publish_alive logged the actual failure with stderr.
+            # Drop the dead handle so is_advertising returns False and the
+            # outer watchdog can retry on the next supervision tick.
+            self._process = None
+            self._running = False
+            return
+
+        log.info(
+            "mDNS advertisement started: %s %s port %d",
+            service_name,
+            SERVICE_TYPE,
+            SERVICE_PORT,
+        )
+        self._start_host_advertisement()
 
     def _start_host_advertisement(self):
         """Publish the unique camera hostname as an mDNS A record."""
@@ -116,13 +160,58 @@ class DiscoveryService:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
             )
-            log.info(
-                "mDNS hostname advertisement started: %s -> %s", host_label, ip_address
-            )
         except FileNotFoundError:
             log.warning("avahi-publish-address not found — hostname mDNS disabled")
+            return
         except OSError as e:
             log.warning("Failed to start hostname mDNS advertisement: %s", e)
+            return
+
+        if not self._verify_publish_alive(self._host_process, "host"):
+            # Service publication is still good — operators can still find
+            # us by service browse, they just lose the cam-id.local A
+            # record. Don't fail the whole start() here.
+            self._host_process = None
+            return
+
+        log.info(
+            "mDNS hostname advertisement started: %s -> %s", host_label, ip_address
+        )
+
+    def _verify_publish_alive(self, process, label):
+        """Confirm an avahi-publish-* helper survived the first window.
+
+        Returns True if the process is still alive at the deadline.
+        Returns False if it exited within the window — the failure is
+        logged at ERROR with the captured stderr (or ``<no stderr>``)
+        and the caller is expected to drop the handle.
+
+        ``label`` is the short descriptor used in log lines to
+        distinguish service-browse failures from hostname-A-record
+        failures (e.g. ``"service"``, ``"host"``).
+        """
+        deadline = time.monotonic() + self.PUBLISH_READINESS_TIMEOUT_SECONDS
+        while True:
+            rc = process.poll()
+            if rc is not None:
+                stderr_text = ""
+                try:
+                    if process.stderr is not None:
+                        stderr_bytes = process.stderr.read() or b""
+                        stderr_text = stderr_bytes.decode(errors="replace").strip()
+                except (OSError, ValueError):
+                    # stderr already closed / not a real pipe (test mock).
+                    pass
+                log.error(
+                    "avahi-publish-%s exited immediately (rc=%d): %s",
+                    label,
+                    rc,
+                    stderr_text or "<no stderr>",
+                )
+                return False
+            if time.monotonic() >= deadline:
+                return True
+            time.sleep(self.PUBLISH_READINESS_POLL_INTERVAL)
 
     def stop(self):
         """Stop mDNS advertisement."""

--- a/app/camera/tests/conftest.py
+++ b/app/camera/tests/conftest.py
@@ -61,6 +61,23 @@ def _camera_skip_mount_check(monkeypatch):
     monkeypatch.setenv("CAMERA_SKIP_MOUNT_CHECK", "1")
 
 
+@pytest.fixture(autouse=True)
+def _camera_fast_discovery_readiness(monkeypatch):
+    """Skip the avahi-publish readiness wait by default in unit tests.
+
+    `DiscoveryService.start()` waits up to 500 ms after `Popen` to
+    confirm the avahi-publish helper didn't immediately exit (issue
+    #198). Existing tests mock `process.poll()` to return None, so the
+    wait would just stall the suite. Tests that explicitly verify the
+    readiness behaviour bump this back up via monkeypatch.
+    """
+    from camera_streamer import discovery
+
+    monkeypatch.setattr(
+        discovery.DiscoveryService, "PUBLISH_READINESS_TIMEOUT_SECONDS", 0.0
+    )
+
+
 @pytest.fixture
 def data_dir(tmp_path):
     """Create a temporary /data directory structure for the camera."""

--- a/app/camera/tests/unit/test_discovery_extra.py
+++ b/app/camera/tests/unit/test_discovery_extra.py
@@ -1,7 +1,11 @@
 # REQ: SWR-015; RISK: RISK-005; SEC: SC-004; TEST: TC-008
 """Additional discovery tests for coverage."""
 
+import io
+import logging
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from camera_streamer.discovery import VERSION, DiscoveryService
 
@@ -104,3 +108,190 @@ class TestDiscoveryResolution:
             with patch("time.sleep"):
                 svc.update_paired_status(True)
             assert mock_popen.call_count == 4
+
+
+class TestPublishReadiness:
+    """Verify the avahi-publish readiness check (issue #198).
+
+    Without these guards, ``Popen`` returning a process handle was
+    treated as success even when avahi-daemon refused the publication
+    or the helper crashed before reaching the wire — operators saw
+    "advertisement started" in the log while the camera was invisible
+    on the network at boot.
+    """
+
+    def _proc(self, *, exit_rc=None, stderr_bytes=b""):
+        """Build a fake avahi-publish process.
+
+        ``exit_rc=None`` means the process is alive across all polls.
+        ``exit_rc=<int>`` makes it appear already-exited on the first
+        poll, with the supplied stderr bytes available for capture.
+        """
+        proc = MagicMock()
+        proc.poll.return_value = exit_rc
+        proc.returncode = exit_rc if exit_rc is not None else 0
+        proc.stderr = io.BytesIO(stderr_bytes) if stderr_bytes else io.BytesIO(b"")
+        proc.wait.return_value = None
+        return proc
+
+    def test_service_exits_immediately_marks_not_advertising(
+        self, camera_config, monkeypatch, caplog
+    ):
+        """A dead service-publish process must not look like a healthy advertiser."""
+        # The conftest autouse fixture zeroes the readiness timeout for
+        # speed; this test deliberately bumps it back up to a small but
+        # non-zero window so the loop body actually runs.
+        monkeypatch.setattr(DiscoveryService, "PUBLISH_READINESS_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(DiscoveryService, "PUBLISH_READINESS_POLL_INTERVAL", 0.01)
+
+        dead = self._proc(
+            exit_rc=2, stderr_bytes=b"Failed to register service: bus not ready\n"
+        )
+        with (
+            patch("subprocess.Popen", return_value=dead),
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+            caplog.at_level(logging.ERROR, logger="camera-streamer.discovery"),
+        ):
+            svc = DiscoveryService(camera_config)
+            svc.start()
+
+            # The service handle is dropped so is_advertising reports the
+            # truth and the outer watchdog can retry.
+            assert svc.is_advertising is False
+            assert svc._process is None
+            assert svc._running is False
+
+            # And the actual error reached the log so operators have a
+            # diagnostic instead of a silent failure.
+            assert any(
+                "avahi-publish-service exited immediately" in r.message
+                and "bus not ready" in r.message
+                for r in caplog.records
+            ), [r.message for r in caplog.records]
+
+    def test_host_exits_immediately_keeps_service_advertisement(
+        self, camera_config, monkeypatch, caplog
+    ):
+        """A host-record failure must not collapse the whole service-browse advertisement."""
+        monkeypatch.setattr(DiscoveryService, "PUBLISH_READINESS_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(DiscoveryService, "PUBLISH_READINESS_POLL_INTERVAL", 0.01)
+
+        live_service = self._proc(exit_rc=None)
+        dead_host = self._proc(
+            exit_rc=1, stderr_bytes=b"Failed to add address: name collision\n"
+        )
+
+        with (
+            patch("subprocess.Popen", side_effect=[live_service, dead_host]),
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+            caplog.at_level(logging.ERROR, logger="camera-streamer.discovery"),
+        ):
+            svc = DiscoveryService(camera_config)
+            svc.start()
+
+            # Service browse is still alive — a name-collision on the A
+            # record is recoverable, the camera is still findable.
+            assert svc.is_advertising is True
+            # ...but the dead host handle is dropped so we don't try to
+            # terminate a phantom process at shutdown.
+            assert svc._host_process is None
+
+            assert any(
+                "avahi-publish-host exited immediately" in r.message
+                and "name collision" in r.message
+                for r in caplog.records
+            ), [r.message for r in caplog.records]
+
+            svc.stop()
+
+    def test_alive_process_passes_readiness_check(self, camera_config):
+        """The happy path: both publishers stay alive across the readiness window."""
+        # Default conftest fast-paths the timeout to 0.0 already; this
+        # test verifies the contract for the fast path.
+        live_service = self._proc(exit_rc=None)
+        live_host = self._proc(exit_rc=None)
+        with (
+            patch("subprocess.Popen", side_effect=[live_service, live_host]),
+            patch(
+                "camera_streamer.discovery.wifi.get_hostname", return_value="cam-test"
+            ),
+            patch(
+                "camera_streamer.discovery.wifi.get_ip_address",
+                return_value="192.168.1.50",
+            ),
+        ):
+            svc = DiscoveryService(camera_config)
+            svc.start()
+            assert svc.is_advertising is True
+            assert svc._host_process is live_host
+            svc.stop()
+
+    def test_readiness_check_handles_missing_stderr(
+        self, camera_config, monkeypatch, caplog
+    ):
+        """A process exited but with stderr=None must not raise — log says <no stderr>."""
+        monkeypatch.setattr(DiscoveryService, "PUBLISH_READINESS_TIMEOUT_SECONDS", 0.02)
+        monkeypatch.setattr(DiscoveryService, "PUBLISH_READINESS_POLL_INTERVAL", 0.01)
+
+        dead = MagicMock()
+        dead.poll.return_value = 1
+        dead.returncode = 1
+        dead.stderr = None  # explicit "no pipe" — must not crash
+
+        with (
+            patch("subprocess.Popen", return_value=dead),
+            caplog.at_level(logging.ERROR, logger="camera-streamer.discovery"),
+        ):
+            svc = DiscoveryService(camera_config)
+            svc.start()
+
+            assert svc.is_advertising is False
+            assert any("<no stderr>" in r.message for r in caplog.records), [
+                r.message for r in caplog.records
+            ]
+
+    def test_readiness_check_returns_true_for_alive_process(self, camera_config):
+        """Direct unit test of _verify_publish_alive happy path."""
+        live = self._proc(exit_rc=None)
+        svc = DiscoveryService(camera_config)
+        # Force a non-zero window so the loop runs at least one iteration.
+        svc.PUBLISH_READINESS_TIMEOUT_SECONDS = 0.02
+        svc.PUBLISH_READINESS_POLL_INTERVAL = 0.005
+        assert svc._verify_publish_alive(live, "service") is True
+
+    @pytest.mark.parametrize(
+        "stderr,expected_fragment",
+        [
+            (b"Failed to register service: bus not ready\n", "bus not ready"),
+            (b"D-Bus error: AccessDenied\n", "D-Bus error"),
+            (b"", "<no stderr>"),
+        ],
+    )
+    def test_failure_log_quotes_stderr(
+        self, camera_config, monkeypatch, caplog, stderr, expected_fragment
+    ):
+        """Operators need the actual avahi error in the log to debug boot races."""
+        monkeypatch.setattr(DiscoveryService, "PUBLISH_READINESS_TIMEOUT_SECONDS", 0.02)
+        monkeypatch.setattr(DiscoveryService, "PUBLISH_READINESS_POLL_INTERVAL", 0.01)
+        dead = self._proc(exit_rc=1, stderr_bytes=stderr)
+        with (
+            patch("subprocess.Popen", return_value=dead),
+            caplog.at_level(logging.ERROR, logger="camera-streamer.discovery"),
+        ):
+            svc = DiscoveryService(camera_config)
+            svc.start()
+            assert any(expected_fragment in r.message for r in caplog.records), [
+                r.message for r in caplog.records
+            ]


### PR DESCRIPTION
## Summary

- `DiscoveryService.start()` was treating a successful `Popen` return as proof the mDNS publication reached the wire — but `avahi-publish-*` exits non-zero immediately if avahi-daemon isn't ready on the bus, on a name collision, or on a malformed TXT. At cold boot the camera was logging "advertisement started" while in reality nothing was published, and the server only found it after a much later watchdog cycle.
- After every `Popen` we now briefly poll the process; if it has exited we capture stderr, log the actual error, drop the handle so `is_advertising` reports the truth, and let the outer supervisor retry. Service-browse and host-A-record processes are checked independently so a name-collision on the A record doesn't take the whole advertisement down.
- The readiness window is class-level so the camera test conftest can fast-path it to 0.0 for existing tests; the new `TestPublishReadiness` cases bump it back up to small non-zero values to actually exercise the poll loop.

Closes #198. Tracks #90.

## Test plan
- [x] New `TestPublishReadiness` covers: dead service-publish drops the handle + logs stderr; dead host-publish keeps the service handle alive; live processes pass through; missing stderr logs `<no stderr>`; parametrized log-quoting check across three stderr fragments.
- [x] Existing 17 discovery tests still pass (conftest fast-path keeps them at 0 wall-time wait).
- [x] `ruff check` + `ruff format --check` clean on all three files.
- [ ] Live verification on `rpi-divinu-cam` (192.168.1.115): SSH-deploy the new `discovery.py`, restart `camera-streamer.service`, observe `avahi-browse -ar -t` from server still shows `_rtsp._tcp` and `cam-id.local` records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)