### PR TITLE
fix: make Agentry wrapper checks safe while running

### DIFF
--- a/agentry/README.md
+++ b/agentry/README.md
@@ -99,10 +99,13 @@ new autonomous issue discovery or release automation.
 instead of pinning a dated Claude model unless a rollback is intentional.
 
 The start scripts currently pin Agentry to
-`e7c8c9c18b9464b819549cea495c340532545ecb`, which includes the reviewer
+`79714f02dd0de8b94817ae4b676791cb5bd3b0d5`, which includes the reviewer
 comment workflow, the stream-json watchdog fix for active Claude Code tool
 activity during check-ins, branch-reset hardening, and Tester PR body-file
-creation.
+creation, plus safe wrapper subcommands. Wrapper subcommands such as `status`,
+`doctor`, `configure`, and `gui` reuse an existing venv instead of
+force-reinstalling only because the local install-ref marker is missing or
+stale, so health checks are safe while Agentry is live.
 
 ## Start
 
@@ -136,12 +139,13 @@ so a visible PID means there is still an active role process to inspect or stop.
 ## Upgrade
 
 The start scripts install Agentry from the Git ref pinned in the script. To
-upgrade intentionally, update that ref or set `AGENTRY_INSTALL_REF`, delete
-`.venv/`, and rerun the start script.
+upgrade intentionally, update that ref or set `AGENTRY_INSTALL_REF`, stop any
+running Agentry process that uses this venv, and rerun the wrapper with
+`AGENTRY_FORCE_INSTALL=1`. If the venv is already corrupted, delete `.venv/`
+and rerun the start script.
 
-On Windows, stop any running Agentry process before changing the pin. The venv
-cannot replace `agentry\.venv\Scripts\agentry.exe` while an old supervisor is
-still using it.
+On Windows, the venv cannot replace `agentry\.venv\Scripts\agentry.exe` while
+an old supervisor is still using it.
 
 ## Remove
 

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -31,8 +31,10 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = 'e7c8c9c18b9464b819549cea495c340532545ecb'
+$AgentryRef = '79714f02dd0de8b94817ae4b676791cb5bd3b0d5'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
+$AgentryExe = Join-Path $Venv 'Scripts\agentry.exe'
+$ForceInstall = $env:AGENTRY_FORCE_INSTALL -in @('1', 'true', 'TRUE', 'yes', 'YES')
 
 # Locate Python.
 $python = $null
@@ -63,17 +65,21 @@ if (Test-Path $InstallRefFile) {
     $InstalledRef = (Get-Content $InstallRefFile -Raw).Trim()
 }
 if ($InstalledRef -ne $AgentryRef) {
-    Write-Host "==> Installing agentry from GitHub at $AgentryRef" -ForegroundColor Cyan
-    & (Join-Path $Venv 'Scripts\python.exe') -m pip install --upgrade --force-reinstall "git+$AgentryRepo@$AgentryRef"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "agentry install failed" -ForegroundColor Red
-        exit 1
+    if (($AgentryArgs.Count -gt 0) -and (Test-Path $AgentryExe) -and (-not $ForceInstall)) {
+        Write-Host "==> Agentry install ref is missing or different; using existing venv for this CLI command." -ForegroundColor Yellow
+        Write-Host "==> Stop Agentry and set AGENTRY_FORCE_INSTALL=1 to refresh the venv to $AgentryRef." -ForegroundColor Yellow
+    } else {
+        Write-Host "==> Installing agentry from GitHub at $AgentryRef" -ForegroundColor Cyan
+        & (Join-Path $Venv 'Scripts\python.exe') -m pip install --upgrade --force-reinstall "git+$AgentryRepo@$AgentryRef"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "agentry install failed" -ForegroundColor Red
+            exit 1
+        }
+        Set-Content -Path $InstallRefFile -Value $AgentryRef -Encoding ASCII
+        Write-Host "==> Agentry install complete" -ForegroundColor Green
     }
-    Set-Content -Path $InstallRefFile -Value $AgentryRef -Encoding ASCII
-    Write-Host "==> Agentry install complete" -ForegroundColor Green
 }
 
