### PR TITLE
chore: update Agentry dirty-worktree guard pin

### DIFF
--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -31,7 +31,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = 'd912825074a5a12d6658461e0facc40729aff728'
+$AgentryRef = 'f7d0dc583440117c8b5f13e57d6cf9b5ade9903f'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 # Locate Python.

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-d912825074a5a12d6658461e0facc40729aff728}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-f7d0dc583440117c8b5f13e57d6cf9b5ade9903f}"
 
 # Locate Python.
 PYTHON=""

--- a/docs/history/planning/agentry-smoke-test-state.md
+++ b/docs/history/planning/agentry-smoke-test-state.md
@@ -13,7 +13,7 @@ Two repositories stay separate:
 
 | Repository | Responsibility | Current baseline |
 |---|---|---|
-| `vinu-dev/agentry` | Universal platform, supervisor, prompts, session handling | `d912825074a5a12d6658461e0facc40729aff728` |
+| `vinu-dev/agentry` | Universal platform, supervisor, prompts, session handling | `f7d0dc583440117c8b5f13e57d6cf9b5ade9903f` |
 | `vinu-dev/rpi-home-monitor` | Target config, product code, product docs, role guidance | pinned to the Agentry baseline above |
 
 Do not mix platform fixes into this repo. Do not put target project fixes in
@@ -33,7 +33,7 @@ the Agentry repo.
 The target Agentry scripts pin the platform to:
 
 ```text
-d912825074a5a12d6658461e0facc40729aff728
+f7d0dc583440117c8b5f13e57d6cf9b5ade9903f
 ```
 
 Model routing:


### PR DESCRIPTION
## Summary\n- pin target Agentry start scripts to platform commit f7d0dc583440117c8b5f13e57d6cf9b5ade9903f\n- update the smoke-test state doc to record the new platform baseline\n\n## Validation\n- python tools/docs/check_doc_map.py\n- python scripts/ai/validate_repo_ai_setup.py\n- python scripts/ai/check_doc_links.py\n- python scripts/ai/check_shell_scripts.py\n- python scripts/check_version_consistency.py\n- python scripts/check_versioning_design.py\n- python -m pre_commit run --all-files\n\nPlatform PR: https://github.com/vinu-dev/agentry/pull/18