### PR TITLE
docs: use portable pre-commit validation command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Core rules:
 - do not commit directly to `main`
 
 Key validation:
-- repo governance: `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `pre-commit run --all-files`
+- repo governance: `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `python -m pre_commit run --all-files`
 - server: `pytest app/server/tests/ -v`, `ruff check .`, `ruff format --check .`
 - camera: `pytest app/camera/tests/ -v`, `ruff check .`, `ruff format --check .`
 - Yocto: `bitbake -p` and VM build for affected images

--- a/app/server/tests/unit/test_time_health_service.py
+++ b/app/server/tests/unit/test_time_health_service.py
@@ -135,7 +135,7 @@ class TestComputeHealth:
         assert result["server"]["ntp_active"] is False
 
     def test_amber_hysteresis_requires_clear_margin(self):
-        now = datetime.now(UTC)
+        now = datetime(2026, 5, 4, 12, 0, 0, tzinfo=UTC)
         svc, store, _ = _service(
             cameras=[
                 _camera(

--- a/docs/ai/roles/implementer.md
+++ b/docs/ai/roles/implementer.md
@@ -39,7 +39,7 @@ Per `docs/ai/validation-and-release.md`. Run only the rows that apply:
 |---|---|
 | `app/server/**` | `pytest app/server/tests/ -v --cov=app/server --cov-fail-under=85`, `ruff check .`, `ruff format --check .` |
 | `app/camera/**` | `pytest app/camera/tests/ -v --cov=app/camera --cov-fail-under=80`, `ruff check .`, `ruff format --check .` |
-| any code change | `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `python scripts/ai/check_doc_links.py`, `python scripts/ai/check_shell_scripts.py`, `python scripts/check_version_consistency.py`, `python scripts/check_versioning_design.py`, `pre-commit run --all-files` |
+| any code change | `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `python scripts/ai/check_doc_links.py`, `python scripts/ai/check_shell_scripts.py`, `python scripts/check_version_consistency.py`, `python scripts/check_versioning_design.py`, `python -m pre_commit run --all-files` |
 | `meta-home-monitor/**`, `config/**` | `bitbake -p` (skip if no Yocto SDK on host — note in PR) |
 | `docs/ai/**`, `AGENTS.md`, `CLAUDE.md`, `.github/copilot-*` | the full "any code change" row plus adapter-specific checks |
 | traceability files (REQ, RISK, SEC, TEST IDs touched) | `python tools/traceability/check_traceability.py` |

--- a/docs/ai/roles/tester.md
+++ b/docs/ai/roles/tester.md
@@ -13,7 +13,7 @@ and run the rows that apply:
 |---|---|
 | `app/server/**` | `pytest app/server/tests/ -v --cov=app/server --cov-fail-under=85`<br>`ruff check .`<br>`ruff format --check .` |
 | `app/camera/**` | `pytest app/camera/tests/ -v --cov=app/camera --cov-fail-under=80`<br>`ruff check .`<br>`ruff format --check .` |
-| Any code change / repo governance / docs | `python tools/docs/check_doc_map.py`<br>`python scripts/ai/validate_repo_ai_setup.py`<br>`python scripts/ai/check_doc_links.py`<br>`python scripts/ai/check_shell_scripts.py`<br>`python scripts/check_version_consistency.py`<br>`python scripts/check_versioning_design.py`<br>`pre-commit run --all-files` |
+| Any code change / repo governance / docs | `python tools/docs/check_doc_map.py`<br>`python scripts/ai/validate_repo_ai_setup.py`<br>`python scripts/ai/check_doc_links.py`<br>`python scripts/ai/check_shell_scripts.py`<br>`python scripts/check_version_consistency.py`<br>`python scripts/check_versioning_design.py`<br>`python -m pre_commit run --all-files` |
 | Traceability touched | `python tools/traceability/check_traceability.py` |
 | `meta-home-monitor/**`, `config/**` (Yocto) | `bitbake -p` |
 | `scripts/**`, `.github/workflows/**` | `bash -n <script>`, `shellcheck <script>` |
@@ -55,7 +55,7 @@ Closes #<id>
 - python scripts/ai/check_shell_scripts.py: PASS
 - python scripts/check_version_consistency.py: PASS
 - python scripts/check_versioning_design.py: PASS
-- pre-commit run --all-files: PASS
+- python -m pre_commit run --all-files: PASS
 - ruff check .: PASS
 - ruff format --check .: PASS
 - coverage: server <pct>% / camera <pct>%
@@ -79,7 +79,7 @@ Closes #<id>
 - Flaky test → still label `tests-failed`. Implementer triages on next
   pickup.
 
-Missing local tooling is not a pass. Install reasonable Python tools such as
+Missing local tooling is not a pass. Install reasonable Python packages such as
 `pre-commit`; otherwise mark the row as blocked and do not claim green.
 
 ## Don't suppress, don't lower thresholds, don't auto-merge

--- a/docs/ai/validation-and-release.md
+++ b/docs/ai/validation-and-release.md
@@ -4,7 +4,7 @@
 
 | Area touched | Required validation |
 |--------------|---------------------|
-| Repository governance, docs, adapters | `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `python scripts/ai/check_doc_links.py`, `python scripts/ai/check_shell_scripts.py`, `python scripts/check_version_consistency.py`, `python scripts/check_versioning_design.py`, `pre-commit run --all-files` |
+| Repository governance, docs, adapters | `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `python scripts/ai/check_doc_links.py`, `python scripts/ai/check_shell_scripts.py`, `python scripts/check_version_consistency.py`, `python scripts/check_versioning_design.py`, `python -m pre_commit run --all-files` |
 | Requirements, risk, security, traceability, annotated code | `python tools/traceability/check_traceability.py`, `python scripts/ai/check_doc_links.py`, relevant tests |
 | Server Python | `pytest app/server/tests/ -v`, `ruff check .`, `ruff format --check .` |
 | Camera Python | `pytest app/camera/tests/ -v`, `ruff check .`, `ruff format --check .` |
@@ -69,7 +69,7 @@ repo rules passed. At minimum, code changes must report:
 - `python scripts/ai/check_shell_scripts.py`
 - `python scripts/check_version_consistency.py`
 - `python scripts/check_versioning_design.py`
-- `pre-commit run --all-files`
+- `python -m pre_commit run --all-files`
 - `ruff check .`
 - `ruff format --check .`
 - the relevant server, camera, contract, security, coverage, Yocto, or hardware
@@ -77,8 +77,8 @@ repo rules passed. At minimum, code changes must report:
 
 If a required command cannot run on the host, the PR must state the exact
 command, the reason it could not run, and the follow-up environment needed. A
-missing local tool such as `pre-commit` is not a pass; install it or report the
-validation as blocked.
+missing local Python package such as `pre-commit` is not a pass; install it or
+report the validation as blocked.
 
 ## Branch Protection Recommendation
 

--- a/scripts/ai/build_instruction_files.py
+++ b/scripts/ai/build_instruction_files.py
@@ -57,7 +57,7 @@ def render_agents() -> str:
         - do not commit directly to `main`
 
         Key validation:
-        - repo governance: `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `pre-commit run --all-files`
+        - repo governance: `python tools/docs/check_doc_map.py`, `python scripts/ai/validate_repo_ai_setup.py`, `python -m pre_commit run --all-files`
         - server: `pytest app/server/tests/ -v`, `ruff check .`, `ruff format --check .`
         - camera: `pytest app/camera/tests/ -v`, `ruff check .`, `ruff format --check .`
         - Yocto: `bitbake -p` and VM build for affected images


### PR DESCRIPTION
## Summary
- Replace bare pre-commit CLI examples with python -m pre_commit so Windows Agentry/Codex runs use the installed Python module entrypoint.
- Regenerate AGENTS.md from the canonical adapter builder.
- Stabilize the time-health hysteresis unit test by pinning the timestamp to an exact second; this fixes the existing CI flake where ISO-second truncation could turn a 1.9s drift into 1.0s.

## Validation
- python -m pre_commit run --all-files: PASS
- python tools/docs/check_doc_map.py: PASS
- python scripts/ai/validate_repo_ai_setup.py: PASS
- python scripts/ai/check_doc_links.py: PASS
- python scripts/ai/check_shell_scripts.py: PASS
- python scripts/check_version_consistency.py: PASS
- python scripts/check_versioning_design.py: PASS
- ruff check .: PASS
- ruff format --check .: PASS
- git diff --check: PASS
- pytest app/server/tests/unit/test_time_health_service.py -v: PASS
- pytest app/server/tests/unit -n auto: PASS

## Notes
- Target repo validation/docs fix plus a deterministic test repair exposed by CI.