### PR TITLE
fix: break stuck-pending config_sync loop (#231)

### DIFF
--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -26,6 +26,7 @@ import urllib.error
 import urllib.request
 
 from camera_streamer.control import ControlHandler, parse_control_request
+from camera_streamer.server_notifier import notify_config_change
 
 log = logging.getLogger("camera-streamer.heartbeat")
 
@@ -408,7 +409,18 @@ class HeartbeatSender:
             log.warning("Failed to send SIGTERM to self: %s", exc)
 
     def _apply_pending_config(self, pending: dict) -> None:
-        """Apply a pending stream config pushed back by the server."""
+        """Apply a pending stream config pushed back by the server.
+
+        On a successful apply we POST an explicit ack to
+        ``/api/v1/cameras/config-notify`` via ``notify_config_change``.
+        Without this the server has no way to detect that the
+        server-origin push has landed (the local-UI flow in
+        ``status_server`` only notifies on ``origin="local"``), so the
+        bidirectional sync stalls in ``pending`` forever and the
+        dashboard badge never returns to ``synced`` (issue #231). The
+        notify is fire-and-forget — failures are logged but do not
+        block the apply itself.
+        """
         log.info("Applying pending config from server heartbeat response: %s", pending)
         try:
             body = json.dumps(pending).encode()
@@ -420,7 +432,26 @@ class HeartbeatSender:
             result, error, _ = handler.set_config(params, request_id=0, origin="server")
             if error:
                 log.warning("Failed to apply pending config: %s", error)
-            else:
-                log.info("Pending config applied: %s", result)
+                return
+            log.info("Pending config applied: %s", result)
+            self._notify_server_of_apply()
         except Exception as exc:
             log.warning("Exception applying pending config: %s", exc)
+
+    def _notify_server_of_apply(self) -> None:
+        """Fire-and-forget POST to /config-notify so the server can mark synced.
+
+        Spawned on a daemon thread because the server might be slow,
+        unreachable, or returning a transient 5xx — we never want to
+        block the heartbeat loop on the ack path. Same threading
+        pattern the local-UI flow uses in ``status_server``.
+        """
+        try:
+            threading.Thread(
+                target=notify_config_change,
+                args=(self._config, self._pairing),
+                daemon=True,
+                name="config-notify-after-apply",
+            ).start()
+        except Exception as exc:
+            log.warning("Failed to spawn config-notify thread: %s", exc)

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -338,6 +338,10 @@ class TestHeartbeatSender:
             patch(
                 "camera_streamer.heartbeat.ControlHandler", return_value=mock_handler
             ),
+            # Stub the new server-notify path so the test doesn't try
+            # to reach the network — that's covered by dedicated tests
+            # below.
+            patch("camera_streamer.heartbeat.notify_config_change"),
         ):
             sender._apply_pending_config(pending)
 
@@ -345,6 +349,129 @@ class TestHeartbeatSender:
         call_kwargs = mock_handler.set_config.call_args
         # Verify origin="server" is passed (prevents ping-pong)
         assert call_kwargs.kwargs.get("origin") == "server"