-$AgentryExe = Join-Path $Venv 'Scripts\agentry.exe'
 if (-not (Test-Path $AgentryExe)) {
     Write-Host "agentry binary not found at $AgentryExe - venv may be corrupted" -ForegroundColor Red
     Write-Host "Delete agentry\.venv and re-run this script." -ForegroundColor Yellow

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,9 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-e7c8c9c18b9464b819549cea495c340532545ecb}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-79714f02dd0de8b94817ae4b676791cb5bd3b0d5}"
+AGENTRY_BIN="$VENV/bin/agentry"
+FORCE_INSTALL="${AGENTRY_FORCE_INSTALL:-}"
 
 # Locate Python.
 PYTHON=""
@@ -44,14 +46,19 @@ if [[ -f "$INSTALL_REF_FILE" ]]; then
     INSTALLED_REF="$(tr -d '[:space:]' < "$INSTALL_REF_FILE")"
 fi
 if [[ "$INSTALLED_REF" != "$AGENTRY_REF" ]]; then
-    echo "==> Installing agentry from GitHub at $AGENTRY_REF"
-    "$VENV/bin/python" -m pip install --upgrade --force-reinstall "git+$AGENTRY_REPO@$AGENTRY_REF"
-    printf '%s\n' "$AGENTRY_REF" > "$INSTALL_REF_FILE"
-    echo "==> Agentry install complete"
+    if [[ "$#" -gt 0 && -x "$AGENTRY_BIN" && "$FORCE_INSTALL" != "1" && "$FORCE_INSTALL" != "true" && "$FORCE_INSTALL" != "TRUE" && "$FORCE_INSTALL" != "yes" && "$FORCE_INSTALL" != "YES" ]]; then
+        echo "==> Agentry install ref is missing or different; using existing venv for this CLI command."
+        echo "==> Stop Agentry and set AGENTRY_FORCE_INSTALL=1 to refresh the venv to $AGENTRY_REF."
+    else
+        echo "==> Installing agentry from GitHub at $AGENTRY_REF"
+        "$VENV/bin/python" -m pip install --upgrade --force-reinstall "git+$AGENTRY_REPO@$AGENTRY_REF"
+        printf '%s\n' "$AGENTRY_REF" > "$INSTALL_REF_FILE"
+        echo "==> Agentry install complete"
+    fi
 fi
 
-if [[ ! -x "$VENV/bin/agentry" ]]; then
-    echo "agentry binary not found at $VENV/bin/agentry - venv may be corrupted"
+if [[ ! -x "$AGENTRY_BIN" ]]; then
+    echo "agentry binary not found at $AGENTRY_BIN - venv may be corrupted"
     echo "Delete agentry/.venv and re-run this script."
     exit 1
 fi
@@ -59,9 +66,9 @@ fi
 echo "==> Starting agentry against $TARGET_ROOT"
 if [[ "$#" -gt 0 ]]; then
     echo "==> Running agentry $*"
-    exec "$VENV/bin/agentry" "$@"
+    exec "$AGENTRY_BIN" "$@"
 fi
 
 echo "==> Running doctor"
-"$VENV/bin/agentry" doctor --target "$TARGET_ROOT"
-exec "$VENV/bin/agentry" start --target "$TARGET_ROOT"
+"$AGENTRY_BIN" doctor --target "$TARGET_ROOT"
+exec "$AGENTRY_BIN" start --target "$TARGET_ROOT"


### PR DESCRIPTION
## Summary
- prevent start.ps1/start.sh wrapper subcommands from force-reinstalling Agentry into an existing venv just because the install-ref marker is missing or stale
- update target Agentry pin to vinu-dev/agentry@79714f02dd0de8b94817ae4b676791cb5bd3b0d5
- document the safe status/doctor behavior and explicit AGENTRY_FORCE_INSTALL=1 refresh path

## Validation
- PowerShell parser check for agentry/start.ps1
- bash -n agentry/start.sh
- python tools/docs/check_doc_map.py
- python scripts/ai/validate_repo_ai_setup.py
- python -m pre_commit run --all-files