### PR TITLE
fix(camera): broadcast mDNS goodbye on hostname change (#200)

### DIFF
--- a/app/camera/camera_streamer/wifi.py
+++ b/app/camera/camera_streamer/wifi.py
@@ -10,6 +10,7 @@ for platform abstraction.
 
 import logging
 import os
+import socket
 import subprocess
 import time
 
@@ -297,13 +298,41 @@ def get_hostname() -> str:
 
 
 def set_hostname(hostname: str) -> bool:
-    """Set the system hostname and notify NetworkManager and Avahi.
+    """Set the system hostname and notify Avahi with a proper goodbye.
 
     Uses transient hostname (memory-only) so it works on read-only rootfs.
     The hostname is saved to /data/config/hostname for persistence across
     reboots — the lifecycle restores it on every boot.
+
+    mDNS goodbye contract (issue #200, RFC 6762 §10.1): when the
+    hostname changes we MUST broadcast a record with TTL=0 for the
+    previous name so cached resolvers around the network drop the
+    stale entry immediately. The previous implementation did
+    ``systemctl restart avahi-daemon`` which kills the daemon without
+    giving it time to send goodbyes — operators chasing "the old name
+    still resolves" wasted hours on dead leads.
+
+    Approach: hand the new name to avahi-daemon over D-Bus via
+    ``avahi-set-host-name``. The daemon owns the swap, broadcasts the
+    cache-flush for the OLD name's A record (its self-publication),
+    and announces the NEW name in the same transition. No daemon
+    restart, no race with our own avahi-publish-* helpers running
+    inside DiscoveryService.
+
+    The goodbye is best-effort. If ``avahi-set-host-name`` is missing
+    or returns non-zero, we still set the kernel hostname and fall
+    back to a daemon restart so at least the new name reaches the
+    wire. Failure of the goodbye does not block the hostname change.
     """
     try:
+        # Snapshot the previous hostname so we can log the rotation
+        # explicitly. avahi-daemon itself is what knew the old name —
+        # we read socket.gethostname() purely for the log line.
+        try:
+            previous_hostname = socket.gethostname()
+        except OSError:
+            previous_hostname = ""
+
         # Set kernel hostname directly (works on read-only rootfs where
         # hostnamectl --transient is ignored due to static hostname in /etc)
         subprocess.run(["hostname", hostname], capture_output=True, timeout=5)
@@ -315,12 +344,86 @@ def set_hostname(hostname: str) -> bool:
                 f.write(hostname + "\n")
         except OSError:
             pass
-        # Restart avahi so mDNS advertises the new name
-        subprocess.run(
-            ["systemctl", "restart", "avahi-daemon"], capture_output=True, timeout=10
-        )
+
+        if previous_hostname and previous_hostname != hostname:
+            log.info(
+                "mDNS hostname change: %s -> %s (issuing goodbye + announce)",
+                previous_hostname,
+                hostname,
+            )
+        else:
+            log.info("Hostname set to %s (no prior name to flush)", hostname)
+
+        announced = _avahi_set_host_name(hostname)
+        if not announced:
+            # Last-resort fallback: restart the daemon. No goodbye for
+            # the old name, but at least the new name reaches the wire
+            # — strictly preserves the pre-fix behaviour.
+            log.warning(
+                "Falling back to avahi-daemon restart (no mDNS goodbye for %s)",
+                previous_hostname or "<unknown>",
+            )
+            try:
+                subprocess.run(
+                    ["systemctl", "restart", "avahi-daemon"],
+                    capture_output=True,
+                    timeout=10,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+                log.warning("avahi-daemon restart fallback failed: %s", e)
+
         log.info("Hostname set to %s", hostname)
         return True
     except Exception as e:
         log.warning("Failed to set hostname: %s", e)
         return False
+
+
+def _avahi_set_host_name(hostname: str) -> bool:
+    """Tell avahi-daemon to swap to ``hostname`` over D-Bus.
+
+    Returns True on success (daemon accepted the new name and will
+    broadcast the goodbye for the old one + announce the new one).
+    Returns False if the helper is missing, the daemon refused, or
+    the call timed out — caller falls back to a daemon restart.
+
+    Split out from ``set_hostname`` so the test suite can mock just
+    the avahi side of the flow without re-stubbing kernel hostname /
+    persistence calls.
+    """
+    try:
+        result = subprocess.run(
+            ["avahi-set-host-name", hostname],
+            capture_output=True,
+            timeout=5,
+        )
+    except FileNotFoundError:
+        log.warning(
+            "avahi-set-host-name not found — cannot send mDNS goodbye for old name"
+        )
+        return False
+    except subprocess.TimeoutExpired:
+        log.warning("avahi-set-host-name timed out — daemon may be stuck")
+        return False
+    except OSError as e:
+        log.warning("avahi-set-host-name failed: %s", e)
+        return False
+
+    if result.returncode == 0:
+        return True
+
+    # avahi-set-host-name prints diagnostic on stderr — surface it so
+    # operators know whether it was a name conflict, a permissions
+    # issue, or the daemon rejecting the call.
+    detail = (
+        result.stderr.decode(errors="replace").strip()
+        or result.stdout.decode(errors="replace").strip()
+        or "<no output>"
+    )
+    log.warning(
+        "avahi-set-host-name returned %d for %s: %s",
+        result.returncode,
+        hostname,
+        detail,
+    )
+    return False

--- a/app/camera/tests/unit/test_wifi.py
+++ b/app/camera/tests/unit/test_wifi.py
@@ -385,3 +385,195 @@ class TestSetHostname:
         # Verify we tried to open the persistence file path
         open_calls = [str(c) for c in mock_open.call_args_list]
         assert any("/data/config/hostname" in c for c in open_calls)
+
+
+class TestSetHostnameMdnsGoodbye:
+    """Verify the mDNS goodbye path on hostname change (issue #200, RFC 6762 §10.1).
+
+    The daemon-restart shortcut used previously kills avahi-daemon
+    before it can broadcast cache-flush records for the OLD hostname,
+    so cached resolvers around the network keep the old name
+    resolvable for its full TTL window. ``avahi-set-host-name`` swaps
+    the daemon's owned name in-place: goodbye for old + announce for
+    new in one atomic transition.
+    """
+
+    def _ok(self):
+        """Stand-in for a successful subprocess.run result."""
+        return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+    def _err(self, rc=1, stderr=b"D-Bus error: AccessDenied\n"):
+        return MagicMock(returncode=rc, stdout=b"", stderr=stderr)
+
+    def test_calls_avahi_set_host_name_with_new_name(self, tmp_path):
+        """The new name must be handed to avahi-daemon via the D-Bus helper."""
+        runs = []
+
+        def fake_run(cmd, **kwargs):
+            runs.append(cmd)
+            return self._ok()
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch("camera_streamer.wifi.socket.gethostname", return_value="rpi-old"),
+        ):
+            assert set_hostname("rpi-new") is True
+
+        # The D-Bus helper was invoked with the new name.
+        assert ["avahi-set-host-name", "rpi-new"] in runs, runs
+
+    def test_does_not_restart_avahi_when_set_host_name_succeeds(self, tmp_path):
+        """The whole point of the fix: no daemon restart when goodbye succeeded."""
+        runs = []
+
+        def fake_run(cmd, **kwargs):
+            runs.append(cmd)
+            return self._ok()
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch("camera_streamer.wifi.socket.gethostname", return_value="rpi-old"),
+        ):
+            set_hostname("rpi-new")
+
+        commands = [c[0] for c in runs]
+        assert "avahi-set-host-name" in commands
+        # No fallback restart should fire on the happy path.
+        for cmd in runs:
+            assert cmd[:2] != ["systemctl", "restart"], (
+                f"unexpected daemon restart on success path: {cmd}"
+            )
+
+    def test_falls_back_to_daemon_restart_when_set_host_name_returns_nonzero(
+        self, tmp_path
+    ):
+        """Daemon refused → still publish the new name (without goodbye)."""
+        runs = []
+
+        def fake_run(cmd, **kwargs):
+            runs.append(cmd)
+            if cmd[0] == "avahi-set-host-name":
+                return self._err(rc=2, stderr=b"name conflict\n")
+            return self._ok()
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch("camera_streamer.wifi.socket.gethostname", return_value="rpi-old"),
+        ):
+            assert set_hostname("rpi-new") is True
+
+        commands = [c for c in runs]
+        assert ["avahi-set-host-name", "rpi-new"] in commands
+        assert ["systemctl", "restart", "avahi-daemon"] in commands
+
+    def test_falls_back_when_set_host_name_missing(self, tmp_path):
+        """No avahi-set-host-name binary → fallback to daemon restart."""
+        runs = []
+
+        def fake_run(cmd, **kwargs):
+            runs.append(cmd)
+            if cmd[0] == "avahi-set-host-name":
+                raise FileNotFoundError(2, "No such file")
+            return self._ok()
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch("camera_streamer.wifi.socket.gethostname", return_value="rpi-old"),
+        ):
+            set_hostname("rpi-new")
+
+        assert ["systemctl", "restart", "avahi-daemon"] in runs
+
+    def test_falls_back_when_set_host_name_times_out(self, tmp_path):
+        """Daemon stuck → still set the new name and try the restart fallback."""
+        runs = []
+
+        def fake_run(cmd, **kwargs):
+            runs.append(cmd)
+            if cmd[0] == "avahi-set-host-name":
+                raise subprocess.TimeoutExpired(cmd, 5)
+            return self._ok()
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch("camera_streamer.wifi.socket.gethostname", return_value="rpi-old"),
+        ):
+            assert set_hostname("rpi-new") is True
+
+        assert ["systemctl", "restart", "avahi-daemon"] in runs
+
+    def test_logs_old_to_new_rotation(self, tmp_path, caplog):
+        """The rotation log line must include both the old and new name for debug."""
+        import logging as _logging
+
+        with (
+            patch(
+                "camera_streamer.wifi.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout=b"", stderr=b""),
+            ),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch(
+                "camera_streamer.wifi.socket.gethostname", return_value="rpi-old-d8ee"
+            ),
+            caplog.at_level(_logging.INFO, logger="camera-streamer.wifi"),
+        ):
+            set_hostname("rpi-new-a5cf")
+
+        rotation_lines = [
+            r.message for r in caplog.records if "mDNS hostname change" in r.message
+        ]
+        assert any(
+            "rpi-old-d8ee" in line and "rpi-new-a5cf" in line for line in rotation_lines
+        ), rotation_lines
+
+    def test_no_rotation_log_when_unchanged(self, tmp_path, caplog):
+        """Idempotent set (same name) should log a different message — no goodbye dance implied."""
+        import logging as _logging
+
+        with (
+            patch(
+                "camera_streamer.wifi.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout=b"", stderr=b""),
+            ),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch("camera_streamer.wifi.socket.gethostname", return_value="rpi-same"),
+            caplog.at_level(_logging.INFO, logger="camera-streamer.wifi"),
+        ):
+            set_hostname("rpi-same")
+
+        for r in caplog.records:
+            assert "mDNS hostname change" not in r.message, r.message
+
+    def test_socket_gethostname_failure_does_not_break_path(self, tmp_path):
+        """socket.gethostname() failures fall through — the change still proceeds."""
+        runs = []
+
+        def fake_run(cmd, **kwargs):
+            runs.append(cmd)
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch(
+                "camera_streamer.wifi.socket.gethostname",
+                side_effect=OSError("EFAULT"),
+            ),
+        ):
+            assert set_hostname("rpi-new") is True
+
+        # Even with no prior name, we still hand the new name to avahi.
+        assert ["avahi-set-host-name", "rpi-new"] in runs


### PR DESCRIPTION
## Summary

- `wifi.set_hostname()` was using `systemctl restart avahi-daemon` to republish the new name. That kills the daemon before it can send RFC 6762 cache-flush records (TTL=0) for the OLD hostname's A record, so cached resolvers around the network keep `<old>.local` resolvable for the full TTL window after the camera has moved on. Operators chasing "the old name still resolves" follow dead leads (the historical `-d8ee` CPU-serial-suffix migration in #90 is the canonical scenario).
- Switch to `avahi-set-host-name <new>` over D-Bus. avahi-daemon owns the swap and broadcasts goodbye-for-old + announce-for-new in one atomic transition — no daemon restart, no race with the `avahi-publish-*` helpers in `DiscoveryService`.
- Best-effort: if the helper is missing, times out, or returns non-zero, we still update the kernel hostname and fall back to the old daemon-restart path so the new name reaches the wire. Strictly preserves pre-fix behaviour on the failure leg.

Closes #200. Tracks #90.

## Test plan
- [x] 8 new `TestSetHostnameMdnsGoodbye` cases cover: helper invoked with new name; no daemon-restart on success; fallback on non-zero rc, missing binary, and timeout; rotation log includes both names; idempotent set doesn't claim a rotation; `socket.gethostname()` failure doesn't break the path.
- [x] Existing 33 wifi tests still pass (the new code reduces to the old-style call sequence when `avahi-set-host-name` returns 0, which is what their `subprocess.run` mocks always return).
- [x] Full camera unit suite green: 420 passed (the 2 pre-existing `test_config` failures are Windows-host artefacts of a Linux-mountpoint check, not from this change).
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live verification on `rpi-divinu-cam-a5cf` (192.168.1.115): trigger a hostname change, observe the goodbye + announce sequence in `tcpdump port 5353`, confirm a third device immediately stops resolving the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)