+
+    def test_apply_pending_config_notifies_server_on_success(self):
+        """After a successful apply, the camera must POST /config-notify so
+        the server can mark config_sync=synced — this is the explicit ack
+        that breaks the stuck-pending loop in #231 from the camera side."""
+        cfg = _make_config()
+        stream = MagicMock()
+        pairing = _make_pairing()
+        sender = HeartbeatSender(cfg, pairing, stream_manager=stream)
+
+        pending = {"fps": 30}
+
+        mock_handler = MagicMock()
+        mock_handler.set_config.return_value = ({"applied": True}, "", 200)
+
+        # Capture the thread args so we can assert what would have been
+        # sent without actually starting a real thread.
+        captured = {}
+
+        def fake_thread(**kwargs):
+            captured["target"] = kwargs.get("target")
+            captured["args"] = kwargs.get("args")
+            captured["name"] = kwargs.get("name")
+            captured["daemon"] = kwargs.get("daemon")
+            t = MagicMock()
+            t.start = MagicMock()
+            return t
+
+        with (
+            patch(
+                "camera_streamer.heartbeat.parse_control_request",
+                return_value=(pending, 0, ""),
+            ),
+            patch(
+                "camera_streamer.heartbeat.ControlHandler", return_value=mock_handler
+            ),
+            patch("camera_streamer.heartbeat.notify_config_change") as mock_notify,
+            patch(
+                "camera_streamer.heartbeat.threading.Thread",
+                side_effect=fake_thread,
+            ),
+        ):
+            sender._apply_pending_config(pending)
+
+        # The notify thread was scheduled with the right callable + args.
+        assert captured["target"] is mock_notify
+        assert captured["args"] == (cfg, pairing)
+        assert captured["daemon"] is True
+        assert "config-notify" in captured["name"]
+
+    def test_apply_pending_config_does_not_notify_on_failure(self):
+        """If set_config returned an error, the apply did NOT land —
+        notifying the server would falsely advance config_sync to synced
+        on a failed push."""
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        pending = {"fps": 30}
+
+        mock_handler = MagicMock()
+        # Non-empty error string from set_config means apply failed.
+        mock_handler.set_config.return_value = (None, "rejected: bad fps", 400)
+
+        with (
+            patch(
+                "camera_streamer.heartbeat.parse_control_request",
+                return_value=(pending, 0, ""),
+            ),
+            patch(
+                "camera_streamer.heartbeat.ControlHandler", return_value=mock_handler
+            ),
+            patch("camera_streamer.heartbeat.notify_config_change") as mock_notify,
+            patch("camera_streamer.heartbeat.threading.Thread") as mock_thread_cls,
+        ):
+            sender._apply_pending_config(pending)
+
+        # No notify thread spawned, no notify called.
+        mock_thread_cls.assert_not_called()
+        mock_notify.assert_not_called()
+
+    def test_apply_pending_config_does_not_notify_on_parse_error(self):
+        """A malformed pending payload short-circuits before set_config —
+        the notify path must not fire on this branch either."""
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        with (
+            patch(
+                "camera_streamer.heartbeat.parse_control_request",
+                return_value=(None, 0, "schema mismatch"),
+            ),
+            patch("camera_streamer.heartbeat.ControlHandler") as mock_handler_cls,
+            patch("camera_streamer.heartbeat.threading.Thread") as mock_thread_cls,
+        ):
+            sender._apply_pending_config({"fps": "garbage"})
+
+        mock_handler_cls.assert_not_called()
+        mock_thread_cls.assert_not_called()
+
+    def test_notify_thread_failure_does_not_propagate(self):
+        """Threading.Thread itself raising must not break the apply path —
+        the camera should log and continue, not crash the heartbeat loop."""
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        mock_handler = MagicMock()
+        mock_handler.set_config.return_value = ({"applied": True}, "", 200)
+
+        with (
+            patch(
+                "camera_streamer.heartbeat.parse_control_request",
+                return_value=({"fps": 30}, 0, ""),
+            ),
+            patch(
+                "camera_streamer.heartbeat.ControlHandler", return_value=mock_handler
+            ),
+            patch(
+                "camera_streamer.heartbeat.threading.Thread",
+                side_effect=RuntimeError("can't allocate thread"),
+            ),
+        ):
+            # Must not raise
+            sender._apply_pending_config({"fps": 30})
 
     def test_start_stop_thread(self):
         cfg = _make_config()

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -115,6 +115,49 @@ def _stream_params_from_camera(camera) -> dict:
     return params
 
 
