### PR TITLE
chore: pin Agentry reviewer comment workflow

### DIFF
--- a/agentry/README.md
+++ b/agentry/README.md
@@ -90,6 +90,11 @@ new autonomous issue discovery or release automation.
 `opus` is the Claude Code alias for the latest Opus model. Keep this alias
 instead of pinning a dated Claude model unless a rollback is intentional.
 
+The start scripts currently pin Agentry to
+`f8da18a92e6fbbc87e77c56164f24e1317bb66c4`, which includes the reviewer
+comment workflow and the stream-json watchdog fix for active Claude Code tool
+activity during check-ins.
+
 ## Start
 
 ```powershell

--- a/agentry/README.md
+++ b/agentry/README.md
@@ -79,6 +79,11 @@ This repo is configured to use alternating model perspectives:
 - Tester: Codex via `npx @openai/codex -m gpt-5.4`
 - Reviewer: Claude Code via `npx @anthropic-ai/claude-code --model opus`
 
+Reviewer approval is recorded with a PR comment beginning
+`Agentry review outcome:` plus the `agent-approved` label. The target config
+does not use formal `gh pr review` by default because GitHub rejects
+same-author self-review.
+
 Researcher and Release are disabled by default. Enable them only when you want
 new autonomous issue discovery or release automation.
 

--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -503,23 +503,24 @@ agents:
          - repo policy compliance
       7. APPROVE:
            gh label create agent-approved --color 0e8a16 --force
-           gh pr review <n> --approve --body "Agentry review outcome: APPROVED\n\n<concise summary>"
+           gh pr comment <n> --body "Agentry review outcome: APPROVED\n\n<concise summary>"
            gh pr edit <n> --add-label agent-approved --remove-label ready-for-review --remove-label blocked
-         If `gh pr review` fails or GitHub refuses self-review, use
-         `gh pr comment <n> --body "Agentry review outcome: APPROVED\n\n<concise summary>"`.
          The verified comment plus `agent-approved` is the canonical Agentry
-         approval signal. Still add `agent-approved`, remove `ready-for-review`
-         and `blocked`, verify with `gh pr view`, and leave the linked issue's
-         `pr-open` label in place until the PR or issue closes.
+         approval signal. Do not call `gh pr review --approve` by default:
+         GitHub rejects self-review when the pipeline and PR author share an
+         account, which creates noisy false failures. Projects that need formal
+         GitHub reviews can add that locally after confirming the reviewer actor
+         is allowed to review the PR. Still add `agent-approved`, remove
+         `ready-for-review` and `blocked`, verify with `gh pr view`, and leave
+         the linked issue's `pr-open` label in place until the PR or issue
+         closes.
          (Do NOT click merge — code-owner human merges.)
          BLOCK (any item failed):
            gh label create agent-approved --color 0e8a16 --force
-           gh pr review <n> --request-changes --body "Agentry review outcome: REQUEST CHANGES\n\n<itemized issues>"
+           gh pr comment <n> --body "Agentry review outcome: REQUEST CHANGES\n\n<itemized issues>"
            gh pr edit <n> --remove-label agent-approved --add-label blocked --remove-label ready-for-review
            gh issue edit <id> --add-label changes-requested --add-label pr-open --remove-label ready-for-test
            gh issue comment <id> --body "<short review-fix summary and PR link>"
-         If `gh pr review` fails, use `gh pr comment <n> --body "<REQUEST
-         CHANGES: ...>"`, then perform the same PR and issue label updates.
          Verify the PR no longer has `ready-for-review` or `agent-approved`
          and the issue has `changes-requested` plus `pr-open`.
       8. Append distilled cycle entry to

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -31,7 +31,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = 'ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4'
+$AgentryRef = '74231a7b43fdab5b46c6192c6843b2ee700a04cf'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 # Locate Python.

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -31,7 +31,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = '74231a7b43fdab5b46c6192c6843b2ee700a04cf'
+$AgentryRef = 'f8da18a92e6fbbc87e77c56164f24e1317bb66c4'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 # Locate Python.

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-74231a7b43fdab5b46c6192c6843b2ee700a04cf}"
 
 # Locate Python.
 PYTHON=""

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-74231a7b43fdab5b46c6192c6843b2ee700a04cf}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-f8da18a92e6fbbc87e77c56164f24e1317bb66c4}"
 
 # Locate Python.
 PYTHON=""

--- a/docs/history/planning/agentry-smoke-test-state.md
+++ b/docs/history/planning/agentry-smoke-test-state.md
@@ -13,7 +13,7 @@ Two repositories stay separate:
 
 | Repository | Responsibility | Current baseline |
 |---|---|---|
