### PR TITLE
[codex] Pin latest Agentry with role model routing

### DIFF
--- a/agentry/.env.example
+++ b/agentry/.env.example
@@ -1,16 +1,31 @@
-# Agentry environment file. Copy to .env and fill in values.
-# .env is gitignored; .env.example is committed.
+# Agentry — secrets template
+# =============================================================================
+#
+# Copy this file to agentry/.env in the same folder, then fill in your values.
+# .env is gitignored; .env.example is committed as a reference.
 
-# Required: GitHub token with `repo` and `workflow` scopes.
-# Create at https://github.com/settings/tokens
+# REQUIRED: GitHub fine-grained Personal Access Token.
+# Generate at: https://github.com/settings/personal-access-tokens
+# Scopes: contents (read+write), issues (read+write), pull_requests
+# (read+write), metadata (read). Restrict to the target repo this folder
+# lives in.
 GITHUB_TOKEN=
 
-# Optional: Discord webhook for lifecycle notifications.
-# DISCORD_WEBHOOK_URL=
+# OPTIONAL: Discord webhook URL. If set, agentry posts agent lifecycle
+# events here (started, exited, stalled, timed-out). If unset, you get
+# the same info from the log files in agentry/logs/<role>/.
+DISCORD_WEBHOOK_URL=
 
-# LLM auth — agentry inherits whatever auth `claude` and `codex` are using.
-# If you've already run `claude login` and `codex login`, you don't need
-# anything here. Override with API keys only if you want to bypass the
-# subscription path:
-# ANTHROPIC_API_KEY=
-# OPENAI_API_KEY=
+# OPTIONAL: API key fallback for when subscription auth (claude login /
+# codex login) hits rate limits. Skip if you only use subscriptions.
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+
+# OPTIONAL: env vars used by specific role rule files (only fill if your
+# docs/ai/roles/*.md references them, e.g. for hardware tests, signing,
+# or remote build infrastructure).
+SWU_SIGNING_KEY_PATH=
+KASA_USERNAME=
+KASA_PASSWORD=
+TAILSCALE_AUTH_KEY=
+GCP_VM_SSH_KEY_PATH=

--- a/agentry/.gitignore
+++ b/agentry/.gitignore
@@ -1,6 +1,6 @@
+# Agentry runtime data — never commit
 .env
 .venv/
 logs/
 state/
-*.pyc
-__pycache__/
+worktrees/

--- a/agentry/README.md
+++ b/agentry/README.md
@@ -1,81 +1,120 @@
-# `agentry/` — local Agentry installation for this repo
+# `agentry/` - Local Agentry Installation
 