+def _heartbeat_stream_config_matches(camera, sc: dict) -> bool:
+    """Does the camera's heartbeat-reported ``stream_config`` match stored values?
+
+    Used by ``record_heartbeat`` to detect that a server-pushed
+    pending config has actually landed even when the camera didn't
+    POST the explicit ``/config-notify`` ack — without this hook the
+    bidirectional sync stalls in a "pending forever" loop (issue #231:
+    server-origin applies on the camera don't fire ``notify_config_change``,
+    and the heartbeat path was previously gated by ``not had_pending``,
+    so once we entered ``pending`` there was no exit).
+
+    Conservative comparison: we walk every stream parameter present in
+    ``sc`` and require equality with the stored value. Keys missing
+    from ``sc`` are tolerated — the camera reports only the 9 stream-
+    pipeline fields (width/height/fps/bitrate/h264_profile/keyframe_interval/
+    rotation/hflip/vflip), not motion_sensitivity / image_quality /
+    motion_detection. Cameras whose pending state is gated on those
+    other fields fall through to the camera-side fix in #231 (notify
+    after apply) and don't reach this path.
+
+    The wire alias for ``recording_motion_enabled`` (translated to
+    ``motion_detection`` on the way out by ``_translate_stream_params_for_wire``)
+    is accepted on either name so a future camera that echoes the wire
+    keys back doesn't trip us up.
+    """
+    for key in STREAM_PARAMS:
+        if key == "recording_motion_enabled":
+            if "recording_motion_enabled" in sc:
+                cam_value = sc["recording_motion_enabled"]
+            elif "motion_detection" in sc:
+                cam_value = sc["motion_detection"]
+            else:
+                continue
+        elif key in sc:
+            cam_value = sc[key]
+        else:
+            continue
+        stored = getattr(camera, key, STREAM_PARAM_DEFAULTS.get(key))
+        if cam_value != stored:
+            return False
+    return True
+
+
 def _sensor_mode_max_fps(sensor_modes: list[dict]) -> dict[tuple[int, int], int]:
     """Map each reported sensor resolution to its highest supported fps."""
     # REQ: SWR-011; RISK: RISK-007; TEST: TC-012
@@ -636,16 +679,25 @@ class CameraService:
         # potentially-stale values.
         had_pending = camera.config_sync == "pending"
 
-        if (
-            "stream_config" in data
-            and isinstance(data["stream_config"], dict)
-            and not had_pending
-        ):
+        if "stream_config" in data and isinstance(data["stream_config"], dict):
             sc = data["stream_config"]
-            for key in sc:
-                if key in STREAM_PARAMS:
-                    setattr(camera, key, sc[key])
-            camera.config_sync = "synced"
+            if had_pending:
+                # The camera reports its current config in every heartbeat.
+                # If those values match what we stored as the desired
+                # pending state, the camera HAS applied the server-pushed
+                # config (via _apply_pending_config) — it just didn't
+                # POST an explicit /config-notify ack because that path
+                # only fires for origin="local" applies (#231). Treat
+                # the matching heartbeat as the implicit ack so we exit
+                # the otherwise-stuck-forever pending loop.
+                if _heartbeat_stream_config_matches(camera, sc):
+                    camera.config_sync = "synced"
+                    had_pending = False
+            else:
+                for key in sc:
+                    if key in STREAM_PARAMS:
+                        setattr(camera, key, sc[key])
+                camera.config_sync = "synced"
 
         self._store.save_camera(camera)
 

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -960,6 +960,192 @@ class TestAcceptHeartbeat:
         assert not error
 
 