-| `vinu-dev/agentry` | Universal platform, supervisor, prompts, session handling | `ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4` |
+| `vinu-dev/agentry` | Universal platform, supervisor, prompts, session handling | `74231a7b43fdab5b46c6192c6843b2ee700a04cf` |
 | `vinu-dev/rpi-home-monitor` | Target config, product code, product docs, role guidance | pinned to the Agentry baseline above |
 
 Do not mix platform fixes into this repo. Do not put target project fixes in
@@ -31,13 +31,16 @@ the Agentry repo.
   status/dashboard, the runtime contract forbids role-level wakeup/scheduling
   tools, and the standard Reviewer leaves pending-CI PRs in
   `ready-for-review` for the next orchestrator interval.
+- `vinu-dev/agentry#20`: Reviewer outcomes now use deterministic PR comments
+  plus labels as the canonical Agentry approval/block signal, avoiding noisy
+  GitHub self-review failures when the pipeline and PR author share an account.
 
 ## Target Configuration
 
 The target Agentry scripts pin the platform to:
 
 ```text
-ad2c7a8535c1ebdcfcd9bcb922e1500d61a8d6b4
+74231a7b43fdab5b46c6192c6843b2ee700a04cf
 ```
 
 Model routing:

--- a/docs/history/planning/agentry-smoke-test-state.md
+++ b/docs/history/planning/agentry-smoke-test-state.md
@@ -13,7 +13,7 @@ Two repositories stay separate:
 
 | Repository | Responsibility | Current baseline |
 |---|---|---|
-| `vinu-dev/agentry` | Universal platform, supervisor, prompts, session handling | `74231a7b43fdab5b46c6192c6843b2ee700a04cf` |
+| `vinu-dev/agentry` | Universal platform, supervisor, prompts, session handling | `f8da18a92e6fbbc87e77c56164f24e1317bb66c4` |
 | `vinu-dev/rpi-home-monitor` | Target config, product code, product docs, role guidance | pinned to the Agentry baseline above |
 
 Do not mix platform fixes into this repo. Do not put target project fixes in
@@ -34,13 +34,16 @@ the Agentry repo.
 - `vinu-dev/agentry#20`: Reviewer outcomes now use deterministic PR comments
   plus labels as the canonical Agentry approval/block signal, avoiding noisy
   GitHub self-review failures when the pipeline and PR author share an account.
+- `vinu-dev/agentry#21`: stream-json check-ins now treat fresh Claude Code tool
+  activity as progress, so an active reviewer is not killed just because it is
+  inside a long-running tool call and has not emitted a textual `STATUS:`.
 
 ## Target Configuration
 
 The target Agentry scripts pin the platform to:
 
 ```text
-74231a7b43fdab5b46c6192c6843b2ee700a04cf
+f8da18a92e6fbbc87e77c56164f24e1317bb66c4
 ```
 
 Model routing:
@@ -59,13 +62,14 @@ large Claude model without hardcoding a dated model name.
 
 As of this update:
 
-- #238 is `tests-failed`. Tester found real failures: formatting drift, missing
-  traceability IDs, and settings-service test failures.
-- #239 is in implementation for outbound webhook delivery.
-- #240, #241, and #242 were moved by Architect to `ready-for-implementation`.
-- #243 and newer issues remain in `ready-for-design`.
-- No Researcher or Release automation should run unless explicitly enabled by
-  an operator.
+- #265 and #267 are open with green CI and are waiting on Agentry review /
+  supervisor-approved merge handling.
+- #268 updates the target Agentry pin and should merge before restarting the
+  pipeline so new sessions use the fixed platform.
+- #246 active-session UI work has a local implementation commit in the
+  Implementer worktree and still needs rebase, validation, push, and PR flow.
+- Researcher and Release remain disabled and should not run unless explicitly
+  enabled by an operator.
 
 ## Operator Workflow
 


### PR DESCRIPTION
## Summary
- pin target Agentry scripts to platform commit 74231a7b43fdab5b46c6192c6843b2ee700a04cf from vinu-dev/agentry#20
- copy the reviewer comment+label approval workflow into target agentry/config.yml
- document reviewer approval signaling and update the live smoke-test handoff

## Validation
- agentry config YAML parse check
- python tools/docs/check_doc_map.py
- python scripts/ai/validate_repo_ai_setup.py
- python scripts/ai/check_doc_links.py
- git diff --check