### PR TITLE
[240] Feature: Config backup and restore (settings, users, cameras, retention policy)

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -21,6 +21,7 @@ from monitor.services.camera_control_client import CameraControlClient
 from monitor.services.camera_ota_client import CameraOTAClient
 from monitor.services.camera_service import CameraService
 from monitor.services.cert_service import CertService
+from monitor.services.config_backup_service import ConfigBackupService
 from monitor.services.discovery import DiscoveryService
 from monitor.services.factory_reset_service import FactoryResetService
 from monitor.services.loop_recorder import LoopRecorder
@@ -339,6 +340,14 @@ def _init_services(app):
         store=app.store,
         audit=app.audit,
         data_dir=app.config["DATA_DIR"],
+    )
+    app.config_backup_service = ConfigBackupService(
+        store=app.store,
+        audit=app.audit,
+        settings_service=app.settings_service,
+        data_dir=app.config["DATA_DIR"],
+        config_dir=app.config["CONFIG_DIR"],
+        certs_dir=app.config["CERTS_DIR"],
     )
 
     # Connect storage manager → streaming service for dir change notifications.

--- a/app/server/monitor/api/system.py
+++ b/app/server/monitor/api/system.py
@@ -12,14 +12,20 @@ Endpoints:
   POST /system/tailscale/disable       - Disable tailscaled daemon
   POST /system/tailscale/apply-config  - Apply saved Tailscale settings
   POST /system/factory-reset           - Wipe all data and return to first-boot state
+  POST /system/backup/export           - Download a signed configuration bundle
+  POST /system/backup/preview          - Validate + preview a backup bundle
+  POST /system/backup/import           - Restore a backup bundle
+  GET  /system/backup/snapshots        - List rollback snapshots created on import
 """
 
 import time
 from datetime import datetime
+from io import BytesIO
 
-from flask import Blueprint, current_app, jsonify, request, session
+from flask import Blueprint, current_app, jsonify, request, send_file, session
 
 from monitor.auth import admin_required, csrf_protect, login_required
+from monitor.services.config_backup_service import ConfigBackupError
 from monitor.services.health import get_health_summary, get_uptime
 
 system_bp = Blueprint("system", __name__)
@@ -38,6 +44,107 @@ def _read_os_release():
             return result
     except OSError:
         return {}
+
+
+def _bool_from_request(value, default=False):
+    """Parse booleans from JSON/form data."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _log_backup_audit(event: str, *, user: str, ip: str, detail: str) -> None:
+    """Best-effort audit logging for backup actions."""
+    audit = getattr(current_app, "audit", None)
+    if not audit:
+        return
+    try:
+        audit.log_event(event, user=user, ip=ip, detail=detail)
+    except Exception:
+        current_app.logger.debug("Backup audit log failed for %s", event)
+
+
+def _backup_scope_from_body(body: dict | None) -> dict:
+    """Normalise export-scope booleans from a JSON request body."""
+    body = body or {}
+    scope = body.get("scope") if isinstance(body.get("scope"), dict) else {}
+    return {
+        "users": _bool_from_request(scope.get("users", body.get("users", True)), True),
+        "cameras": _bool_from_request(
+            scope.get("cameras", body.get("cameras", True)),
+            True,
+        ),
+        "settings": _bool_from_request(
+            scope.get("settings", body.get("settings", True)),
+            True,
+        ),
+        "include_user_credentials": _bool_from_request(
+            body.get("include_user_credentials", False),
+            False,
+        ),
+        "include_camera_trust": _bool_from_request(
+            body.get("include_camera_trust", True),
+            True,
+        ),
+        "include_webhook_secrets": _bool_from_request(
+            body.get("include_webhook_secrets", False),
+            False,
+        ),
+        "include_tailscale_auth_key": _bool_from_request(
+            body.get("include_tailscale_auth_key", False),
+            False,
+        ),
+    }
+
+
+def _backup_restore_scope(form) -> dict:
+    """Normalise explicit restore-scope booleans from a multipart upload."""
+    scope = {}
+    for key in ("users", "cameras", "settings", "camera_trust"):
+        if key in form:
+            scope[key] = _bool_from_request(form.get(key), False)
+    return scope
+
+
+def _scope_detail(scope: dict) -> str:
+    """Format enabled scope names for audit detail strings."""
+    enabled = [name for name, value in scope.items() if value]
+    return ",".join(enabled) if enabled else "none"
+
+
+def _read_uploaded_bundle() -> tuple[bytes, str]:
+    """Read the uploaded backup bundle from multipart form data."""
+    if "file" not in request.files:
+        raise ConfigBackupError("No backup bundle provided", reason="missing_bundle")
+    file = request.files["file"]
+    filename = file.filename or "backup.hmb"
+    payload = file.read()
+    if not payload:
+        raise ConfigBackupError(
+            "Uploaded backup bundle is empty", reason="empty_bundle"
+        )
+    return payload, filename
+
+
+def _read_passphrase(source: dict | None) -> str:
+    """Read and validate the backup passphrase from request data."""
+    source = source or {}
+    passphrase = source.get("passphrase")
+    if not isinstance(passphrase, str) or not passphrase.strip():
+        raise ConfigBackupError(
+            "Passphrase is required",
+            reason="missing_passphrase",
+        )
+    return passphrase
+
+
+def _backup_error_response(exc: ConfigBackupError):
+    """Return a consistent JSON error payload for backup routes."""
+    return jsonify({"error": str(exc), "reason": exc.reason}), exc.status_code
 
 
 @system_bp.route("/time", methods=["GET"])
@@ -251,3 +358,135 @@ def factory_reset():
         requesting_ip=ip,
     )
     return jsonify({"message": msg}), status
+
+
+@system_bp.route("/backup/export", methods=["POST"])
+@admin_required
+@csrf_protect
+def backup_export():
+    """Export a signed configuration backup bundle. Admin only."""
+    body = request.get_json(silent=True) or {}
+    user = session.get("username", "")
+    ip = request.remote_addr or ""
+
+    try:
+        passphrase = _read_passphrase(body)
+        options = _backup_scope_from_body(body)
+        filename, bundle_bytes, preview = (
+            current_app.config_backup_service.export_bundle(
+                passphrase=passphrase,
+                options=options,
+            )
+        )
+    except ConfigBackupError as exc:
+        _log_backup_audit(
+            "CONFIG_BACKUP_EXPORT_REJECTED",
+            user=user,
+            ip=ip,
+            detail=f"reason={exc.reason}",
+        )
+        return _backup_error_response(exc)
+
+    _log_backup_audit(
+        "CONFIG_BACKUP_EXPORTED",
+        user=user,
+        ip=ip,
+        detail=(
+            f"scope={_scope_detail(preview.get('scope', {}))}; "
+            f"users={preview.get('counts', {}).get('users', 0)}; "
+            f"cameras={preview.get('counts', {}).get('cameras', 0)}"
+        ),
+    )
+    return send_file(
+        BytesIO(bundle_bytes),
+        mimetype="application/vnd.home-monitor.backup+json",
+        as_attachment=True,
+        download_name=filename,
+    )
+
+
+@system_bp.route("/backup/preview", methods=["POST"])
+@admin_required
+@csrf_protect
+def backup_preview():
+    """Validate and preview a backup bundle before restore. Admin only."""
+    user = session.get("username", "")
+    ip = request.remote_addr or ""
+
+    try:
+        bundle_bytes, filename = _read_uploaded_bundle()
+        passphrase = _read_passphrase(request.form)
+        preview = current_app.config_backup_service.preview_bundle(
+            bundle_bytes,
+            passphrase=passphrase,
+        )
+    except ConfigBackupError as exc:
+        _log_backup_audit(
+            "CONFIG_BACKUP_PREVIEW_REJECTED",
+            user=user,
+            ip=ip,
+            detail=f"reason={exc.reason}",
+        )
+        return _backup_error_response(exc)
+
+    _log_backup_audit(
+        "CONFIG_BACKUP_PREVIEWED",
+        user=user,
+        ip=ip,
+        detail=f"filename={filename}; scope={_scope_detail(preview.get('scope', {}))}",
+    )
+    return jsonify({"filename": filename, "preview": preview}), 200
+
+
+@system_bp.route("/backup/import", methods=["POST"])
+@admin_required
+@csrf_protect
+def backup_import():
+    """Restore a validated backup bundle. Admin only."""
+    user = session.get("username", "")
+    ip = request.remote_addr or ""
+
+    try:
+        bundle_bytes, filename = _read_uploaded_bundle()
+        passphrase = _read_passphrase(request.form)
+        restore_options = _backup_restore_scope(request.form)
+        _log_backup_audit(
+            "CONFIG_BACKUP_IMPORT_ATTEMPT",
+            user=user,
+            ip=ip,
+            detail=(f"filename={filename}; scope={_scope_detail(restore_options)}"),
+        )
+        result = current_app.config_backup_service.import_bundle(
+            bundle_bytes,
+            passphrase=passphrase,
+            restore_options=restore_options,
+        )
+    except ConfigBackupError as exc:
+        _log_backup_audit(
+            "CONFIG_BACKUP_IMPORT_REJECTED",
+            user=user,
+            ip=ip,
+            detail=f"reason={exc.reason}",
+        )
+        return _backup_error_response(exc)
+
+    _log_backup_audit(
+        "CONFIG_BACKUP_IMPORTED",
+        user=user,
+        ip=ip,
+        detail=(
+            f"filename={filename}; "
+            f"snapshot={result.get('snapshot', {}).get('id', '')}; "
+            f"scope={_scope_detail({name: True for name in result.get('restored_components', [])})}"
+        ),
+    )
+    return jsonify(result), 200
+
+
+@system_bp.route("/backup/snapshots", methods=["GET"])
+@admin_required
+def backup_snapshots():
+    """List rollback snapshots created during restore. Admin only."""
+    return jsonify(
+        {"snapshots": current_app.config_backup_service.list_snapshots()}
+    ), 200

--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -256,6 +256,7 @@ class Settings:
     require_2fa_for_remote: bool = False
     webhook_destinations: list[WebhookDestination] = field(default_factory=list)
     webhook_delivery_history_retention_days: int = 30
+    backup_max_history: int = 3
 
     def __post_init__(self) -> None:
         normalised: list[WebhookDestination] = []

--- a/app/server/monitor/services/backup_paths.py
+++ b/app/server/monitor/services/backup_paths.py
@@ -1,0 +1,119 @@
+# REQ: SWR-018, SWR-034; RISK: RISK-006, RISK-019; SEC: SC-006, SC-017; TEST: TC-015, TC-032
+"""
+Shared path catalogue for server-side mutable configuration.
+
+Config backup/import and factory reset both operate on the same set of
+server-owned files. Keeping the path inventory in one place prevents
+those flows from silently drifting apart.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BackupPaths:
+    """Resolved filesystem paths for mutable server state."""
+
+    data_dir: Path
+    config_dir: Path
+    certs_dir: Path
+
+    @property
+    def users_file(self) -> Path:
+        return self.config_dir / "users.json"
+
+    @property
+    def cameras_file(self) -> Path:
+        return self.config_dir / "cameras.json"
+
+    @property
+    def settings_file(self) -> Path:
+        return self.config_dir / "settings.json"
+
+    @property
+    def hostname_file(self) -> Path:
+        return self.config_dir / "hostname"
+
+    @property
+    def session_secret_file(self) -> Path:
+        return self.config_dir / ".secret_key"
+
+    @property
+    def motion_events_file(self) -> Path:
+        return self.config_dir / "motion_events.json"
+
+    @property
+    def alert_read_state_file(self) -> Path:
+        return self.config_dir / "alert_read_state.json"
+
+    @property
+    def logs_dir(self) -> Path:
+        return self.data_dir / "logs"
+
+    @property
+    def live_dir(self) -> Path:
+        return self.data_dir / "live"
+
+    @property
+    def recordings_dir(self) -> Path:
+        return self.data_dir / "recordings"
+
+    @property
+    def tailscale_dir(self) -> Path:
+        return self.data_dir / "tailscale"
+
+    @property
+    def ota_dir(self) -> Path:
+        return self.data_dir / "ota"
+
+    @property
+    def wifi_connections_dir(self) -> Path:
+        return self.data_dir / "network" / "system-connections"
+
+    @property
+    def wifi_wiped_marker(self) -> Path:
+        return self.data_dir / "network" / ".wifi-wiped"
+
+    @property
+    def backup_snapshot_root(self) -> Path:
+        return self.data_dir / "backup-snapshots"
+
+    @property
+    def resettable_config_files(self) -> tuple[Path, ...]:
+        return (
+            self.cameras_file,
+            self.users_file,
+            self.settings_file,
+            self.session_secret_file,
+            self.hostname_file,
+            self.motion_events_file,
+            self.alert_read_state_file,
+        )
+
+    @property
+    def resettable_dirs(self) -> tuple[Path, ...]:
+        return (
+            self.certs_dir,
+            self.live_dir,
+            self.recordings_dir,
+            self.logs_dir,
+            self.tailscale_dir,
+            self.ota_dir,
+        )
+
+
+def build_backup_paths(
+    data_dir: str = "/data",
+    config_dir: str | None = None,
+    certs_dir: str | None = None,
+) -> BackupPaths:
+    """Resolve the path catalogue from the app's configured roots."""
+    data_root = Path(data_dir)
+    config_root = Path(config_dir) if config_dir else data_root / "config"
+    certs_root = Path(certs_dir) if certs_dir else data_root / "certs"
+    return BackupPaths(
+        data_dir=data_root,
+        config_dir=config_root,
+        certs_dir=certs_root,
+    )

