### PR TITLE
[codex] Update Agentry pin to Claude stream-json fix

### DIFF
--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -31,7 +31,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = '914da62cf21684112c7f1ff9bf665b9fa46c56ee'
+$AgentryRef = '89128f8a32fb2bd8634591bf636468dc061eb597'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 # Locate Python.

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-914da62cf21684112c7f1ff9bf665b9fa46c56ee}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-89128f8a32fb2bd8634591bf636468dc061eb597}"
 
 # Locate Python.
 PYTHON=""


### PR DESCRIPTION
﻿## Summary
- Update bundled Agentry launcher pins to platform commit `89128f8a32fb2bd8634591bf636468dc061eb597`.
- Keeps Windows and POSIX target launchers aligned with the merged Claude stream-json supervisor fix from `vinu-dev/agentry#16`.

## Validation
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\agentry\start.ps1 status --target .` -> reinstalled Agentry at `89128f8a32fb2bd8634591bf636468dc061eb597` and printed status
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\agentry\start.ps1 doctor --target . --init-labels` -> PASS
- `git diff --check` -> passed

## Notes
- `bash -n agentry/start.sh` could not be run on this Windows host because `bash` is not installed; `start.sh` changed only the pinned SHA string.
