### PR TITLE
fix(camera): raw-UDP mDNS goodbye fallback when avahi D-Bus denied (#233)

### DIFF
--- a/app/camera/camera_streamer/wifi.py
+++ b/app/camera/camera_streamer/wifi.py
@@ -11,6 +11,7 @@ for platform abstraction.
 import logging
 import os
 import socket
+import struct
 import subprocess
 import time
 
@@ -356,11 +357,24 @@ def set_hostname(hostname: str) -> bool:
 
         announced = _avahi_set_host_name(hostname)
         if not announced:
-            # Last-resort fallback: restart the daemon. No goodbye for
-            # the old name, but at least the new name reaches the wire
-            # — strictly preserves the pre-fix behaviour.
+            # avahi-set-host-name needs D-Bus access to
+            # org.freedesktop.Avahi.Server.SetHostName, which is gated
+            # to root + user `avahi` by default — the camera-streamer
+            # service runs as user `camera` and gets "Access denied"
+            # (#233). The daemon-restart fallback alone doesn't send a
+            # goodbye, leaving stale `<old>.local` cache entries on the
+            # LAN. Send the goodbye directly via raw multicast UDP
+            # before restarting the daemon — multicast/5353 is
+            # privilege-free and satisfies #200's contract regardless
+            # of avahi's D-Bus policy.
+            if previous_hostname and previous_hostname != hostname:
+                _broadcast_mdns_goodbye(
+                    previous_hostname, get_ip_address() or "0.0.0.0"
+                )
+
             log.warning(
-                "Falling back to avahi-daemon restart (no mDNS goodbye for %s)",
+                "Falling back to avahi-daemon restart for new-name announce "
+                "(direct goodbye sent for %s if reachable)",
                 previous_hostname or "<unknown>",
             )
             try:
@@ -427,3 +441,135 @@ def _avahi_set_host_name(hostname: str) -> bool:
         detail,
     )
     return False