--- a/app/server/monitor/services/config_backup_service.py
+++ b/app/server/monitor/services/config_backup_service.py
@@ -1,0 +1,931 @@
+# REQ: SWR-023, SWR-024, SWR-034, SWR-045; RISK: RISK-011, RISK-012, RISK-019, RISK-020; SEC: SC-011, SC-012, SC-017, SC-020, SC-021; TEST: TC-022, TC-023, TC-032, TC-041, TC-042
+"""
+Configuration backup/export service.
+
+This service serialises the server's mutable configuration into a signed
+bundle, previews the bundle before restore, and restores selected
+configuration components with rollback-on-error semantics.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import asdict, fields
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+
+from monitor.models import Camera, Settings, User
+from monitor.services.backup_paths import build_backup_paths
+
+log = logging.getLogger("monitor.services.config_backup")
+
+BUNDLE_FORMAT = "home-monitor-config-backup.v1"
+BUNDLE_SCHEMA_VERSION = 1
+PBKDF2_ITERATIONS = 200_000
+MIN_PASSPHRASE_LENGTH = 12
+DEFAULT_SNAPSHOT_HISTORY = 3
+
+
+class ConfigBackupError(ValueError):
+    """Raised when a bundle cannot be exported, previewed, or imported."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: str = "invalid_bundle",
+        status_code: int = 400,
+    ) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.status_code = status_code
+
+
+class ConfigBackupService:
+    """Export, preview, and restore configuration bundles."""
+
+    def __init__(
+        self,
+        store,
+        audit=None,
+        settings_service=None,
+        data_dir: str = "/data",
+        config_dir: str | None = None,
+        certs_dir: str | None = None,
+    ):
+        self._store = store
+        self._audit = audit
+        self._settings_service = settings_service
+        self._paths = build_backup_paths(
+            data_dir=data_dir,
+            config_dir=config_dir,
+            certs_dir=certs_dir,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def export_bundle(
+        self,
+        *,
+        passphrase: str,
+        options: dict | None = None,
+    ) -> tuple[str, bytes, dict]:
+        """Build a downloadable bundle and a human-readable preview."""
+        options = self._normalise_export_options(options)
+        payload = self._build_payload(options)
+        manifest = self._build_manifest(payload, options)
+        signature = self._sign_manifest_and_payload(
+            manifest=manifest,
+            payload=payload,
+            passphrase=passphrase,
+        )
+        bundle = {
+            "manifest": manifest,
+            "payload": payload,
+            "signature": signature,
+        }
+        created_at = manifest["created_at"].replace(":", "").replace("-", "")
+        filename = f"home-monitor-config-{created_at}.hmb"
+        preview = self._build_preview(manifest, payload)
+        return filename, self._canonical_json(bundle), preview
+
+    def preview_bundle(self, bundle_bytes: bytes, *, passphrase: str) -> dict:
+        """Validate and summarise a bundle before restore."""
+        bundle = self._load_bundle(bundle_bytes, passphrase=passphrase)
+        return self._build_preview(bundle["manifest"], bundle["payload"])
+
+    def import_bundle(
+        self,
+        bundle_bytes: bytes,
+        *,
+        passphrase: str,
+        restore_options: dict | None = None,
+    ) -> dict:
+        """Restore a validated bundle into the live data directory."""
+        bundle = self._load_bundle(bundle_bytes, passphrase=passphrase)
+        restore = self._normalise_restore_options(
+            restore_options,
+            manifest=bundle["manifest"],
+        )
+        payload = self._normalise_payload(bundle["payload"], restore=restore)
+        snapshot = self._create_snapshot(
+            restore=restore,
+            manifest=bundle["manifest"],
+            payload=payload,
+        )
+        try:
+            self._apply_import(payload=payload, restore=restore)
+        except Exception as exc:  # pragma: no cover - defensive rollback path
+            self._restore_snapshot(snapshot)
+            raise ConfigBackupError(
+                "Restore failed and prior state was restored",
+                reason="import_failed",
+                status_code=500,
+            ) from exc
+        self._prune_snapshots()
+        return {
+            "message": "Configuration restored",
+            "snapshot": snapshot["metadata"],
+            "preview": self._build_preview(bundle["manifest"], bundle["payload"]),
+            "restored_components": sorted(
+                name for name, enabled in restore.items() if enabled
+            ),
+        }
+
+    def list_snapshots(self) -> list[dict]:
+        """Return stored rollback snapshots, newest first."""
+        result: list[dict] = []
+        root = self._paths.backup_snapshot_root
+        if not root.is_dir():
+            return result
+
+        for entry in sorted(root.iterdir(), reverse=True):
+            metadata_file = entry / "metadata.json"
+            if not metadata_file.is_file():
+                continue
+            try:
+                metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            result.append(metadata)
+        return result
+
+    # ------------------------------------------------------------------
+    # Bundle construction
+    # ------------------------------------------------------------------
+    def _build_payload(self, options: dict) -> dict:
+        settings = self._store.get_settings()
+        payload = {
+            "users": [],
+            "cameras": [],
+            "settings": None,
+            "camera_trust": {"entries": []},
+        }
+
+        if options["users"]:
+            payload["users"] = [
+                self._serialise_user(
+                    user,
+                    include_credentials=options["include_user_credentials"],
+                )
+                for user in self._store.get_users()
+            ]
+
+        if options["cameras"]:
+            payload["cameras"] = [
+                self._serialise_camera(
+                    camera,
+                    include_camera_trust=options["include_camera_trust"],
+                )
+                for camera in self._store.get_cameras()
+            ]
+            if options["include_camera_trust"]:
+                payload["camera_trust"]["entries"] = self._serialise_certs()
+
+        if options["settings"]:
+            payload["settings"] = {
+                "config": self._serialise_settings(
+                    settings,
+                    include_webhook_secrets=options["include_webhook_secrets"],
+                    include_tailscale_auth_key=options["include_tailscale_auth_key"],
+                ),
+                "hostname": self._read_hostname(settings.hostname),
+            }
+
+        return payload
+
+    def _build_manifest(self, payload: dict, options: dict) -> dict:
+        created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        salt = os.urandom(16)
+        counts = {
+            "users": len(payload["users"] or []),
+            "cameras": len(payload["cameras"] or []),
+            "webhook_destinations": len(
+                (payload.get("settings") or {})
+                .get("config", {})
+                .get(
+                    "webhook_destinations",
+                    [],
+                )
+            ),
+            "camera_trust_files": len(
+                (payload.get("camera_trust") or {}).get("entries", [])
+            ),
+        }
+        return {
+            "format": BUNDLE_FORMAT,
+            "schema_version": BUNDLE_SCHEMA_VERSION,
+            "created_at": created_at,
+            "salt_b64": base64.b64encode(salt).decode("ascii"),
+            "scope": {
+                "users": options["users"],
+                "cameras": options["cameras"],
+                "settings": options["settings"],
+                "camera_trust": options["cameras"] and options["include_camera_trust"],
+            },
+            "secret_policy": {
+                "include_user_credentials": options["include_user_credentials"],
+                "include_camera_trust": options["include_camera_trust"],
+                "include_webhook_secrets": options["include_webhook_secrets"],
+                "include_tailscale_auth_key": options["include_tailscale_auth_key"],
+            },
+            "counts": counts,
+            "payload_sha256": hashlib.sha256(self._canonical_json(payload)).hexdigest(),
+        }
+
+    def _build_preview(self, manifest: dict, payload: dict) -> dict:
+        users = payload.get("users") or []
+        cameras = payload.get("cameras") or []
+        settings_payload = payload.get("settings") or {}
+        settings_config = settings_payload.get("config") or {}
+
+        user_ids = {item.get("id", "") for item in users if isinstance(item, dict)}
+        camera_ids = {item.get("id", "") for item in cameras if isinstance(item, dict)}
+
+        current_users = self._store.get_users()
+        current_cameras = self._store.get_cameras()
+        current_settings = asdict(self._store.get_settings())
+
+        current_user_ids = {user.id for user in current_users}
+        current_camera_ids = {camera.id for camera in current_cameras}
+
+        warnings: list[str] = []
+        secret_policy = manifest.get("secret_policy", {})
+        if not secret_policy.get("include_user_credentials", False):
+            warnings.append(
+                "User credentials are excluded; restored accounts will need new passwords."
+            )
+        if not secret_policy.get("include_webhook_secrets", False):
+            warnings.append(
+                "Webhook secrets are excluded; authenticated webhook destinations restore disabled."
+            )
+        if not secret_policy.get("include_tailscale_auth_key", False):
+            warnings.append(
+                "The Tailscale auth key is excluded; remote re-authentication may be required."
+            )
+        if not secret_policy.get("include_camera_trust", False) and manifest.get(
+            "scope",
+            {},
+        ).get("cameras"):
+            warnings.append(
+                "Camera trust material is excluded; restored cameras will need re-pairing."
+            )
+
+        changed_setting_keys = sorted(
+            key
+            for key, value in settings_config.items()
+            if current_settings.get(key) != value
+        )
+
+        return {
+            "created_at": manifest.get("created_at", ""),
+            "schema_version": manifest.get("schema_version"),
+            "scope": manifest.get("scope", {}),
+            "secret_policy": secret_policy,
+            "warnings": warnings,
+            "counts": manifest.get("counts", {}),
+            "users": {
+                "current": len(current_users),
+                "incoming": len(users),
+                "create": len(user_ids - current_user_ids),
+                "update": len(user_ids & current_user_ids),
+                "remove": len(current_user_ids - user_ids)
+                if manifest.get("scope", {}).get("users")
+                else 0,
+                "accounts": [
+                    {
+                        "id": item.get("id", ""),
+                        "username": item.get("username", ""),
+                        "role": item.get("role", "viewer"),
+                    }
+                    for item in users
+                ],
+            },
+            "cameras": {
+                "current": len(current_cameras),
+                "incoming": len(cameras),
+                "create": len(camera_ids - current_camera_ids),
+                "update": len(camera_ids & current_camera_ids),
+                "remove": len(current_camera_ids - camera_ids)
+                if manifest.get("scope", {}).get("cameras")
+                else 0,
+                "items": [
+                    {
+                        "id": item.get("id", ""),
+                        "name": item.get("name", ""),
+                        "location": item.get("location", ""),
+                    }
+                    for item in cameras
+                ],
+            },
+            "settings": {
+                "hostname": settings_payload.get("hostname", ""),
+                "changed_keys": changed_setting_keys,
+                "webhook_destination_count": len(
+                    settings_config.get("webhook_destinations", [])
+                ),
+            },
+            "restore_defaults": {
+                "users": bool(manifest.get("scope", {}).get("users")),
+                "cameras": bool(manifest.get("scope", {}).get("cameras")),
+                "settings": bool(manifest.get("scope", {}).get("settings")),
+                "camera_trust": bool(manifest.get("scope", {}).get("camera_trust")),
+            },
+        }
+
+    def _sign_manifest_and_payload(
+        self,
+        *,
+        manifest: dict,
+        payload: dict,
+        passphrase: str,
+    ) -> str:
+        key = self._derive_key(passphrase=passphrase, salt_b64=manifest["salt_b64"])
+        body = self._canonical_json({"manifest": manifest, "payload": payload})
+        return hmac.new(key, body, hashlib.sha256).hexdigest()
+
+    def _load_bundle(self, bundle_bytes: bytes, *, passphrase: str) -> dict:
+        self._validate_passphrase(passphrase)
+        try:
+            bundle = json.loads(bundle_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ConfigBackupError(
+                "Bundle is not valid JSON",
+                reason="corrupt_bundle",
+            ) from exc
+
+        if not isinstance(bundle, dict):
+            raise ConfigBackupError(
+                "Bundle payload is malformed", reason="corrupt_bundle"
+            )
+
+        manifest = bundle.get("manifest")
+        payload = bundle.get("payload")
+        signature = bundle.get("signature", "")
+        if not isinstance(manifest, dict) or not isinstance(payload, dict):
+            raise ConfigBackupError(
+                "Bundle payload is malformed", reason="corrupt_bundle"
+            )
+        if not isinstance(signature, str) or not signature:
+            raise ConfigBackupError(
+                "Bundle signature is missing", reason="corrupt_bundle"
+            )
+
+        if manifest.get("format") != BUNDLE_FORMAT:
+            raise ConfigBackupError(
+                "Bundle format is not supported by this server",
+                reason="format_mismatch",
+            )
+        if manifest.get("schema_version") != BUNDLE_SCHEMA_VERSION:
+            raise ConfigBackupError(
+                "Bundle schema version does not match this server",
+                reason="schema_mismatch",
+            )
+
+        expected_checksum = hashlib.sha256(self._canonical_json(payload)).hexdigest()
+        if manifest.get("payload_sha256") != expected_checksum:
+            raise ConfigBackupError(
+                "Bundle contents do not match the signed manifest",
+                reason="signature_mismatch",
+            )
+
+        expected_signature = self._sign_manifest_and_payload(
+            manifest=manifest,
+            payload=payload,
+            passphrase=passphrase,
+        )
+        if not hmac.compare_digest(expected_signature, signature):
+            raise ConfigBackupError(
+                "Bundle signature verification failed",
+                reason="signature_mismatch",
+            )
+
+        return {
+            "manifest": manifest,
+            "payload": payload,
+            "signature": signature,
+        }
+
+    # ------------------------------------------------------------------
+    # Restore paths and snapshots
+    # ------------------------------------------------------------------
+    def _normalise_payload(self, payload: dict, *, restore: dict) -> dict:
+        users: list[User] = []
+        cameras: list[Camera] = []
+        settings: Settings | None = None
+        hostname = ""
+        cert_entries: list[dict] = []
+
+        if restore["users"]:
+            raw_users = payload.get("users")
+            if not isinstance(raw_users, list):
+                raise ConfigBackupError("Bundle users payload is malformed")
+            users = [self._build_dataclass(User, item) for item in raw_users]
+            if not any(user.role == "admin" for user in users):
+                raise ConfigBackupError(
+                    "Restoring users requires at least one admin account",
+                    reason="invalid_users",
+                )
+
+        if restore["cameras"]:
+            raw_cameras = payload.get("cameras")
+            if not isinstance(raw_cameras, list):
+                raise ConfigBackupError("Bundle cameras payload is malformed")
+            cameras = [self._build_dataclass(Camera, item) for item in raw_cameras]
+
+        if restore["settings"]:
+            raw_settings = (payload.get("settings") or {}).get("config")
+            if not isinstance(raw_settings, dict):
+                raise ConfigBackupError("Bundle settings payload is malformed")
+            settings = self._build_dataclass(Settings, raw_settings)
+            hostname = str(
+                (payload.get("settings") or {}).get("hostname") or ""
+            ).strip()
+            if not hostname:
+                hostname = settings.hostname
+
+        if restore["camera_trust"]:
+            raw_entries = (payload.get("camera_trust") or {}).get("entries")
+            if not isinstance(raw_entries, list):
+                raise ConfigBackupError("Bundle camera trust payload is malformed")
+            cert_entries = self._normalise_cert_entries(raw_entries)
+
+        return {
+            "users": users,
+            "cameras": cameras,
+            "settings": settings,
+            "hostname": hostname,
+            "camera_trust": cert_entries,
+        }
+
+    def _apply_import(self, *, payload: dict, restore: dict) -> None:
+        targets = self._render_targets(payload=payload, restore=restore)
+        for target in targets:
+            if target["kind"] == "file":
+                self._replace_file(target["path"], target["content"])
+            else:
+                self._replace_dir(target["path"], target["entries"])
+
+        if restore["settings"] and payload["settings"] is not None:
+            self._reapply_runtime_settings(payload["settings"])
+
+    def _render_targets(self, *, payload: dict, restore: dict) -> list[dict]:
+        targets: list[dict] = []
+        if restore["users"]:
+            targets.append(
+                {
+                    "name": "users",
+                    "kind": "file",
+                    "path": self._paths.users_file,
+                    "content": self._render_json(
+                        [asdict(user) for user in payload["users"]]
+                    ),
+                }
+            )
+        if restore["cameras"]:
+            targets.append(
+                {
+                    "name": "cameras",
+                    "kind": "file",
+                    "path": self._paths.cameras_file,
+                    "content": self._render_json(
+                        [asdict(camera) for camera in payload["cameras"]]
+                    ),
+                }
+            )
+        if restore["settings"] and payload["settings"] is not None:
+            targets.append(
+                {
+                    "name": "settings",
+                    "kind": "file",
+                    "path": self._paths.settings_file,
+                    "content": self._render_json(asdict(payload["settings"])),
+                }
+            )
+            targets.append(
+                {
+                    "name": "hostname",
+                    "kind": "file",
+                    "path": self._paths.hostname_file,
+                    "content": f"{payload['hostname'].strip()}\n".encode(),
+                }
+            )
+        if restore["camera_trust"]:
+            targets.append(
+                {
+                    "name": "certs",
+                    "kind": "dir",
+                    "path": self._paths.certs_dir,
+                    "entries": payload["camera_trust"],
+                }
+            )
+        return targets
+
+    def _create_snapshot(self, *, restore: dict, manifest: dict, payload: dict) -> dict:
+        root = self._paths.backup_snapshot_root
+        root.mkdir(parents=True, exist_ok=True)
+        snapshot_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        snapshot_dir = root / f"{snapshot_id}-{os.urandom(3).hex()}"
+        state_dir = snapshot_dir / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        snapshot_created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        metadata = {
+            "id": snapshot_dir.name,
+            "created_at": snapshot_created_at,
+            "bundle_created_at": manifest.get("created_at", ""),
+            "restore_components": {
+                key: bool(value) for key, value in restore.items() if value
+            },
+            "counts": {
+                "users": len(payload["users"]) if restore["users"] else 0,
+                "cameras": len(payload["cameras"]) if restore["cameras"] else 0,
+                "camera_trust_files": len(payload["camera_trust"])
+                if restore["camera_trust"]
+                else 0,
+            },
+            "targets": [],
+        }
+
+        for target in self._render_targets(payload=payload, restore=restore):
+            alias = self._snapshot_alias(target["name"])
+            snapshot_target = state_dir / alias
+            existed = target["path"].exists()
+            metadata["targets"].append(
+                {
+                    "name": target["name"],
+                    "kind": target["kind"],
+                    "alias": alias,
+                    "path": str(target["path"]),
+                    "existed": existed,
+                }
+            )
+            if not existed:
+                continue
+            if target["kind"] == "file":
+                snapshot_target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(target["path"], snapshot_target)
+            else:
+                shutil.copytree(target["path"], snapshot_target)
+
+        (snapshot_dir / "metadata.json").write_text(
+            json.dumps(metadata, indent=2),
+            encoding="utf-8",
+        )
+        return {
+            "dir": snapshot_dir,
+            "state_dir": state_dir,
+            "metadata": metadata,
+        }
+
+    def _restore_snapshot(self, snapshot: dict) -> None:
+        state_dir = snapshot["state_dir"]
+        for target in snapshot["metadata"].get("targets", []):
+            path = Path(target["path"])
+            if path.exists():
+                if target["kind"] == "file":
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                else:
+                    shutil.rmtree(path, ignore_errors=True)
+
+            if not target.get("existed"):
+                continue
+
+            snapshot_target = state_dir / target["alias"]
+            if target["kind"] == "file":
+                path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(snapshot_target, path)
+            else:
+                shutil.copytree(snapshot_target, path)
+
+    def _prune_snapshots(self) -> None:
+        keep = DEFAULT_SNAPSHOT_HISTORY
+        try:
+            keep = int(getattr(self._store.get_settings(), "backup_max_history", keep))
+        except Exception:
+            keep = DEFAULT_SNAPSHOT_HISTORY
+
+        root = self._paths.backup_snapshot_root
+        if not root.is_dir():
+            return
+        entries = sorted(
+            [entry for entry in root.iterdir() if entry.is_dir()],
+            reverse=True,
+        )
+        for stale in entries[keep:]:
+            shutil.rmtree(stale, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Runtime helpers
+    # ------------------------------------------------------------------
+    def _reapply_runtime_settings(self, settings: Settings) -> None:
+        if not self._settings_service:
+            return
+        updated_fields = {
+            "timezone",
+            "ntp_mode",
+            "storage_threshold_percent",
+            "clip_duration_seconds",
+            "session_timeout_minutes",
+            "loop_low_watermark_percent",
+            "loop_hysteresis_percent",
+        }
+        try:
+            self._settings_service._apply_runtime_changes(settings, updated_fields)
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("Failed to reapply restored runtime settings: %s", exc)
+
+    def _replace_file(self, path: Path, content: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent),
+            prefix=f"{path.name}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(content)
+            os.replace(tmp_name, path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+
+    def _replace_dir(self, path: Path, entries: list[dict]) -> None:
+        parent = path.parent
+        parent.mkdir(parents=True, exist_ok=True)
+        staging_dir = Path(tempfile.mkdtemp(prefix=f"{path.name}.", dir=str(parent)))
+        try:
+            for entry in entries:
+                relative = PurePosixPath(entry["path"])
+                target = staging_dir / Path(*relative.parts)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(base64.b64decode(entry["content_b64"]))
+            if path.exists():
+                shutil.rmtree(path)
+            shutil.move(str(staging_dir), str(path))
+        finally:
+            if staging_dir.exists():
+                shutil.rmtree(staging_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+    def _serialise_user(self, user: User, *, include_credentials: bool) -> dict:
+        payload = asdict(user)
+        if not include_credentials:
+            payload["password_hash"] = ""
+            payload["totp_secret"] = ""
+            payload["must_change_password"] = True
+            payload["failed_logins"] = 0
+            payload["locked_until"] = ""
+        return payload
+
+    def _serialise_camera(self, camera: Camera, *, include_camera_trust: bool) -> dict:
+        payload = asdict(camera)
+        if not include_camera_trust:
+            payload["pairing_secret"] = ""
+            payload["cert_serial"] = ""
+        return payload
+
+    def _serialise_settings(
+        self,
+        settings: Settings,
+        *,
+        include_webhook_secrets: bool,
+        include_tailscale_auth_key: bool,
+    ) -> dict:
+        payload = asdict(settings)
+        if not include_tailscale_auth_key:
+            payload["tailscale_auth_key"] = ""
+        if not include_webhook_secrets:
+            sanitised = []
+            for destination in payload.get("webhook_destinations", []):
+                if not isinstance(destination, dict):
+                    continue
+                cleaned = dict(destination)
+                auth_type = cleaned.get("auth_type", "none")
+                if auth_type != "none":
+                    cleaned["secret"] = ""
+                    cleaned["enabled"] = False
+                sanitised.append(cleaned)
+            payload["webhook_destinations"] = sanitised
+        return payload
+
+    def _serialise_certs(self) -> list[dict]:
+        entries: list[dict] = []
+        if not self._paths.certs_dir.is_dir():
+            return entries
+        for file_path in sorted(self._paths.certs_dir.rglob("*")):
+            if not file_path.is_file():
+                continue
+            entries.append(
+                {
+                    "path": file_path.relative_to(self._paths.certs_dir).as_posix(),
+                    "content_b64": base64.b64encode(file_path.read_bytes()).decode(
+                        "ascii"
+                    ),
+                }
+            )
+        return entries
+
+    def _normalise_cert_entries(self, entries: list[dict]) -> list[dict]:
+        normalised: list[dict] = []
+        for item in entries:
+            if not isinstance(item, dict):
+                raise ConfigBackupError("Bundle camera trust payload is malformed")
+            rel_path = str(item.get("path", ""))
+            content_b64 = str(item.get("content_b64", ""))
+            if not rel_path or not content_b64:
+                raise ConfigBackupError("Bundle camera trust payload is malformed")
+            rel = PurePosixPath(rel_path)
+            if rel.is_absolute() or ".." in rel.parts:
+                raise ConfigBackupError(
+                    "Bundle camera trust path is invalid",
+                    reason="corrupt_bundle",
+                )
+            try:
+                base64.b64decode(content_b64, validate=True)
+            except (binascii.Error, ValueError) as exc:
+                raise ConfigBackupError(
+                    "Bundle camera trust payload is malformed",
+                    reason="corrupt_bundle",
+                ) from exc
+            normalised.append({"path": rel.as_posix(), "content_b64": content_b64})
+        return normalised
+
+    def _build_dataclass(self, cls, raw: dict):
+        if not isinstance(raw, dict):
+            raise ConfigBackupError(
+                "Bundle payload is malformed", reason="corrupt_bundle"
+            )
+        allowed = {field.name for field in fields(cls)}
+        filtered = {key: value for key, value in raw.items() if key in allowed}
+        try:
+            return cls(**filtered)
+        except TypeError as exc:
+            raise ConfigBackupError(
+                "Bundle payload is malformed", reason="corrupt_bundle"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Request parsing helpers
+    # ------------------------------------------------------------------
+    def _normalise_export_options(self, options: dict | None) -> dict:
+        options = options or {}
+        scope = options.get("scope") if isinstance(options.get("scope"), dict) else {}
+        result = {
+            "users": self._as_bool(scope.get("users", options.get("users", True))),
+            "cameras": self._as_bool(
+                scope.get("cameras", options.get("cameras", True))
+            ),
+            "settings": self._as_bool(
+                scope.get("settings", options.get("settings", True))
+            ),
+            "include_user_credentials": self._as_bool(
+                options.get("include_user_credentials", False)
+            ),
+            "include_camera_trust": self._as_bool(
+                options.get("include_camera_trust", True)
+            ),
+            "include_webhook_secrets": self._as_bool(
+                options.get("include_webhook_secrets", False)
+            ),
+            "include_tailscale_auth_key": self._as_bool(
+                options.get("include_tailscale_auth_key", False)
+            ),
+        }
+        if not result["users"]:
+            result["include_user_credentials"] = False
+        if not result["cameras"]:
+            result["include_camera_trust"] = False
+        if not result["settings"]:
+            result["include_webhook_secrets"] = False
+            result["include_tailscale_auth_key"] = False
+        if not any(result[key] for key in ("users", "cameras", "settings")):
+            raise ConfigBackupError("Select at least one component to export")
+        return result
+
+    def _normalise_restore_options(
+        self, options: dict | None, *, manifest: dict
+    ) -> dict:
+        options = options or {}
+        scope = manifest.get("scope", {})
+        result = {
+            "users": self._as_bool(options["users"])
+            if "users" in options
+            else self._as_bool(scope.get("users", False)),
+            "cameras": self._as_bool(options["cameras"])
+            if "cameras" in options
+            else self._as_bool(scope.get("cameras", False)),
+            "settings": self._as_bool(options["settings"])
+            if "settings" in options
+            else self._as_bool(scope.get("settings", False)),
+            "camera_trust": self._as_bool(options["camera_trust"])
+            if "camera_trust" in options
+            else self._as_bool(scope.get("camera_trust", False)),
+        }
+        available = {
+            "users": self._as_bool(scope.get("users", False)),
+            "cameras": self._as_bool(scope.get("cameras", False)),
+            "settings": self._as_bool(scope.get("settings", False)),
+            "camera_trust": self._as_bool(scope.get("camera_trust", False)),
+        }
+        for key, label in (
+            ("users", "user data"),
+            ("cameras", "camera data"),
+            ("settings", "settings data"),
+            ("camera_trust", "camera trust material"),
+        ):
+            if result[key] and not available[key]:
+                raise ConfigBackupError(
+                    f"Bundle does not contain {label}",
+                    reason="invalid_restore_scope",
+                )
+        if result["camera_trust"] and not result["cameras"]:
+            raise ConfigBackupError(
+                "Camera trust restore requires camera restore",
+                reason="invalid_restore_scope",
+            )
+        if not any(result.values()):
+            raise ConfigBackupError("Select at least one component to restore")
+        return result
+
+    def _validate_passphrase(self, passphrase: str) -> None:
+        if (
+            not isinstance(passphrase, str)
+            or len(passphrase.strip()) < MIN_PASSPHRASE_LENGTH
+        ):
+            raise ConfigBackupError(
+                f"Passphrase must be at least {MIN_PASSPHRASE_LENGTH} characters",
+                reason="weak_passphrase",
+            )
+
+    def _derive_key(self, *, passphrase: str, salt_b64: str) -> bytes:
+        self._validate_passphrase(passphrase)
+        try:
+            salt = base64.b64decode(salt_b64)
+        except (binascii.Error, ValueError) as exc:
+            raise ConfigBackupError(
+                "Bundle salt is invalid", reason="corrupt_bundle"
+            ) from exc
+        return hashlib.pbkdf2_hmac(
+            "sha256",
+            passphrase.encode("utf-8"),
+            salt,
+            PBKDF2_ITERATIONS,
+            dklen=32,
+        )
+
+    # ------------------------------------------------------------------
+    # Small utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _canonical_json(payload: dict) -> bytes:
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+
+    @staticmethod
+    def _render_json(payload: dict | list) -> bytes:
+        return (json.dumps(payload, indent=2, default=str) + "\n").encode("utf-8")
+
+    @staticmethod
+    def _as_bool(value) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _read_hostname(self, default: str) -> str:
+        try:
+            value = self._paths.hostname_file.read_text(encoding="utf-8").strip()
+            return value or default
+        except OSError:
+            return default
+
+    @staticmethod
+    def _snapshot_alias(name: str) -> str:
+        mapping = {
+            "users": "config/users.json",
+            "cameras": "config/cameras.json",
+            "settings": "config/settings.json",
+            "hostname": "config/hostname",
+            "certs": "certs",
+        }
+        return mapping[name]

--- a/app/server/monitor/services/factory_reset_service.py
+++ b/app/server/monitor/services/factory_reset_service.py
@@ -18,6 +18,8 @@ import shutil
 import subprocess
 import threading
 
+from monitor.services.backup_paths import build_backup_paths
+
 log = logging.getLogger("monitor.services.factory_reset")
 
 
@@ -28,6 +30,7 @@ class FactoryResetService:
         self._store = store
         self._audit = audit
         self._data_dir = data_dir
+        self._paths = build_backup_paths(data_dir=data_dir)
 
     def execute_reset(
         self,
@@ -56,42 +59,19 @@ class FactoryResetService:
         stamp = os.path.join(self._data_dir, ".setup-done")
         self._safe_remove(stamp, errors)
 
-        # 2. Clear config files (users, cameras, settings, secret key)
-        config_dir = os.path.join(self._data_dir, "config")
-        for filename in [
-            "cameras.json",
-            "users.json",
-            "settings.json",
-            ".secret_key",
-        ]:
-            self._safe_remove(os.path.join(config_dir, filename), errors)
+        # 2. Clear config files shared with backup/import. Keep the
+        # config directory itself so first-boot code can recreate
+        # defaults in place.
+        for target in self._paths.resettable_config_files:
+            self._safe_remove(str(target), errors)
 
-        # 3. Clear certificates (server certs regenerated on boot)
-        certs_dir = os.path.join(self._data_dir, "certs")
-        self._safe_rmtree(certs_dir, errors)
+        # 3. Clear mutable state directories shared with backup/import.
+        for target in self._paths.resettable_dirs:
+            if target == self._paths.recordings_dir and keep_recordings:
+                continue
+            self._safe_rmtree(str(target), errors)
 
-        # 4. Clear live streaming buffer
-        live_dir = os.path.join(self._data_dir, "live")
-        self._safe_rmtree(live_dir, errors)
-
-        # 5. Optionally clear recordings
-        if not keep_recordings:
-            recordings_dir = os.path.join(self._data_dir, "recordings")
-            self._safe_rmtree(recordings_dir, errors)
-
-        # 6. Clear logs (audit log already has the reset event)
-        logs_dir = os.path.join(self._data_dir, "logs")
-        self._safe_rmtree(logs_dir, errors)
-
-        # 7. Clear Tailscale state
-        ts_dir = os.path.join(self._data_dir, "tailscale")
-        self._safe_rmtree(ts_dir, errors)
-
-        # 8. Clear OTA staging area
-        ota_dir = os.path.join(self._data_dir, "ota")
-        self._safe_rmtree(ota_dir, errors)
-
-        # 9. Clear WiFi credentials via hotspot script (ADR-0013)
+        # 4. Clear WiFi credentials via hotspot script (ADR-0013)
         self._clear_wifi(errors)
 
         if errors:
@@ -157,12 +137,15 @@ class FactoryResetService:
 
         # 2. Always wipe /data/network/system-connections/ directly
         #    (nm-persist.sh restores connections from here on every boot)
-        persist_dir = os.path.join(self._data_dir, "network", "system-connections")
-        self._wipe_dir_contents(persist_dir, "persistent WiFi", errors)
+        self._wipe_dir_contents(
+            str(self._paths.wifi_connections_dir),
+            "persistent WiFi",
+            errors,
+        )
 
         # 3. Write a marker so nm-persist.sh skips re-seeding from rootfs
         #    (rootfs may have baked-in WiFi connections from dev builds)
-        marker = os.path.join(self._data_dir, "network", ".wifi-wiped")
+        marker = str(self._paths.wifi_wiped_marker)
         try:
             os.makedirs(os.path.dirname(marker), exist_ok=True)
             with open(marker, "w") as f:

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -201,6 +201,151 @@
         </div>
     </div>
 
+    <div class="settings-section">
+        <div class="settings-section__title">Configuration Backup</div>
+        <div class="card">
+            <p class="text-small text-muted" style="margin-bottom:var(--space-3);">
+                Export server-side users, paired cameras, settings, and trust material into a signed `.hmb` bundle. Keep bundles secure if you include credentials or camera trust.
+            </p>
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="backup-export-passphrase">Passphrase</label>
+                    <input id="backup-export-passphrase" type="password" class="form-input"
+                           placeholder="At least 12 characters"
+                           x-model="backup.exportForm.passphrase">
+                </div>
+            </div>
+            <div class="form-row">
+                <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">
+                    <input type="checkbox" x-model="backup.exportForm.scope.users">
+                    <span>Users</span>
+                </label>
+                <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">
+                    <input type="checkbox" x-model="backup.exportForm.scope.cameras">
+                    <span>Cameras</span>
+                </label>
+                <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">
+                    <input type="checkbox" x-model="backup.exportForm.scope.settings">
+                    <span>Settings</span>
+                </label>
+            </div>
+            <div class="form-group" style="margin-top:var(--space-2);">
+                <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">
+                    <input type="checkbox" x-model="backup.exportForm.include_user_credentials">
+                    <span>Include user credentials and TOTP secrets</span>
+                </label>
+                <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer; margin-top:6px;">
+                    <input type="checkbox" x-model="backup.exportForm.include_camera_trust">
+                    <span>Include camera certificates and pairing trust</span>
+                </label>
+                <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer; margin-top:6px;">
+                    <input type="checkbox" x-model="backup.exportForm.include_webhook_secrets">
+                    <span>Include webhook secrets</span>
+                </label>
+                <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer; margin-top:6px;">
+                    <input type="checkbox" x-model="backup.exportForm.include_tailscale_auth_key">
+                    <span>Include Tailscale auth key</span>
+                </label>
+            </div>
+            <div class="text-small text-muted" style="margin-bottom:var(--space-3);">
+                Excluding credentials keeps restored accounts and integrations in a safer reset-required state.
+            </div>
+            <button class="btn btn--primary" @click="exportBackup()" :disabled="backup.exporting">
+                <span x-text="backup.exporting ? 'Preparing backup...' : 'Download Backup'"></span>
+            </button>
+        </div>
+    </div>
+
+    <div class="settings-section">
+        <div class="settings-section__title">Configuration Restore</div>
+        <div class="card">
+            <p class="text-small text-muted" style="margin-bottom:var(--space-3);">
+                Upload a backup bundle, preview the changes, then confirm restore. A rollback snapshot is created automatically before import.
+            </p>
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="backup-import-passphrase">Passphrase</label>
+                    <input id="backup-import-passphrase" type="password" class="form-input"
+                           placeholder="Passphrase used during export"
+                           x-model="backup.importForm.passphrase">
+                </div>
+                <div class="form-group">
+                    <label for="backup-import-file">Bundle file</label>
+                    <input id="backup-import-file" type="file" class="form-input" accept=".hmb,.json"
+                           @change="setBackupFile($event)">
+                </div>
+            </div>
+            <div class="text-small text-muted" x-show="backup.importForm.filename" x-text="'Selected: ' + backup.importForm.filename"></div>
+            <div style="display:flex; gap:var(--space-2); margin-top:var(--space-3);">
+                <button class="btn btn--secondary" @click="previewBackupImport()" :disabled="backup.importForm.previewing || !backup.importForm.file">
+                    <span x-text="backup.importForm.previewing ? 'Validating...' : 'Preview Restore'"></span>
+                </button>
+                <button class="btn btn--danger" @click="importBackup()"
+                        :disabled="backup.importForm.importing || !backup.importForm.preview">
+                    <span x-text="backup.importForm.importing ? 'Restoring...' : 'Confirm Restore'"></span>
+                </button>
+            </div>
+
+            <template x-if="backup.importForm.preview">
+                <div style="margin-top:var(--space-4); border-top:1px solid var(--color-border); padding-top:var(--space-4);">
+                    <div class="info-row">
+                        <span class="info-row__label">Bundle created</span>
+                        <span class="info-row__value" x-text="formatLocalTime(backup.importForm.preview.created_at)"></span>
+                    </div>
+                    <div class="info-row">
+                        <span class="info-row__label">Users</span>
+                        <span class="info-row__value" x-text="backup.importForm.preview.users.incoming + ' incoming · ' + backup.importForm.preview.users.create + ' new · ' + backup.importForm.preview.users.update + ' updates · ' + backup.importForm.preview.users.remove + ' removals'"></span>
+                    </div>
+                    <div class="info-row">
+                        <span class="info-row__label">Cameras</span>
+                        <span class="info-row__value" x-text="backup.importForm.preview.cameras.incoming + ' incoming · ' + backup.importForm.preview.cameras.create + ' new · ' + backup.importForm.preview.cameras.update + ' updates · ' + backup.importForm.preview.cameras.remove + ' removals'"></span>
+                    </div>
+                    <div class="info-row" style="border-bottom:none;">
+                        <span class="info-row__label">Settings changes</span>
+                        <span class="info-row__value" x-text="(backup.importForm.preview.settings.changed_keys || []).length ? backup.importForm.preview.settings.changed_keys.join(', ') : 'No settings changes detected'"></span>
+                    </div>
+                    <div class="form-row" style="margin-top:var(--space-3);">
+                        <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">
+                            <input type="checkbox" x-model="backup.importForm.scope.users">
+                            <span>Restore users</span>
+                        </label>
+                        <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">
+                            <input type="checkbox" x-model="backup.importForm.scope.cameras">
+                            <span>Restore cameras</span>
+                        </label>
+                        <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">
+                            <input type="checkbox" x-model="backup.importForm.scope.settings">
+                            <span>Restore settings</span>
+                        </label>
+                        <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">
+                            <input type="checkbox" x-model="backup.importForm.scope.camera_trust">
+                            <span>Restore camera trust</span>
+                        </label>
+                    </div>
+                    <template x-if="backup.importForm.preview.warnings && backup.importForm.preview.warnings.length">
+                        <div class="warnings-list" style="margin-top:var(--space-3);">
+                            <template x-for="warning in backup.importForm.preview.warnings" :key="warning">
+                                <div class="warning-item" x-text="warning"></div>
+                            </template>
+                        </div>
+                    </template>
+                </div>
+            </template>
+        </div>
+    </div>
+
+    <div class="settings-section" x-show="backup.snapshots.length > 0">
+        <div class="settings-section__title">Recent Rollback Snapshots</div>
+        <div class="card">
+            <template x-for="snapshot in backup.snapshots" :key="snapshot.id">
+                <div class="info-row">
+                    <span class="info-row__label" x-text="snapshot.id"></span>
+                    <span class="info-row__value" x-text="formatLocalTime(snapshot.created_at)"></span>
+                </div>
+            </template>
+        </div>
+    </div>
+
     <!-- Factory Reset -->
     <div class="settings-section">
         <div class="settings-section__title">Factory Reset</div>
@@ -1656,6 +1801,27 @@ function settingsPage() {
                 enabled: true,
             },
         },
+        backup: {
+            exporting: false,
+            snapshots: [],
+            exportForm: {
+                passphrase: '',
+                scope: { users: true, cameras: true, settings: true },
+                include_user_credentials: false,
+                include_camera_trust: true,
+                include_webhook_secrets: false,
+                include_tailscale_auth_key: false,
+            },
+            importForm: {
+                passphrase: '',
+                file: null,
+                filename: '',
+                preview: null,
+                previewing: false,
+                importing: false,
+                scope: { users: true, cameras: true, settings: true, camera_trust: true },
+            },
+        },
 
         resetConfirm: false,
         resetKeepRecordings: false,
@@ -1705,6 +1871,7 @@ function settingsPage() {
                 this.loadTailscale();
                 this.loadRecordingCameras();
                 this.loadWebhooks();
+                this.loadBackupSnapshots();
             }
         },
 
@@ -2014,6 +2181,151 @@ function settingsPage() {
                 window.HM.toast('Settings saved', 'success');
                 this.loadTimeStatus();
             } catch(e) { window.HM.toast(e.message || 'Failed to save settings', 'error'); }
+        },
+
+        setBackupFile(event) {
+            var file = event && event.target && event.target.files ? event.target.files[0] : null;
+            this.backup.importForm.file = file || null;
+            this.backup.importForm.filename = file ? file.name : '';
+            this.backup.importForm.preview = null;
+        },
+
+        async exportBackup() {
+            if (!this.backup.exportForm.passphrase || this.backup.exportForm.passphrase.length < 12) {
+                window.HM.toast('Backup passphrase must be at least 12 characters', 'error');
+                return;
+            }
+            this.backup.exporting = true;
+            try {
+                var resp = await fetch('/api/v1/system/backup/export', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': window.HM.auth.getCsrfToken() || '',
+                    },
+                    body: JSON.stringify(this.backup.exportForm),
+                });
+                if (!resp.ok) {
+                    var errData = await resp.json();
+                    throw new Error(errData.error || 'Backup export failed');
+                }
+                var blob = await resp.blob();
+                var disposition = resp.headers.get('Content-Disposition') || '';
+                var match = disposition.match(/filename="?([^";]+)"?/);
+                var filename = match ? match[1] : 'home-monitor-config-backup.hmb';
+                var url = window.URL.createObjectURL(blob);
+                var link = document.createElement('a');
+                link.href = url;
+                link.download = filename;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                window.URL.revokeObjectURL(url);
+                window.HM.toast('Backup downloaded', 'success');
+            } catch (e) {
+                window.HM.toast(e.message || 'Backup export failed', 'error');
+            } finally {
+                this.backup.exporting = false;
+            }
+        },
+
+        async previewBackupImport() {
+            if (!this.backup.importForm.file) {
+                window.HM.toast('Choose a backup bundle first', 'error');
+                return;
+            }
+            if (!this.backup.importForm.passphrase || this.backup.importForm.passphrase.length < 12) {
+                window.HM.toast('Backup passphrase must be at least 12 characters', 'error');
+                return;
+            }
+            this.backup.importForm.previewing = true;
+            try {
+                var form = new FormData();
+                form.append('passphrase', this.backup.importForm.passphrase);
+                form.append('file', this.backup.importForm.file);
+                var resp = await fetch('/api/v1/system/backup/preview', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'X-CSRF-Token': window.HM.auth.getCsrfToken() || '',
+                    },
+                    body: form,
+                });
+                var data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(data.error || 'Backup preview failed');
+                }
+                this.backup.importForm.preview = data.preview;
+                this.backup.importForm.filename = data.filename || this.backup.importForm.filename;
+                this.backup.importForm.scope = {
+                    users: !!data.preview.restore_defaults.users,
+                    cameras: !!data.preview.restore_defaults.cameras,
+                    settings: !!data.preview.restore_defaults.settings,
+                    camera_trust: !!data.preview.restore_defaults.camera_trust,
+                };
+                window.HM.toast('Backup preview ready', 'success');
+            } catch (e) {
+                this.backup.importForm.preview = null;
+                window.HM.toast(e.message || 'Backup preview failed', 'error');
+            } finally {
+                this.backup.importForm.previewing = false;
+            }
+        },
+
+        async importBackup() {
+            if (!this.backup.importForm.preview || !this.backup.importForm.file) {
+                window.HM.toast('Preview a backup before restoring it', 'error');
+                return;
+            }
+            if (!confirm('Restore this configuration bundle? Current users, cameras, settings, and trust material may be replaced.')) return;
+            this.backup.importForm.importing = true;
+            try {
+                var restoreCameraTrust = !!this.backup.importForm.scope.cameras && !!this.backup.importForm.scope.camera_trust;
+                var form = new FormData();
+                form.append('passphrase', this.backup.importForm.passphrase);
+                form.append('file', this.backup.importForm.file);
+                form.append('users', this.backup.importForm.scope.users ? 'true' : 'false');
+                form.append('cameras', this.backup.importForm.scope.cameras ? 'true' : 'false');
+                form.append('settings', this.backup.importForm.scope.settings ? 'true' : 'false');
+                form.append('camera_trust', restoreCameraTrust ? 'true' : 'false');
+                var resp = await fetch('/api/v1/system/backup/import', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'X-CSRF-Token': window.HM.auth.getCsrfToken() || '',
+                    },
+                    body: form,
+                });
+                var data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(data.error || 'Backup restore failed');
+                }
+                window.HM.toast(data.message || 'Configuration restored', 'success');
+                this.backup.importForm.preview = null;
+                await Promise.all([
+                    this.loadSettings(),
+                    this.loadSystemInfo(),
+                    this.loadTimeStatus(),
+                    this.loadUsers(),
+                    this.loadRecordingCameras(),
+                    this.loadWebhooks(),
+                    this.loadBackupSnapshots(),
+                ]);
+            } catch (e) {
+                window.HM.toast(e.message || 'Backup restore failed', 'error');
+            } finally {
+                this.backup.importForm.importing = false;
+            }
+        },
+
+        async loadBackupSnapshots() {
+            try {
+                var data = await window.HM.api.get('/api/v1/system/backup/snapshots');
+                this.backup.snapshots = data.snapshots || [];
+            } catch (e) {
+                this.backup.snapshots = [];
+            }
         },
 
         /* --- Date & Time (ADR-0019) --- */

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -8,13 +8,14 @@ tests but will break the frontend. Contract tests make field names explicit.
 Layer 4 of the testing pyramid (see docs/guides/development-guide.md Section 3.8).
 """
 
+import io
 import json
 import os
 import time
 from unittest.mock import MagicMock, patch
 
 from monitor.auth import hash_password
-from monitor.models import Camera, User
+from monitor.models import Camera, Settings, User, WebhookDestination
 from monitor.services.webhook_delivery_service import HttpResult
 
 # ---------------------------------------------------------------------------
@@ -34,6 +35,43 @@ def _add_camera(app, cam_id="cam-001", status="online"):
     )
     app.store.save_camera(cam)
     return cam
+
+
+def _seed_backup_state(app):
+    """Seed users, settings, hostname, and certs for backup API contracts."""
+    app.store.save_user(
+        User(
+            id="user-owner",
+            username="owner",
+            password_hash="hash-owner",
+            role="admin",
+            totp_secret="totp-owner",
+        )
+    )
+    _add_camera(app, "cam-001")
+    camera = app.store.get_camera("cam-001")
+    camera.pairing_secret = "ab" * 32
+    camera.cert_serial = "SER-001"
+    app.store.save_camera(camera)
+    app.store.save_settings(
+        Settings(
+            hostname="backup-box",
+            webhook_destinations=[
+                WebhookDestination(
+                    id="wh-001",
+                    url="https://hooks.example.com/inbound",
+                    auth_type="hmac",
+                    secret="whsec-test",
+                    event_classes=("motion",),
+                )
+            ],
+        )
+    )
+    os.makedirs(os.path.join(app.config["CERTS_DIR"], "cameras"), exist_ok=True)
+    with open(os.path.join(app.config["CONFIG_DIR"], "hostname"), "w") as handle:
+        handle.write("backup-box\n")
+    with open(os.path.join(app.config["CERTS_DIR"], "ca.crt"), "w") as handle:
+        handle.write("root-cert")
 
 
 def _assert_fields(data, required_fields, msg=""):
@@ -785,6 +823,155 @@ class TestSystemSummaryContract:
 
     def test_requires_login(self, client):
         resp = client.get("/api/v1/system/summary")
+        assert resp.status_code == 401
+
+
+class TestBackupExportContract:
+    """POST /api/v1/system/backup/export."""
+
+    PASSPHRASE = "correct horse battery staple"
+
+    def test_download_headers(self, app, logged_in_client):
+        _seed_backup_state(app)
+        client = logged_in_client()
+        resp = client.post(
+            "/api/v1/system/backup/export",
+            json={"passphrase": self.PASSPHRASE},
+        )
+        assert resp.status_code == 200
+        assert "attachment" in resp.headers.get("Content-Disposition", "")
+        assert resp.data
+
+    def test_requires_admin(self, app, logged_in_client):
+        client = logged_in_client("viewer")
+        resp = client.post(
+            "/api/v1/system/backup/export",
+            json={"passphrase": self.PASSPHRASE},
+        )
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client):
+        resp = client.post(
+            "/api/v1/system/backup/export",
+            json={"passphrase": self.PASSPHRASE},
+        )
+        assert resp.status_code == 401
+
+
+class TestBackupPreviewContract:
+    """POST /api/v1/system/backup/preview."""
+
+    PASSPHRASE = "correct horse battery staple"
+
+    def test_fields(self, app, logged_in_client):
+        _seed_backup_state(app)
+        client = logged_in_client()
+        bundle = client.post(
+            "/api/v1/system/backup/export",
+            json={"passphrase": self.PASSPHRASE},
+        ).data
+        resp = client.post(
+            "/api/v1/system/backup/preview",
+            data={
+                "passphrase": self.PASSPHRASE,
+                "file": (io.BytesIO(bundle), "config-backup.hmb"),
+            },
+            content_type="multipart/form-data",
+        )
+        data = resp.get_json()
+        _assert_fields(data, {"filename", "preview"})
+        _assert_has_fields(
+            data["preview"],
+            {
+                "created_at",
+                "schema_version",
+                "scope",
+                "secret_policy",
+                "warnings",
+                "counts",
+                "users",
+                "cameras",
+                "settings",
+                "restore_defaults",
+            },
+        )
+
+    def test_requires_admin(self, app, logged_in_client):
+        client = logged_in_client("viewer")
+        resp = client.post("/api/v1/system/backup/preview", data={})
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client):
+        resp = client.post("/api/v1/system/backup/preview", data={})
+        assert resp.status_code == 401
+
+
+class TestBackupImportContract:
+    """POST /api/v1/system/backup/import."""
+
+    PASSPHRASE = "correct horse battery staple"
+
+    def test_success_fields(self, app, logged_in_client):
+        _seed_backup_state(app)
+        client = logged_in_client()
+        bundle = client.post(
+            "/api/v1/system/backup/export",
+            json={
+                "passphrase": self.PASSPHRASE,
+                "include_user_credentials": True,
+                "include_webhook_secrets": True,
+            },
+        ).data
+        resp = client.post(
+            "/api/v1/system/backup/import",
+            data={
+                "passphrase": self.PASSPHRASE,
+                "file": (io.BytesIO(bundle), "config-backup.hmb"),
+            },
+            content_type="multipart/form-data",
+        )
+        data = resp.get_json()
+        _assert_fields(data, {"message", "snapshot", "preview", "restored_components"})
+        _assert_has_fields(
+            data["snapshot"],
+            {
+                "id",
+                "created_at",
+                "bundle_created_at",
+                "restore_components",
+                "counts",
+                "targets",
+            },
+        )
+        assert isinstance(data["restored_components"], list)
+
+    def test_requires_admin(self, app, logged_in_client):
+        client = logged_in_client("viewer")
+        resp = client.post("/api/v1/system/backup/import", data={})
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client):
+        resp = client.post("/api/v1/system/backup/import", data={})
+        assert resp.status_code == 401
+
+
+class TestBackupSnapshotsContract:
+    """GET /api/v1/system/backup/snapshots."""
+
+    def test_fields(self, app, logged_in_client):
+        client = logged_in_client()
+        resp = client.get("/api/v1/system/backup/snapshots")
+        data = resp.get_json()
+        _assert_fields(data, {"snapshots"})
+        assert isinstance(data["snapshots"], list)
+
+    def test_requires_admin(self, app, logged_in_client):
+        client = logged_in_client("viewer")
+        resp = client.get("/api/v1/system/backup/snapshots")
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client):
+        resp = client.get("/api/v1/system/backup/snapshots")
         assert resp.status_code == 401
 
 

--- a/app/server/tests/integration/test_api_blueprints.py
+++ b/app/server/tests/integration/test_api_blueprints.py
@@ -81,6 +81,7 @@ _AUTH_REQUIRED_GETS = [
     "/api/v1/users",
     "/api/v1/ota/status",
     "/api/v1/system/health",
+    "/api/v1/system/backup/snapshots",
     "/api/v1/audit/events",
     "/api/v1/auth/me",
 ]
@@ -139,6 +140,13 @@ _STATE_CHANGING_ROUTES = [
     ("DELETE", "/api/v1/users/user-nobody", None),
     ("PUT", "/api/v1/users/user-nobody/password", {"new_password": "newpass1234"}),
     ("POST", "/api/v1/ota/server/upload", None),
+    (
+        "POST",
+        "/api/v1/system/backup/export",
+        {"passphrase": "correct horse battery staple"},
+    ),
+    ("POST", "/api/v1/system/backup/preview", {}),
+    ("POST", "/api/v1/system/backup/import", {}),
 ]
 
 

--- a/app/server/tests/integration/test_api_system.py
+++ b/app/server/tests/integration/test_api_system.py
@@ -1,7 +1,11 @@
-# REQ: SWR-032, SWR-020, SWR-018; RISK: RISK-005, RISK-017, RISK-006; SEC: SC-020, SC-004, SC-006; TEST: TC-029, TC-010, TC-015
+# REQ: SWR-032, SWR-020, SWR-018, SWR-023, SWR-024, SWR-034, SWR-045; RISK: RISK-005, RISK-006, RISK-011, RISK-012, RISK-017, RISK-019, RISK-020; SEC: SC-004, SC-006, SC-011, SC-012, SC-017, SC-020, SC-021; TEST: TC-010, TC-015, TC-022, TC-023, TC-029, TC-032, TC-041, TC-042
 """Tests for the system API."""
 
+import io
+import json
 from unittest.mock import MagicMock, patch
+
+from monitor.models import Camera, Settings, User, WebhookDestination
 
 
 class TestHealthEndpoint:
@@ -255,3 +259,203 @@ class TestFactoryReset:
             requesting_ip=mock_log.call_args.kwargs.get("requesting_ip", ""),
             detail="keep_recordings=False",
         )
+
+
+class TestConfigBackup:
+    """Test configuration backup endpoints."""
+
+    PASSPHRASE = "correct horse battery staple"
+
+    def _seed_backup_state(self, app):
+        app.store.save_user(
+            User(
+                id="user-owner",
+                username="owner",
+                password_hash="hash-owner",
+                role="admin",
+                totp_secret="totp-owner",
+            )
+        )
+        app.store.save_camera(
+            Camera(
+                id="cam-001",
+                name="Front Door",
+                location="Porch",
+                status="online",
+                pairing_secret="ab" * 32,
+                cert_serial="SER-001",
+            )
+        )
+        app.store.save_settings(
+            Settings(
+                hostname="backup-box",
+                tailscale_auth_key="tskey-auth-test",
+                webhook_destinations=[
+                    WebhookDestination(
+                        id="wh-001",
+                        url="https://hooks.example.com/inbound",
+                        auth_type="hmac",
+                        secret="whsec-test",
+                        event_classes=("motion",),
+                    )
+                ],
+            )
+        )
+        config_dir = app.config["CONFIG_DIR"]
+        certs_dir = app.config["CERTS_DIR"]
+        with open(f"{config_dir}/hostname", "w") as handle:
+            handle.write("backup-box\n")
+        import os
+
+        os.makedirs(f"{certs_dir}/cameras", exist_ok=True)
+        with open(f"{certs_dir}/ca.crt", "w") as handle:
+            handle.write("root-cert")
+        with open(f"{certs_dir}/cameras/cam-001.crt", "w") as handle:
+            handle.write("camera-cert")
+
+    def _export_bundle(self, client):
+        response = client.post(
+            "/api/v1/system/backup/export",
+            json={
+                "passphrase": self.PASSPHRASE,
+                "include_user_credentials": True,
+                "include_webhook_secrets": True,
+                "include_tailscale_auth_key": True,
+            },
+        )
+        assert response.status_code == 200
+        return response.data
+
+    def test_backup_export_requires_admin(self, logged_in_client):
+        client = logged_in_client("viewer")
+        response = client.post(
+            "/api/v1/system/backup/export",
+            json={"passphrase": self.PASSPHRASE},
+        )
+        assert response.status_code == 403
+
+    def test_backup_export_requires_auth(self, client):
+        response = client.post(
+            "/api/v1/system/backup/export",
+            json={"passphrase": self.PASSPHRASE},
+        )
+        assert response.status_code == 401
+
+    def test_backup_export_downloads_bundle(self, app, logged_in_client):
+        self._seed_backup_state(app)
+        client = logged_in_client()
+
+        response = client.post(
+            "/api/v1/system/backup/export",
+            json={"passphrase": self.PASSPHRASE},
+        )
+
+        assert response.status_code == 200
+        assert response.mimetype == "application/vnd.home-monitor.backup+json"
+        assert "attachment" in response.headers["Content-Disposition"]
+        bundle = json.loads(response.data)
+        assert bundle["manifest"]["schema_version"] == 1
+
+    def test_backup_preview_returns_summary(self, app, logged_in_client):
+        self._seed_backup_state(app)
+        client = logged_in_client()
+        bundle_bytes = self._export_bundle(client)
+
+        app.store.save_user(
+            User(
+                id="user-late",
+                username="late-user",
+                password_hash="hash-late",
+                role="viewer",
+            )
+        )
+
+        response = client.post(
+            "/api/v1/system/backup/preview",
+            data={
+                "passphrase": self.PASSPHRASE,
+                "file": (io.BytesIO(bundle_bytes), "config-backup.hmb"),
+            },
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["filename"] == "config-backup.hmb"
+        assert data["preview"]["users"]["remove"] == 1
+
+    def test_backup_import_restores_state(self, app, logged_in_client):
+        self._seed_backup_state(app)
+        client = logged_in_client()
+        bundle_bytes = self._export_bundle(client)
+
+        app.store.save_user(
+            User(
+                id="user-temp",
+                username="temp-user",
+                password_hash="hash-temp",
+                role="viewer",
+            )
+        )
+        app.store.save_camera(Camera(id="cam-999", name="Garage", status="offline"))
+        settings = app.store.get_settings()
+        settings.tailscale_auth_key = ""
+        settings.webhook_destinations = []
+        app.store.save_settings(settings)
+        with open(f"{app.config['CONFIG_DIR']}/hostname", "w") as handle:
+            handle.write("changed-host\n")
+        with open(f"{app.config['CERTS_DIR']}/ca.crt", "w") as handle:
+            handle.write("rotated-cert")
+
+        response = client.post(
+            "/api/v1/system/backup/import",
+            data={
+                "passphrase": self.PASSPHRASE,
+                "file": (io.BytesIO(bundle_bytes), "config-backup.hmb"),
+            },
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["message"] == "Configuration restored"
+        assert {user.username for user in app.store.get_users()} == {"admin", "owner"}
+        assert [camera.id for camera in app.store.get_cameras()] == ["cam-001"]
+        assert app.store.get_settings().tailscale_auth_key == "tskey-auth-test"
+        assert app.store.get_settings().webhook_destinations[0].secret == "whsec-test"
+
+    def test_backup_import_rejects_wrong_passphrase(self, app, logged_in_client):
+        self._seed_backup_state(app)
+        client = logged_in_client()
+        bundle_bytes = self._export_bundle(client)
+
+        response = client.post(
+            "/api/v1/system/backup/import",
+            data={
+                "passphrase": "this is the wrong secret",
+                "file": (io.BytesIO(bundle_bytes), "config-backup.hmb"),
+            },
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()["reason"] == "signature_mismatch"
+
+    def test_backup_snapshots_lists_metadata(self, app, logged_in_client):
+        self._seed_backup_state(app)
+        client = logged_in_client()
+        bundle_bytes = self._export_bundle(client)
+
+        response = client.post(
+            "/api/v1/system/backup/import",
+            data={
+                "passphrase": self.PASSPHRASE,
+                "file": (io.BytesIO(bundle_bytes), "config-backup.hmb"),
+            },
+            content_type="multipart/form-data",
+        )
+        assert response.status_code == 200
+
+        snapshots = client.get("/api/v1/system/backup/snapshots")
+        assert snapshots.status_code == 200
+        assert len(snapshots.get_json()["snapshots"]) == 1

--- a/app/server/tests/security/test_security.py
+++ b/app/server/tests/security/test_security.py
@@ -110,6 +110,13 @@ _CSRF_PROTECTED_ENDPOINTS = [
     ("POST", "/api/v1/users", {"username": "newuser1", "password": "password1234"}),
     ("DELETE", "/api/v1/users/user-nobody", None),
     ("PUT", "/api/v1/users/user-nobody/password", {"new_password": "newpass1234"}),
+    (
+        "POST",
+        "/api/v1/system/backup/export",
+        {"passphrase": "correct horse battery staple"},
+    ),
+    ("POST", "/api/v1/system/backup/preview", {}),
+    ("POST", "/api/v1/system/backup/import", {}),
 ]
 
 

--- a/app/server/tests/unit/test_models.py
+++ b/app/server/tests/unit/test_models.py
@@ -91,7 +91,8 @@ class TestSettings:
         assert isinstance(d, dict)
         # 9 base + 5 tailscale + 2 ADR-0017 watermarks + 1 ADR-0019 ntp_mode
         # + 1 motion post-roll + 1 TOTP 2FA policy + 2 outbound webhook settings
-        assert len(d) == 21
+        # + 1 backup snapshot-retention setting
+        assert len(d) == 22
         assert d["ntp_mode"] == "auto"
         assert d["loop_low_watermark_percent"] == 10
         assert d["loop_hysteresis_percent"] == 5
@@ -99,6 +100,7 @@ class TestSettings:
         assert d["require_2fa_for_remote"] is False
         assert d["webhook_destinations"] == []
         assert d["webhook_delivery_history_retention_days"] == 30
+        assert d["backup_max_history"] == 3
 
 
 class TestClip:

--- a/app/server/tests/unit/test_svc_config_backup.py
+++ b/app/server/tests/unit/test_svc_config_backup.py
@@ -1,0 +1,278 @@
+# REQ: SWR-023, SWR-024, SWR-034, SWR-045; RISK: RISK-011, RISK-012, RISK-019, RISK-020; SEC: SC-011, SC-012, SC-017, SC-020, SC-021; TEST: TC-022, TC-023, TC-032, TC-041, TC-042
+"""Unit tests for ConfigBackupService."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from monitor.models import Camera, Settings, User, WebhookDestination
+from monitor.services.config_backup_service import (
+    ConfigBackupError,
+    ConfigBackupService,
+)
+from monitor.store import Store
+
+PASSPHRASE = "correct horse battery staple"
+
+
+@pytest.fixture
+def backup_env(tmp_path):
+    """Seed a realistic server config + cert state for backup tests."""
+    data_dir = tmp_path
+    config_dir = data_dir / "config"
+    certs_dir = data_dir / "certs"
+    config_dir.mkdir()
+    (certs_dir / "cameras").mkdir(parents=True)
+
+    store = Store(str(config_dir))
+    store.save_user(
+        User(
+            id="user-admin",
+            username="admin",
+            password_hash="hash-admin",
+            role="admin",
+            totp_secret="totp-admin",
+        )
+    )
+    store.save_user(
+        User(
+            id="user-viewer",
+            username="viewer",
+            password_hash="hash-viewer",
+            role="viewer",
+        )
+    )
+    store.save_camera(
+        Camera(
+            id="cam-001",
+            name="Front Door",
+            location="Porch",
+            status="online",
+            cert_serial="SER-001",
+            pairing_secret="ab" * 32,
+        )
+    )
+    store.save_settings(
+        Settings(
+            hostname="home-monitor",
+            tailscale_auth_key="tskey-auth-test",
+            webhook_destinations=[
+                WebhookDestination(
+                    id="wh-001",
+                    url="https://hooks.example.com/inbound",
+                    auth_type="hmac",
+                    secret="whsec-test",
+                    event_classes=("motion",),
+                    enabled=True,
+                )
+            ],
+        )
+    )
+    (config_dir / "hostname").write_text("backup-box\n", encoding="utf-8")
+    (certs_dir / "ca.crt").write_text("root-cert", encoding="utf-8")
+    (certs_dir / "cameras" / "cam-001.crt").write_text(
+        "camera-cert",
+        encoding="utf-8",
+    )
+
+    service = ConfigBackupService(
+        store=store,
+        audit=MagicMock(),
+        settings_service=MagicMock(),
+        data_dir=str(data_dir),
+        config_dir=str(config_dir),
+        certs_dir=str(certs_dir),
+    )
+    return {
+        "service": service,
+        "store": store,
+        "data_dir": data_dir,
+        "config_dir": config_dir,
+        "certs_dir": certs_dir,
+    }
+
+
+class TestConfigBackupExport:
+    """Export + preview behavior."""
+
+    def test_export_excludes_secrets_by_default(self, backup_env):
+        service = backup_env["service"]
+
+        filename, bundle_bytes, preview = service.export_bundle(passphrase=PASSPHRASE)
+        bundle = json.loads(bundle_bytes)
+
+        assert filename.endswith(".hmb")
+        assert bundle["manifest"]["scope"]["camera_trust"] is True
+        assert preview["counts"]["users"] == 2
+        assert preview["counts"]["cameras"] == 1
+        assert bundle["payload"]["users"][0]["password_hash"] == ""
+        assert bundle["payload"]["users"][0]["totp_secret"] == ""
+        assert bundle["payload"]["settings"]["config"]["tailscale_auth_key"] == ""
+        assert (
+            bundle["payload"]["settings"]["config"]["webhook_destinations"][0]["secret"]
+            == ""
+        )
+        assert (
+            bundle["payload"]["settings"]["config"]["webhook_destinations"][0][
+                "enabled"
+            ]
+            is False
+        )
+        assert len(bundle["payload"]["camera_trust"]["entries"]) == 2
+
+    def test_preview_reports_removals_and_secret_warnings(self, backup_env):
+        service = backup_env["service"]
+        store = backup_env["store"]
+
+        _, bundle_bytes, _ = service.export_bundle(passphrase=PASSPHRASE)
+        store.save_user(
+            User(
+                id="user-extra",
+                username="late-user",
+                password_hash="hash-extra",
+                role="viewer",
+            )
+        )
+        store.save_camera(Camera(id="cam-999", name="Garage", status="online"))
+
+        preview = service.preview_bundle(bundle_bytes, passphrase=PASSPHRASE)
+
+        assert preview["users"]["remove"] == 1
+        assert preview["cameras"]["remove"] == 1
+        assert any(
+            "User credentials are excluded" in warning
+            for warning in preview["warnings"]
+        )
+        assert any(
+            "Webhook secrets are excluded" in warning for warning in preview["warnings"]
+        )
+
+
+class TestConfigBackupImport:
+    """Restore behavior, validation, and rollback."""
+
+    def test_full_round_trip_restores_state(self, backup_env):
+        service = backup_env["service"]
+        store = backup_env["store"]
+        config_dir = backup_env["config_dir"]
+        certs_dir = backup_env["certs_dir"]
+
+        _, bundle_bytes, _ = service.export_bundle(
+            passphrase=PASSPHRASE,
+            options={
+                "include_user_credentials": True,
+                "include_webhook_secrets": True,
+                "include_tailscale_auth_key": True,
+            },
+        )
+
+        store.save_user(
+            User(
+                id="user-temp",
+                username="temp-user",
+                password_hash="hash-temp",
+                role="viewer",
+            )
+        )
+        store.save_camera(Camera(id="cam-002", name="Garage", status="offline"))
+        settings = store.get_settings()
+        settings.hostname = "changed-host"
+        settings.tailscale_auth_key = ""
+        settings.webhook_destinations = []
+        store.save_settings(settings)
+        (config_dir / "hostname").write_text("changed-host\n", encoding="utf-8")
+        (certs_dir / "ca.crt").write_text("rotated-cert", encoding="utf-8")
+
+        result = service.import_bundle(bundle_bytes, passphrase=PASSPHRASE)
+
+        assert result["message"] == "Configuration restored"
+        assert set(result["restored_components"]) == {
+            "camera_trust",
+            "cameras",
+            "settings",
+            "users",
+        }
+        assert {user.username for user in store.get_users()} == {"admin", "viewer"}
+        assert store.get_user_by_username("admin").password_hash == "hash-admin"
+        assert [camera.id for camera in store.get_cameras()] == ["cam-001"]
+        restored_settings = store.get_settings()
+        assert restored_settings.tailscale_auth_key == "tskey-auth-test"
+        assert restored_settings.webhook_destinations[0].secret == "whsec-test"
+        assert (config_dir / "hostname").read_text(
+            encoding="utf-8"
+        ).strip() == "backup-box"
+        assert (certs_dir / "ca.crt").read_text(encoding="utf-8") == "root-cert"
+        assert result["snapshot"]["bundle_created_at"]
+
+    def test_rejects_tampered_bundle(self, backup_env):
+        service = backup_env["service"]
+
+        _, bundle_bytes, _ = service.export_bundle(passphrase=PASSPHRASE)
+        bundle = json.loads(bundle_bytes)
+        bundle["payload"]["users"][0]["username"] = "mallory"
+        tampered_bytes = json.dumps(bundle).encode("utf-8")
+
+        with pytest.raises(ConfigBackupError) as excinfo:
+            service.preview_bundle(tampered_bytes, passphrase=PASSPHRASE)
+
+        assert excinfo.value.reason == "signature_mismatch"
+
+    def test_rejects_restore_scope_not_present_in_bundle(self, backup_env):
+        service = backup_env["service"]
+
+        _, bundle_bytes, _ = service.export_bundle(
+            passphrase=PASSPHRASE,
+            options={"users": False, "settings": False},
+        )
+
+        with pytest.raises(ConfigBackupError) as excinfo:
+            service.import_bundle(
+                bundle_bytes,
+                passphrase=PASSPHRASE,
+                restore_options={"users": True},
+            )
+
+        assert excinfo.value.reason == "invalid_restore_scope"
+
+    def test_rolls_back_partial_restore_failure(self, backup_env, monkeypatch):
+        service = backup_env["service"]
+        store = backup_env["store"]
+        config_dir = backup_env["config_dir"]
+
+        _, bundle_bytes, _ = service.export_bundle(
+            passphrase=PASSPHRASE,
+            options={"include_user_credentials": True},
+        )
+        store.save_user(
+            User(
+                id="user-extra",
+                username="extra",
+                password_hash="hash-extra",
+                role="viewer",
+            )
+        )
+        current_users_json = (config_dir / "users.json").read_text(encoding="utf-8")
+        current_cameras_json = (config_dir / "cameras.json").read_text(encoding="utf-8")
+
+        original_replace_file = service._replace_file
+
+        def crash_on_camera(path, content):
+            original_replace_file(path, content)
+            if path.name == "cameras.json":
+                raise RuntimeError("disk full")
+
+        monkeypatch.setattr(service, "_replace_file", crash_on_camera)
+
+        with pytest.raises(ConfigBackupError) as excinfo:
+            service.import_bundle(bundle_bytes, passphrase=PASSPHRASE)
+
+        assert excinfo.value.reason == "import_failed"
+        assert (config_dir / "users.json").read_text(
+            encoding="utf-8"
+        ) == current_users_json
+        assert (config_dir / "cameras.json").read_text(
+            encoding="utf-8"
+        ) == current_cameras_json

