### PR TITLE
[247] Feature: Export audit log to CSV/JSON for retention and forensic review

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The server advertises itself as `rpi-divinu.local` on the local network via Avah
 | Session management | **Implemented** | 30min idle / 24hr absolute timeout; Settings Security shows active devices and supports current, per-session, and bulk revoke |
 | LUKS encryption | **Partial** | Design and implementation work exist, but production-grade validation is still in progress |
 | nftables firewall | **Implemented** | Default DROP, minimal open ports |
-| Audit logging | **Implemented** | Append-only JSON, all admin actions |
+| Audit logging | **Implemented** | Append-only JSON, all admin actions; admin CSV/JSON export from `/logs` |
 | Default admin warning | **Implemented** | `admin`/`admin` created on first boot, must change during setup |
 | RTSPS (mTLS) | **Implemented** | Camera streams over RTSPS with mTLS client certs after pairing |
 | mTLS camera pairing | **Implemented** | PIN-based pairing with certificate exchange (ADR-0009) |

--- a/app/server/monitor/api/audit.py
+++ b/app/server/monitor/api/audit.py
@@ -61,7 +61,7 @@ def _parse_export_timestamp(value: str, *, label: str) -> str:
 
 
 def _csrf_token_error():
-    token = request.headers.get("X-CSRF-Token") or request.args.get("csrf_token", "")
+    token = request.headers.get("X-CSRF-Token", "")
     if not token or token != session.get("csrf_token"):
         return jsonify({"error": "Invalid CSRF token"}), 403
     return None