+class TestPendingReconciliationFromHeartbeat:
+    """Server-side reconciliation that breaks the stuck-pending loop (#231).
+
+    Before this change the heartbeat path was gated on ``not had_pending``
+    and the only exit from ``pending`` was an explicit
+    ``/config-notify`` POST from the camera — which the camera doesn't
+    fire for server-origin applies, so the loop ran forever:
+
+      camera applies pending_config -> server has no ack -> next heartbeat returns
+      pending_config again -> camera applies again -> ... (every 15s, forever).
+
+    The reconciliation matches the camera's heartbeat-reported
+    stream_config against the server's stored values and treats a full
+    match as an implicit ack.
+    """
+
+    def _basic_payload_with_stream_config(self, **stream_overrides):
+        """Build a heartbeat payload whose stream_config matches the
+        defaults the camera ships with. Tests override individual
+        fields to drift it intentionally."""
+        sc = {
+            "width": 1920,
+            "height": 1080,
+            "fps": 25,
+            "bitrate": 4000000,
+            "h264_profile": "high",
+            "keyframe_interval": 30,
+            "rotation": 0,
+            "hflip": False,
+            "vflip": False,
+        }
+        sc.update(stream_overrides)
+        return {
+            "streaming": True,
+            "cpu_temp": 50.0,
+            "memory_percent": 40,
+            "uptime_seconds": 1000,
+            "stream_config": sc,
+        }
+
+    def test_matching_heartbeat_marks_pending_camera_synced(self):
+        """The whole point: when camera reports values matching server,
+        we exit the pending loop."""
+        cam = _make_camera(
+            config_sync="pending",
+            width=1920,
+            height=1080,
+            fps=25,
+            bitrate=4000000,
+            h264_profile="high",
+            keyframe_interval=30,
+            rotation=0,
+            hflip=False,
+            vflip=False,
+        )
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+
+        response, _, code = svc.accept_heartbeat(
+            "cam-001", self._basic_payload_with_stream_config()
+        )
+
+        assert code == 200
+        assert cam.config_sync == "synced"
+        # And critically: stop returning pending_config so the camera
+        # stops re-applying every 15 seconds.
+        assert "pending_config" not in response
+
+    def test_mismatching_heartbeat_keeps_pending(self):
+        """Stale camera (still on old fps) must stay pending so we keep pushing."""
+        cam = _make_camera(config_sync="pending", fps=30)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+
+        # Camera still reports the OLD fps=25 — server wants 30.
+        response, _, code = svc.accept_heartbeat(
+            "cam-001", self._basic_payload_with_stream_config(fps=25)
+        )
+
+        assert code == 200
+        assert cam.config_sync == "pending"
+        assert "pending_config" in response
+        assert response["pending_config"]["fps"] == 30
+
+    def test_synced_camera_unchanged_by_reconciliation(self):
+        """The reconciliation only fires under had_pending — synced state
+        still goes through the original setattr path."""
+        cam = _make_camera(config_sync="synced", fps=15)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+
+        # Heartbeat carries fps=25; the original code path overwrites
+        # camera.fps with what the camera reports (heartbeat is the
+        # source of truth for synced cameras).
+        svc.accept_heartbeat("cam-001", self._basic_payload_with_stream_config(fps=25))
+
+        assert cam.fps == 25
+        assert cam.config_sync == "synced"
+
+    def test_reconciliation_does_not_overwrite_stored_values(self):
+        """Matching reconciliation must NOT touch camera.fps etc — those
+        are already what we stored. Defending against a future refactor
+        that accidentally reintroduces setattr in the pending branch."""
+        cam = _make_camera(
+            config_sync="pending",
+            width=1640,
+            height=1232,
+            fps=30,
+            bitrate=6000000,
+            h264_profile="high",
+            keyframe_interval=30,
+            rotation=180,
+            hflip=True,
+            vflip=True,
+        )
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+
+        # Camera reports the same values — should match.
+        response, _, code = svc.accept_heartbeat(
+            "cam-001",
+            self._basic_payload_with_stream_config(
+                width=1640,
+                height=1232,
+                fps=30,
+                bitrate=6000000,
+                rotation=180,
+                hflip=True,
+                vflip=True,
+            ),
+        )
+
+        assert code == 200
+        assert cam.config_sync == "synced"
+        assert cam.fps == 30
+        assert cam.width == 1640
+        assert cam.height == 1232
+        assert "pending_config" not in response
+
+    def test_partial_heartbeat_match_does_not_synced(self):
+        """If camera reports 8 of 9 fields matching but one differs,
+        we must NOT mark synced."""
+        cam = _make_camera(
+            config_sync="pending",
+            width=1920,
+            height=1080,
+            fps=25,
+            bitrate=4000000,
+            rotation=0,
+        )
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+
+        # Eight match, one (rotation) drifted.
+        svc.accept_heartbeat(
+            "cam-001", self._basic_payload_with_stream_config(rotation=90)
+        )
+
+        assert cam.config_sync == "pending"
+
+    def test_camera_omitting_stream_config_keeps_pending(self):
+        """Old-firmware camera that doesn't report stream_config at all
+        falls through to the camera-side notify-on-apply fix."""
+        cam = _make_camera(config_sync="pending", fps=30)
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+
+        payload = {
+            "streaming": True,
+            "cpu_temp": 50.0,
+            "memory_percent": 40,
+            "uptime_seconds": 1000,
+            # No stream_config key at all.
+        }
+        _, _, code = svc.accept_heartbeat("cam-001", payload)
+
+        assert code == 200
+        assert cam.config_sync == "pending"
+
+
 # --- Sensor capabilities (#173) ---
 
 