-This folder is the gtest-style "fetched dependency" for [Agentry](https://github.com/vinu-dev/agentry). It's how the orchestrator runs against THIS repo. Each target repo gets its own copy.
+This folder is the repo-local Agentry dependency for this target repository.
+Each target repo gets its own copy.
 
-## What's in here
+## What Is In Here
 
-| File | Purpose | Committed? |
-|------|---------|-----------|
-| `config.yml` | Picks which LLM CLI handles each role (Claude / Codex / etc.) and the timeouts | yes |
-| `start.ps1` / `start.sh` | The entry point. Run this every time you want Agentry running. Creates `.venv/` and installs Agentry on first run. | yes |
-| `.env.example` | Template for your secrets (GITHUB_TOKEN etc.) | yes |
-| `.gitignore` | Ignores the next four entries | yes |
-| `.env` | Your actual secrets — copied from `.env.example` and filled in by you | **no, gitignored** |
-| `.venv/` | Python venv with Agentry pip-installed; auto-created on first run | **no, gitignored** |
-| `logs/` | Per-role agent stdout, one timestamped file per run | **no, gitignored** |
-| `state/` | Runtime state | **no, gitignored** |
+| Path | Purpose | Commit? |
+|------|---------|---------|
+| `config.yml` | Role roster, model/CLI assignment, timeouts, run mode | yes |
+| `start.ps1` / `start.sh` | Entry points for start, GUI, configure, stop | yes |
+| `.env.example` | Secrets template | yes |
+| `.gitignore` | Ignores local runtime files | yes |
+| `.env` | Real secrets | no |
+| `.venv/` | Repo-local Agentry Python venv | no |
+| `logs/` | Per-role stdout logs | no |
+| `state/` | Runtime sessions and role continuity notes | no |
+| `worktrees/` | Per-role git worktrees when enabled | no |
 
-## Where role rule files live
+## Role Rules
 
-NOT here. They live at the **standard target-repo location**:
+Project-specific role rules live here:
 
+```text
+docs/ai/roles/
+  researcher.md
+  architect.md
+  implementer.md
+  tester.md
+  reviewer.md
+  release.md
 ```
-<this-repo>/docs/ai/roles/
-├── researcher.md
-├── architect.md
-├── implementer.md
-├── tester.md
-├── reviewer.md
-└── release.md
-```
 
-Edit those for project-specific instructions per role. The prompts in `agentry/config.yml` already point at them.
+Edit those files for project behavior. The prompts in `agentry/config.yml`
+point at them.
 
-## How to use
+## Machine Setup
 
-### One time per machine
-Install Python, Node.js, Claude Code, Codex CLI:
+Run once per machine:
 
 ```powershell
-# Windows
 iwr -useb https://raw.githubusercontent.com/vinu-dev/agentry/main/scripts/install-deps.ps1 | iex
 ```
 
 ```bash
-# Linux
 curl -fsSL https://raw.githubusercontent.com/vinu-dev/agentry/main/scripts/install-deps.sh | bash
 ```
 
-Then authenticate the LLM CLIs (browser flow):
+Then authenticate the LLM CLIs you plan to use:
 
-```
-claude login
+```bash
+npx --yes @anthropic-ai/claude-code login
 codex login
 ```
 
-### One time per repo (this folder)
-1. Copy `.env.example` to `.env` and fill in `GITHUB_TOKEN`
-2. Edit `config.yml` — pick which CLI handles each role
-3. Edit `../docs/ai/roles/*.md` if you want project-specific role instructions
-
-### Every time you want Agentry running
+## Configure Without Starting Agents
 
 ```powershell
-# Windows
+.\agentry\start.ps1 configure --target . --defaults
+.\agentry\start.ps1 gui --target .
+```
+
+```bash
+./agentry/start.sh configure --target . --defaults
+./agentry/start.sh gui --target .
+```
+
+Default mode is `pipeline`: existing GitHub labels move through the pipeline,
+but Researcher does not create new issues. Use `manual` when you want no roles
+to start. Use `autonomous` only when Researcher should be allowed to create new
+work.
+
+## Model Routing For This Repo
+
+This repo is configured to use alternating model perspectives:
+
+- Architect: Claude Code via `npx @anthropic-ai/claude-code`
+- Implementer: Codex
+- Tester: Codex mini
+- Reviewer: Claude Code via `npx @anthropic-ai/claude-code`
+
+Researcher and Release are disabled by default. Enable them only when you want
+new autonomous issue discovery or release automation.
+
+## Start
+
+```powershell
 .\agentry\start.ps1
 ```
 
 ```bash
-# Linux
 ./agentry/start.sh
 ```
 
-Foreground. Ctrl-C to stop. Close the terminal to stop. Reboot kills it. **No service.** Run the script again when you want it running again.
+Foreground only. Ctrl-C, closing the terminal, or rebooting stops it. There is
+no background service by default.
 
-## To upgrade Agentry
+## Stop
 
-Delete `.venv/` and run `start.ps1` / `start.sh` again. The venv is recreated and pulls the latest from GitHub.
+```powershell
+.\agentry\start.ps1 stop --target . --all
+```
 
-## To remove Agentry from this repo
+```bash
+./agentry/start.sh stop --target . --all
+```
 
-Just delete this `agentry/` folder. Optionally also delete `docs/ai/roles/` (or keep them — they're useful project documentation regardless of whether Agentry is running).
+Stop is conservative: Agentry kills only currently running session PIDs, not
+completed or stale records.
+
+## Upgrade
+
+The start scripts install Agentry from the Git ref pinned in the script. To
+upgrade intentionally, update that ref or set `AGENTRY_INSTALL_REF`, delete
+`.venv/`, and rerun the start script.
+
+## Remove
+
+Delete this `agentry/` folder. Optionally keep or delete `docs/ai/roles/`
+depending on whether you want to preserve the project role documentation.

--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -8,6 +8,14 @@
 #   - distilled per-issue log writing
 #   - session-continuity write
 #
+# Agentry's check-in protocol: when an agent's stall_min or total_min
+# threshold hits, the orchestrator sends an AGENTRY-CHECKIN: message via
+# stdin (stream-json input mode for claude). The agent must reply with one
+# of STATUS:WORKING / STATUS:DONE / STATUS:BLOCKED <reason> /
+# STATUS:NEEDMORETIME N — the orchestrator extends the budget, accepts
+# completion, or stops the agent based on the reply. Killing is the LAST
+# resort, only used when the agent fails to respond to the check-in.
+#
 # Agentry's branch model: ONE shared `feature/<id>-<slug>` branch per issue.
 # Architect creates it, Implementer/Tester/Reviewer rebase on `origin/main`
 # at the start of THEIR cycle and add their commits. Branch protection on
@@ -16,17 +24,47 @@
 # The rule file at docs/ai/roles/<role>.md is for PROJECT-SPECIFIC guidance
 # only (mission, anti-goals, validation matrix, sensitive paths, traceability,
 # review criteria). The orchestrator workflow lives here in the prompt.
+#
+# Expensive LLM runs are gated by cheap scheduler checks:
+#   trigger.issue_labels -> run only when a matching open issue exists
+#   trigger.pr_labels    -> run only when a matching open PR exists
+# Run mode defaults to pipeline: Agentry processes existing GitHub labels but
+# does not create new research issues unless the operator explicitly switches
+# to autonomous mode and enables researcher.
+#
+# This target intentionally alternates provider perspectives:
+#   - Claude Code via npx handles design and review judgment
+#   - Codex via npx handles implementation and test execution
+#   - Researcher and release stay disabled until the operator enables them
+# Swap cli/args per role for Claude, Codex, local Llama/Ollama, or wrappers.
 
 target_repo: vinu-dev/rpi-home-monitor
+mode: pipeline                        # manual | pipeline | autonomous
+isolate_worktrees: true              # one git worktree per role for safe parallelism
+
+automation:
+  auto_merge: false                   # human/code-owner merge by default
+  stop_when_queue_empty: false        # foreground process waits for future work
+
+research:
+  allow_create_issues: false          # researcher off unless autonomous
+  max_open_ready_for_design: 3
 
 agents:
 
   researcher:
-    cli: claude
-    args: ["-p", "--model", "claude-haiku-4-5-20251001", "--input-format=stream-json", "--output-format=stream-json", "--verbose", "--dangerously-skip-permissions"]
-    interval_min: 60
+    enabled: false                    # enable only for autonomous discovery
+    cli: npx                          # agentry resolves npx.cmd on Windows
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4-mini", "--dangerously-bypass-approvals-and-sandbox"]
+    # Research is intentionally scheduled, not startup-triggered: it is the
+    # highest-token role and should not run every time the host reboots.
+    run_on_start: false
+    interval_min: 1440
     total_min: 30
     stall_min: 30        # = total_min: no stall-kill, only total-timeout safety
+    max_sessions: 1
+    token_budget: 20000
+    checkin_response_seconds: 90
     prompt: |
       You are the Researcher in a parallel multi-agent pipeline. Other roles
       (architect, implementer, tester, reviewer, release) run concurrently.
@@ -83,6 +121,24 @@ agents:
       - Don't open issues requiring regulatory clearance, hardware
         redesign, or major architecture rework — those need humans.
 
+      ## Check-in protocol (universal — read carefully)
+
+      The orchestrator may send a check-in message during your run. If you
+      receive a user message starting with "AGENTRY-CHECKIN:", reply
+      IMMEDIATELY (before continuing other work) with EXACTLY ONE LINE in
+      one of these forms:
+
+        STATUS:WORKING
+        STATUS:DONE
+        STATUS:BLOCKED <one-line reason>
+        STATUS:NEEDMORETIME <integer minutes>
+
+      After replying, continue your work normally if WORKING or
+      NEEDMORETIME. The orchestrator parses the FIRST STATUS: line in your
+      reply and decides whether to extend your time, accept your
+      completion, or stop you. Killing is the LAST resort, only used when
+      you fail to respond to the check-in.
+
       ## Project specifics
 
       Read docs/ai/roles/researcher.md for:
@@ -94,11 +150,16 @@ agents:
       If that file is missing, exit with error.
 
   architect:
-    cli: claude
-    args: ["-p", "--model", "claude-haiku-4-5-20251001", "--input-format=stream-json", "--output-format=stream-json", "--verbose", "--dangerously-skip-permissions"]
+    cli: npx                          # Claude Code design; agentry resolves npx.cmd on Windows
+    args: ["--yes", "@anthropic-ai/claude-code", "-p", "--model", "claude-haiku-4-5-20251001", "--input-format=stream-json", "--output-format=stream-json", "--verbose", "--dangerously-skip-permissions"]
+    trigger:
+      issue_labels: ["ready-for-design"]
     interval_min: 5
     total_min: 30
     stall_min: 30        # = total_min
+    max_sessions: 1
+    token_budget: 25000
+    checkin_response_seconds: 90
     prompt: |
       You are the Architect in a parallel multi-agent pipeline. Other roles
       run concurrently with you.
@@ -158,6 +219,24 @@ agents:
       - Don't change docs/ai/ (canonical policy).
       - Never push to main.
 
+      ## Check-in protocol (universal — read carefully)
+
+      The orchestrator may send a check-in message during your run. If you
+      receive a user message starting with "AGENTRY-CHECKIN:", reply
+      IMMEDIATELY (before continuing other work) with EXACTLY ONE LINE in
+      one of these forms:
+
+        STATUS:WORKING
+        STATUS:DONE
+        STATUS:BLOCKED <one-line reason>
+        STATUS:NEEDMORETIME <integer minutes>
+
+      After replying, continue your work normally if WORKING or
+      NEEDMORETIME. The orchestrator parses the FIRST STATUS: line in your
+      reply and decides whether to extend your time, accept your
+      completion, or stop you. Killing is the LAST resort, only used when
+      you fail to respond to the check-in.
+
       ## Project specifics
 
       Read docs/ai/roles/architect.md for:
@@ -170,29 +249,39 @@ agents:
       If that file is missing, exit with error.
 
   implementer:
-    cli: claude                       # claude.cmd on Windows
-    args: ["-p", "--model", "claude-haiku-4-5-20251001", "--input-format=stream-json", "--output-format=stream-json", "--verbose", "--dangerously-skip-permissions"]
+    cli: npx                          # Codex implementation; agentry resolves npx.cmd on Windows
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      issue_labels: ["changes-requested", "tests-failed", "ready-for-implementation"]
     interval_min: 5
     total_min: 60
     stall_min: 60        # = total_min
+    max_sessions: 1
+    token_budget: 60000
+    checkin_response_seconds: 90
     prompt: |
       You are the Implementer in a parallel multi-agent pipeline. Other
       roles run concurrently with you.
 
       ## Workflow (universal)
 
-      INPUT: Issues labeled `ready-for-implementation` or `tests-failed`
-      (oldest first; tests-failed takes priority).
+      INPUT: Issues labeled `changes-requested`, `tests-failed`, or
+      `ready-for-implementation` (oldest first; changes-requested and
+      tests-failed take priority).
 
       STEPS:
       1. Read agentry/state/sessions/implementer/latest.md if it exists.
       2. Pick the oldest:
+           gh issue list --label changes-requested --state open --json number,title --jq 'sort_by(.number)[0]'
            gh issue list --label tests-failed --state open --json number,title --jq 'sort_by(.number)[0]'
            gh issue list --label ready-for-implementation --state open --json number,title --jq 'sort_by(.number)[0]'
-         Tests-failed first if both have items. Exit 0 if neither.
-      3. If tests-failed: read the failure from the issue + the relevant
-         agentry/logs/issues/<id>-<slug>/tester.log entry so you know what
-         to fix.
+         Changes-requested first, then tests-failed, then ready-for-implementation.
+         Exit 0 if none exist.
+      3. If changes-requested: read the PR review/comment findings and the
+         relevant agentry/logs/issues/<id>-<slug>/reviewer.log entry. If
+         tests-failed: read the failure from the issue + the relevant
+         agentry/logs/issues/<id>-<slug>/tester.log entry. Use that context
+         to fix only the requested scope.
       4. Switch to the shared feature branch and rebase:
            slug=<from spec filename>
            git fetch origin
@@ -211,7 +300,9 @@ agents:
            git commit -m "[<id>] impl: <one-line>"
            git push origin "feature/<id>-${slug}" --force-with-lease
       9. Move label + comment:
-           if tests-failed:
+           if changes-requested:
+             gh issue edit <id> --add-label ready-for-test --remove-label changes-requested
+           elif tests-failed:
              gh issue edit <id> --add-label ready-for-test --remove-label tests-failed
            else:
              gh issue edit <id> --add-label ready-for-test --remove-label ready-for-implementation
@@ -230,6 +321,24 @@ agents:
       - Hardware-only behavior → write what unit/integration tests you can,
         let Tester decide on `needs-hardware-verification`.
 
+      ## Check-in protocol (universal — read carefully)
+
+      The orchestrator may send a check-in message during your run. If you
+      receive a user message starting with "AGENTRY-CHECKIN:", reply
+      IMMEDIATELY (before continuing other work) with EXACTLY ONE LINE in
+      one of these forms:
+
+        STATUS:WORKING
+        STATUS:DONE
+        STATUS:BLOCKED <one-line reason>
+        STATUS:NEEDMORETIME <integer minutes>
+
+      After replying, continue your work normally if WORKING or
+      NEEDMORETIME. The orchestrator parses the FIRST STATUS: line in your
+      reply and decides whether to extend your time, accept your
+      completion, or stop you. Killing is the LAST resort, only used when
+      you fail to respond to the check-in.
+
       ## Project specifics
 
       Read docs/ai/roles/implementer.md for:
@@ -242,11 +351,16 @@ agents:
       If that file is missing, exit with error.
 
   tester:
-    cli: claude
-    args: ["-p", "--model", "claude-haiku-4-5-20251001", "--input-format=stream-json", "--output-format=stream-json", "--verbose", "--dangerously-skip-permissions"]
+    cli: npx                          # Codex validation; agentry resolves npx.cmd on Windows
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4-mini", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      issue_labels: ["ready-for-test"]
     interval_min: 5
     total_min: 30
     stall_min: 30        # = total_min
+    max_sessions: 1
+    token_budget: 30000
+    checkin_response_seconds: 90
     prompt: |
       You are the Tester in a parallel multi-agent pipeline. Other roles run
       concurrently with you.
@@ -273,10 +387,16 @@ agents:
       5. Run the relevant rows. Skip any the host cannot run (e.g.,
          Yocto bitbake on Windows) and note skips in the PR body.
       6. ALL GREEN:
-           gh pr create --base main --head "feature/<id>-${slug}" \
-             --title "[<id>] <title>" --body "<see template in tester.md>"
-           gh pr edit <pr> --add-label ready-for-review
-           gh issue edit <id> --remove-label ready-for-test
+           pr=$(gh pr list --head "feature/<id>-${slug}" --state open --json number --jq '.[0].number')
+           if [ -z "$pr" ]; then
+             gh pr create --base main --head "feature/<id>-${slug}" \
+               --title "[<id>] <title>" --body "<see template in tester.md>"
+             pr=$(gh pr list --head "feature/<id>-${slug}" --state open --json number --jq '.[0].number')
+           fi
+           gh label create agent-approved --color 0e8a16 --force
+           gh label create pr-open --color 1d76db --force
+           gh pr edit <pr> --add-label ready-for-review --remove-label blocked --remove-label agent-approved
+           gh issue edit <id> --add-label pr-open --remove-label ready-for-test
            gh issue comment <id> --body "Tests passed; PR #<pr> opened."
          ANY RED:
            gh issue edit <id> --add-label tests-failed --remove-label ready-for-test
@@ -296,6 +416,24 @@ agents:
       - Don't lower coverage thresholds.
       - One issue per run.
 
+      ## Check-in protocol (universal — read carefully)
+
+      The orchestrator may send a check-in message during your run. If you
+      receive a user message starting with "AGENTRY-CHECKIN:", reply
+      IMMEDIATELY (before continuing other work) with EXACTLY ONE LINE in
+      one of these forms:
+
+        STATUS:WORKING
+        STATUS:DONE
+        STATUS:BLOCKED <one-line reason>
+        STATUS:NEEDMORETIME <integer minutes>
+
+      After replying, continue your work normally if WORKING or
+      NEEDMORETIME. The orchestrator parses the FIRST STATUS: line in your
+      reply and decides whether to extend your time, accept your
+      completion, or stop you. Killing is the LAST resort, only used when
+      you fail to respond to the check-in.
+
       ## Project specifics
 
       Read docs/ai/roles/tester.md for:
@@ -308,11 +446,16 @@ agents:
       If that file is missing, exit with error.
 
   reviewer:
-    cli: claude
-    args: ["-p", "--model", "claude-haiku-4-5-20251001", "--input-format=stream-json", "--output-format=stream-json", "--verbose", "--dangerously-skip-permissions"]
+    cli: npx                          # Claude Code review; agentry resolves npx.cmd on Windows
+    args: ["--yes", "@anthropic-ai/claude-code", "-p", "--model", "claude-haiku-4-5-20251001", "--input-format=stream-json", "--output-format=stream-json", "--verbose", "--dangerously-skip-permissions"]
+    trigger:
+      pr_labels: ["ready-for-review"]
     interval_min: 5
     total_min: 20
     stall_min: 20        # = total_min
+    max_sessions: 1
+    token_budget: 25000
+    checkin_response_seconds: 90
     prompt: |
       You are the Reviewer in a parallel multi-agent pipeline. Other roles
       run concurrently with you.
@@ -347,12 +490,26 @@ agents:
          - traceability
          - repo policy compliance
       6. APPROVE:
-           gh pr review <n> --approve --body "<concise summary>"
-           gh pr edit <n> --remove-label ready-for-review
+           gh label create agent-approved --color 0e8a16 --force
+           gh pr review <n> --approve --body "Agentry review outcome: APPROVED\n\n<concise summary>"
+           gh pr edit <n> --add-label agent-approved --remove-label ready-for-review --remove-label blocked
+         If `gh pr review` fails or GitHub refuses self-review, use
+         `gh pr comment <n> --body "Agentry review outcome: APPROVED\n\n<concise summary>"`.
+         The verified comment plus `agent-approved` is the canonical Agentry
+         approval signal. Still add `agent-approved`, remove `ready-for-review`
+         and `blocked`, verify with `gh pr view`, and leave the linked issue's
+         `pr-open` label in place until the PR or issue closes.
          (Do NOT click merge — code-owner human merges.)
          BLOCK (any item failed):
-           gh pr review <n> --request-changes --body "<itemized issues>"
-           gh pr edit <n> --add-label blocked --remove-label ready-for-review
+           gh label create agent-approved --color 0e8a16 --force
+           gh pr review <n> --request-changes --body "Agentry review outcome: REQUEST CHANGES\n\n<itemized issues>"
+           gh pr edit <n> --remove-label agent-approved --add-label blocked --remove-label ready-for-review
+           gh issue edit <id> --add-label changes-requested --add-label pr-open --remove-label ready-for-test
+           gh issue comment <id> --body "<short review-fix summary and PR link>"
+         If `gh pr review` fails, use `gh pr comment <n> --body "<REQUEST
+         CHANGES: ...>"`, then perform the same PR and issue label updates.
+         Verify the PR no longer has `ready-for-review` or `agent-approved`
+         and the issue has `changes-requested` plus `pr-open`.
       7. Append distilled cycle entry to
          agentry/logs/issues/<id>-<slug>/reviewer.log
       8. Overwrite session summary. Exit 0.
@@ -365,6 +522,24 @@ agents:
         block.
       - Don't dismiss prior human reviews.
 
+      ## Check-in protocol (universal — read carefully)
+
+      The orchestrator may send a check-in message during your run. If you
+      receive a user message starting with "AGENTRY-CHECKIN:", reply
+      IMMEDIATELY (before continuing other work) with EXACTLY ONE LINE in
+      one of these forms:
+
+        STATUS:WORKING
+        STATUS:DONE
+        STATUS:BLOCKED <one-line reason>
+        STATUS:NEEDMORETIME <integer minutes>
+
+      After replying, continue your work normally if WORKING or
+      NEEDMORETIME. The orchestrator parses the FIRST STATUS: line in your
+      reply and decides whether to extend your time, accept your
+      completion, or stop you. Killing is the LAST resort, only used when
+      you fail to respond to the check-in.
+
       ## Project specifics
 
       Read docs/ai/roles/reviewer.md for:
@@ -376,11 +551,17 @@ agents:
       If that file is missing, exit with error.
 
   release:
-    cli: claude
-    args: ["-p", "--model", "claude-haiku-4-5-20251001", "--input-format=stream-json", "--output-format=stream-json", "--verbose", "--dangerously-skip-permissions"]
+    enabled: false                    # enable when the repo has a release plan
+    cli: npx                          # agentry resolves npx.cmd on Windows
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4-mini", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      issue_labels: ["release-approved"]
     interval_min: 1440
     total_min: 60
     stall_min: 60        # = total_min
+    max_sessions: 1
+    token_budget: 30000
+    checkin_response_seconds: 90
     prompt: |
       You are the Release Engineer in a parallel multi-agent pipeline. Other
       roles run concurrently with you.
@@ -405,6 +586,24 @@ agents:
       - Never bypass hardware sign-off.
       - Never release if any blocker is open in scope.
 
+      ## Check-in protocol (universal — read carefully)
+
+      The orchestrator may send a check-in message during your run. If you
+      receive a user message starting with "AGENTRY-CHECKIN:", reply
+      IMMEDIATELY (before continuing other work) with EXACTLY ONE LINE in
+      one of these forms:
+
+        STATUS:WORKING
+        STATUS:DONE
+        STATUS:BLOCKED <one-line reason>
+        STATUS:NEEDMORETIME <integer minutes>
+
+      After replying, continue your work normally if WORKING or
+      NEEDMORETIME. The orchestrator parses the FIRST STATUS: line in your
+      reply and decides whether to extend your time, accept your
+      completion, or stop you. Killing is the LAST resort, only used when
+      you fail to respond to the check-in.
+
       ## Project specifics
 
       Read docs/ai/roles/release.md for:
@@ -416,8 +615,21 @@ agents:
       If that file is missing, exit with error.
 
 # Paths the Reviewer's rule file should treat as block-worthy.
-# Customize per your project — these are placeholders.
 sensitive_paths:
   - "**/auth/**"
   - "**/secrets/**"
   - "**/.github/workflows/**"
+  - "app/server/**/auth/**"
+  - "app/server/monitor/services/**"
+  - "app/camera/camera_streamer/lifecycle.py"
+  - "app/camera/**/wifi*"
+  - "app/camera/**/pairing*"
+  - "meta-home-monitor/**"
+  - "config/**"
+  - "scripts/build.sh"
+  - "scripts/setup-env.sh"
+  - "docs/cybersecurity/**"
+  - "docs/risk/**"
+  - "AGENTS.md"
+  - "CLAUDE.md"
+  - ".github/copilot-instructions.md"

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -4,14 +4,14 @@
 
 .DESCRIPTION
     Runs in foreground until you Ctrl-C or close the terminal. There is no
-    Windows Service install — every reboot, you run this script again.
+    Windows Service install - every reboot, you run this script again.
 
     On first run, this script creates a local Python venv at
     <target>/agentry/.venv/ and pip-installs agentry into it. On subsequent
     runs it just activates the venv and starts the orchestrator.
 
     Run this script from the target repo root or from inside the agentry/
-    folder — both work.
+    folder - both work.
 
 .EXAMPLE
     cd C:\projects\rpi-home-monitor
@@ -19,13 +19,20 @@
 #>
 
 [CmdletBinding()]
-param()
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$AgentryArgs
+)
 
 $ErrorActionPreference = 'Stop'
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
+$InstallRefFile = Join-Path $Venv '.agentry-install-ref'
+$AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
+$AgentryRef = '914da62cf21684112c7f1ff9bf665b9fa46c56ee'
+if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 # Locate Python.
 $python = $null
@@ -40,7 +47,7 @@ if (-not $python) {
     exit 1
 }
 
-# Create venv on first run; pip-install agentry into it.
+# Create venv on first run; reinstall agentry when the pinned ref changes.
 if (-not (Test-Path (Join-Path $Venv 'Scripts\python.exe'))) {
     Write-Host "==> First-time setup: creating venv at $Venv" -ForegroundColor Cyan
     & $python -m venv $Venv
@@ -49,21 +56,41 @@ if (-not (Test-Path (Join-Path $Venv 'Scripts\python.exe'))) {
         exit 1
     }
     & (Join-Path $Venv 'Scripts\python.exe') -m pip install --upgrade pip
-    Write-Host "==> Installing agentry from GitHub" -ForegroundColor Cyan
-    & (Join-Path $Venv 'Scripts\python.exe') -m pip install 'git+https://github.com/vinu-dev/agentry.git'
+}
+
+$InstalledRef = ''
+if (Test-Path $InstallRefFile) {
+    $InstalledRef = (Get-Content $InstallRefFile -Raw).Trim()
+}
+if ($InstalledRef -ne $AgentryRef) {
+    Write-Host "==> Installing agentry from GitHub at $AgentryRef" -ForegroundColor Cyan
+    & (Join-Path $Venv 'Scripts\python.exe') -m pip install --upgrade --force-reinstall "git+$AgentryRepo@$AgentryRef"
     if ($LASTEXITCODE -ne 0) {
         Write-Host "agentry install failed" -ForegroundColor Red
         exit 1
     }
-    Write-Host "==> Setup complete" -ForegroundColor Green
+    Set-Content -Path $InstallRefFile -Value $AgentryRef -Encoding ASCII
+    Write-Host "==> Agentry install complete" -ForegroundColor Green
 }
 
 $AgentryExe = Join-Path $Venv 'Scripts\agentry.exe'
 if (-not (Test-Path $AgentryExe)) {
-    Write-Host "agentry binary not found at $AgentryExe — venv may be corrupted" -ForegroundColor Red
+    Write-Host "agentry binary not found at $AgentryExe - venv may be corrupted" -ForegroundColor Red
     Write-Host "Delete agentry\.venv and re-run this script." -ForegroundColor Yellow
     exit 1
 }
 
 Write-Host "==> Starting agentry against $TargetRoot" -ForegroundColor Cyan
+if ($AgentryArgs.Count -gt 0) {
+    Write-Host "==> Running agentry $($AgentryArgs -join ' ')" -ForegroundColor Cyan
+    & $AgentryExe @AgentryArgs
+    exit $LASTEXITCODE
+}
+
+Write-Host "==> Running doctor" -ForegroundColor Cyan
+& $AgentryExe doctor --target $TargetRoot
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "agentry doctor failed; fix the issues above and rerun start.ps1" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
 & $AgentryExe start --target $TargetRoot

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -2,7 +2,7 @@
 # Start Agentry against this target repository.
 #
 # Runs in foreground until you Ctrl-C or close the terminal. There is no
-# systemd install — every reboot, you run this script again.
+# systemd install - every reboot, you run this script again.
 #
 # On first run, this script creates a local Python venv at
 # <target>/agentry/.venv/ and pip-installs agentry into it. On subsequent
@@ -13,6 +13,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
+INSTALL_REF_FILE="$VENV/.agentry-install-ref"
+AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-914da62cf21684112c7f1ff9bf665b9fa46c56ee}"
 
 # Locate Python.
 PYTHON=""
