### PR TITLE
docs: add folder wayfinding indexes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,8 @@ programmatic checks:
 
 ## Human Guides
 
-Use [`guides/`](guides/) for practical operating and development material:
+Use [`guides/README.md`](guides/README.md) for practical operating and
+development material:
 
 - [`guides/hardware-setup.md`](guides/hardware-setup.md)
 - [`guides/build-setup.md`](guides/build-setup.md)
@@ -62,8 +63,9 @@ Use [`guides/`](guides/) for practical operating and development material:
 
 ## History
 
-Use [`history/`](history/) for design history and planning records that inform
-the current controlled records but are not themselves the first place to edit:
+Use [`history/README.md`](history/README.md) for design history and planning
+records that inform the current controlled records but are not themselves the
+first place to edit:
 
 - [`history/adr/`](history/adr/)
 - [`history/specs/`](history/specs/)
@@ -73,9 +75,9 @@ the current controlled records but are not themselves the first place to edit:
 
 ## Active And Archived Plans
 
-Use [`exec-plans/`](exec-plans/) only for active, resumable implementation
-plans and the template. Completed plans and field records live in
-[`archive/exec-plans/`](archive/exec-plans/).
+Use [`exec-plans/README.md`](exec-plans/README.md) only for active, resumable
+implementation plans and the template. Completed plans and field records live
+under [`archive/README.md`](archive/README.md).
 
 ## Rules For AI Agents
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,27 @@
+---
+title: Archive Index
+status: archived
+audience: [human, ai]
+owner: engineering
+source_of_truth: false
+---
+
+# Archive
+
+This folder holds completed records retained for context. Archived records are
+not current source of truth unless a current controlled document links to them
+explicitly.
+
+## Sections
+
+| Section | Contents |
+|---|---|
+| [`exec-plans/`](exec-plans/) | Completed execution plans and validation records |
+
+## Editing Rules
+
+- Prefer moving completed records here instead of deleting them.
+- Do not use archived plans as implementation instructions without checking
+  current requirements, architecture, risk, security, and tests.
+- If archived material contains operational details that should no longer be
+  retained, sanitize it and leave a short note explaining the replacement.

--- a/docs/doc-map.yml
+++ b/docs/doc-map.yml
@@ -88,7 +88,7 @@
   status: active
   audience: [human, ai]
   source_of_truth: false
-  notes: Practical operator and developer guides.
+  notes: Practical operator and developer guides. Start with docs/guides/README.md.
 
 - path: docs/exec-plans/
   title: Active Execution Plans
@@ -96,7 +96,15 @@
   status: active
   audience: [human, ai]
   source_of_truth: false
-  notes: Only active resumable plans and the template belong here.
+  notes: Only active resumable plans and the template belong here. Start with docs/exec-plans/README.md.
+
+- path: docs/history/
+  title: History
+  type: design-history
+  status: historical
+  audience: [human, ai]
+  source_of_truth: false
+  notes: Historical context and design memory. Start with docs/history/README.md.
 
 - path: docs/history/adr/
   title: Architecture Decision Records
@@ -139,4 +147,4 @@
   status: archived
   audience: [human, ai]
   source_of_truth: false
-  notes: Do not use as current truth without a current record link.
+  notes: Do not use as current truth without a current record link. Start with docs/archive/README.md.

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,31 @@
+---
+title: Active Execution Plans
+status: active
+audience: [human, ai]
+owner: engineering
+source_of_truth: false
+---
+
+# Active Execution Plans
+
+This folder is for active, resumable implementation plans. Completed plans and
+field records belong in [`../archive/exec-plans/`](../archive/exec-plans/).
+
+Use [`template.md`](template.md) for new plans.
+
+## Active Plans
+
+| Plan | Purpose |
+|---|---|
+| [`hardware-lab-rollout.md`](hardware-lab-rollout.md) | Hardware lab rollout and validation |
+| [`luks-post-pair-migration.md`](luks-post-pair-migration.md) | LUKS migration after pairing |
+| [`motion-mode-pre-roll.md`](motion-mode-pre-roll.md) | Motion-mode pre-roll delivery |
+| [`on-demand-streaming.md`](on-demand-streaming.md) | Viewer-driven streaming |
+| [`ota-rollout-and-validation.md`](ota-rollout-and-validation.md) | OTA rollout validation |
+
+## Editing Rules
+
+- Keep only active plans here.
+- Move finished plans to [`../archive/exec-plans/`](../archive/exec-plans/).
+- Keep plan references aligned with current requirements, architecture, risk,
+  security, and tests before implementation PRs merge.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,35 @@
+---
+title: Guide Index
+status: active
+audience: [human, ai]
+owner: engineering
+source_of_truth: false
+---
+
+# Guides
+
+This folder holds practical operating and development instructions. Guides are
+optimized for doing work; controlled requirements, risk, security, and
+traceability records live in their dedicated folders.
+
+## Start Here
+
+| Need | Read |
+|---|---|
+| Build the project or images | [`build-setup.md`](build-setup.md) |
+| Work on application code | [`development-guide.md`](development-guide.md) |
+| Run validation | [`testing-guide.md`](testing-guide.md) |
+| Assemble or provision hardware | [`hardware-setup.md`](hardware-setup.md) |
+| Release safely | [`release-runbook.md`](release-runbook.md) |
+| Manage OTA keys | [`ota-key-management.md`](ota-key-management.md) |
+| Recover admin access | [`admin-recovery.md`](admin-recovery.md) |
+| Plan an AI-delivered feature | [`ai-feature-template.md`](ai-feature-template.md) |
+| Understand connectivity constraints | [`connectivity-and-privacy-constraints.md`](connectivity-and-privacy-constraints.md) |
+
+## Editing Rules
+
+- Keep guides procedural and current.
+- Link controlled requirements, architecture, risk, security, and tests when a
+  guide changes behavior or validation expectations.
+- Move obsolete guide material to [`../history/`](../history/) or
+  [`../archive/`](../archive/) instead of leaving stale instructions in place.

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -1,0 +1,32 @@
+---
+title: History Index
+status: historical
+audience: [human, ai]
+owner: engineering
+source_of_truth: false
+---
+
+# History
+
+This folder preserves design history. It is useful context, but it is not the
+first source of truth for current behavior. Start with [`../README.md`](../README.md)
+and [`../doc-map.yml`](../doc-map.yml), then use these records when you need
+the reasoning behind a decision.
+
+## Sections
+
+| Section | Contents |
+|---|---|
+| [`adr/`](adr/) | Architecture decision records |
+| [`specs/`](specs/) | Feature specs and release-one planning specs |
+| [`releases/`](releases/) | Historical release plans |
+| [`baseline/`](baseline/) | Historical baseline architecture and requirements |
+| [`planning/`](planning/) | Roadmaps and planning notes |
+
+## Editing Rules
+
+- Do not edit history to make current behavior true.
+- Update current controlled records first, then add a note here only when the
+  historical context itself needs clarification.
+- If a historical note becomes actively actionable again, create or update an
+  exec plan in [`../exec-plans/`](../exec-plans/).