+
+
+# ---------------------------------------------------------------------------
+# Raw mDNS goodbye broadcast (#233)
+#
+# When avahi-set-host-name is unavailable (no D-Bus permission, daemon down)
+# we need a privilege-free path to flush cached `<old>.local` bindings on the
+# LAN. RFC 6762 §10.1 specifies a record with TTL=0; §10.2 specifies the
+# cache-flush bit (high bit of the CLASS field) which forces resolvers to
+# replace any existing matching records rather than merge with them. A single
+# multicast UDP packet to 224.0.0.251:5353 carrying such a record satisfies
+# the contract — and multicast send to a link-local group requires no special
+# privilege.
+# ---------------------------------------------------------------------------
+
+# RFC 6762 §3 — IPv4 mDNS group + port.
+_MDNS_GROUP_IPV4 = "224.0.0.251"
+_MDNS_PORT = 5353
+# RFC 6762 §11 — link-scoped multicast TTL must be 255.
+_MDNS_TTL = 255
+
+
+def _broadcast_mdns_goodbye(hostname: str, ip_address: str) -> bool:
+    """Send a goodbye packet (TTL=0, cache-flush) for ``<hostname>.local``.
+
+    Best-effort: multicast UDP gives no delivery acknowledgement, so we
+    send twice ~1s apart per RFC 6762 §10's redundancy recommendation.
+    Returns True if both sends went through, False on construction or
+    socket errors. The caller logs and continues regardless — the
+    goodbye is a hint to LAN caches, not a guarantee.
+
+    The IP in the RDATA matters less than the cache-flush bit + TTL=0
+    (which together tell resolvers to drop the binding). We pass the
+    current IP when we have it for protocol cleanliness; ``0.0.0.0`` is
+    accepted as a "we don't know" fallback.
+    """
+    if not hostname:
+        return False
+    label = hostname.removesuffix(".local").rstrip(".")
+    if not label:
+        return False
+
+    try:
+        ip_packed = socket.inet_aton(ip_address)
+    except OSError:
+        log.warning("mDNS goodbye: invalid IP %r — skipping", ip_address)
+        return False
+
+    try:
+        packet = _build_mdns_goodbye_packet(label, ip_packed)
+    except ValueError as e:
+        log.warning("mDNS goodbye: cannot build packet for %s: %s", label, e)
+        return False
+
+    sock = None
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, _MDNS_TTL)
+        # Two transmissions ~1s apart so a single dropped packet doesn't
+        # leave the LAN with stale cache entries — same redundancy
+        # avahi-daemon uses internally for goodbyes.
+        sock.sendto(packet, (_MDNS_GROUP_IPV4, _MDNS_PORT))
+        time.sleep(1)
+        sock.sendto(packet, (_MDNS_GROUP_IPV4, _MDNS_PORT))
+        log.info("mDNS goodbye broadcast for %s.local (rdata=%s)", label, ip_address)
+        return True
+    except OSError as e:
+        log.warning("mDNS goodbye send failed for %s.local: %s", label, e)
+        return False
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+def _build_mdns_goodbye_packet(label: str, ip_packed: bytes) -> bytes:
+    """Wire-format a DNS response for ``<label>.local`` with TTL=0.
+
+    Layout per RFC 1035 §4 / RFC 6762 §10:
+
+        Header (12 bytes)
+          Transaction ID = 0
+          Flags          = 0x8400  (QR=1 response, AA=1 authoritative)
+          QDCOUNT        = 0
+          ANCOUNT        = 1
+          NSCOUNT        = 0
+          ARCOUNT        = 0
+
+        Answer
+          NAME      = <label>.<local>.<root>     (length-prefixed labels)
+          TYPE      = 1                          (A)
+          CLASS     = 0x8001                     (IN | cache-flush)
+          TTL       = 0                          (goodbye)
+          RDLENGTH  = 4
+          RDATA     = ip_packed                  (4 bytes IPv4)
+
+    Raises ValueError if any label exceeds the 63-byte DNS limit or
+    contains characters outside ASCII (avahi's mDNS doesn't apply
+    Punycode).
+    """
+    header = struct.pack(
+        ">HHHHHH",
+        0x0000,  # Transaction ID — 0 for unsolicited mDNS responses.
+        0x8400,  # Flags: QR=1, AA=1, OPCODE=0, RCODE=0.
+        0,  # QDCOUNT
+        1,  # ANCOUNT
+        0,  # NSCOUNT
+        0,  # ARCOUNT
+    )
+
+    name_section = b""
+    for part in (label, "local"):
+        try:
+            encoded = part.encode("ascii")
+        except UnicodeEncodeError as e:
+            raise ValueError(f"non-ASCII DNS label: {part!r}") from e
+        if not encoded:
+            raise ValueError(f"empty DNS label: {part!r}")
+        if len(encoded) > 63:
+            raise ValueError(f"DNS label exceeds 63 bytes: {part!r}")
+        name_section += bytes([len(encoded)]) + encoded
+    name_section += b"\x00"  # Root label terminator.
+
+    # TYPE=1 (A), CLASS=0x8001 (IN | cache-flush), TTL=0, RDLENGTH=4.
+    answer_meta = struct.pack(">HHIH", 1, 0x8001, 0, 4)
+
+    if len(ip_packed) != 4:
+        raise ValueError(f"IPv4 RDATA must be 4 bytes, got {len(ip_packed)}")
+
+    return header + name_section + answer_meta + ip_packed

--- a/app/camera/tests/unit/test_wifi.py
+++ b/app/camera/tests/unit/test_wifi.py
@@ -577,3 +577,260 @@ class TestSetHostnameMdnsGoodbye:
 
         # Even with no prior name, we still hand the new name to avahi.
         assert ["avahi-set-host-name", "rpi-new"] in runs