@@ -29,21 +32,36 @@ if [[ -z "$PYTHON" ]]; then
     exit 1
 fi
 
-# Create venv on first run; pip-install agentry into it.
+# Create venv on first run; reinstall agentry when the pinned ref changes.
 if [[ ! -x "$VENV/bin/python" ]]; then
     echo "==> First-time setup: creating venv at $VENV"
     "$PYTHON" -m venv "$VENV"
     "$VENV/bin/python" -m pip install --upgrade pip
-    echo "==> Installing agentry from GitHub"
-    "$VENV/bin/python" -m pip install 'git+https://github.com/vinu-dev/agentry.git'
-    echo "==> Setup complete"
+fi
+
+INSTALLED_REF=""
+if [[ -f "$INSTALL_REF_FILE" ]]; then
+    INSTALLED_REF="$(tr -d '[:space:]' < "$INSTALL_REF_FILE")"
+fi
+if [[ "$INSTALLED_REF" != "$AGENTRY_REF" ]]; then
+    echo "==> Installing agentry from GitHub at $AGENTRY_REF"
+    "$VENV/bin/python" -m pip install --upgrade --force-reinstall "git+$AGENTRY_REPO@$AGENTRY_REF"
+    printf '%s\n' "$AGENTRY_REF" > "$INSTALL_REF_FILE"
+    echo "==> Agentry install complete"
 fi
 
 if [[ ! -x "$VENV/bin/agentry" ]]; then
