### PR TITLE
docs: require depot validation evidence

### DIFF
--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -294,6 +294,10 @@ agents:
          service-layer patterns, where state goes, branch naming, sensitive
          paths). Write unit tests alongside code.
       7. Run validators per docs/ai/roles/implementer.md before pushing.
+         For code changes this includes the depot rule gate: doc map, AI setup,
+         doc links, shell-script policy, version checks, pre-commit, Ruff, and
+         the relevant test suites. Do not move labels forward unless every
+         applicable command passed or the exact blocked command is reported.
       8. Commit + push (be EXPLICIT about staged paths — never `git add -A`,
          to avoid pulling in agentry/ or other untracked):
            git add app/ tests/ docs/history/specs/ <other touched paths>
@@ -384,8 +388,9 @@ agents:
            git diff --name-only origin/main...HEAD
          Map paths to rows per the validation matrix in
          docs/ai/roles/tester.md.
-      5. Run the relevant rows. Skip any the host cannot run (e.g.,
-         Yocto bitbake on Windows) and note skips in the PR body.
+      5. Run the relevant rows. For code changes always include the depot rule
+         gate from docs/ai/roles/tester.md. Skip only rows the host truly cannot
+         run (e.g., Yocto bitbake on Windows) and note skips in the PR body.
       6. ALL GREEN:
            pr=$(gh pr list --head "feature/<id>-${slug}" --state open --json number --jq '.[0].number')
            if [ -z "$pr" ]; then

--- a/docs/ai/roles/implementer.md
+++ b/docs/ai/roles/implementer.md
@@ -39,10 +39,17 @@ Per `docs/ai/validation-and-release.md`. Run only the rows that apply:
 |---|---|
 | `app/server/**` | `pytest app/server/tests/ -v --cov=app/server --cov-fail-under=85`, `ruff check .`, `ruff format --check .` |
 | `app/camera/**` | `pytest app/camera/tests/ -v --cov=app/camera --cov-fail-under=80`, `ruff check .`, `ruff format --check .` |