+
+
+class TestRawMdnsGoodbye:
+    """Privilege-free fallback when avahi-set-host-name is denied (#233).
+
+    The camera-streamer service runs as user `camera` and avahi's
+    default D-Bus policy gates SetHostName to root + user `avahi`. The
+    raw-UDP goodbye path constructs an RFC 6762 §10.1-compliant
+    cache-flush record and sends it to 224.0.0.251:5353 — multicast
+    UDP is unrestricted, so this works regardless of D-Bus policy.
+    """
+
+    def test_packet_byte_structure(self):
+        """Byte-for-byte assert the wire format. Future refactors that
+        scramble header flags or forget the cache-flush bit will fail
+        here — operators rely on the exact 0x8001 CLASS for resolvers
+        to actually flush their caches."""
+        from camera_streamer.wifi import _build_mdns_goodbye_packet
+
+        ip = b"\xc0\xa8\x01\x73"  # 192.168.1.115
+        packet = _build_mdns_goodbye_packet("rpi-divinu-cam", ip)
+
+        # Header
+        assert packet[0:2] == b"\x00\x00"  # Transaction ID
+        assert packet[2:4] == b"\x84\x00"  # Flags: QR=1, AA=1
+        assert packet[4:6] == b"\x00\x00"  # QDCOUNT
+        assert packet[6:8] == b"\x00\x01"  # ANCOUNT
+        assert packet[8:10] == b"\x00\x00"  # NSCOUNT
+        assert packet[10:12] == b"\x00\x00"  # ARCOUNT
+
+        # NAME — length-prefixed labels
+        # 0x0e = 14, "rpi-divinu-cam" = 14 bytes
+        assert packet[12:13] == b"\x0e"
+        assert packet[13:27] == b"rpi-divinu-cam"
+        # 0x05 = 5, "local" = 5 bytes
+        assert packet[27:28] == b"\x05"
+        assert packet[28:33] == b"local"
+        # Root terminator
+        assert packet[33:34] == b"\x00"
+
+        # Answer trailer
+        assert packet[34:36] == b"\x00\x01"  # TYPE = A
+        assert packet[36:38] == b"\x80\x01"  # CLASS = IN | cache-flush
+        assert packet[38:42] == b"\x00\x00\x00\x00"  # TTL = 0 (goodbye)
+        assert packet[42:44] == b"\x00\x04"  # RDLENGTH = 4
+        assert packet[44:48] == ip  # RDATA
+
+        assert len(packet) == 48
+
+    def test_packet_handles_long_label(self):
+        """A 63-byte label is the DNS limit; one byte over must raise."""
+        from camera_streamer.wifi import _build_mdns_goodbye_packet
+
+        ip = b"\xc0\xa8\x01\x73"
+        # 63-byte label is fine.
+        ok = _build_mdns_goodbye_packet("a" * 63, ip)
+        assert isinstance(ok, bytes)
+        # 64-byte label must error — we'd otherwise send a malformed packet.
+        try:
+            _build_mdns_goodbye_packet("a" * 64, ip)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError for 64-byte label")
+
+    def test_packet_rejects_non_ascii_label(self):
+        """mDNS names are ASCII (no Punycode here) — a unicode label must raise."""
+        from camera_streamer.wifi import _build_mdns_goodbye_packet
+
+        ip = b"\xc0\xa8\x01\x73"
+        try:
+            _build_mdns_goodbye_packet("rpi-café", ip)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError for non-ASCII label")
+
+    def test_broadcast_sends_to_correct_multicast_target(self):
+        """Multicast group + port + TTL must match RFC 6762 §11."""
+        import socket as _socket
+
+        from camera_streamer.wifi import _broadcast_mdns_goodbye
+
+        sock = MagicMock()
+        with (
+            patch("camera_streamer.wifi.socket.socket", return_value=sock),
+            patch("camera_streamer.wifi.time.sleep"),  # don't sleep 1s in tests
+        ):
+            assert _broadcast_mdns_goodbye("rpi-divinu-cam", "192.168.1.115") is True
+
+        # Both sends went to the right multicast group.
+        assert sock.sendto.call_count == 2
+        for call in sock.sendto.call_args_list:
+            target = call[0][1]
+            assert target == ("224.0.0.251", 5353)
+
+        # TTL=255 set on the socket per RFC 6762 §11. The numeric value
+        # of socket.IP_MULTICAST_TTL differs by platform (Linux=33,
+        # Windows=10, macOS=10) so we match against the live constant
+        # rather than hard-coding it.
+        ttl_calls = [
+            c
+            for c in sock.setsockopt.call_args_list
+            if c[0][0] == _socket.IPPROTO_IP and c[0][1] == _socket.IP_MULTICAST_TTL
+        ]
+        assert ttl_calls, [c.args for c in sock.setsockopt.call_args_list]
+        assert ttl_calls[0][0][2] == 255
+
+    def test_broadcast_strips_dot_local_suffix(self):
+        """Caller may pass ``foo`` or ``foo.local`` — both must produce a
+        packet whose label is plain ``foo``."""
+        from camera_streamer.wifi import _broadcast_mdns_goodbye
+
+        sock = MagicMock()
+        with (
+            patch("camera_streamer.wifi.socket.socket", return_value=sock),
+            patch("camera_streamer.wifi.time.sleep"),
+        ):
+            _broadcast_mdns_goodbye("rpi-cam.local", "192.168.1.50")
+
+        sent = sock.sendto.call_args_list[0][0][0]
+        # 0x07 length = "rpi-cam" (7 bytes)
+        assert sent[12:13] == b"\x07"
+        assert sent[13:20] == b"rpi-cam"
+
+    def test_broadcast_fails_silently_on_send_error(self):
+        """Multicast send raising must be logged and swallowed — the goodbye
+        is best-effort and must never propagate up to break the hostname
+        change itself."""
+        from camera_streamer.wifi import _broadcast_mdns_goodbye
+
+        sock = MagicMock()
+        sock.sendto.side_effect = OSError("ENETUNREACH")
+        with (
+            patch("camera_streamer.wifi.socket.socket", return_value=sock),
+            patch("camera_streamer.wifi.time.sleep"),
+        ):
+            # Must not raise; must return False.
+            assert _broadcast_mdns_goodbye("rpi-cam", "192.168.1.50") is False
+
+    def test_broadcast_skips_invalid_ip(self):
+        """Garbage IP must early-return rather than crash inet_aton at send."""
+        from camera_streamer.wifi import _broadcast_mdns_goodbye
+
+        with patch("camera_streamer.wifi.socket.socket") as mock_sock_cls:
+            assert _broadcast_mdns_goodbye("rpi-cam", "not-an-ip") is False
+            # Socket was never even created.
+            mock_sock_cls.assert_not_called()
+
+    def test_broadcast_skips_empty_hostname(self):
+        from camera_streamer.wifi import _broadcast_mdns_goodbye
+
+        with patch("camera_streamer.wifi.socket.socket") as mock_sock_cls:
+            assert _broadcast_mdns_goodbye("", "192.168.1.1") is False
+            assert _broadcast_mdns_goodbye(".local", "192.168.1.1") is False
+            mock_sock_cls.assert_not_called()
+
+    def test_broadcast_closes_socket_on_success(self):
+        """No fd leaks — socket.close() is called even on the happy path."""
+        from camera_streamer.wifi import _broadcast_mdns_goodbye
+
+        sock = MagicMock()
+        with (
+            patch("camera_streamer.wifi.socket.socket", return_value=sock),
+            patch("camera_streamer.wifi.time.sleep"),
+        ):
+            _broadcast_mdns_goodbye("rpi-cam", "192.168.1.50")
+
+        sock.close.assert_called_once()
+
+    def test_broadcast_closes_socket_on_failure(self):
+        """No fd leaks even when sendto raises mid-flow."""
+        from camera_streamer.wifi import _broadcast_mdns_goodbye
+
+        sock = MagicMock()
+        sock.sendto.side_effect = OSError("EMFILE")
+        with (
+            patch("camera_streamer.wifi.socket.socket", return_value=sock),
+            patch("camera_streamer.wifi.time.sleep"),
+        ):
+            _broadcast_mdns_goodbye("rpi-cam", "192.168.1.50")
+
+        sock.close.assert_called_once()
+
+    def test_set_hostname_calls_raw_goodbye_when_avahi_denied(self):
+        """End-to-end: set_hostname must invoke the raw-UDP goodbye when
+        avahi-set-host-name fails (the production scenario on this image
+        — camera user lacks D-Bus permission)."""
+        runs = []
+
+        def fake_run(cmd, **kwargs):
+            runs.append(cmd)
+            if cmd[0] == "avahi-set-host-name":
+                return MagicMock(returncode=1, stdout=b"", stderr=b"Access denied\n")
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch(
+                "camera_streamer.wifi.socket.gethostname",
+                return_value="rpi-divinu-cam",
+            ),
+            patch("camera_streamer.wifi.get_ip_address", return_value="192.168.1.115"),
+            patch("camera_streamer.wifi._broadcast_mdns_goodbye") as mock_goodbye,
+        ):
+            assert set_hostname("rpi-divinu-cam-a5cf") is True
+
+        # Goodbye fired with old name + current IP.
+        mock_goodbye.assert_called_once_with("rpi-divinu-cam", "192.168.1.115")
+        # Daemon restart still happens after the goodbye so the new name
+        # gets announced (we can't make THAT happen via raw UDP).
+        assert ["systemctl", "restart", "avahi-daemon"] in runs
+
+    def test_set_hostname_skips_raw_goodbye_when_no_change(self):
+        """Idempotent set (same name) must not broadcast a goodbye —
+        there's nothing to flush."""
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "avahi-set-host-name":
+                return MagicMock(returncode=1, stderr=b"denied\n", stdout=b"")
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch("camera_streamer.wifi.socket.gethostname", return_value="rpi-same"),
+            patch("camera_streamer.wifi.get_ip_address", return_value="192.168.1.115"),
+            patch("camera_streamer.wifi._broadcast_mdns_goodbye") as mock_goodbye,
+        ):
+            set_hostname("rpi-same")
+
+        mock_goodbye.assert_not_called()
+
+    def test_set_hostname_skips_raw_goodbye_on_avahi_success(self):
+        """When avahi-set-host-name works (root context), the daemon owns
+        the goodbye + announce — no raw-UDP path needed."""
+
+        def fake_run(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            patch("camera_streamer.wifi.subprocess.run", side_effect=fake_run),
+            patch("camera_streamer.wifi.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+            patch(
+                "camera_streamer.wifi.socket.gethostname",
+                return_value="rpi-old",
+            ),
+            patch("camera_streamer.wifi.get_ip_address", return_value="192.168.1.115"),
+            patch("camera_streamer.wifi._broadcast_mdns_goodbye") as mock_goodbye,
+        ):
+            set_hostname("rpi-new")
+
+        mock_goodbye.assert_not_called()