--- a/app/server/tests/unit/test_svc_factory_reset.py
+++ b/app/server/tests/unit/test_svc_factory_reset.py
@@ -90,6 +90,20 @@ class TestFactoryReset:
     @patch(
         "monitor.services.factory_reset_service.FactoryResetService._schedule_restart"
     )
+    def test_reset_removes_shared_backup_sidecars(self, mock_restart, svc, data_dir):
+        (data_dir / "config" / "hostname").write_text("home-monitor\n")
+        (data_dir / "config" / "motion_events.json").write_text("[]")
+        (data_dir / "config" / "alert_read_state.json").write_text("{}")
+
+        svc.execute_reset()
+
+        assert not (data_dir / "config" / "hostname").exists()
+        assert not (data_dir / "config" / "motion_events.json").exists()
+        assert not (data_dir / "config" / "alert_read_state.json").exists()
+
+    @patch(
+        "monitor.services.factory_reset_service.FactoryResetService._schedule_restart"
+    )
     def test_reset_removes_certs(self, mock_restart, svc, data_dir):
         svc.execute_reset()
         assert not (data_dir / "certs").exists()

--- a/docs/history/specs/240-config-backup-restore.md
+++ b/docs/history/specs/240-config-backup-restore.md
@@ -1,0 +1,341 @@
+# Feature Spec: Config Backup and Restore
+
+Status: Ready for AI implementation planning
+Priority: P1
+Roadmap Slot: Release Next
+Backlog Source: [market-feature-backlog-100.md](../planning/market-feature-backlog-100.md)
+Related Issue: [#240](https://github.com/vinu-dev/rpi-home-monitor/issues/240)
+
+## Problem
+
+A silent failure is worse than no failure. When an SD card fails or hardware is migrated, an admin faces full re-onboarding: re-pairing every camera, re-tuning every threshold, re-entering every user credential, re-configuring retention and alert policy. That's not a product—it's a prototype.
+
+Every appliance-class peer (Synology, UniFi, Home Assistant) ships configuration backup and restore. Users expect it. Today, it is the missing link between "feels like a real product" and "is a real product."
+
+## User Value
+
+- **Disaster recovery**: After SD-card failure, hardware migration, or factory reset, the system returns to its prior state without manual re-onboarding.
+- **System confidence**: Admins know they can recover without data loss.
+- **Competitive parity**: Home Assistant, Synology, and UniFi all offer this. It is now table stakes.
+- **Operational realism**: Deployment paths must be real; recovery is part of real deployment.
+
+Per the mission: "trustworthy, self-hosted home monitoring system that feels like a real product."
+
+## Scope
+
+This slice delivers admin-initiated export and import of signed configuration bundles:
+
+Included:
+- export full or partial configuration (users, cameras, settings, retention policy, alert thresholds, OTA channel selection)
+- signed manifest and integrity verification
+- schema versioning and version mismatch rejection
+- per-secret-class policy (pepper key, TLS material, TOTP secrets, webhook secrets, recovery-code hashes)
+- import preview before committing restore
+- atomic import with rollback on error
+- admin-only UI under Settings → System
+- audit log entries (export, import attempt, import success, rejection, schema mismatch, signature mismatch)
+- bundle format: signed JSON or signed tarball with manifest
+
+## Non-Goals
+
+Not in this slice:
+- backing up recordings or motion-clip media (storage rotation handles those)
+- Yocto image or firmware backup (covered by SWUpdate A/B partition story — ADR-0008)
+- camera-side `/data` backup (cameras re-pair on import; their state is rebuilt from server-side record)
+- cross-major-version restores (refuse with clear error; target same schema version)
+- scheduled or automatic backups in v1 (manual export only; scheduling is a follow-up issue)
+- encrypted-at-rest local archive of multiple historical backups
+- multi-device or cloud-synchronized backup
+
+## Acceptance Criteria
+
+- An admin can export a signed bundle containing selected configuration subsets.
+- The bundle includes a manifest with bundle version, schema hash, export timestamp, and signature.
+- Import preview displays what configuration will be imported (full vs partial, count of users/cameras/rules).
+- Import commits atomically: all changes succeed or none do; on error, the system state is unchanged.
+- Signature verification rejects tampered bundles with a clear error.
+- Schema version mismatch rejects old bundles with a clear error and guidance on upgrade path.
+- Audit log records export, import attempt, import success, and all rejection reasons.
+- Round-trip restore (export then re-import on the same system) reproduces the prior configuration.
+- Partial-restore mode (e.g., import users but not cameras) works correctly and does not orphan related data.
+- Per-secret-class policy is enforced: some secrets are included (with warning), others are re-issued on restore.
+- UI clearly explains which secrets will be restored vs re-issued.
+
+## User Experience
+
+### Entry point
+
+Admin navigates to Settings → System → Configuration Backup.
+
+### Export flow
+
+1. Admin clicks `Export configuration`.
+2. Admin chooses scope: Full backup (all users, all cameras, all settings) or Partial (users only, cameras only, settings only).
+3. Admin is presented with a clear breakdown:
+   - User count, camera count, rule count, etc.
+   - Warning: "Pepper key and TLS certificates will be included. Keep the bundle secure."
+   - Option to exclude sensitive secrets: "Export without secrets — users and cameras will be imported, but secrets will be re-issued on restore."
+4. Admin clicks `Download`. Browser receives a signed `.tar.gz` or `.json` file with metadata.
+5. Export is recorded in audit log.
+
+### Import flow
+
+1. Admin navigates to Settings → System → Configuration Restore.
+2. Admin uploads a bundle file.
+3. System validates: signature check, schema version check.
+4. If validation fails: clear error message (e.g., "Bundle was modified" or "Bundle is from an older version; please upgrade the target system first").
+5. If validation succeeds: **preview** the import:
+   - List of users to be created/updated
+   - List of cameras to be created/updated
+   - Policies and settings to be restored
+   - Warning about any conflicting or stale data (e.g., "2 users will be overwritten"; "1 camera pair-token has changed since backup")
+6. Admin clicks `Confirm restore` to commit atomically.
+7. If import fails (e.g., database corruption, I/O error): rollback to pre-import state; show error and invite support contact.
+8. On success: success message, audit log entry, and automatic redirect to dashboard.
+9. Admin is advised to verify system state (e.g., re-check camera connectivity, user access).
+
+### Secret handling display
+
+UI shows at export and import time:
+
+- **Included with warning** (pepper key, TLS certificates, TOTP secrets):
+  - "These are security-sensitive. Keep the backup file secure. On restore, the system will use the backed-up values."
+  - Option to exclude.
+
+- **Re-issued on restore** (webhook secrets, recovery-code hashes):
+  - "For security, these will be regenerated on restore. Users may need to re-enroll 2FA or re-register webhook endpoints."
+
+## Architecture Fit
+
+This feature fits cleanly within the existing architecture per `docs/ai/design-standards.md`:
+
+- **Service-layer**: business logic in a new `ConfigBackupService` in `app/server/monitor/services/config_backup_service.py`.
+- **Runtime mutable state on `/data`**: bundles are not stored on the system; they are downloaded or uploaded by the user.
+- **Admin-only routes**: new endpoints in `app/server/monitor/api/system.py` (or dedicated `config.py`), protected by admin role check.
+- **Audit trail**: integration with existing `audit.py` service.
+- **No camera changes**: cameras are not aware of this feature; they re-pair post-restore from the server-side record.
+- **No Yocto changes**: this is runtime configuration, not image policy.
+
+## Technical Approach
+
+### Bundle Structure
+
+A bundle is a signed container:
+
+```
+bundle.tar.gz (or bundle.json, to be decided)
+├── manifest.json  (includes schema version, timestamp, signature)
+├── users.json
+├── cameras.json
+├── settings.json
+├── retention_policy.json
+├── alert_rules.json
+└── ota_config.json (optional)
+```
+
+Schema version in manifest allows rejection of incompatible bundles.
+
+### Signing and Verification
+
+- Server has a long-lived signing keypair (generated during first boot or system initialization, stored on `/data`).
+- Manifest is signed with Ed25519 or RSA (TBD in implementation).
+- On import, system verifies the signature. Tampered bundles are rejected.
+- No cloud verification (stays local-first).
+
+### Secret Handling Policy
+
+Per-secret-class decisions (explicit in code and audit log):
+
+| Secret Class | Action | Rationale |
+|---|---|---|
+| Pepper key | Include + warn | Core auth credential; without it, password hashes are invalid. Admin must protect bundle. |
+| TLS certificates + keys | Include + warn | System identity; re-issuing complicates camera trust re-establishment. |
+| TOTP secrets | Include + warn | User 2FA enrollment; re-issuing requires user re-enrollment. |
+| Webhook secrets | Re-issue | Shared secrets; on restore, assume old channel may be compromised. Webhook registrants must re-enroll. |
+| Recovery code hashes | Re-issue | 2FA backup codes; old codes are invalidated; users receive new codes. |
+
+Rationale per security section below.
+
+### Import Atomicity
+
+- Begin transaction.
+- Validate all data before writing.
+- Perform upsert on users, cameras, settings, rules.
+- Commit or rollback on any error.
+- Log outcome.
+
+### Audit Trail
+
+New entries in `audit.py`:
+
+- `action=config_export, scope=full|partial, timestamp, initiator=admin_user`
+- `action=config_import_attempt, bundle_schema_version, timestamp, initiator=admin_user`
+- `action=config_import_success, users_count, cameras_count, timestamp, initiator=admin_user`
+- `action=config_import_rejected, reason=signature_mismatch|schema_version|corruption, timestamp, initiator=admin_user`
+
+## Affected Areas
+
+- `app/server/monitor/services/config_backup_service.py` — new
+- `app/server/monitor/api/system.py` (or dedicated `config.py`) — new routes
+- `app/server/monitor/templates/` — admin UI components
+- `app/server/monitor/services/audit.py` — integration for audit log
+- Database: no schema changes for users/cameras/settings (upsert semantics), but new schema row for bundle version and signing key(s) may be needed.
+- `tests/` — unit tests for bundle creation, signing, verification, import, rollback; contract tests for API; smoke test for round-trip.
+
+## Validation Plan
+
+Per `docs/ai/validation-and-release.md`:
+
+| Area | Required Validation | Evidence |
+|---|---|---|
+| Service logic | Unit tests (bundle creation, signing, verification, import, rollback) + contract tests (API shape) | `pytest app/server/tests/test_config_backup_service.py -v --cov-fail-under=85` |
+| API behavior | Contract tests (export, import, preview endpoints) | HTTP contract test suite |
+| Admin UI | Manual UI verification (export modal, import flow, preview, confirm) | Browser walkthrough + smoke test |
+| Round-trip | Integration test (export, then import on same system, verify state matches) | `pytest tests/test_config_backup_integration.py -v` |
+| Partial restore | Integration test (export full, import partial, verify no orphaned data) | `pytest tests/test_config_backup_partial.py -v` |
+| Rejection cases | Unit + integration tests (tampered bundle, schema mismatch, corrupted JSON) | Dedicated test cases |
+| Audit trail | Integration test (log entries created for export, import, rejection) | Audit log inspection in tests |
+| Smoke test | Hardware verification (export, wipe, restore, verify cameras re-connect, users re-authenticate) | `scripts/smoke-test.sh` extension |
+| Security | Full suite + code review on secret handling, signing, verification, key storage | Pre-merge security review |
+
+## Risk
+
+### ISO 14971-Lite Framing
+
+| Hazard ID | Hazard | Severity | Probability | Proposed Risk Control | Residual Risk |
+|---|---|---|---|---|---|
+| HAZ-001 | Restored bundle contains stale TLS certificates; cameras no longer trust the server. | High | Medium | Certificate re-validation on camera reconnect; audit log documents timestamp. Runbook advises re-pairing cameras if cert changed. | Medium → Low (with runbook) |
+| HAZ-002 | Tampered bundle (signed by attacker) is imported, overwriting valid users/settings. | High | Low | Signature verification (Ed25519 or RSA). Bundle must be signed with the system's private key; external bundles are rejected. | Low (crypto) |
+| HAZ-003 | Schema version mismatch: old bundle from v1.0 imported into v2.0, causing silent data loss or corruption. | High | Medium | Schema version in manifest; strict version check; reject on mismatch with clear error. | Low (explicit check) |
+| HAZ-004 | Bundle export includes secrets; bundle is leaked to an attacker (e.g., left on a USB drive, emailed unencrypted). | High | Medium | UI warning at export time. Admin policy controls per-secret inclusion. Consider recommending password-protected archive (out of scope for v1). | Medium (admin responsibility) |
+| HAZ-005 | Import fails midway (e.g., disk full, database corruption), leaving system in inconsistent state. | Medium | Low | Atomic import (transaction-based rollback). Verify on commit or abort before state change. | Low (atomic) |
+| HAZ-006 | Webhook secrets and recovery codes are re-issued on restore; integrations and users lose 2FA backup codes without warning. | Medium | Medium | UI clearly explains which secrets are re-issued. Audit log documents it. Runbook explains recovery. | Low (with documentation) |
+| HAZ-007 | Restore deletes a recently-created user that wasn't in the backup (user created after backup). | Medium | High | Preview step shows which users will be overwritten. Document (and enforce if time permits) a "merge" mode that updates but does not delete. For v1, "delete absent users" is explicit in UI. | Medium (mitigated by UI clarity) |
+
+**Risk Controls to Implement:**
+
+- Signature verification (cryptographic).
+- Schema version check (strict rejection on mismatch).
+- Atomic import with rollback.
+- Clear UI messaging at export (secret handling, bundle security) and import (preview, consequences).
+- Comprehensive audit log (all actions and rejection reasons).
+- Runbook for recovery after bad restore (rollback procedure, re-pairing cameras).
+
+### Outstanding Risks
+
+- **Cross-version import**: v1 bundles cannot be imported into v2 or later. Upgrade path is "export from v1, upgrade, cannot re-import v1 bundle." This is acceptable for v1 (non-goal) but should be documented and tested before v2.
+- **Operator misuse**: Admin exports bundle with secrets, keeps it insecure. Risk Control: UI warning. Residual: admin responsibility.
+
+## Security
+
+### Threat Model
+
+| Threat ID | Threat | Attacker | Impact | Control | Residual |
+|---|---|---|---|---|---|
+| THREAT-001 | Attacker intercepts bundle (e.g., over HTTP, unencrypted email) and modifies it. | Active MITM | Stale/overwritten users, settings, TLS state. | Signature verification. Bundle is signed with system private key; attacker cannot forge signature without the key. HTTPS should be enforced (out of scope for backup design, but implicit in API design). | Low (crypto + HTTPS) |
+| THREAT-002 | Attacker gains access to server `/data` and steals the signing private key. | Insider / compromised device | Attacker can forge valid bundles and import malicious config. | Private key is stored on `/data`, which is encrypted or trusted per the system's threat model. Host-level access controls are assumed (e.g., SSH keys, /root permissions). | Medium (scope of system threat model) |
+| THREAT-003 | Attacker replays an old, valid bundle to downgrade auth state (e.g., re-create a deleted admin user). | Attacker with bundle from backup + access to import UI | Privilege escalation, unauthorized access. | Timestamp in bundle allows human review ("bundle is from 2024-01-15; are you sure?"). Audit log documents import and source bundle timestamp. Cannot cryptographically prevent replay without additional state (e.g., sequence numbers), which is deferred to v2. | Medium (mitigated by audit + review) |
+| THREAT-004 | Admin exports bundle with secrets enabled, accidentally commits it to GitHub. | Negligent admin | Secret exposure (pepper key, TLS keys, TOTP secrets). | UI warning at export. Recommend `.gitignore` for bundles. Cannot enforce encryption within the scope of v1, but recommend in runbook. | Medium (admin responsibility + warning) |
+| THREAT-005 | Attacker with partial access to the system (e.g., unprivileged user account) tries to export a bundle. | Unprivileged user | Configuration leakage. | Export is admin-only (role-based access control). API enforces `@require_admin`. | Low (RBAC) |
+
+### Sensitive Paths
+
+This feature touches:
+
+- **`app/server/monitor/api/system.py`** (new routes): export, import, preview — must be admin-only.
+- **`app/server/monitor/services/config_backup_service.py`** (new): signing, verification, bundle creation — must handle secrets safely (no plaintext logs, no debug dumps).
+- **`app/server/monitor/services/audit.py`**: integration — must log all export/import events.
+- **Secrets on `/data`**: pepper key, TLS certificates, TOTP secrets — existing infrastructure, but now explicitly included in bundles. Policy is explicit in code and tests.
+
+### Secret Handling Code Comments
+
+Code must include inline comments at the point where each secret class is decided:
+
+```python
+# REQ: SEC-0XX — pepper key is included in backup (user passwords depend on it)
+# THREAT: bundle exposure leaks auth material; admin must protect bundle file
+```
+
+## Traceability
+
+### Requirements to be filled in during implementation
+
+| Type | ID | Title | Status |
+|---|---|---|---|
+| User Need | UN-XXX | Admin can recover system after hardware failure without re-onboarding | Open |
+| System Requirement | SYS-XXX | System shall provide a mechanism to export and import signed configuration bundles | Open |
+| Software Requirement | SWR-XXX | Config backup service shall validate bundle signature before import | Open |
+| Software Requirement | SWR-XXX | Config backup service shall verify schema version and reject mismatches | Open |
+| Software Requirement | SWR-XXX | Export and import shall be recorded in audit log | Open |
+| Security Requirement | SEC-XXX | Backup bundles shall be signed to prevent tampering | Open |
+| Security Requirement | SEC-XXX | Pepper key and TLS material shall be included in backup with explicit admin warning | Open |
+| Architecture | ARCH-XXX | Config backup uses service-layer pattern (ConfigBackupService) | Open |
+| Architecture | SWA-XXX | Bundle signing uses Ed25519 or RSA (TBD) | Open |
+| Risk | RISK-XXX | Stale TLS certificates after restore may break camera trust | Open |
+| Risk | RISK-XXX | Schema mismatch may cause data loss | Open |
+| Risk Control | RC-XXX | Schema version check rejects incompatible bundles | Open |
+| Risk Control | RC-XXX | Atomic import with rollback prevents partial/inconsistent restores | Open |
+| Test Case | TC-XXX | Round-trip export and import succeeds on same system | Open |
+| Test Case | TC-XXX | Tampered bundle is rejected with signature mismatch error | Open |
+| Test Case | TC-XXX | Schema version mismatch is rejected | Open |
+
+### Code Annotation Pattern
+
+Every traceable file must include a `REQ:` annotation, e.g.:
+
+```python
+# REQ: SWR-0XX, SEC-0XX — bundle validation and signature check
+def verify_bundle(bundle_data, public_key):
+    ...
+```
+
+## Deployment Impact
+
+### OTA and Update Path
+
+- **No Yocto changes**: this is a server-side runtime feature.
+- **No schema migration required** for existing tables (users, cameras, settings already exist; upsert is compatible).
+- **New table or `/data` entry**: signing keypair must be generated on first system initialization or during first access to the export feature. Existing systems will generate the key on first import/export attempt.
+- **No firmware or bootloader changes**.
+
+### Rollout and Operator Guidance
+
+- Feature is opt-in from the admin UI.
+- Operator should be advised to:
+  1. Export a backup soon after setup.
+  2. Keep bundles secure (password-protected archive, air-gapped storage).
+  3. Test restore on a development system before relying on it in production.
+  4. Understand that webhook secrets and 2FA recovery codes are re-issued on restore.
+
+### Runbook Additions
+
+- "How to export configuration"
+- "How to restore configuration"
+- "What happens to secrets and API keys after restore"
+- "Troubleshooting: bundle rejected (signature mismatch, schema version)"
+- "Recovery: if restore went wrong, how to rollback"
+
+## Open Questions
+
+1. **Bundle format**: Should we use `.tar.gz` with manifest, or just a single signed JSON file? Trade-off: tar is extensible (future file types), JSON is simpler. Decision needed before implementation.
+
+2. **Signing algorithm**: Ed25519 (recommended for simplicity and speed) or RSA (more common)? If Ed25519, we need a lightweight Rust or Python crypto library. If RSA, we use `cryptography` (already a dependency).
+
+3. **Key generation and storage**: Should the signing keypair be generated:
+   - On first system boot (Yocto recipe)?
+   - On first access to the backup feature (lazy init)?
+   - Both (strict generation, lazy as fallback)?
+
+4. **Secret policy for "re-issue on restore"**: Do webhook secrets and recovery-code hashes get entirely new values, or do we generate them client-side with a seed? Current proposal: re-issue (new values). Confirm.
+
+5. **UI "merge" mode for v2**: For now, import is "replace all" (delete users not in bundle). Should we support "merge" (update what's in the bundle, keep what's not)? Deferred to v2, but should be architected now to avoid redesign.
+
+6. **Encrypted bundles for v2**: Should we support bundling with a password (AES-256)? Out of scope for v1, but should the bundle format be extensible?
+
+---
+
+## Implementation Readiness
+
+This spec is ready for implementation. All acceptance criteria are testable, the threat model is documented, and the architecture fits the existing codebase. The open questions are non-blocking (they are design decisions, not blockers).
+
+**Architect recommendation**: Move to `ready-for-implementation` and assign to Implementation role.


### PR DESCRIPTION
Closes #240

## Summary
An admin can export a signed configuration bundle containing users, paired cameras, settings, retention policy, alert thresholds, and OTA channel state, then preview and import that bundle on the same or a fresh server install to recover after SD-card failure, hardware migration, or factory reset without full re-onboarding. Recordings remain out of scope.

## Spec
`docs/history/specs/240-config-backup-restore.md`

## Validation evidence
- `pytest app/server/tests/ -v --cov=app/server --cov-fail-under=85`: PASS
- `ruff check .`: PASS
- `ruff format --check .`: PASS
- `python tools/docs/check_doc_map.py`: PASS
- `python scripts/ai/validate_repo_ai_setup.py`: PASS
- `python scripts/ai/check_doc_links.py`: PASS
- `python scripts/ai/check_shell_scripts.py`: PASS
- `python scripts/check_version_consistency.py`: PASS
- `python scripts/check_versioning_design.py`: PASS
- `python -m pre_commit run --all-files`: PASS
- `coverage`: server 94.98% / camera n/a (no camera changes)
- `skipped`: hardware verification (local Windows tester host has no attached hardware test environment; human or hardware-attached tester run required before merge)

## Deployment impact
No Yocto, firmware, or bootloader changes. This is a server-side runtime feature; existing systems generate or reuse backup signing material at runtime, and no existing schema migration is required for users, cameras, or settings.

## Traceability
Updated traceability annotations in `app/server/monitor/api/system.py`, `app/server/monitor/services/config_backup_service.py`, `app/server/monitor/services/factory_reset_service.py`, `app/server/tests/integration/test_api_system.py`, and `app/server/tests/unit/test_svc_config_backup.py` covering SWR-018, SWR-020, SWR-023, SWR-024, SWR-032, SWR-034, SWR-045; SC-004, SC-006, SC-011, SC-012, SC-017, SC-020, SC-021; RISK-005, RISK-006, RISK-011, RISK-012, RISK-017, RISK-019, RISK-020; and TC-010, TC-015, TC-022, TC-023, TC-029, TC-032, TC-041, TC-042.

## Out of scope
- Backing up recordings or motion-clip media.
- Yocto image or firmware backup.
- Camera-side `/data` backup.
- Cross-major-version restores.
- Scheduled or automatic backups in v1.
- Encrypted-at-rest local archives of multiple historical backups.
- Multi-device or cloud-synchronized backup.