+| any code change | `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `python scripts/ai/check_doc_links.py`, `python scripts/ai/check_shell_scripts.py`, `python scripts/check_version_consistency.py`, `python scripts/check_versioning_design.py`, `pre-commit run --all-files` |
 | `meta-home-monitor/**`, `config/**` | `bitbake -p` (skip if no Yocto SDK on host — note in PR) |
-| `docs/ai/**`, `AGENTS.md`, `CLAUDE.md`, `.github/copilot-*` | `python scripts/ai/validate_repo_ai_setup.py`, `python scripts/ai/check_doc_links.py`, `pre-commit run --all-files` |
+| `docs/ai/**`, `AGENTS.md`, `CLAUDE.md`, `.github/copilot-*` | the full "any code change" row plus adapter-specific checks |
 | traceability files (REQ, RISK, SEC, TEST IDs touched) | `python tools/traceability/check_traceability.py` |
 | `scripts/**`, `.github/workflows/**` | `bash -n` + `shellcheck` |
+
+Do not move an issue forward as implementation-complete until every applicable
+command above either passes or is explicitly reported as blocked with the exact
+command and host limitation. Missing local tools are not a pass; install them
+when reasonable, or leave the issue in a failure/blocker state for the next
+cycle.
 
 ## Sensitive paths — extra care
 

--- a/docs/ai/roles/tester.md
+++ b/docs/ai/roles/tester.md
@@ -13,7 +13,7 @@ and run the rows that apply:
 |---|---|
 | `app/server/**` | `pytest app/server/tests/ -v --cov=app/server --cov-fail-under=85`<br>`ruff check .`<br>`ruff format --check .` |
 | `app/camera/**` | `pytest app/camera/tests/ -v --cov=app/camera --cov-fail-under=80`<br>`ruff check .`<br>`ruff format --check .` |
-| Repo governance / docs | `python scripts/ai/validate_repo_ai_setup.py`<br>`python scripts/ai/check_doc_links.py`<br>`python scripts/ai/check_shell_scripts.py`<br>`pre-commit run --all-files` |
+| Any code change / repo governance / docs | `python tools/docs/check_doc_map.py`<br>`python scripts/ai/validate_repo_ai_setup.py`<br>`python scripts/ai/check_doc_links.py`<br>`python scripts/ai/check_shell_scripts.py`<br>`python scripts/check_version_consistency.py`<br>`python scripts/check_versioning_design.py`<br>`pre-commit run --all-files` |
 | Traceability touched | `python tools/traceability/check_traceability.py` |
 | `meta-home-monitor/**`, `config/**` (Yocto) | `bitbake -p` |
 | `scripts/**`, `.github/workflows/**` | `bash -n <script>`, `shellcheck <script>` |
@@ -49,6 +49,15 @@ Closes #<id>
 ## Validation evidence
 - <command 1>: PASS
 - <command 2>: PASS
+- python tools/docs/check_doc_map.py: PASS
+- python scripts/ai/validate_repo_ai_setup.py: PASS
+- python scripts/ai/check_doc_links.py: PASS
+- python scripts/ai/check_shell_scripts.py: PASS
+- python scripts/check_version_consistency.py: PASS
+- python scripts/check_versioning_design.py: PASS
+- pre-commit run --all-files: PASS
+- ruff check .: PASS
+- ruff format --check .: PASS
 - coverage: server <pct>% / camera <pct>%
 - skipped: <bitbake / hardware> (reason)
 
@@ -69,6 +78,9 @@ Closes #<id>
   a PR.
 - Flaky test → still label `tests-failed`. Implementer triages on next
   pickup.
+
+Missing local tooling is not a pass. Install reasonable Python tools such as
+`pre-commit`; otherwise mark the row as blocked and do not claim green.
 
 ## Don't suppress, don't lower thresholds, don't auto-merge
 

--- a/docs/ai/validation-and-release.md
+++ b/docs/ai/validation-and-release.md
@@ -4,7 +4,7 @@
 
 | Area touched | Required validation |
 |--------------|---------------------|
-| Repository governance, docs, adapters | `python scripts/ai/validate_repo_ai_setup.py`, `python scripts/ai/check_doc_links.py`, `python scripts/ai/check_shell_scripts.py`, `pre-commit run --all-files` |
+| Repository governance, docs, adapters | `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `python scripts/ai/check_doc_links.py`, `python scripts/ai/check_shell_scripts.py`, `python scripts/check_version_consistency.py`, `python scripts/check_versioning_design.py`, `pre-commit run --all-files` |
 | Requirements, risk, security, traceability, annotated code | `python tools/traceability/check_traceability.py`, `python scripts/ai/check_doc_links.py`, relevant tests |
 | Server Python | `pytest app/server/tests/ -v`, `ruff check .`, `ruff format --check .` |
 | Camera Python | `pytest app/camera/tests/ -v`, `ruff check .`, `ruff format --check .` |
@@ -57,6 +57,28 @@ If code, docs, and device disagree, the device wins until the repo is updated.
 - doc impact
 - traceability impact and unresolved `OPEN QUESTION:` /
   `REGULATORY REVIEW REQUIRED:` items
+
+## Depot Rule Gate
+
+Every code-changing PR must include validation evidence showing the applicable
+repo rules passed. At minimum, code changes must report:
+
+- `python tools/docs/check_doc_map.py`
+- `python scripts/ai/validate_repo_ai_setup.py`
+- `python scripts/ai/check_doc_links.py`
+- `python scripts/ai/check_shell_scripts.py`
+- `python scripts/check_version_consistency.py`
+- `python scripts/check_versioning_design.py`
+- `pre-commit run --all-files`
+- `ruff check .`
+- `ruff format --check .`
+- the relevant server, camera, contract, security, coverage, Yocto, or hardware
+  validators for touched paths
+
+If a required command cannot run on the host, the PR must state the exact
+command, the reason it could not run, and the follow-up environment needed. A
+missing local tool such as `pre-commit` is not a pass; install it or report the
+validation as blocked.
 
 ## Branch Protection Recommendation
 


### PR DESCRIPTION
﻿## Summary
- Require the depot rule gate in Implementer and Tester validation instructions.
- Make PR validation evidence list the repo governance, docs, version, pre-commit, Ruff, and relevant test commands explicitly.
- Update the Agentry role prompts so labels do not move forward unless applicable commands pass or the exact blocked command is reported.

## Validation
- `git diff --check`
- parsed `agentry/config.yml` with PyYAML
- `python tools/docs/check_doc_map.py`
- `python scripts/ai/validate_repo_ai_setup.py`
- `python scripts/ai/check_doc_links.py`
- `python scripts/ai/check_shell_scripts.py`
- `python scripts/check_version_consistency.py`
- `python scripts/check_versioning_design.py`
- `python tools/traceability/check_traceability.py`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pre_commit run --all-files`

## Notes
- This is a workflow/config documentation change; no product runtime code was changed.
- Yocto and hardware validators are not applicable to this branch because no Yocto, device behavior, or product code paths changed.