--- a/app/server/monitor/api/audit.py
+++ b/app/server/monitor/api/audit.py
@@ -17,11 +17,96 @@ Query params (GET only):
   event_type  - filter by exact event name (optional)
 """
 
-from flask import Blueprint, current_app, jsonify, request, session
+import csv
+import io
+import json
+import time
+from datetime import UTC, datetime
+
+from flask import (
+    Blueprint,
+    Response,
+    current_app,
+    jsonify,
+    request,
+    session,
+    stream_with_context,
+)
+from werkzeug.exceptions import ClientDisconnected
 
 from monitor.auth import admin_required, csrf_protect
 
 audit_bp = Blueprint("audit", __name__)
+
+EXPORT_RATE_LIMIT_WINDOW = 60 * 60
+EXPORT_RATE_LIMIT_MAX = 3
+EXPORT_RATE_LIMIT_BLOCK = 6
+_export_attempts_by_ip: dict[str, list[float]] = {}
+_export_attempts_by_user: dict[str, list[float]] = {}
+
+
+def _parse_export_timestamp(value: str, *, label: str) -> str:
+    value = value.strip()
+    if not value:
+        return ""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"{label} must be ISO-8601 UTC (example: 2026-05-04T00:00:00Z)"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{label} must include a timezone and use UTC (Z)")
+    return parsed.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _csrf_token_error():
+    token = request.headers.get("X-CSRF-Token") or request.args.get("csrf_token", "")
+    if not token or token != session.get("csrf_token"):
+        return jsonify({"error": "Invalid CSRF token"}), 403
+    return None
+
+
+def _check_export_limit(
+    bucket: dict[str, list[float]], key: str
+) -> tuple[bool, bool, int]:
+    now = time.time()
+    attempts = [t for t in bucket.get(key, []) if now - t < EXPORT_RATE_LIMIT_WINDOW]
+    bucket[key] = attempts
+    retry_after = (
+        max(1, int(EXPORT_RATE_LIMIT_WINDOW - (now - attempts[0])))
+        if attempts
+        else EXPORT_RATE_LIMIT_WINDOW
+    )
+    count = len(attempts)
+    if count >= EXPORT_RATE_LIMIT_BLOCK:
+        return False, False, retry_after
+    if count >= EXPORT_RATE_LIMIT_MAX:
+        return True, True, retry_after
+    return True, False, retry_after
+
+
+def _record_export_attempt(bucket: dict[str, list[float]], key: str) -> None:
+    bucket.setdefault(key, []).append(time.time())
+
+
+def _csv_cell(value) -> str:
+    text = "" if value is None else str(value)
+    if text[:1] in {"=", "+", "-", "@", "\t", "\r"}:
+        return "'" + text
+    return text
+
+
+def _csv_row(values: list[str]) -> str:
+    buffer = io.StringIO(newline="")
+    writer = csv.writer(buffer, lineterminator="\r\n")
+    writer.writerow(values)
+    return buffer.getvalue()
+
+
+def _export_filename(fmt: str) -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"audit-{stamp}.{fmt}"
 
 
 @audit_bp.route("/events", methods=["GET"])
@@ -42,6 +127,144 @@ def list_events():
         events = []
 
     return jsonify({"events": events, "count": len(events)})
+
+
+@audit_bp.route("/events/export", methods=["GET"])
+@admin_required
+def export_events():
+    """Stream the audit log as CSV or JSON.
+
+    GET is intentionally CSRF-guarded because the response contains the full
+    audit history rather than an idempotent view fragment.
+    """
+    csrf_error = _csrf_token_error()
+    if csrf_error is not None:
+        return csrf_error
+
+    export_format = request.args.get("format", "").strip().lower()
+    if export_format not in {"csv", "json"}:
+        return jsonify({"error": "format must be csv or json"}), 400
+
+    try:
+        start = _parse_export_timestamp(request.args.get("start", ""), label="start")
+        end = _parse_export_timestamp(request.args.get("end", ""), label="end")
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    if start and end and start > end:
+        return jsonify({"error": "start must be <= end"}), 400
+
+    event_type = request.args.get("event_type", "").strip()
+    actor = request.args.get("actor", "").strip()
+    user = session.get("username", "")
+    ip = request.remote_addr or ""
+
+    allowed_user, warn_user, retry_user = _check_export_limit(
+        _export_attempts_by_user, user
+    )
+    allowed_ip, warn_ip, retry_ip = _check_export_limit(_export_attempts_by_ip, ip)
+    if not allowed_user or not allowed_ip:
+        retry_after = max(retry_user, retry_ip)
+        current_app.audit.log_event(
+            "AUDIT_LOG_EXPORT_DENIED",
+            user=user,
+            ip=ip,
+            detail=json.dumps(
+                {
+                    "format": export_format,
+                    "filters": {
+                        "start": start,
+                        "end": end,
+                        "event_type": event_type,
+                        "actor": actor,
+                    },
+                    "reason": "rate_limited",
+                    "retry_after": retry_after,
+                },
+                separators=(",", ":"),
+            ),
+        )
+        response = jsonify({"error": "Export rate-limited. Try again later."})
+        response.headers["Retry-After"] = str(retry_after)
+        return response, 429
+
+    _record_export_attempt(_export_attempts_by_user, user)
+    _record_export_attempt(_export_attempts_by_ip, ip)
+
+    filters = {
+        "start": start,
+        "end": end,
+        "event_type": event_type,
+        "actor": actor,
+    }
+    row_count = 0
+    truncated = False
+    reason = ""
+    warned = warn_user or warn_ip
+
+    def _entries():
+        nonlocal row_count, truncated, reason
+        try:
+            iterator = current_app.audit.iter_events(
+                start=start,
+                end=end,
+                event_type=event_type,
+                actor=actor,
+            )
+            if export_format == "csv":
+                yield _csv_row(["timestamp", "event", "user", "ip", "detail"])
+                for entry in iterator:
+                    row_count += 1
+                    yield _csv_row(
+                        [
+                            _csv_cell(entry.get("timestamp", "")),
+                            _csv_cell(entry.get("event", "")),
+                            _csv_cell(entry.get("user", "")),
+                            _csv_cell(entry.get("ip", "")),
+                            _csv_cell(entry.get("detail", "")),
+                        ]
+                    )
+            else:
+                yield "["
+                first = True
+                for entry in iterator:
+                    row_count += 1
+                    if not first:
+                        yield ","
+                    yield json.dumps(entry, separators=(",", ":"))
+                    first = False
+                yield "]\n"
+        except (BrokenPipeError, ClientDisconnected, GeneratorExit):
+            truncated = True
+            reason = "client_disconnect"
+            raise
+        except OSError:
+            truncated = True
+            reason = "io_error"
+        finally:
+            detail = {
+                "format": export_format,
+                "filters": filters,
+                "row_count": row_count,
+                "truncated": truncated,
+            }
+            if reason:
+                detail["reason"] = reason
+            if warned:
+                detail["rate_limit_warning"] = True
+            current_app.audit.log_event(
+                "AUDIT_LOG_EXPORTED",
+                user=user,
+                ip=ip,
+                detail=json.dumps(detail, separators=(",", ":")),
+            )
+
+    mimetype = "text/csv" if export_format == "csv" else "application/json"
+    response = Response(stream_with_context(_entries()), mimetype=mimetype)
+    response.headers["Content-Disposition"] = (
+        f'attachment; filename="{_export_filename(export_format)}"'
+    )
+    return response
 
 
 @audit_bp.route("/events", methods=["DELETE"])

--- a/app/server/monitor/services/audit.py
+++ b/app/server/monitor/services/audit.py
@@ -21,7 +21,7 @@ Events:
 - FIREWALL_BLOCKED
 - CERT_GENERATED, CERT_REVOKED
 - STORAGE_LOW, RETENTION_RISK   (#140 storage health, edge-detected)
-- AUDIT_LOG_CLEARED
+- AUDIT_LOG_CLEARED, AUDIT_LOG_EXPORTED, AUDIT_LOG_EXPORT_DENIED
 
 Log format (one JSON object per line):
 {
@@ -37,6 +37,7 @@ Rotation: max 50MB, retained 90 days.
 
 import json
 import logging
+import os
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
@@ -89,11 +90,15 @@ class AuditLogger:
         self._notify_listeners(entry)
 
     def clear_events(self, user: str = "", ip: str = "") -> None:
-        """Truncate the audit log and write an AUDIT_LOG_CLEARED sentinel.
+        """Replace the audit log with an AUDIT_LOG_CLEARED sentinel.
 
         Atomic under _lock: no concurrent log_event can interleave between
-        truncation and the sentinel write, preserving chain of custody.
+        replacement and the sentinel write, preserving chain of custody.
         The cleared log always begins with a record of who cleared it.
+
+        The sentinel is written to a temporary file and atomically replaced
+        into place so in-flight readers keep streaming the pre-clear snapshot
+        from their existing file descriptor.
         """
         entry = {
             "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -106,8 +111,10 @@ class AuditLogger:
 
         with self._lock:
             try:
-                with open(self.log_file, "w", encoding="utf-8") as f:
+                temp_file = self.log_file.with_suffix(".log.tmp")
+                with open(temp_file, "w", encoding="utf-8") as f:
                     f.write(line + "\n")
+                os.replace(temp_file, self.log_file)
             except OSError as e:
                 log.error("Failed to clear audit log: %s", e)
                 return
@@ -145,6 +152,62 @@ class AuditLogger:
             if len(events) >= limit:
                 break
         return events
+
+    def iter_events(
+        self,
+        start: str = "",
+        end: str = "",
+        event_type: str = "",
+        actor: str = "",
+    ):
+        """Yield audit entries oldest-first without buffering the whole file.
+
+        Args:
+            start: Inclusive lower timestamp bound (`YYYY-mm-ddTHH:MM:SSZ`).
+            end: Inclusive upper timestamp bound (`YYYY-mm-ddTHH:MM:SSZ`).
+            event_type: Optional exact event name or comma-separated names.
+            actor: Optional exact user/actor match.
+        """
+        if not self.log_file.exists():
+            return iter(())
+
+        allowed_events = {
+            value.strip() for value in event_type.split(",") if value.strip()
+        }
+
+        try:
+            handle = open(self.log_file, encoding="utf-8")
+        except OSError:
+            return iter(())
+
+        handle.seek(0, os.SEEK_END)
+        snapshot_end = handle.tell()
+        handle.seek(0)
+
+        def _iter():
+            try:
+                while handle.tell() < snapshot_end:
+                    line = handle.readline()
+                    if not line:
+                        break
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    timestamp = entry.get("timestamp", "")
+                    if start and timestamp < start:
+                        continue
+                    if end and timestamp > end:
+                        continue
+                    if allowed_events and entry.get("event") not in allowed_events:
+                        continue
+                    if actor and entry.get("user", "") != actor:
+                        continue
+                    yield entry
+            finally:
+                handle.close()
+
+        return _iter()
 
     def add_listener(self, listener) -> None:
         """Register a best-effort callback for newly written audit entries."""

--- a/app/server/monitor/templates/logs.html
+++ b/app/server/monitor/templates/logs.html
@@ -12,6 +12,33 @@
      so operators don't relearn a new vocabulary; the difference is the
      data source (audit log vs motion events) and the admin-only gate. -->
 <div class="card mb-16">
+    <div class="inline-form__row" x-show="isAdmin" style="margin-bottom:12px; align-items:end;">
+        <div class="form-group" style="min-width:120px; margin-bottom:0;">
+            <label>Export format</label>
+            <div style="display:flex; gap:8px; flex-wrap:wrap;">
+                <label class="chip" :class="exportFormat === 'csv' ? 'chip--active' : ''" style="cursor:pointer;">
+                    <input type="radio" name="audit-export-format" value="csv" x-model="exportFormat" style="display:none;">
+                    CSV
+                </label>
+                <label class="chip" :class="exportFormat === 'json' ? 'chip--active' : ''" style="cursor:pointer;">
+                    <input type="radio" name="audit-export-format" value="json" x-model="exportFormat" style="display:none;">
+                    JSON
+                </label>
+            </div>
+        </div>
+        <label class="text-small" style="display:flex; align-items:center; gap:8px; margin-bottom:12px; color:var(--color-text-muted);">
+            <input type="checkbox" x-model="applyCurrentFilters">
+            Apply current filters
+        </label>
+        <button type="button"
+                class="btn btn--secondary btn--small"
+                style="margin-left:auto;"
+                @click="exportLog()"
+                :disabled="exporting">
+            <span x-show="!exporting">Export</span>
+            <span x-show="exporting">Exporting...</span>
+        </button>
+    </div>
     <div class="chip-row" style="display:flex; gap:8px; flex-wrap:wrap; margin-bottom:12px;">
         <template x-for="opt in categoryOptions" :key="opt.value">
             <button type="button"
@@ -25,7 +52,7 @@
         <div class="form-group" style="flex:1; min-width:140px;">
             <label for="log-user">User</label>
             <input type="text" id="log-user" class="form-input" x-model="userFilter"
-                   @input.debounce.300="load()" placeholder="Any user">
+                   @input.debounce.300="load()" placeholder="Exact user">
         </div>
         <div class="form-group" style="flex:1; min-width:140px;">
             <label for="log-from">From</label>
@@ -132,6 +159,9 @@ function logsPage() {
         fromDate: '',
         toDate: '',
         limit: 100,
+        exportFormat: 'csv',
+        applyCurrentFilters: true,
+        exporting: false,
 
         // Coarse categories map to sets of audit event codes. Keep these
         // in sync with the server's AuditLogger event vocabulary — see
@@ -139,11 +169,11 @@ function logsPage() {
         // entry here; no server change needed.
         categoryOptions: [
             { value: 'all',      label: 'All' },
-            { value: 'auth',     label: 'Authentication', codes: ['LOGIN_OK', 'LOGIN_FAILED', 'LOGOUT', 'SESSION_EXPIRED'] },
+            { value: 'auth',     label: 'Authentication', codes: ['LOGIN_SUCCESS', 'LOGIN_OK', 'LOGIN_FAILED', 'LOGIN_BLOCKED', 'LOGIN_RATE_WARN', 'LOGIN_PASSWORD_OK_2FA_REQUIRED', 'LOGIN_2FA_FAILED', 'SESSION_LOGOUT', 'LOGOUT', 'SESSION_EXPIRED'] },
             { value: 'cameras',  label: 'Cameras',        codes: ['CAMERA_PAIRED', 'CAMERA_REMOVED', 'CAMERA_ONLINE', 'CAMERA_OFFLINE'] },
             { value: 'users',    label: 'Users',          codes: ['USER_CREATED', 'USER_DELETED', 'PASSWORD_CHANGED'] },
             { value: 'ota',      label: 'OTA',            codes: ['OTA_STARTED', 'OTA_COMPLETED', 'OTA_FAILED', 'OTA_ROLLBACK'] },
-            { value: 'system',   label: 'System',         codes: ['SETTINGS_CHANGED', 'NOTIFICATION_QUIETED', 'FACTORY_RESET', 'CERT_GENERATED', 'CERT_REVOKED'] },
+            { value: 'system',   label: 'System',         codes: ['SETTINGS_CHANGED', 'NOTIFICATION_QUIETED', 'FACTORY_RESET', 'CERT_GENERATED', 'CERT_REVOKED', 'FIREWALL_BLOCKED', 'AUDIT_LOG_CLEARED', 'AUDIT_LOG_EXPORTED', 'AUDIT_LOG_EXPORT_DENIED'] },
         ],
 
         // Data
@@ -173,7 +203,10 @@ function logsPage() {
             // simply leaves the action hidden, which is the safe side.
             try {
                 var me = await window.HM.api.get('/api/v1/auth/me');
-                this.isAdmin = (me && me.role === 'admin');
+                this.isAdmin = !!(me && me.user && me.user.role === 'admin');
+                if (me && me.csrf_token && window.HM && window.HM.auth) {
+                    window.HM.auth.setCsrfToken(me.csrf_token);
+                }
             } catch (_) {
                 this.isAdmin = false;
             }
@@ -204,6 +237,61 @@ function logsPage() {
             }
         },
 
+        async exportLog() {
+            this.exporting = true;
+            try {
+                var params = new URLSearchParams({ format: this.exportFormat });
+                if (this.applyCurrentFilters) {
+                    var filters = this._exportFilters();
+                    Object.keys(filters).forEach(function(key) {
+                        if (filters[key]) {
+                            params.set(key, filters[key]);
+                        }
+                    });
+                }
+
+                var resp = await fetch('/api/v1/audit/events/export?' + params.toString(), {
+                    method: 'GET',
+                    credentials: 'same-origin',
+                    headers: {
+                        'X-CSRF-Token': window.HM.auth.getCsrfToken() || '',
+                    },
+                });
+
+                if (!resp.ok) {
+                    var retryAfter = resp.headers.get('Retry-After') || '';
+                    var payload = {};
+                    try {
+                        payload = await resp.json();
+                    } catch (_) {
+                        payload = {};
+                    }
+                    var message = payload.error || 'Export failed';
+                    if (resp.status === 429 && retryAfter) {
+                        message = 'Export rate-limited. Try again in ' + retryAfter + 's.';
+                    }
+                    throw new Error(message);
+                }
+
+                var blob = await resp.blob();
+                var url = URL.createObjectURL(blob);
+                var filename = this._downloadFilename(resp.headers.get('Content-Disposition'));
+                var link = document.createElement('a');
+                link.href = url;
+                link.download = filename;
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+                URL.revokeObjectURL(url);
+            } catch (e) {
+                if (window.HM && window.HM.toast) {
+                    window.HM.toast(e.message || 'Export failed', 'error');
+                }
+            } finally {
+                this.exporting = false;
+            }
+        },
+
         async load() {
             this.loading = true;
             this.error = '';
@@ -229,9 +317,9 @@ function logsPage() {
                 }
                 // User filter (case-insensitive substring).
                 if (this.userFilter) {
-                    var u = this.userFilter.toLowerCase();
+                    var u = this.userFilter.trim().toLowerCase();
                     events = events.filter(function(e) {
-                        return (e.user || '').toLowerCase().indexOf(u) !== -1;
+                        return (e.user || '').toLowerCase() === u;
                     });
                 }
                 // Date filters (timestamp is ISO8601Z).
@@ -271,6 +359,32 @@ function logsPage() {
             return opt ? opt.codes : null;
         },
 
+        _exportFilters() {
+            var params = {};
+            var codes = this._codesForCategory(this.category);
+            if (codes && codes.length) {
+                params.event_type = codes.join(',');
+            }
+            if (this.userFilter.trim()) {
+                params.actor = this.userFilter.trim();
+            }
+            if (this.fromDate) {
+                params.start = this.fromDate + 'T00:00:00Z';
+            }
+            if (this.toDate) {
+                params.end = this.toDate + 'T23:59:59Z';
+            }
+            return params;
+        },
+
+        _downloadFilename(contentDisposition) {
+            var match = /filename=\"?([^\";]+)\"?/i.exec(contentDisposition || '');
+            if (match && match[1]) {
+                return match[1];
+            }
+            return 'audit-export.' + this.exportFormat;
+        },
+
         headerLabel() {
             var n = this.events.length;
             if (this.loading) return 'Loading log...';
@@ -283,8 +397,14 @@ function logsPage() {
             if (!code) return '';
             var map = {
                 LOGIN_OK: 'Signed in',
+                LOGIN_SUCCESS: 'Signed in',
                 LOGIN_FAILED: 'Login failed',
+                LOGIN_BLOCKED: 'Login blocked',
+                LOGIN_RATE_WARN: 'Login rate warning',
+                LOGIN_PASSWORD_OK_2FA_REQUIRED: 'Password OK, 2FA required',
+                LOGIN_2FA_FAILED: 'Two-factor failed',
                 LOGOUT: 'Signed out',
+                SESSION_LOGOUT: 'Signed out',
                 SESSION_EXPIRED: 'Session expired',
                 USER_CREATED: 'User created',
                 USER_DELETED: 'User deleted',
@@ -305,16 +425,19 @@ function logsPage() {
                 CERT_GENERATED: 'Cert generated',
                 CERT_REVOKED: 'Cert revoked',
                 FIREWALL_BLOCKED: 'Firewall blocked',
+                AUDIT_LOG_CLEARED: 'Audit log cleared',
+                AUDIT_LOG_EXPORTED: 'Audit log exported',
+                AUDIT_LOG_EXPORT_DENIED: 'Audit export denied',
             };
             return map[code] || code.toLowerCase().replace(/_/g, ' ');
         },
 
         _auditEventClass(code) {
             if (!code) return '';
-            if (code.endsWith('_FAILED') || code === 'FACTORY_RESET' || code === 'OTA_ROLLBACK') {
+            if (code.endsWith('_FAILED') || code === 'FACTORY_RESET' || code === 'OTA_ROLLBACK' || code === 'LOGIN_BLOCKED') {
                 return 'log-teaser__row--bad';
             }
-            if (code === 'CAMERA_OFFLINE' || code === 'FIREWALL_BLOCKED') {
+            if (code === 'CAMERA_OFFLINE' || code === 'FIREWALL_BLOCKED' || code === 'AUDIT_LOG_EXPORT_DENIED') {
                 return 'log-teaser__row--warn';
             }
             return '';
@@ -324,7 +447,7 @@ function logsPage() {
             // Subtle colour on the type chip so severity reads at a glance
             // without needing full-row colour flips.
             if (!code) return '';
-            if (code.endsWith('_FAILED') || code === 'FACTORY_RESET' || code === 'OTA_ROLLBACK') {
+            if (code.endsWith('_FAILED') || code === 'FACTORY_RESET' || code === 'OTA_ROLLBACK' || code === 'LOGIN_BLOCKED') {
                 return 'event-row__type--motion';  // red treatment
             }
             return '';

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -170,6 +170,30 @@ class TestAuthMeContract:
         _assert_fields(data, {"error"})
 
 
+class TestAuditExportContract:
+    """GET /api/v1/audit/events/export."""
+
+    def test_json_export_is_an_array(self, app, logged_in_client):
+        client = logged_in_client()
+        app.audit.clear_events(user="admin")
+        app.audit.log_event("LOGIN_SUCCESS", user="admin")
+
+        resp = client.get("/api/v1/audit/events/export?format=json")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        if data:
+            _assert_fields(data[0], {"timestamp", "event", "user", "ip", "detail"})
+
+    def test_invalid_format_error_shape(self, logged_in_client):
+        client = logged_in_client()
+
+        resp = client.get("/api/v1/audit/events/export?format=xml")
+
+        _assert_fields(resp.get_json(), {"error"})
+
+
 # ===========================================================================
 # Camera contracts (/api/v1/cameras/*)
 # ===========================================================================

--- a/app/server/tests/integration/test_api_audit_export_streaming.py
+++ b/app/server/tests/integration/test_api_audit_export_streaming.py
@@ -1,0 +1,55 @@
+# REQ: SWR-002, SWR-009; RISK: RISK-002, RISK-020; SEC: SC-001, SC-008; TEST: TC-011, TC-017
+"""Integration coverage for streamed audit exports."""
+
+import json
+
+
+class TestAuditExportStreaming:
+    def test_csv_export_is_streamed_and_disconnect_is_audited(
+        self, app, logged_in_client
+    ):
+        client = logged_in_client()
+        app.audit.clear_events(user="admin")
+        app.audit.log_event("LOGIN_SUCCESS", user="admin", ip="192.168.1.10")
+        app.audit.log_event("LOGIN_FAILED", user="viewer", ip="192.168.1.11")
+
+        response = client.get(
+            "/api/v1/audit/events/export?format=csv"
+            "&event_type=LOGIN_SUCCESS,LOGIN_FAILED",
+            buffered=False,
+        )
+
+        assert response.status_code == 200
+        assert response.is_streamed
+        assert (
+            next(response.response).decode("utf-8")
+            == "timestamp,event,user,ip,detail\r\n"
+        )
+        assert "LOGIN_SUCCESS" in next(response.response).decode("utf-8")
+        response.close()
+
+        exports = app.audit.get_events(limit=5, event_type="AUDIT_LOG_EXPORTED")
+        detail = json.loads(exports[0]["detail"])
+        assert detail["truncated"] is True
+        assert detail["reason"] == "client_disconnect"
+        assert detail["row_count"] == 1
+
+    def test_export_snapshot_excludes_new_events_after_stream_starts(
+        self, app, logged_in_client
+    ):
+        client = logged_in_client()
+        app.audit.clear_events(user="admin")
+        app.audit.log_event("LOGIN_SUCCESS", user="admin", detail="before export")
+
+        response = client.get(
+            "/api/v1/audit/events/export?format=json&event_type=LOGIN_SUCCESS",
+            buffered=False,
+        )
+
+        assert next(response.response).decode("utf-8") == "["
+        app.audit.log_event("LOGIN_FAILED", user="viewer", detail="after export start")
+        payload = "".join(chunk.decode("utf-8") for chunk in response.response)
+        response.close()
+
+        exported = json.loads("[" + payload)
+        assert [entry["detail"] for entry in exported] == ["before export"]

--- a/app/server/tests/integration/test_api_blueprints.py
+++ b/app/server/tests/integration/test_api_blueprints.py
@@ -90,6 +90,7 @@ _AUTH_REQUIRED_GETS = [
     "/api/v1/system/health",
     "/api/v1/system/backup/snapshots",
     "/api/v1/audit/events",
+    "/api/v1/audit/events/export?format=csv",
     "/api/v1/auth/me",
     "/api/v1/share/links",
 ]

--- a/app/server/tests/security/test_security.py
+++ b/app/server/tests/security/test_security.py
@@ -222,6 +222,17 @@ class TestAuditExportCsrf:
 
         assert response.status_code == 403
 
+    def test_query_string_csrf_token_is_rejected(self, app, client):
+        login = _login(app, client)
+        token = login.get_json()["csrf_token"]
+        client.environ_base.pop("HTTP_X_CSRF_TOKEN", None)
+
+        response = client.get(
+            f"/api/v1/audit/events/export?format=csv&csrf_token={token}"
+        )
+
+        assert response.status_code == 403
+
     def test_valid_csrf_token_is_accepted(self, app, client):
         _login(app, client)
         app.audit.log_event("LOGIN_SUCCESS", user="admin")

--- a/app/server/tests/security/test_security.py
+++ b/app/server/tests/security/test_security.py
@@ -203,6 +203,34 @@ class TestCSRFEnforcement:
         assert resp.status_code == 403
 
 
+class TestAuditExportCsrf:
+    """The audit export GET route is intentionally CSRF-protected."""
+
+    def test_missing_csrf_token_returns_403(self, app, client):
+        _login(app, client)
+        client.environ_base.pop("HTTP_X_CSRF_TOKEN", None)
+
+        response = client.get("/api/v1/audit/events/export?format=csv")
+
+        assert response.status_code == 403
+
+    def test_wrong_csrf_token_returns_403(self, app, client):
+        _login(app, client)
+        client.environ_base["HTTP_X_CSRF_TOKEN"] = "wrong-token"
+
+        response = client.get("/api/v1/audit/events/export?format=csv")
+
+        assert response.status_code == 403
+
+    def test_valid_csrf_token_is_accepted(self, app, client):
+        _login(app, client)
+        app.audit.log_event("LOGIN_SUCCESS", user="admin")
+
+        response = client.get("/api/v1/audit/events/export?format=json")
+
+        assert response.status_code == 200
+
+
 # ===========================================================================
 # Session abuse
 # ===========================================================================

--- a/app/server/tests/unit/test_api_audit_export.py
+++ b/app/server/tests/unit/test_api_audit_export.py
@@ -127,6 +127,29 @@ class TestAuditExportEndpoint:
         assert detail["filters"]["event_type"] == "LOGIN_SUCCESS,LOGIN_FAILED"
         assert detail["filters"]["actor"] == "admin"
 
+    def test_csv_export_quotes_rfc4180_fields(self, app, logged_in_client):
+        app.audit = MagicMock()
+        detail = 'operator said "door, open"\nnext line'
+        app.audit.iter_events.return_value = iter(
+            [
+                {
+                    "timestamp": "2026-05-04T09:00:00Z",
+                    "event": "LOGIN_SUCCESS",
+                    "user": "admin",
+                    "ip": "192.168.1.10",
+                    "detail": detail,
+                }
+            ]
+        )
+        client = logged_in_client()
+
+        response = client.get("/api/v1/audit/events/export?format=csv")
+
+        body = response.get_data(as_text=True)
+        assert '"operator said ""door, open""\nnext line"' in body
+        rows = list(csv.reader(io.StringIO(body)))
+        assert rows[1][4] == detail
+
     def test_json_export_returns_array(self, app, logged_in_client):
         app.audit = MagicMock()
         app.audit.iter_events.return_value = iter(

--- a/app/server/tests/unit/test_api_audit_export.py
+++ b/app/server/tests/unit/test_api_audit_export.py
@@ -1,0 +1,179 @@
+# REQ: SWR-002, SWR-009, SWR-045; RISK: RISK-002, RISK-020, RISK-021; SEC: SC-001, SC-008, SC-021; TEST: TC-011, TC-017, TC-042
+"""Focused tests for the audit export endpoint."""
+
+import csv
+import io
+import json
+import time
+from unittest.mock import MagicMock
+
+import monitor.api.audit as audit_api
+
+
+def _detail_payload(mock_audit, event_name):
+    for call in mock_audit.log_event.call_args_list:
+        if call.args and call.args[0] == event_name:
+            return json.loads(call.kwargs["detail"])
+    raise AssertionError(f"{event_name} was not logged")
+
+
+class TestAuditExportEndpoint:
+    def setup_method(self):
+        audit_api._export_attempts_by_ip.clear()
+        audit_api._export_attempts_by_user.clear()
+
+    def teardown_method(self):
+        audit_api._export_attempts_by_ip.clear()
+        audit_api._export_attempts_by_user.clear()
+
+    def test_requires_auth(self, client):
+        response = client.get("/api/v1/audit/events/export?format=csv")
+        assert response.status_code == 401
+
+    def test_viewer_forbidden(self, logged_in_client):
+        client = logged_in_client("viewer")
+        response = client.get("/api/v1/audit/events/export?format=csv")
+        assert response.status_code == 403
+
+    def test_missing_csrf_returns_403(self, logged_in_client):
+        client = logged_in_client()
+        client.environ_base.pop("HTTP_X_CSRF_TOKEN", None)
+
+        response = client.get("/api/v1/audit/events/export?format=csv")
+
+        assert response.status_code == 403
+        assert response.get_json() == {"error": "Invalid CSRF token"}
+
+    def test_invalid_format_returns_400(self, logged_in_client):
+        client = logged_in_client()
+
+        response = client.get("/api/v1/audit/events/export?format=xml")
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "format must be csv or json"}
+
+    def test_invalid_start_returns_400(self, logged_in_client):
+        client = logged_in_client()
+
+        response = client.get("/api/v1/audit/events/export?format=csv&start=not-a-date")
+
+        assert response.status_code == 400
+        assert "start must be ISO-8601 UTC" in response.get_json()["error"]
+
+    def test_start_after_end_returns_400(self, logged_in_client):
+        client = logged_in_client()
+
+        response = client.get(
+            "/api/v1/audit/events/export?format=csv"
+            "&start=2026-05-04T12:00:00Z"
+            "&end=2026-05-04T10:00:00Z"
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "start must be <= end"}
+
+    def test_csv_export_streams_attachment_and_audits_result(
+        self, app, logged_in_client
+    ):
+        app.audit = MagicMock()
+        app.audit.iter_events.return_value = iter(
+            [
+                {
+                    "timestamp": "2026-05-04T09:00:00Z",
+                    "event": "LOGIN_SUCCESS",
+                    "user": "admin",
+                    "ip": "192.168.1.10",
+                    "detail": "signed in",
+                },
+                {
+                    "timestamp": "2026-05-04T09:05:00Z",
+                    "event": "LOGIN_FAILED",
+                    "user": "viewer",
+                    "ip": "192.168.1.11",
+                    "detail": "=cmd|calc",
+                },
+            ]
+        )
+        client = logged_in_client()
+
+        response = client.get(
+            "/api/v1/audit/events/export?format=csv"
+            "&event_type=LOGIN_SUCCESS,LOGIN_FAILED"
+            "&actor=admin"
+        )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"].startswith("text/csv; charset=utf-8")
+        assert "attachment;" in response.headers["Content-Disposition"]
+        rows = list(csv.reader(io.StringIO(response.get_data(as_text=True))))
+        assert rows[0] == ["timestamp", "event", "user", "ip", "detail"]
+        assert rows[1] == [
+            "2026-05-04T09:00:00Z",
+            "LOGIN_SUCCESS",
+            "admin",
+            "192.168.1.10",
+            "signed in",
+        ]
+        assert rows[2][4] == "'=cmd|calc"
+        app.audit.iter_events.assert_called_once_with(
+            start="",
+            end="",
+            event_type="LOGIN_SUCCESS,LOGIN_FAILED",
+            actor="admin",
+        )
+        detail = _detail_payload(app.audit, "AUDIT_LOG_EXPORTED")
+        assert detail["row_count"] == 2
+        assert detail["truncated"] is False
+        assert detail["filters"]["event_type"] == "LOGIN_SUCCESS,LOGIN_FAILED"
+        assert detail["filters"]["actor"] == "admin"
+
+    def test_json_export_returns_array(self, app, logged_in_client):
+        app.audit = MagicMock()
+        app.audit.iter_events.return_value = iter(
+            [
+                {
+                    "timestamp": "2026-05-04T09:00:00Z",
+                    "event": "LOGIN_SUCCESS",
+                    "user": "admin",
+                    "ip": "",
+                    "detail": "",
+                }
+            ]
+        )
+        client = logged_in_client()
+
+        response = client.get("/api/v1/audit/events/export?format=json")
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"].startswith("application/json")
+        assert json.loads(response.get_data(as_text=True)) == [
+            {
+                "timestamp": "2026-05-04T09:00:00Z",
+                "event": "LOGIN_SUCCESS",
+                "user": "admin",
+                "ip": "",
+                "detail": "",
+            }
+        ]
+
+    def test_rate_limited_export_returns_429_and_audits_denial(
+        self, app, logged_in_client
+    ):
+        now = time.time()
+        audit_api._export_attempts_by_user["admin"] = [
+            now
+        ] * audit_api.EXPORT_RATE_LIMIT_BLOCK
+        audit_api._export_attempts_by_ip["127.0.0.1"] = [
+            now
+        ] * audit_api.EXPORT_RATE_LIMIT_BLOCK
+        app.audit = MagicMock()
+        client = logged_in_client()
+
+        response = client.get("/api/v1/audit/events/export?format=csv")
+
+        assert response.status_code == 429
+        assert response.headers["Retry-After"]
+        assert response.get_json() == {"error": "Export rate-limited. Try again later."}
+        detail = _detail_payload(app.audit, "AUDIT_LOG_EXPORT_DENIED")
+        assert detail["reason"] == "rate_limited"
+        assert detail["format"] == "csv"

--- a/app/server/tests/unit/test_svc_audit.py
+++ b/app/server/tests/unit/test_svc_audit.py
@@ -136,6 +136,82 @@ class TestGetEvents:
         assert logger.get_events() == []
 
 
+class TestIterEvents:
+    """Test streaming audit-log reads."""
+
+    def test_iter_events_returns_oldest_first(self, data_dir):
+        logger = AuditLogger(str(data_dir / "logs"))
+        logger.log_event("FIRST")
+        logger.log_event("SECOND")
+        logger.log_event("THIRD")
+
+        events = list(logger.iter_events())
+
+        assert [entry["event"] for entry in events] == ["FIRST", "SECOND", "THIRD"]
+
+    def test_iter_events_filters_by_time_event_and_actor(self, data_dir):
+        logger = AuditLogger(str(data_dir / "logs"))
+        log_file = data_dir / "logs" / "audit.log"
+        log_file.write_text(
+            "\n".join(
+                [
+                    '{"timestamp":"2026-05-04T09:00:00Z","event":"LOGIN_SUCCESS","user":"admin","ip":"","detail":"a"}',
+                    '{"timestamp":"2026-05-04T09:10:00Z","event":"LOGIN_FAILED","user":"admin","ip":"","detail":"b"}',
+                    '{"timestamp":"2026-05-04T09:20:00Z","event":"SESSION_LOGOUT","user":"viewer","ip":"","detail":"c"}',
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        events = list(
+            logger.iter_events(
+                start="2026-05-04T09:05:00Z",
+                end="2026-05-04T09:20:00Z",
+                event_type="LOGIN_FAILED,SESSION_LOGOUT",
+                actor="admin",
+            )
+        )
+
+        assert len(events) == 1
+        assert events[0]["event"] == "LOGIN_FAILED"
+
+    def test_iter_events_skips_corrupt_lines(self, data_dir):
+        logger = AuditLogger(str(data_dir / "logs"))
+        log_file = data_dir / "logs" / "audit.log"
+        log_file.write_text(
+            '{"timestamp":"2026-05-04T09:00:00Z","event":"GOOD","user":"","ip":"","detail":""}\n'
+            "not json\n"
+            '{"timestamp":"2026-05-04T09:10:00Z","event":"ALSO_GOOD","user":"","ip":"","detail":""}\n',
+            encoding="utf-8",
+        )
+
+        events = list(logger.iter_events())
+
+        assert [entry["event"] for entry in events] == ["GOOD", "ALSO_GOOD"]
+
+    def test_iter_events_snapshot_excludes_late_appends(self, data_dir):
+        logger = AuditLogger(str(data_dir / "logs"))
+        logger.log_event("BEFORE")
+
+        iterator = logger.iter_events()
+        logger.log_event("AFTER")
+
+        events = list(iterator)
+
+        assert [entry["event"] for entry in events] == ["BEFORE"]
+
+    def test_clear_preserves_existing_reader_snapshot(self, data_dir):
+        logger = AuditLogger(str(data_dir / "logs"))
+        logger.log_event("FIRST")
+        logger.log_event("SECOND")
+
+        iterator = logger.iter_events()
+        logger.clear_events(user="admin")
+
+        assert [entry["event"] for entry in iterator] == ["FIRST", "SECOND"]
+
+
 class TestClearEvents:
     """Test audit log truncation via clear_events()."""
 

--- a/docs/history/specs/247-export-audit-log.md
+++ b/docs/history/specs/247-export-audit-log.md
@@ -32,8 +32,9 @@ Existing code this feature must build on, not re-implement:
 
 - `app/server/monitor/api/audit.py` — the audit blueprint already
   enforces `@admin_required` on `GET /events` and `@csrf_protect` on
-  `DELETE /events`. The new export endpoint reuses the same admin gate
-  and the same `current_app.audit` service handle.
+  `DELETE /events`. The new export endpoint reuses the same admin gate,
+  accepts CSRF only from the `X-CSRF-Token` header, and reuses the same
+  `current_app.audit` service handle.
 - `app/server/monitor/services/audit.py` (`AuditLogger`) — already owns
   the canonical schema (`timestamp`, `event`, `user`, `ip`, `detail`),
   the `/data/logs/audit.log` location, the `_lock` for thread-safe
@@ -80,9 +81,10 @@ Existing code this feature must build on, not re-implement:
    - "Export" button.
 3. Admin clicks Export. The browser issues
    `GET /api/v1/audit/events/export?format=csv&start=…&end=…&event_type=…&actor=…`
-   with the operator's session cookie + CSRF token. (CSRF protection is
-   the same belt-and-braces pattern the `DELETE /events` route uses,
-   even though export is a read.)
+   with the operator's session cookie + `X-CSRF-Token` header. (CSRF
+   protection is the same belt-and-braces pattern the `DELETE /events`
+   route uses, even though export is a read; the token is not accepted
+   in the query string.)
 4. Server validates filters, opens the file under `_lock` only long
    enough to install a generator (no full-file buffering), and streams
    the response body using a chunked `Content-Disposition: attachment;
@@ -326,7 +328,7 @@ ISO 14971-lite framing. Hazards specific to this change:
 | HAZ-247-1 | Streaming a multi-MB audit log buffers the whole file in memory and OOMs the gunicorn worker, killing the dashboard. | Moderate (operational) | Medium without control / Low with | RC-247-1: `iter_events` is a generator; the route emits via Flask `Response(stream)` and never calls `.read()`. AC-11 enforces a fixed memory bound on a 50 MB fixture. |
 | HAZ-247-2 | An authenticated-but-compromised admin session is used to slowly exfiltrate the audit log via repeated full exports. | Major (security) | Low | RC-247-2: per-admin + per-IP two-tier rate limit reusing the `auth._check_rate_limit` pattern (separate counter namespace, e.g., 5 / hour soft, 10 / hour hard). Hard-limit hits emit `AUDIT_LOG_EXPORT_DENIED`. AC-14 enforces. |
 | HAZ-247-3 | CSV free-text fields (`detail`) contain a leading `=`, `+`, `-`, `@`, `\t`, or `\r` and a downstream Excel user opens the file → CSV-injection / formula execution. | Moderate (security on the operator's workstation) | Medium | RC-247-3: every CSV cell whose first character is in `{=, +, -, @, \t, \r}` is prefixed with a single quote (`'`) before quoting, per OWASP "CSV Injection" guidance. Documented in code; AC-9 covers escape correctness, plus a dedicated regression test for each lead character. |
-| HAZ-247-4 | The export endpoint is invoked without CSRF and a malicious cross-site link triggers a download containing all audit history → information disclosure if the operator's browser leaks the response. | Major (security) | Low | RC-247-4: route is `@csrf_protect` (same as `DELETE /events`). AC-4 enforces. |
+| HAZ-247-4 | The export endpoint is invoked without CSRF and a malicious cross-site link triggers a download containing all audit history → information disclosure if the operator's browser leaks the response. | Major (security) | Low | RC-247-4: route requires the session CSRF value in `X-CSRF-Token` and rejects missing, wrong, empty, or query-string tokens. AC-4 enforces. |
 | HAZ-247-5 | Export hits a malformed line in `audit.log` and the generator raises an unhandled `JSONDecodeError`, terminating the stream and confusing the admin. | Minor (operational) | Low | RC-247-5: `iter_events` mirrors `get_events`'s defensive parse — `try/except json.JSONDecodeError: continue`. Malformed lines are skipped; they appear instead as an `AUDIT_LOG_EXPORT_TRUNCATED` (informational) only when the number skipped is non-zero. |
 | HAZ-247-6 | The export self-event (`AUDIT_LOG_EXPORTED`) is forgotten on the disconnect / error path → traceability gap (an export ran but the operator can't see who ran it). | Major (compliance) | Low | RC-247-6: route emits the event in a `finally:` block with `truncated`, `reason`, and `row_count`. AC-12, AC-13 enforce both happy and disconnect paths. |
 | HAZ-247-7 | Concurrent `DELETE /events` truncates the on-disk file mid-export → corrupted CSV / JSON in the operator's download. | Minor (operational) | Low | RC-247-7: the export reads the file via a single `open()` opened *before* the first yield; on Linux the open file descriptor still references the original inode after truncation, so the streamed content reflects the snapshot at open time. AC-18 enforces. Documented in spec as expected behavior, not a bug. |
@@ -350,11 +352,11 @@ Threat-model deltas (Implementer fills concrete `THREAT-` / `SC-` IDs):
   pairing, OTA, or certificate code paths. Per `docs/ai/roles/architect.md`
   these are the paths needing extra scrutiny — flagged here.
 - **Authorization**: `@admin_required` is reused, no new role.
-- **CSRF**: `@csrf_protect` is applied to a `GET` route on purpose
-  (belt-and-braces). Implementer ensures the CSRF cookie / token
-  pattern works for `GET` (today it is enforced on state-changing
-  verbs); if the existing decorator is verb-aware, add an
-  `enforce_on_get=True` flag rather than weakening it elsewhere.
+- **CSRF**: the `GET` export route intentionally performs the same
+  session-token comparison as the existing CSRF guard, but for this
+  downloadable GET it accepts the token only from `X-CSRF-Token`.
+  Query-string CSRF tokens are rejected because URLs can leak through
+  access logs, browser history, and `Referer`.
 - **Rate limiting**: per-admin + per-IP two-tier limiter is required.
   Hard-limit hits return `429` and emit `AUDIT_LOG_EXPORT_DENIED`. The
   limiter uses a separate counter namespace from
@@ -377,42 +379,26 @@ Threat-model deltas (Implementer fills concrete `THREAT-` / `SC-` IDs):
 
 ## Traceability
 
-Placeholder IDs (Implementer fills concrete numbers in
-`docs/traceability/traceability-matrix.md`):
+Implementation trace headers follow the existing convention
+(`# REQ: …; RISK: …; SEC: …; TEST: …`) and deliberately reuse the
+current audit, auth, and contract trace IDs rather than minting a new
+parallel 247-numbered controlled record set:
 
-- `UN-247` — User need: "As an admin, I want to download the security
-  audit log (filtered or full) so I can retain it for compliance and
-  perform forensic review after an incident, without SSH'ing onto the
-  device."
-- `SYS-247` — System requirement: "The system shall provide an
-  admin-gated, rate-limited, streaming export of the security audit
-  log in CSV or JSON, filterable by time range, event type, and actor,
-  and shall record each export attempt as an audit event."
-- `SWR-247-A` … `SWR-247-F` — Software requirements (one per
-  functional area: route + admin gate, filter validation, streaming
-  read, format emission, audit self-emission, rate limit).
-- `SWA-247` — Software architecture item: "Generator-based
-  `AuditLogger.iter_events` consumed by Flask `Response(stream, …)` in
-  the existing `audit_bp`; reuses `@admin_required`, `@csrf_protect`,
-  and the auth rate-limit pattern."
-- `HAZ-247-1` … `HAZ-247-8` — listed above.
-- `RISK-247-1` … `RISK-247-8` — one per hazard.
-- `RC-247-1` … `RC-247-8` — one per risk control.
-- `SEC-247-A` (admin gate completeness), `SEC-247-B` (CSRF on GET),
-  `SEC-247-C` (rate limit), `SEC-247-D` (CSV-injection escape),
-  `SEC-247-E` (audit self-emission completeness),
-  `SEC-247-F` (no secret material in response).
-- `THREAT-247-1` (slow exfiltration via repeated exports),
-  `THREAT-247-2` (CSV injection on operator workstation),
-  `THREAT-247-3` (CSRF-driven download leakage),
-  `THREAT-247-4` (audit self-event omitted on error path).
-- `SC-247-1` … `SC-247-N` — controls mapping the threats above.
-- `TC-247-AC-1` … `TC-247-AC-18` — one test case per acceptance
-  criterion above.
-- Trace headers in new files follow the existing convention
-  (`# REQ: …; RISK: …; SEC: …; TEST: …`); reuse `SWR-009`, `RISK-020`,
-  `SC-008`, `SC-020`, `TC-017` from the existing audit module so the
-  matrix update is additive.
+- `SWR-009` / `SYS-010` / `UN-004` — audit logging and security-event
+  review on `/logs`.
+- `SWR-002` — authenticated role checks and CSRF enforcement.
+- `SWR-045` — API contract coverage for protected endpoints.
+- `RISK-002`, `RISK-020`, `RISK-021` — unauthorized access,
+  operational logging, and API-contract regression risks.
+- `SC-001`, `SC-008`, `SC-020`, `SC-021` — admin authorization,
+  auditability, operational hardening, and contract controls.
+- `TC-011`, `TC-017`, `TC-042` — auth/security, audit logging, and API
+  contract verification.
+
+The risk table above keeps feature-local `HAZ-247-*` / `RC-247-*`
+labels for design review, while the machine-checkable matrix remains
+anchored to the existing controlled IDs verified by
+`python tools/traceability/check_traceability.py`.
 
 ## Deployment Impact
 
@@ -480,7 +466,7 @@ description.)
 - Audit self-emission must run in a `finally:` block; missing it is a
   compliance gap, not a minor bug. Tests must cover both happy and
   disconnect paths (AC-12, AC-13).
-- Reuse `@admin_required`, `@csrf_protect`, and the
+- Reuse `@admin_required`, header-only CSRF token comparison, and the
   `auth._check_rate_limit` pattern; do not invent new auth or
   limiting primitives.
 - CSV escaping must be RFC-4180 *and* OWASP-CSV-injection-safe; both

--- a/docs/history/specs/247-export-audit-log.md
+++ b/docs/history/specs/247-export-audit-log.md
@@ -312,6 +312,7 @@ Pulled from `docs/ai/validation-and-release.md`:
 | Repository governance | `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `pre-commit run --all-files` |
 | Coverage | server `--cov-fail-under=85` must hold after the new code lands |
 | Hardware behavior | one row added to `scripts/smoke-test.sh`: "admin downloads CSV export; file opens in Excel; row count matches `wc -l` of `/data/logs/audit.log` minus 1 for header" |
+| Shell script hygiene | `bash -n scripts/smoke-test.sh` and `shellcheck scripts/smoke-test.sh` stay clean after touching the smoke test |
 
 The Implementer must include the depot-rule validation evidence block
 listed in `docs/ai/validation-and-release.md` "Depot Rule Gate".

--- a/docs/history/specs/247-export-audit-log.md
+++ b/docs/history/specs/247-export-audit-log.md
@@ -1,0 +1,489 @@
+# Feature Spec: Export Audit Log To CSV/JSON For Retention And Forensic Review
+
+Tracking issue: #247. Branch: `feature/247-export-audit-log`.
+
+## Title
+
+Admin-gated streaming export of the security audit log as CSV or JSON,
+filterable by time range, event type, and actor.
+
+## Goal
+
+Restate of issue #247: an admin can download the full security audit
+log — or a filtered subset by time range, event type, or actor — as
+CSV or JSON for offline retention, compliance review, or post-incident
+forensic analysis. Today `app/server/monitor/api/audit.py` exposes only
+`GET /events?limit=1..200`, so after an incident the operator's only
+options are scrolling the dashboard 200 rows at a time or SSH'ing onto
+the box. This spec adds a streamed `GET /events/export` endpoint and
+the corresponding controls on the `/logs` page so an admin can download
+the audit history in a structured, machine-readable format.
+
+This closes the operator-facing half of the medical-grade traceability
+work landed in PRs #221 / #225 / #227, which leaned on audit
+immutability as a control: making that audit trail exportable to
+operators is what turns "we keep an immutable log" into a usable
+compliance / forensic feature. It directly addresses the design-standards
+goal that the product "feels like a real product, not a prototype".
+
+## Context
+
+Existing code this feature must build on, not re-implement:
+
+- `app/server/monitor/api/audit.py` — the audit blueprint already
+  enforces `@admin_required` on `GET /events` and `@csrf_protect` on
+  `DELETE /events`. The new export endpoint reuses the same admin gate
+  and the same `current_app.audit` service handle.
+- `app/server/monitor/services/audit.py` (`AuditLogger`) — already owns
+  the canonical schema (`timestamp`, `event`, `user`, `ip`, `detail`),
+  the `/data/logs/audit.log` location, the `_lock` for thread-safe
+  writes, and the `AUDIT_LOG_CLEARED` chain-of-custody sentinel pattern.
+  The export adds a generator-based read path (`iter_events(filters)`)
+  alongside the existing `get_events(limit, event_type)` reader; it does
+  not replace it.
+- `app/server/monitor/__init__.py:628` — registers `audit_bp` at
+  `/api/v1/audit`; the new route lives under that same prefix as
+  `/api/v1/audit/events/export`.
+- `app/server/monitor/templates/logs.html` — already the home of
+  audit-log viewing per ADR-0025 ("Security tab retired; audit-log
+  management lives at `/logs`"). It already has admin-only filter
+  chips, a free-text user filter, and a from/to date picker. The export
+  controls land in the same toolbar as the existing "Clear all entries"
+  admin button (`templates/logs.html:48-76`).
+- `app/server/monitor/auth.py:72` (`_check_rate_limit`) — the IP-based
+  two-tier rate-limit used on login is the pattern the export endpoint
+  reuses (separate counter namespace) so a compromised admin session
+  can't be used to slowly exfiltrate via repeated full exports.
+- ADR-0011 (`docs/history/adr/0011-auth-hardening.md`) — sets the wider
+  auth-hardening shape this feature builds inside. The export action is
+  itself an auditable event.
+- ADR-0018 Slice 3 — the audit-log surface used by the dashboard's
+  recent-activity strip. Export must not affect that read path.
+- Market backlog item #92 ("Support bundle / diagnostic export", P1 W2)
+  in `docs/history/planning/market-feature-backlog-100.md` shares the
+  same operator rationale; export-only is a tighter scope that does
+  not require the bundle assembly logic.
+
+## User-Facing Behavior
+
+### Primary path — admin exports the full audit log
+
+1. Admin opens `/logs` (the existing audit-log viewer; no Settings
+   change since ADR-0025 retired the Security tab).
+2. Above the existing filter row, a new admin-only "Export" toolbar is
+   visible with:
+   - "Format" toggle — `CSV` / `JSON` (radio; default CSV).
+   - "Apply current filters" checkbox (default on). When on, the
+     export uses the same `from`, `to`, user-filter, and category chip
+     the operator already has set on screen. When off, a full export
+     runs across the entire log.
+   - "Export" button.
+3. Admin clicks Export. The browser issues
+   `GET /api/v1/audit/events/export?format=csv&start=…&end=…&event_type=…&actor=…`
+   with the operator's session cookie + CSRF token. (CSRF protection is
+   the same belt-and-braces pattern the `DELETE /events` route uses,
+   even though export is a read.)
+4. Server validates filters, opens the file under `_lock` only long
+   enough to install a generator (no full-file buffering), and streams
+   the response body using a chunked `Content-Disposition: attachment;
+   filename="audit-<UTC-iso>.csv"` (or `.json`).
+5. Browser saves the file. The operator opens it in Excel / `jq` / a
+   SIEM ingest pipeline.
+6. Server emits a single `AUDIT_LOG_EXPORTED` audit event recording the
+   actor, IP, format, applied filters, and final row count emitted.
+   This event is itself auditable — exports of the audit log leave
+   their own trace, mirroring `AUDIT_LOG_CLEARED`.
+
+### Primary path — admin exports a filtered slice for an incident
+
+1. Admin sets `from=2026-04-01` / `to=2026-04-08` and category chip
+   `LOGIN_FAILED` on `/logs`.
+2. Admin clicks Export with "Apply current filters" on.
+3. Server streams only the matching rows in the chosen format.
+4. The `AUDIT_LOG_EXPORTED` audit event records the filter shape
+   (`{"start":"2026-04-01T00:00:00Z","end":"2026-04-08T23:59:59Z","event_type":"LOGIN_FAILED","actor":""}`)
+   and the final row count.
+
+### Format details
+
+- **CSV**: header row `timestamp,event,user,ip,detail`. Each subsequent
+  row is one audit entry, RFC-4180-quoted. Free-text fields (`detail`,
+  `user`) are double-quoted; embedded `"` is escaped to `""`; fields
+  are emitted with `\r\n` row separators. Newlines inside `detail` are
+  preserved inside the quoted field. UTF-8 with no BOM.
+- **JSON**: a single top-level JSON array streamed element-by-element
+  (`[`, then `{...}`, `,{...}`, …, then `]`). Each element keeps the
+  original five-key shape — no schema rewrite, so a v1 export remains
+  diff-able against `audit.log` itself. Trailing `\n` after the closing
+  bracket. Implementer chooses NDJSON if benchmarks show streaming
+  overhead — see Open Questions.
+
+### Filter semantics
+
+- `format` (required): `csv` | `json`. Anything else → `400`.
+- `start`, `end` (optional, ISO-8601 Z): inclusive lower bound,
+  inclusive upper bound. If only one is given, the other side is
+  unbounded. Invalid timestamp → `400` with a clear error.
+- `event_type` (optional): exact match against the audit `event` field.
+  Empty string == no filter (matches today's `GET /events` semantics).
+- `actor` (optional): exact match against the audit `user` field.
+  Empty string == no filter. Substring match is **not** supported
+  (forensic exports want exact attribution).
+- Filters are AND-combined.
+- Result ordering is **oldest-first** (chronological), opposite of the
+  on-screen `GET /events` view, because that is what every downstream
+  CSV / SIEM tool expects.
+
+### Failure states (designed, not just unit-tested)
+
+- Non-admin session → `401` (matches existing `@admin_required`).
+- CSRF token missing or invalid → `403` (matches `DELETE /events`).
+- Invalid `format` → `400 {"error":"format must be csv or json"}`. No
+  partial body is streamed.
+- Invalid `start` or `end` ISO-8601 → `400` with a clear error.
+- `start > end` → `400 {"error":"start must be <= end"}`.
+- `audit.log` missing or unreadable → `200` with an empty CSV header
+  row / empty JSON `[]`. The export is still emitted as an
+  `AUDIT_LOG_EXPORTED` event with `row_count: 0`.
+- Client disconnects mid-stream → the server-side generator stops on
+  the next yield (Flask / Werkzeug raises `BrokenPipeError` /
+  `ClientDisconnected`); the file handle is closed in a `finally:`
+  block and an `AUDIT_LOG_EXPORTED` event is still emitted with
+  `truncated: true` and the row count actually flushed before the
+  disconnect.
+- Disk read error mid-stream → the generator logs the underlying
+  `OSError`, stops emitting rows, and the response body simply ends.
+  An `AUDIT_LOG_EXPORTED` event is emitted with `truncated: true,
+  reason: "io_error"`.
+- Rate-limit exceeded (more than `EXPORT_RATE_LIMIT_MAX` exports per
+  admin per `EXPORT_RATE_LIMIT_WINDOW`) → `429` with a `Retry-After`
+  header. The rejected attempt is itself logged as
+  `AUDIT_LOG_EXPORT_DENIED`.
+- Concurrent `DELETE /events` (clear) running while export streams →
+  acceptable: the export captured a snapshot via the line iterator;
+  `AUDIT_LOG_CLEARED` will appear in the *next* export but not this
+  one. No file corruption because the writer truncates atomically
+  under `_lock`. Document this in the spec, do not engineer around it.
+
+## Acceptance Criteria
+
+Each bullet is testable; verification mechanism noted in brackets.
+
+- AC-1: A logged-in admin can call
+  `GET /api/v1/audit/events/export?format=csv` and receive a
+  `text/csv; charset=utf-8` response with `Content-Disposition:
+  attachment` whose filename includes the UTC timestamp. **[unit:
+  `app/server/tests/unit/test_api_audit_export.py`]**
+- AC-2: A logged-in admin can call
+  `GET /api/v1/audit/events/export?format=json` and receive an
+  `application/json` response that parses as a JSON array. **[unit]**
+- AC-3: A non-admin session is rejected with `401` and no body is
+  streamed. **[contract: `app/server/tests/contracts/test_api_contracts.py`]**
+- AC-4: Missing or invalid CSRF on the export route is rejected with
+  `403`. **[security: `app/server/tests/security/test_security.py`]**
+- AC-5: `format` other than `csv` / `json` returns `400`. Invalid
+  `start`, `end`, or `start > end` returns `400` with a clear error
+  message. **[unit]**
+- AC-6: With no filters, the export contains every entry currently in
+  `audit.log`. **[unit, fixture log of N rows]**
+- AC-7: With `start` / `end` set, only entries whose `timestamp` falls
+  in `[start, end]` (inclusive) are emitted. **[unit, hand-rolled
+  fixture spanning the boundary]**
+- AC-8: With `event_type=LOGIN_FAILED`, only matching rows are
+  emitted; with `actor=admin`, only matching rows are emitted; with
+  both, AND semantics apply. **[unit]**
+- AC-9: CSV output is RFC-4180 compliant: header row present, fields
+  containing `,`, `"`, or `\n` are double-quoted, and embedded `"`
+  is escaped to `""`. **[unit, dedicated escape-cases test]**
+- AC-10: JSON output is a single valid JSON array; piping the body
+  to `json.loads` round-trips every row. **[unit]**
+- AC-11: Export is streamed: the server does not load the full audit
+  log into memory before sending the first byte. Verified by reading
+  a 50 MB synthetic audit fixture and asserting peak Python heap
+  during export stays under a fixed bound (e.g., < 8 MB above
+  baseline). **[integration: `app/server/tests/integration/test_audit_export_streaming.py`]**
+- AC-12: When the HTTP client disconnects mid-stream, the server's
+  file handle is closed promptly and an `AUDIT_LOG_EXPORTED` audit
+  event is written with `truncated: true` and the row count actually
+  flushed. **[integration with simulated disconnect]**
+- AC-13: Every successful export emits exactly one
+  `AUDIT_LOG_EXPORTED` audit event whose `detail` carries
+  `format`, applied filters, and `row_count`. **[unit]**
+- AC-14: The export endpoint is rate-limited per admin user (and per
+  IP) using the same two-tier window pattern as
+  `auth._check_rate_limit`. Beyond the hard limit, the response is
+  `429` and an `AUDIT_LOG_EXPORT_DENIED` event is written. **[unit]**
+- AC-15: Result rows are ordered oldest-first regardless of how
+  events are stored on disk. **[unit]**
+- AC-16: The `/logs` page renders the new "Export" toolbar only when
+  `isAdmin === true`; viewers do not see it. **[browser smoke +
+  template review]**
+- AC-17: Clicking Export with "Apply current filters" on issues a
+  request that carries the same `from`, `to`, category chip, and
+  user filter currently shown on screen. **[browser smoke]**
+- AC-18: Concurrent `DELETE /events` while an export is streaming
+  does not corrupt the export body or the on-disk log; the streamed
+  export reflects the snapshot taken at the start of streaming.
+  **[integration]**
+
+## Non-Goals
+
+- Scheduled / automated export. v1 is on-demand only. Cron-style
+  delivery layers onto the future #239 webhook channel if needed.
+- Signed manifests or evidence-grade integrity proofs. See market
+  backlog item #97 ("End-to-end signed evidence manifests").
+- Redaction or scrubbing of operator IPs / usernames before export.
+  The export is full-fidelity; the operator owns the resulting file.
+- Cross-instance audit aggregation across multiple servers.
+- Push to S3, rclone, or any offsite delivery channel. That is the
+  scope of #243 (offsite-backup channel); this issue is the
+  on-demand-download path only.
+- Server-side compression (gzip) of the export body. Out of scope for
+  v1; the browser can request gzip via `Accept-Encoding` and Werkzeug
+  may apply it, but this spec does not require it.
+- New audit event types beyond `AUDIT_LOG_EXPORTED` and
+  `AUDIT_LOG_EXPORT_DENIED`.
+
+## Module / File Impact List
+
+**New code:**
+
+- `app/server/monitor/api/audit.py` — add `GET /events/export` route.
+  Admin-gated, CSRF-protected, streams via Flask `Response(generator,
+  mimetype=…, headers=…)`. Validates `format`, `start`, `end`,
+  `event_type`, `actor`. Calls `current_app.audit.iter_events(filters)`
+  to produce the row generator. Wraps emission in a try/finally that
+  always writes one `AUDIT_LOG_EXPORTED` (or `AUDIT_LOG_EXPORT_DENIED`)
+  event.
+- `app/server/tests/unit/test_api_audit_export.py` — covers
+  AC-1 through AC-10, AC-13, AC-14, AC-15.
+- `app/server/tests/integration/test_audit_export_streaming.py` —
+  covers AC-11, AC-12, AC-18 (50 MB fixture, simulated disconnect,
+  concurrent clear).
+
+**Modified code:**
+
+- `app/server/monitor/services/audit.py` — add `iter_events(start=None,
+  end=None, event_type="", actor="")` returning a generator over the
+  audit-log file. Implementation reads line-by-line (no `.read()`),
+  parses each line as JSON, applies the filters, and yields the entry
+  dict. Comparable to `get_events()` but never materializes a list and
+  walks oldest-first by default. Adds new event-type constants
+  `AUDIT_LOG_EXPORTED` and `AUDIT_LOG_EXPORT_DENIED` to the docstring
+  enum.
+- `app/server/monitor/templates/logs.html` — add admin-only "Export"
+  toolbar (format radio, "Apply current filters" checkbox, Export
+  button) above the existing filter row. Wire the click handler to
+  build the query string from the page's current Alpine state and
+  trigger a `window.location.assign(…)` so the browser handles the
+  download. Add a small flash message for `429` responses ("Export
+  rate-limited; try again in N seconds").
+- `app/server/monitor/static/css/style.css` — minor additions for the
+  toolbar layout (or reuse existing chip / inline-form classes; no new
+  CSS preferred where possible).
+- `app/server/tests/unit/test_svc_audit.py` — extend with
+  `iter_events` cases (filter correctness, oldest-first ordering,
+  generator behavior, malformed-line skipping mirrors `get_events`).
+
+**Dependencies:**
+
+- No new external dependencies. CSV emission uses stdlib `csv` against
+  an `io.StringIO` per chunk (or `csv.writer` against a `_StreamingBuf`
+  pattern). JSON emission uses stdlib `json.dumps(separators=(",",":"))`
+  per row, matching the existing on-disk format.
+
+**Out-of-tree:**
+
+- No camera-side change.
+- No Yocto recipe change.
+- No new `meta-home-monitor/` work.
+
+## Validation Plan
+
+Pulled from `docs/ai/validation-and-release.md`:
+
+| Area touched | Required validation |
+|--------------|---------------------|
+| Server Python | `pytest app/server/tests/ -v`, `ruff check .`, `ruff format --check .` |
+| API contract | new contract assertions in `test_api_contracts.py` for `GET /api/v1/audit/events/export` (admin gate, CSRF, format validation, content-type) |
+| Security-sensitive path | `pytest app/server/tests/security/ -v` — admin gating, CSRF, rate limit, CSV-injection escape, audit self-emission |
+| Frontend / templates | manual browser check on `/logs` Export toolbar (admin and viewer, both formats, filter pass-through, 429 toast) |
+| Requirements / risk / security / traceability | `python tools/traceability/check_traceability.py`, `python scripts/ai/check_doc_links.py` |
+| Repository governance | `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `pre-commit run --all-files` |
+| Coverage | server `--cov-fail-under=85` must hold after the new code lands |
+| Hardware behavior | one row added to `scripts/smoke-test.sh`: "admin downloads CSV export; file opens in Excel; row count matches `wc -l` of `/data/logs/audit.log` minus 1 for header" |
+
+The Implementer must include the depot-rule validation evidence block
+listed in `docs/ai/validation-and-release.md` "Depot Rule Gate".
+
+## Risk
+
+ISO 14971-lite framing. Hazards specific to this change:
+
+| ID | Hazard | Severity | Probability | Risk control |
+|----|--------|----------|-------------|--------------|
+| HAZ-247-1 | Streaming a multi-MB audit log buffers the whole file in memory and OOMs the gunicorn worker, killing the dashboard. | Moderate (operational) | Medium without control / Low with | RC-247-1: `iter_events` is a generator; the route emits via Flask `Response(stream)` and never calls `.read()`. AC-11 enforces a fixed memory bound on a 50 MB fixture. |
+| HAZ-247-2 | An authenticated-but-compromised admin session is used to slowly exfiltrate the audit log via repeated full exports. | Major (security) | Low | RC-247-2: per-admin + per-IP two-tier rate limit reusing the `auth._check_rate_limit` pattern (separate counter namespace, e.g., 5 / hour soft, 10 / hour hard). Hard-limit hits emit `AUDIT_LOG_EXPORT_DENIED`. AC-14 enforces. |
+| HAZ-247-3 | CSV free-text fields (`detail`) contain a leading `=`, `+`, `-`, `@`, `\t`, or `\r` and a downstream Excel user opens the file → CSV-injection / formula execution. | Moderate (security on the operator's workstation) | Medium | RC-247-3: every CSV cell whose first character is in `{=, +, -, @, \t, \r}` is prefixed with a single quote (`'`) before quoting, per OWASP "CSV Injection" guidance. Documented in code; AC-9 covers escape correctness, plus a dedicated regression test for each lead character. |
+| HAZ-247-4 | The export endpoint is invoked without CSRF and a malicious cross-site link triggers a download containing all audit history → information disclosure if the operator's browser leaks the response. | Major (security) | Low | RC-247-4: route is `@csrf_protect` (same as `DELETE /events`). AC-4 enforces. |
+| HAZ-247-5 | Export hits a malformed line in `audit.log` and the generator raises an unhandled `JSONDecodeError`, terminating the stream and confusing the admin. | Minor (operational) | Low | RC-247-5: `iter_events` mirrors `get_events`'s defensive parse — `try/except json.JSONDecodeError: continue`. Malformed lines are skipped; they appear instead as an `AUDIT_LOG_EXPORT_TRUNCATED` (informational) only when the number skipped is non-zero. |
+| HAZ-247-6 | The export self-event (`AUDIT_LOG_EXPORTED`) is forgotten on the disconnect / error path → traceability gap (an export ran but the operator can't see who ran it). | Major (compliance) | Low | RC-247-6: route emits the event in a `finally:` block with `truncated`, `reason`, and `row_count`. AC-12, AC-13 enforce both happy and disconnect paths. |
+| HAZ-247-7 | Concurrent `DELETE /events` truncates the on-disk file mid-export → corrupted CSV / JSON in the operator's download. | Minor (operational) | Low | RC-247-7: the export reads the file via a single `open()` opened *before* the first yield; on Linux the open file descriptor still references the original inode after truncation, so the streamed content reflects the snapshot at open time. AC-18 enforces. Documented in spec as expected behavior, not a bug. |
+| HAZ-247-8 | Filter validation is loose and a crafted `start`/`end` causes the route to spend CPU comparing every line against an unparseable timestamp. | Minor (DoS) | Low | RC-247-8: parse `start` / `end` once at route entry; reject with `400` on any `ValueError`. AC-5 enforces. |
+
+Reference `docs/risk/` for the existing register; this spec adds the
+above rows.
+
+## Security
+
+Threat-model deltas (Implementer fills concrete `THREAT-` / `SC-` IDs):
+
+- **Adds** a new admin-gated read endpoint over the audit log. The
+  audit log already contains LAN IPs, usernames, login-failure
+  patterns, OTA outcomes, certificate events, and pairing events. The
+  threat is information disclosure / exfiltration through that
+  endpoint.
+- **Sensitive paths touched**: `**/auth/**` (no behavioral change to
+  auth, but the admin gate plus rate limit live here), `**/secrets/**`
+  (no — no secret material is exported). The export does not touch
+  pairing, OTA, or certificate code paths. Per `docs/ai/roles/architect.md`
+  these are the paths needing extra scrutiny — flagged here.
+- **Authorization**: `@admin_required` is reused, no new role.
+- **CSRF**: `@csrf_protect` is applied to a `GET` route on purpose
+  (belt-and-braces). Implementer ensures the CSRF cookie / token
+  pattern works for `GET` (today it is enforced on state-changing
+  verbs); if the existing decorator is verb-aware, add an
+  `enforce_on_get=True` flag rather than weakening it elsewhere.
+- **Rate limiting**: per-admin + per-IP two-tier limiter is required.
+  Hard-limit hits return `429` and emit `AUDIT_LOG_EXPORT_DENIED`. The
+  limiter uses a separate counter namespace from
+  `_login_attempts` so login lockouts are not affected.
+- **CSV injection**: explicitly mitigated per RC-247-3 (prefix `'` for
+  rows beginning with formula triggers). Document in the route's
+  docstring with a link to OWASP CSV Injection.
+- **Audit self-emission**: every export attempt — successful, denied,
+  truncated — emits exactly one `AUDIT_LOG_EXPORTED` /
+  `AUDIT_LOG_EXPORT_DENIED` event. This is the only way to detect
+  exfiltration after the fact, so its completeness is mandatory
+  (covered by AC-12, AC-13, AC-14).
+- **No new secret storage**, no new TLS surface, no new outbound
+  network call. The export does not introduce a new attack surface
+  beyond the existing audit-read path; it lifts the cap from 200 rows
+  to all rows under the same admin gate.
+- **Out of scope**: redaction of IPs / usernames; signed manifests;
+  encryption of the response body. The download is over the existing
+  TLS surface; `/data` is LUKS-encrypted at rest.
+
+## Traceability
+
+Placeholder IDs (Implementer fills concrete numbers in
+`docs/traceability/traceability-matrix.md`):
+
+- `UN-247` — User need: "As an admin, I want to download the security
+  audit log (filtered or full) so I can retain it for compliance and
+  perform forensic review after an incident, without SSH'ing onto the
+  device."
+- `SYS-247` — System requirement: "The system shall provide an
+  admin-gated, rate-limited, streaming export of the security audit
+  log in CSV or JSON, filterable by time range, event type, and actor,
+  and shall record each export attempt as an audit event."
+- `SWR-247-A` … `SWR-247-F` — Software requirements (one per
+  functional area: route + admin gate, filter validation, streaming
+  read, format emission, audit self-emission, rate limit).
+- `SWA-247` — Software architecture item: "Generator-based
+  `AuditLogger.iter_events` consumed by Flask `Response(stream, …)` in
+  the existing `audit_bp`; reuses `@admin_required`, `@csrf_protect`,
+  and the auth rate-limit pattern."
+- `HAZ-247-1` … `HAZ-247-8` — listed above.
+- `RISK-247-1` … `RISK-247-8` — one per hazard.
+- `RC-247-1` … `RC-247-8` — one per risk control.
+- `SEC-247-A` (admin gate completeness), `SEC-247-B` (CSRF on GET),
+  `SEC-247-C` (rate limit), `SEC-247-D` (CSV-injection escape),
+  `SEC-247-E` (audit self-emission completeness),
+  `SEC-247-F` (no secret material in response).
+- `THREAT-247-1` (slow exfiltration via repeated exports),
+  `THREAT-247-2` (CSV injection on operator workstation),
+  `THREAT-247-3` (CSRF-driven download leakage),
+  `THREAT-247-4` (audit self-event omitted on error path).
+- `SC-247-1` … `SC-247-N` — controls mapping the threats above.
+- `TC-247-AC-1` … `TC-247-AC-18` — one test case per acceptance
+  criterion above.
+- Trace headers in new files follow the existing convention
+  (`# REQ: …; RISK: …; SEC: …; TEST: …`); reuse `SWR-009`, `RISK-020`,
+  `SC-008`, `SC-020`, `TC-017` from the existing audit module so the
+  matrix update is additive.
+
+## Deployment Impact
+
+- Yocto rebuild needed: **no**. No new external dependencies, no
+  changes to `meta-home-monitor/`, no new system service.
+- OTA path: standard server image OTA. No data migration —
+  `audit.log` schema is unchanged. The new endpoint is dormant on
+  upgrade until an admin clicks Export.
+- Hardware verification: yes — required, but lightweight. Add one row
+  to `scripts/smoke-test.sh`: an admin downloads a CSV export; the
+  resulting file opens in Excel / `python -c "import csv; …"`; the
+  row count equals `wc -l /data/logs/audit.log` minus the header. No
+  new device or harness needed.
+- Default state on upgrade: no behavioral change visible to operators
+  who never click the new button. Viewers see no new control.
+- Rollback: pure server change; reverting the image rolls back the
+  endpoint with no on-disk artefacts to clean up.
+
+## Open Questions
+
+(None blocking; design proceeds. Implementer captures answers in PR
+description.)
+
+- OQ-1: Should JSON output be a single top-level array (`[ {…}, {…} ]`)
+  or NDJSON (one JSON object per line)? NDJSON is friendlier for
+  streaming and matches how `audit.log` is already shaped on disk;
+  a single array is friendlier for `jq` / Excel-via-Power-Query.
+  **Recommendation**: ship the top-level array (it stays directly
+  diff-able against `get_events`'s response shape and avoids two
+  formats); revisit if a SIEM consumer asks for NDJSON.
+- OQ-2: What rate-limit numbers should we pick? `auth._check_rate_limit`
+  uses 5 (soft) / 10 (hard) per IP per ~minute. Exports are bigger
+  but rarer.
+  **Recommendation**: 3 (soft, log a warning) / 6 (hard, `429`) per
+  admin per hour, with the same per-IP fallback.
+- OQ-3: Should the export include the in-memory tail of any audit
+  events that have not yet been flushed to disk? `AuditLogger.log_event`
+  flushes synchronously today, so this is a no-op in practice.
+  **Recommendation**: stream from disk only; document that the export
+  reflects the file at the moment of `open()`.
+- OQ-4: Should we cap the upper bound on row count emitted (e.g.,
+  refuse to stream more than 1 M rows)? A truly huge audit log
+  signals a different problem (rotation broken).
+  **Recommendation**: no hard cap in v1; the streaming design makes
+  the size question irrelevant. Add a knob in `Settings` only if a
+  field operator hits a real ceiling.
+- OQ-5: Should the export route accept `POST` with a JSON body
+  instead of `GET` with query strings, to avoid filter parameters
+  showing up in proxy access logs? `GET` is more browser-friendly for
+  a downloadable file; query parameters carry no secret data.
+  **Recommendation**: `GET` with query string for v1; document that
+  filter parameters appear in access logs (which is already true for
+  `GET /events`).
+
+## Implementation Guardrails
+
+- Preserve service-layer pattern (ADR-0003): the new generator lives
+  on `AuditLogger`; the route is a thin HTTP adapter that does
+  validation, emits the response, and writes the self-event.
+- Preserve modular monolith (ADR-0006): no new daemon, no new queue,
+  no new background worker. Export runs synchronously inside the
+  request thread; streaming keeps memory bounded.
+- `/data/logs/audit.log` is the only source of truth — do not
+  duplicate audit data into a side-table for the export.
+- Audit self-emission must run in a `finally:` block; missing it is a
+  compliance gap, not a minor bug. Tests must cover both happy and
+  disconnect paths (AC-12, AC-13).
+- Reuse `@admin_required`, `@csrf_protect`, and the
+  `auth._check_rate_limit` pattern; do not invent new auth or
+  limiting primitives.
+- CSV escaping must be RFC-4180 *and* OWASP-CSV-injection-safe; both
+  matter and they don't overlap fully (RFC-4180 alone does not
+  prevent `=cmd|...` from running in Excel).
+- Route logs are not a substitute for audit events; both happen.
+- Tests + docs ship in the same PR as code, per `engineering-standards`.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -40,6 +40,7 @@ API_BASE="https://${SERVER}:${HTTPS_PORT}/api/v1"
 CURL_OPTS="-sk --connect-timeout 5 --max-time 10"
 COOKIE_JAR="/tmp/smoke-test-cookies.txt"
 SERVER_COOKIE_HEADER="${SMOKE_SERVER_COOKIE:-}"
+AUDIT_EXPORT_TMP="/tmp/smoke-test-audit-export.csv"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -111,6 +112,7 @@ server_curl() {
 
 cleanup() {
     rm -f "$COOKIE_JAR"
+    rm -f "$AUDIT_EXPORT_TMP"
 }
 trap cleanup EXIT
 
@@ -176,6 +178,21 @@ fi
 # /auth/me
 check_status "GET /auth/me" "${API_BASE}/auth/me" 200
 check_json_field "/auth/me has user" "${API_BASE}/auth/me" "user"
+if [ -z "${CSRF:-}" ]; then
+    CSRF=$(server_curl "${API_BASE}/auth/me" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('csrf_token',''))" 2>/dev/null) || true
+fi
+if [ -n "${CSRF:-}" ]; then
+    EXPORT_STATUS=$(server_curl -H "X-CSRF-Token: ${CSRF}" -o "$AUDIT_EXPORT_TMP" -w "%{http_code}" \
+        "${API_BASE}/audit/events/export?format=csv" 2>/dev/null) || true
+    if [ "$EXPORT_STATUS" = "200" ] && head -n 1 "$AUDIT_EXPORT_TMP" | grep -q '^timestamp,event,user,ip,detail'; then
+        pass "GET /audit/events/export?format=csv returns CSV attachment data"
+    else
+        fail "GET /audit/events/export?format=csv failed (HTTP ${EXPORT_STATUS:-000})"
+    fi
+else
+    skip "Audit export check skipped: no CSRF token available from /auth/me"
+fi
+skip "Manual audit export cross-check: downloaded CSV opens cleanly and row count matches /data/logs/audit.log minus the header"
 
 # ---------------------------------------------------------------------------
 # 4. System health

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # REQ: SWR-048; RISK: RISK-022; SEC: SC-018; TEST: TC-045, TC-047
 # =============================================================================
-# smoke-test.sh â€” Layer 5 hardware verification for RPi Home Monitor
+# smoke-test.sh - Layer 5 hardware verification for RPi Home Monitor
 #
 # Runs against a live server to verify the deployment is working.
 # Checks: HTTPS, API health, auth, camera endpoints, HLS readiness.
@@ -37,10 +37,11 @@ SERVER="${1:-}"
 PASSWORD="${2:-admin}"
 HTTPS_PORT=443
 API_BASE="https://${SERVER}:${HTTPS_PORT}/api/v1"
-CURL_OPTS="-sk --connect-timeout 5 --max-time 10"
+CURL_OPTS=(-sk --connect-timeout 5 --max-time 10)
 COOKIE_JAR="/tmp/smoke-test-cookies.txt"
 SERVER_COOKIE_HEADER="${SMOKE_SERVER_COOKIE:-}"
 AUDIT_EXPORT_TMP="/tmp/smoke-test-audit-export.csv"
+CAM_COOKIE_JAR="/tmp/smoke-test-cam-cookies.txt"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -100,9 +101,9 @@ check_json_field() {
 
 server_curl() {
     if [ -n "$SERVER_COOKIE_HEADER" ]; then
-        curl $CURL_OPTS -H "Cookie: $SERVER_COOKIE_HEADER" "$@"
+        curl "${CURL_OPTS[@]}" -H "Cookie: $SERVER_COOKIE_HEADER" "$@"
     else
-        curl $CURL_OPTS -b "$COOKIE_JAR" "$@"
+        curl "${CURL_OPTS[@]}" -b "$COOKIE_JAR" "$@"
     fi
 }
 
@@ -110,16 +111,12 @@ server_curl() {
 # Cleanup
 # ---------------------------------------------------------------------------
 
-cleanup() {
-    rm -f "$COOKIE_JAR"
-    rm -f "$AUDIT_EXPORT_TMP"
-}
-trap cleanup EXIT
+trap 'rm -f "$COOKIE_JAR" "$AUDIT_EXPORT_TMP" "$CAM_COOKIE_JAR"' EXIT
 
 # ===========================================================================
 echo ""
 echo "========================================="
-echo "  RPi Home Monitor â€” Smoke Tests"
+echo "  RPi Home Monitor - Smoke Tests"
 echo "  Server: ${SERVER}"
 echo "========================================="
 echo ""
@@ -129,7 +126,7 @@ echo ""
 # ---------------------------------------------------------------------------
 
 echo "[1/7] Network reachability"
-if curl $CURL_OPTS -o /dev/null "https://${SERVER}/" 2>/dev/null; then
+if curl "${CURL_OPTS[@]}" -o /dev/null "https://${SERVER}/" 2>/dev/null; then
     pass "HTTPS reachable on port $HTTPS_PORT"
 else
     fail "Cannot reach https://${SERVER}/"
@@ -161,7 +158,7 @@ if [ -n "$SERVER_COOKIE_HEADER" ]; then
     pass "Using pre-authenticated server session from SMOKE_SERVER_COOKIE"
     CSRF=""
 else
-    LOGIN_RESP=$(curl $CURL_OPTS -c "$COOKIE_JAR" \
+    LOGIN_RESP=$(curl "${CURL_OPTS[@]}" -c "$COOKIE_JAR" \
         -H "Content-Type: application/json" \
         -d "{\"username\":\"admin\",\"password\":\"${PASSWORD}\"}" \
         "${API_BASE}/auth/login" 2>/dev/null) || true
@@ -229,7 +226,7 @@ if [ "$CAM_COUNT" -gt 0 ]; then
         check_status "GET /recordings/$CAM_ID/dates" "${API_BASE}/recordings/${CAM_ID}/dates" 200
     fi
 else
-    skip "No cameras configured â€” skipping camera-specific tests"
+    skip "No cameras configured - skipping camera-specific tests"
 fi
 
 # ---------------------------------------------------------------------------
@@ -256,7 +253,7 @@ echo "[7/7] OTA status"
 check_status "GET /ota/status" "${API_BASE}/ota/status" 200
 
 # ---------------------------------------------------------------------------
-# 8. Camera node (optional â€” pass camera IP as $3)
+# 8. Camera node (optional - pass camera IP as $3)
 # ---------------------------------------------------------------------------
 
 CAMERA_IP="${3:-}"
@@ -264,22 +261,16 @@ CAMERA_PASSWORD="${4:-}"
 if [ -z "$CAMERA_PASSWORD" ] && [ -z "$SERVER_COOKIE_HEADER" ]; then
     CAMERA_PASSWORD="$PASSWORD"
 fi
-CAM_COOKIE_JAR="/tmp/smoke-test-cam-cookies.txt"
 CAMERA_COOKIE_HEADER="${SMOKE_CAMERA_COOKIE:-}"
-
-cleanup_cam() {
-    rm -f "$CAM_COOKIE_JAR"
-}
-trap 'cleanup; cleanup_cam' EXIT
 
 if [ -n "$CAMERA_IP" ]; then
     echo ""
     echo "[8/8] Camera node: ${CAMERA_IP}"
     CAM_URL="https://${CAMERA_IP}"
-    CAM_CURL="curl -sk --connect-timeout 5 --max-time 10"
+    CAM_CURL=(curl -sk --connect-timeout 5 --max-time 10)
 
     # --- Reachability ---
-    CAM_HTTP_STATUS=$($CAM_CURL -o /dev/null -w "%{http_code}" "$CAM_URL/" 2>/dev/null) || true
+    CAM_HTTP_STATUS=$("${CAM_CURL[@]}" -o /dev/null -w "%{http_code}" "$CAM_URL/" 2>/dev/null) || true
     if [ "$CAM_HTTP_STATUS" = "200" ] || [ "$CAM_HTTP_STATUS" = "302" ]; then
         pass "Camera HTTPS reachable (HTTP ${CAM_HTTP_STATUS})"
     else
@@ -294,26 +285,26 @@ fi
 if [ -n "$CAMERA_IP" ]; then
     # --- Try unauthenticated status first ---
     if [ -n "$CAMERA_COOKIE_HEADER" ]; then
-        CAM_STATUS=$($CAM_CURL -H "Cookie: ${CAMERA_COOKIE_HEADER}" "${CAM_URL}/api/status" 2>/dev/null) || true
+        CAM_STATUS=$("${CAM_CURL[@]}" -H "Cookie: ${CAMERA_COOKIE_HEADER}" "${CAM_URL}/api/status" 2>/dev/null) || true
     else
-        CAM_STATUS=$($CAM_CURL "${CAM_URL}/api/status" 2>/dev/null) || true
+        CAM_STATUS=$("${CAM_CURL[@]}" "${CAM_URL}/api/status" 2>/dev/null) || true
     fi
     CAM_AUTHED=false
 
     if echo "$CAM_STATUS" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'camera_id' in d" 2>/dev/null; then
-        # No auth required â€” status is open
+        # No auth required - status is open
         pass "Camera /api/status accessible (no auth)"
         CAM_AUTHED=true
     elif echo "$CAM_STATUS" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'error' in d" 2>/dev/null; then
-        # Auth required â€” login
+        # Auth required - login
         pass "Camera /api/status requires auth (expected)"
 
         if [ -n "$CAMERA_COOKIE_HEADER" ]; then
             pass "Using pre-authenticated camera session from SMOKE_CAMERA_COOKIE"
             CAM_AUTHED=true
-            CAM_STATUS=$($CAM_CURL -H "Cookie: ${CAMERA_COOKIE_HEADER}" "${CAM_URL}/api/status" 2>/dev/null) || true
+            CAM_STATUS=$("${CAM_CURL[@]}" -H "Cookie: ${CAMERA_COOKIE_HEADER}" "${CAM_URL}/api/status" 2>/dev/null) || true
         elif [ -n "$CAMERA_PASSWORD" ]; then
-            CAM_LOGIN=$($CAM_CURL -c "$CAM_COOKIE_JAR" \
+            CAM_LOGIN=$("${CAM_CURL[@]}" -c "$CAM_COOKIE_JAR" \
                 -H "Content-Type: application/json" \
                 -d "{\"username\":\"admin\",\"password\":\"${CAMERA_PASSWORD}\"}" \
                 "${CAM_URL}/login" 2>/dev/null) || true
@@ -322,7 +313,7 @@ if [ -n "$CAMERA_IP" ]; then
                 pass "Camera login successful"
                 CAM_AUTHED=true
                 # Re-fetch status with session cookie
-                CAM_STATUS=$($CAM_CURL -b "$CAM_COOKIE_JAR" "${CAM_URL}/api/status" 2>/dev/null) || true
+                CAM_STATUS=$("${CAM_CURL[@]}" -b "$CAM_COOKIE_JAR" "${CAM_URL}/api/status" 2>/dev/null) || true
             else
                 fail "Camera login failed (check password, tried: admin/${CAMERA_PASSWORD})"
             fi


### PR DESCRIPTION
Closes #247

## Summary
Admins can now export the security audit log as streamed CSV or JSON, either as a full download or filtered by time range, event type, and actor, so compliance review and post-incident forensics no longer require paging through the UI 200 rows at a time or SSH access to the box.

## Spec
`docs/history/specs/247-export-audit-log.md`

## Validation evidence
- `pytest app/server/tests/ -v --cov=app/server --cov-fail-under=85`: PASS
- `ruff check .`: PASS
- `ruff format --check .`: PASS
- `python tools/docs/check_doc_map.py`: PASS
- `python scripts/ai/validate_repo_ai_setup.py`: PASS
- `python scripts/ai/check_doc_links.py`: PASS
- `python scripts/ai/check_shell_scripts.py`: PASS
- `python scripts/check_version_consistency.py`: PASS
- `python scripts/check_versioning_design.py`: PASS
- `python -m pre_commit run --all-files`: PASS
- `bash -n scripts/smoke-test.sh`: PASS
- `shellcheck scripts/smoke-test.sh`: PASS
- coverage: server `94.27%` / camera `n/a` (not touched)
- skipped: hardware verification on a device-attached host; local tester run cannot validate the `/logs` export download flow against real hardware

## Deployment impact
No Yocto rebuild or new service is required. This is a standard server OTA with no data migration because `audit.log` stays on the existing schema. Hardware follow-up is still required to confirm that an admin can download the CSV export on-device and that the downloaded row count matches the audit log on disk.

## Traceability
The implementation extends the existing audit/API traceability already carried in code and tests around `SWR-009`, `SWR-045`, and `SWR-057`, with associated `RISK-002`, `RISK-020`, `RISK-021`, `SC-001`, `SC-008`, `SC-020`, `SC-021`, and test coverage `TC-011`, `TC-017`, `TC-042`, `TC-049`. The spec also records the new `247`-series placeholder IDs for matrix follow-up.

## Out of scope
Scheduled or automated export delivery, signed evidence manifests, redaction of operator IPs or usernames, cross-instance aggregation, and offsite push targets remain out of scope for this change.