-    echo "agentry binary not found at $VENV/bin/agentry — venv may be corrupted"
+    echo "agentry binary not found at $VENV/bin/agentry - venv may be corrupted"
     echo "Delete agentry/.venv and re-run this script."
     exit 1
 fi
 
 echo "==> Starting agentry against $TARGET_ROOT"
+if [[ "$#" -gt 0 ]]; then
+    echo "==> Running agentry $*"
+    exec "$VENV/bin/agentry" "$@"
+fi
+
+echo "==> Running doctor"
+"$VENV/bin/agentry" doctor --target "$TARGET_ROOT"
 exec "$VENV/bin/agentry" start --target "$TARGET_ROOT"


### PR DESCRIPTION
﻿## Summary
- Pin the repo-local Agentry start scripts to `914da62cf21684112c7f1ff9bf665b9fa46c56ee` instead of mutable main.
- Upgrade `agentry/config.yml` to the latest pipeline/watchdog schema with trigger gates, check-ins, disabled Researcher/Release defaults, and PR-status labels.
- Configure alternating model perspectives for this repo: Claude Code via `npx` for Architect/Reviewer, Codex via `npx` for Implementer/Tester.
- Refresh Agentry README, secrets template, and runtime ignore rules for the latest setup flow.

## Validation
- `python scripts/ai/validate_repo_ai_setup.py`
- `python scripts/ai/check_doc_links.py`
- `python scripts/ai/check_shell_scripts.py`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\agentry\start.ps1 doctor --target . --init-labels`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\agentry\start.ps1 status --target .`
- `npx.cmd --yes @anthropic-ai/claude-code --version`
- `npx.cmd --yes @openai/codex --version`