### PR DESCRIPTION
## Summary

- Bidirectional config sync (ADR-0015) had a state-machine dead end: once `config_sync` flipped to `pending` (e.g. transient network blip during an `update_camera()` push), the only way back to `synced` was an explicit `/api/v1/cameras/config-notify` POST from the camera — which the camera only fires for `origin="local"` applies in `status_server.py`. Server-origin pending applies (the ones the heartbeat retry loop is meant to deliver) never produced an ack, and the heartbeat path's `not had_pending` gate refused to mark `synced` even when the camera reported matching values.
- Net effect on the live deployment: `cam-0fcea5cf` (Test Camera 2) was logging `Applying pending config from server heartbeat response: {...}` every 15 s, forever. Dashboard badge stuck at ⌛ pending despite the camera having the right values on disk.

**Two surgical changes, defence-in-depth.**

- **Server-side** (`camera_service.py`): when `had_pending` is True and the camera's heartbeat-reported `stream_config` matches stored values across all reported keys, mark `synced` and drop `pending_config` from the response. Breaks the loop on already-deployed cameras without a re-flash. New helper `_heartbeat_stream_config_matches` accepts the wire alias for `recording_motion_enabled`/`motion_detection`.
- **Camera-side** (`heartbeat.py`): after `_apply_pending_config` succeeds, spawn a daemon thread to POST `/config-notify` via the existing `notify_config_change` helper — same fire-and-forget pattern the local-UI flow uses. Failure paths (parse error, set_config error, thread spawn failure) all skip the notify so we never falsely advance `synced` on a failed apply.

Closes #231.

## Test plan
- [x] 6 new `TestPendingReconciliationFromHeartbeat` cases on the server: matching heartbeat marks pending camera synced; mismatching keeps pending; synced camera unchanged; reconciliation doesn't overwrite stored values; partial mismatch keeps pending; missing `stream_config` keeps pending.
- [x] 4 new camera-side cases on `_apply_pending_config`: notifies on success; does NOT notify on `set_config` error; does NOT notify on parse error; thread spawn failure does not propagate.
- [x] Existing 22 server heartbeat tests still pass.
- [x] Existing camera heartbeat test extended with `notify_config_change` patch.
- [x] Full server `test_camera_service.py` (95 tests) + camera `test_heartbeat.py` (33 tests) green.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live verification on `192.168.1.115`: server-side change deployed via SSH first; expect dashboard badge for `cam-0fcea5cf` to flip from ⌛ pending to ✓ synced within 15 s of restart, before camera-side fix is even pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)