### PR TITLE
chore: update Agentry pin for branch reset fix

### DIFF
--- a/agentry/README.md
+++ b/agentry/README.md
@@ -34,6 +34,11 @@ docs/ai/roles/
 Edit those files for project behavior. The prompts in `agentry/config.yml`
 point at them.
 
+The standard Implementer retry path and Tester workflow reset clean local
+feature branches from `origin/feature/<id>-<slug>` before rebasing. This keeps
+stale role worktrees from reporting false merge conflicts after a supervisor or
+agent force-with-lease push.
+
 ## Machine Setup
 
 Run once per machine:

--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -285,7 +285,7 @@ agents:
       4. Switch to the shared feature branch and rebase:
            slug=<from spec filename>
            git fetch origin
-           git switch "feature/<id>-${slug}"
+           git switch -C "feature/<id>-${slug}" "origin/feature/<id>-${slug}"
            git rebase origin/main
          Conflict → label `merge-conflict`, comment, exit 0.
       5. Read JUST what you need: the spec at docs/history/specs/<id>-<slug>.md
@@ -381,7 +381,7 @@ agents:
       3. Switch to feature branch and rebase:
            slug=<from spec filename>
            git fetch origin
-           git switch "feature/<id>-${slug}"
+           git switch -C "feature/<id>-${slug}" "origin/feature/<id>-${slug}"
            git rebase origin/main
          Conflict → label `merge-conflict`, exit 0.
       4. Determine which validation rows apply by inspecting the diff:

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -31,7 +31,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = 'f8da18a92e6fbbc87e77c56164f24e1317bb66c4'
+$AgentryRef = '5e3e66b88d9ea1a404c975fdefdbac221348ecf1'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 # Locate Python.

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-f8da18a92e6fbbc87e77c56164f24e1317bb66c4}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-5e3e66b88d9ea1a404c975fdefdbac221348ecf1}"
 
 # Locate Python.
 PYTHON=""


### PR DESCRIPTION
## Summary
- update Agentry pin to vinu-dev/agentry@5e3e66b
- update local Agentry config so Implementer retry and Tester reset clean feature branches from origin before rebasing
- document why stale role branches are treated as disposable cache state

## Validation
- python tools/docs/check_doc_map.py
- python scripts/ai/validate_repo_ai_setup.py
- python scripts/ai/check_doc_links.py
- python scripts/ai/check_shell_scripts.py
- python -m pre_commit run --all-files
- git diff --check

Platform PR: https://github.com/vinu-dev/agentry/pull/22