### PR TITLE
chore: pin Agentry reviewer supervision fix

### DIFF
--- a/agentry/README.md
+++ b/agentry/README.md
@@ -111,6 +111,9 @@ no background service by default.
 Stop is conservative: Agentry kills only currently running session PIDs, not
 completed or stale records.
 
+Completed sessions clear their recorded PID before status/dashboard rendering,
+so a visible PID means there is still an active role process to inspect or stop.
+
 ## Upgrade
 
 The start scripts install Agentry from the Git ref pinned in the script. To

--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -487,14 +487,21 @@ agents:
            commits_behind=$(git rev-list --count "origin/feature/<id>-${slug}..origin/main")
          If commits_behind > 0 → label `needs-rebase`, remove ready-for-review,
          comment "rebase required". Exit 0.
-      5. Run review checklist per docs/ai/roles/reviewer.md:
+      5. Check CI status:
+           gh pr checks <n> --json name,state,bucket
+         If checks are pending, queued, or in progress, append a concise
+         reviewer log entry, leave labels unchanged, and exit 0. Do not call
+         scheduling or wakeup tools such as `ScheduleWakeup`, `Cron*`,
+         `PushNotification`, or `RemoteTrigger`; Agentry will retry on the
+         next orchestrator interval.
+      6. Run review checklist per docs/ai/roles/reviewer.md:
          - spec adherence (acceptance criteria, non-goals respected)
          - engineering / design standards
          - validation evidence (CI green, coverage, validators ran)
          - sensitive-path scrutiny
          - traceability
          - repo policy compliance
-      6. APPROVE:
+      7. APPROVE:
            gh label create agent-approved --color 0e8a16 --force
            gh pr review <n> --approve --body "Agentry review outcome: APPROVED\n\n<concise summary>"
            gh pr edit <n> --add-label agent-approved --remove-label ready-for-review --remove-label blocked
@@ -515,9 +522,9 @@ agents:
          CHANGES: ...>"`, then perform the same PR and issue label updates.
          Verify the PR no longer has `ready-for-review` or `agent-approved`
          and the issue has `changes-requested` plus `pr-open`.
-      7. Append distilled cycle entry to
+      8. Append distilled cycle entry to
          agentry/logs/issues/<id>-<slug>/reviewer.log
-      8. Overwrite session summary. Exit 0.
+      9. Overwrite session summary. Exit 0.
 
       CONSTRAINTS:
       - Never click merge — code-owner is required by branch protection.

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -31,7 +31,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = 'f7d0dc583440117c8b5f13e57d6cf9b5ade9903f'
+$AgentryRef = 'ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 # Locate Python.

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-f7d0dc583440117c8b5f13e57d6cf9b5ade9903f}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4}"
 
 # Locate Python.
 PYTHON=""

--- a/docs/history/planning/agentry-smoke-test-state.md
+++ b/docs/history/planning/agentry-smoke-test-state.md
@@ -13,7 +13,7 @@ Two repositories stay separate:
 
 | Repository | Responsibility | Current baseline |
 |---|---|---|
-| `vinu-dev/agentry` | Universal platform, supervisor, prompts, session handling | `f7d0dc583440117c8b5f13e57d6cf9b5ade9903f` |
+| `vinu-dev/agentry` | Universal platform, supervisor, prompts, session handling | `ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4` |
 | `vinu-dev/rpi-home-monitor` | Target config, product code, product docs, role guidance | pinned to the Agentry baseline above |
 
 Do not mix platform fixes into this repo. Do not put target project fixes in
@@ -27,13 +27,17 @@ the Agentry repo.
 - `vinu-dev/agentry#17`: universal role prompts now instruct each role to
   process exactly one work item per run, then exit. This prevents Architect or
   another role from burning tokens by drifting into the next issue.
+- `vinu-dev/agentry#19`: completed sessions clear stale PIDs from
+  status/dashboard, the runtime contract forbids role-level wakeup/scheduling
+  tools, and the standard Reviewer leaves pending-CI PRs in
+  `ready-for-review` for the next orchestrator interval.
 
 ## Target Configuration
 
 The target Agentry scripts pin the platform to:
 
 ```text
-f7d0dc583440117c8b5f13e57d6cf9b5ade9903f
+ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4
 ```
 
 Model routing:


### PR DESCRIPTION
﻿## Summary
- pin target Agentry start scripts to vinu-dev/agentry@ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4
- copy the reviewer pending-CI / no wakeup-tool workflow into this target config
- update operator docs and the Agentry smoke-test handoff with the platform PR #19 behavior

## Validation
- `git diff --check`
- `python tools/docs/check_doc_map.py`
- `python scripts/ai/validate_repo_ai_setup.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path(''agentry/config.yml'').read_text(encoding=''utf-8'')); print(''agentry config yaml ok'')"`
