### PR TITLE
Pin Agentry body-file prompt fix

### DIFF
--- a/agentry/README.md
+++ b/agentry/README.md
@@ -39,6 +39,9 @@ feature branches from `origin/feature/<id>-<slug>` before rebasing. This keeps
 stale role worktrees from reporting false merge conflicts after a supervisor or
 agent force-with-lease push.
 
+The standard Tester prompt opens pull requests with `gh pr create --body-file`
+so multi-line validation evidence does not depend on shell quoting behavior.
+
 ## Machine Setup
 
 Run once per machine:
@@ -96,9 +99,10 @@ new autonomous issue discovery or release automation.
 instead of pinning a dated Claude model unless a rollback is intentional.
 
 The start scripts currently pin Agentry to
-`f8da18a92e6fbbc87e77c56164f24e1317bb66c4`, which includes the reviewer
-comment workflow and the stream-json watchdog fix for active Claude Code tool
-activity during check-ins.
+`e7c8c9c18b9464b819549cea495c340532545ecb`, which includes the reviewer
+comment workflow, the stream-json watchdog fix for active Claude Code tool
+activity during check-ins, branch-reset hardening, and Tester PR body-file
+creation.
 
 ## Start
 

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -31,7 +31,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = '5e3e66b88d9ea1a404c975fdefdbac221348ecf1'
+$AgentryRef = 'e7c8c9c18b9464b819549cea495c340532545ecb'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 # Locate Python.

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-5e3e66b88d9ea1a404c975fdefdbac221348ecf1}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-e7c8c9c18b9464b819549cea495c340532545ecb}"
 
 # Locate Python.
 PYTHON=""


### PR DESCRIPTION
## Summary
- updates the repo-local Agentry start scripts to pin platform commit `e7c8c9c18b9464b819549cea495c340532545ecb`
- documents that this pin includes Tester PR body-file creation for robust multi-line PR descriptions

## Platform source
- vinu-dev/agentry#23
- Merged platform commit: `e7c8c9c18b9464b819549cea495c340532545ecb`

## Validation
- `python tools/docs/check_doc_map.py`: PASS
- `python scripts/ai/check_doc_links.py`: PASS
- `python scripts/ai/check_shell_scripts.py`: PASS
- `git diff --check`: PASS
- `python -m pre_commit run --all-files`: PASS

## Runtime note
I did not reinstall the active Agentry venv while the scheduler was running. The new pin is ready for the next intentional restart/install.