### PR DESCRIPTION
## Summary

- PR #230 (closes #200) shipped `avahi-set-host-name` for the goodbye-on-hostname-change path, but hardware testing revealed it's dormant in production: the camera-streamer service runs as `User=camera` and avahi's default D-Bus policy only grants `SetHostName` to root + user `avahi`. `avahi-set-host-name` returns "Access denied", we fall through to daemon-restart, and no goodbye is broadcast — same behaviour as before #200.
- This change adds a privilege-free fallback: when `avahi-set-host-name` fails AND the hostname actually changed, construct an RFC 6762 §10.1-compliant cache-flush record (TTL=0, CLASS=IN | cache-flush bit) for `<old>.local` and send it directly to `224.0.0.251:5353`. Multicast UDP to a link-local group requires no special privilege. Send twice ~1s apart per RFC 6762 §10's redundancy guidance, then fall through to the existing daemon-restart so the new name still announces.
- Wire format asserted byte-for-byte in tests so future refactors can't accidentally drop the cache-flush bit (the actual mechanism that forces resolvers to drop the binding rather than merge with it).

Closes #233. Tracks #90, #200.

## Test plan
- [x] 13 new `TestRawMdnsGoodbye` cases: byte-structure assertion of constructed packet (header flags, label encoding, TYPE/CLASS, TTL=0, RDATA); 63-byte label OK / 64-byte rejected; non-ASCII rejected; multicast group/port/TTL=255 verified; `.local` suffix stripped; send error swallowed; invalid IP early-return; empty hostname early-return; socket closed on success and on failure; end-to-end `set_hostname` invokes raw goodbye when avahi denied; idempotent set skips goodbye; avahi-success path skips raw goodbye.
- [x] Existing 33 wifi tests + 8 set-hostname tests still pass (54 total now in test_wifi.py).
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Live verification on `192.168.1.115`: `tcpdump -i wlan0 -n udp port 5353 -X` from a separate device captures the goodbye packet (ANCOUNT=1, TTL=0, name=old, 0x80 in CLASS) within 2s of triggering a hostname rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)