--- a/docs/quality-records/document-index.md
+++ b/docs/quality-records/document-index.md
@@ -19,6 +19,7 @@ Status: Draft prepared to support expert regulatory review.
 | `docs/verification-validation/*` | Test plan, test cases, report template. | `docs/guides/testing-guide.md`, CI workflows, test suites |
 | `docs/traceability/*` | End-to-end traceability matrix. | New machine-checkable matrix |
 | `docs/quality-records/regulatory-review-gap-assessment.md` | Regulatory-review-style gap assessment and human review queue. | New review record linked to expanded draft artifacts |
+| `docs/README.md`, `docs/doc-map.yml` | Human and AI documentation routing. | Front door and machine-readable map for current docs, guides, history, and archive |
 
 ## Existing Docs Retained
 
@@ -28,6 +29,10 @@ execution records. This index maps them into the quality-record structure.
 
 | Existing doc | Keep as | Quality-record relation |
 |---|---|---|
+| `docs/guides/README.md` | Guide folder index. | Helps humans and agents find practical instructions |
+| `docs/exec-plans/README.md` | Active execution plan index. | Helps distinguish active plans from archived records |
+| `docs/history/README.md` | Historical record index. | Prevents historical context from being mistaken for current source of truth |
+| `docs/archive/README.md` | Archive index. | Explains archived-record handling and review cautions |
 | `docs/history/baseline/requirements.md` | Historical product requirements baseline. | Source for `UN-*`, `SYS-*`, `SWR-*`, `HWR-*` |
 | `docs/history/baseline/architecture.md` | Main system/software architecture narrative. | Source for `ARCH-*`, `SWA-*`, `HWA-*` |
 | `docs/history/adr/` | Decision records. | Supporting rationale for architecture, risk, and security controls |

--- a/tools/docs/check_doc_map.py
+++ b/tools/docs/check_doc_map.py
@@ -31,6 +31,12 @@ CURRENT_SOURCE_PREFIXES = {
     "docs/traceability/",
     "docs/quality-records/",
 }
+REQUIRED_WAYFINDING = {
+    "docs/guides/README.md",
+    "docs/exec-plans/README.md",
+    "docs/history/README.md",
+    "docs/archive/README.md",
+}
 
 
 def parse_doc_map() -> list[dict[str, str]]:
@@ -92,6 +98,10 @@ def main() -> int:
     for prefix in sorted(CURRENT_SOURCE_PREFIXES):
         if prefix not in mapped_paths:
             failures.append(f"Current source prefix missing from doc map: {prefix}")
+
+    for readme in sorted(REQUIRED_WAYFINDING):
+        if not (ROOT / readme).exists():
+            failures.append(f"Required documentation wayfinding file missing: {readme}")
 
     for markdown_file in DOCS.glob("*.md"):
         if markdown_file.name not in ALLOWED_TOP_LEVEL_MARKDOWN:


### PR DESCRIPTION
﻿## Summary

- Add README wayfinding files for `docs/guides/`, `docs/exec-plans/`, `docs/history/`, and `docs/archive/`.
- Update `docs/README.md`, `docs/doc-map.yml`, and the quality document index to point humans and agents at those folder indexes.
- Extend `tools/docs/check_doc_map.py` so the folder wayfinding files are required by governance checks.

## Validation

- `python tools/docs/check_doc_map.py`
- `python scripts/ai/check_doc_links.py`
- `python scripts/ai/validate_repo_ai_setup.py`
- `python tools/traceability/check_traceability.py`
- `python -m pre_commit run --all-files`

Prepared to support expert regulatory review.
