### PR TITLE
[113] Enhancement: Split camera human-admin surface from machine control surface

### DIFF
--- a/app/camera/camera_streamer/control.py
+++ b/app/camera/camera_streamer/control.py
@@ -2,8 +2,10 @@
 Camera control API handler — processes configuration commands from the server.
 
 The server pushes stream parameter changes via HTTPS to this handler.
-Authentication is via mTLS (server presents its certificate signed by
-the same CA used during pairing). See ADR-0015.
+Issue #113 split the machine-control listener onto its own mTLS-only
+HTTPS port, but this class remains the single business-logic owner for
+control operations. Authentication is via mTLS (server presents its
+certificate signed by the same CA used during pairing). See ADR-0015.
 
 Controllable parameters (all require stream pipeline restart):
   width, height, fps, bitrate, h264_profile, keyframe_interval,

--- a/app/camera/camera_streamer/control_server.py
+++ b/app/camera/camera_streamer/control_server.py
@@ -1,0 +1,218 @@
+# REQ: SWR-013, SWR-039; RISK: RISK-002, RISK-007; SEC: SC-001, SC-002; TEST: TC-004, TC-037
+"""
+Dedicated HTTPS listener for the camera's server-only control API.
+
+Issue #113 splits machine control off the human-admin listener so the
+control plane can require mTLS at the TLS layer without affecting
+browser compatibility on port 443.
+"""
+
+import http.server
+import json
+import logging
+import os
+import ssl
+import threading
+
+from camera_streamer import status_server as status_server_module
+from camera_streamer.control import parse_control_request
+
+log = logging.getLogger("camera-streamer.control-server")
+
+CONTROL_LISTEN_PORT = 8443
+CONTROL_API_PREFIX = "/api/v1/control/"
+CONTROL_ROUTE_MATRIX = {
+    "GET": frozenset(
+        {
+            "/api/v1/control/config",
+            "/api/v1/control/capabilities",
+            "/api/v1/control/status",
+            "/api/v1/control/stream/state",
+        }
+    ),
+    "PUT": frozenset({"/api/v1/control/config"}),
+    "POST": frozenset(
+        {
+            "/api/v1/control/restart-stream",
+            "/api/v1/control/stream/start",
+            "/api/v1/control/stream/stop",
+        }
+    ),
+}
+
+
+def _control_ca_path(config):
+    """Return the CA bundle used to verify the paired server certificate."""
+    return os.path.join(config.certs_dir, "ca.crt")
+
+
+def _wrap_https_server(server, config):
+    """Wrap the control server socket with mTLS-required TLS."""
+    cert_path, key_path = status_server_module._ensure_tls_material(config)
+    ca_path = _control_ca_path(config)
+    if not os.path.isfile(ca_path):
+        raise FileNotFoundError(f"missing control-listener CA bundle: {ca_path}")
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(cert_path, key_path)
+    ctx.check_hostname = False
+    ctx.load_verify_locations(ca_path)
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    return server
+
+
+class CameraControlServer:
+    """Dedicated HTTPS listener for `/api/v1/control/*` routes."""
+
+    def __init__(self, config, control_handler, stream_manager=None):
+        if control_handler is None:
+            raise ValueError("control_handler is required")
+        self._config = config
+        self._control = control_handler
+        self._stream = stream_manager
+        self._server = None
+        self._thread = None
+
+    def start(self):
+        """Start the mTLS-only control listener when pairing material exists."""
+        ca_path = _control_ca_path(self._config)
+        if not os.path.isfile(ca_path):
+            log.info("Control listener disabled until pairing (missing %s)", ca_path)
+            return False
+
+        handler = _make_control_handler(self._control, self._stream)
+        server = None
+        try:
+            server = http.server.HTTPServer(("0.0.0.0", CONTROL_LISTEN_PORT), handler)
+            self._server = _wrap_https_server(server, self._config)
+            self._thread = threading.Thread(
+                target=self._server.serve_forever,
+                daemon=True,
+                name="control-https",
+            )
+            self._thread.start()
+            log.info("Control server listening on HTTPS port %d", CONTROL_LISTEN_PORT)
+            return True
+        except Exception as exc:
+            if server is not None:
+                try:
+                    server.server_close()
+                except OSError:
+                    pass
+            self._server = None
+            self._thread = None
+            log.error("Failed to start control server: %s", exc)
+            return False
+
+    def stop(self):
+        """Stop the control HTTPS server."""
+        if self._server:
+            if self._thread and self._thread.is_alive():
+                self._server.shutdown()
+                self._thread.join(timeout=5)
+            self._server.server_close()
+            self._server = None
+            self._thread = None
+            log.info("Control server stopped")
+
+
+def _make_control_handler(control_handler, stream_manager):
+    """Create the HTTP adapter for the mTLS-only control API."""
+
+    class ControlRequestHandler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            log.debug("Control HTTPS: " + format % args)
+
+        def _has_mtls_client_cert(self):
+            """Return True when the peer presented a validated client cert."""
+            try:
+                peer_cert = self.request.getpeercert()
+            except (AttributeError, ValueError):
+                return False
+            return bool(peer_cert)
+
+        def _require_mtls(self):
+            """Keep an application-layer guard in addition to CERT_REQUIRED."""
+            if self._has_mtls_client_cert():
+                return True
+            self._json_response({"error": "Client certificate required"}, 401)
+            return False
+
+        def _json_response(self, data, code=200):
+            body = json.dumps(data).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if not self._require_mtls():
+                return
+
+            if self.path == "/api/v1/control/config":
+                self._json_response(control_handler.get_config())
+                return
+            if self.path == "/api/v1/control/capabilities":
+                self._json_response(control_handler.get_capabilities())
+                return
+            if self.path == "/api/v1/control/status":
+                self._json_response(control_handler.get_status())
+                return
+            if self.path == "/api/v1/control/stream/state":
+                self._json_response(control_handler.get_stream_state())
+                return
+
+            self.send_error(404)
+
+        def do_PUT(self):
+            if not self._require_mtls():
+                return
+
+            content_len = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_len) if content_len > 0 else b""
+
+            if self.path == "/api/v1/control/config":
+                params, request_id, err = parse_control_request(body)
+                if err:
+                    self._json_response({"error": err}, 400)
+                    return
+                result, error, status = control_handler.set_config(params, request_id)
+                if error:
+                    self._json_response({"error": error}, status)
+                else:
+                    self._json_response(result, status)
+                return
+
+            self.send_error(404)
+
+        def do_POST(self):
+            if not self._require_mtls():
+                return
+
+            if self.path == "/api/v1/control/restart-stream":
+                if stream_manager:
+                    ok = stream_manager.restart()
+                    self._json_response({"restarted": ok, "status": "ok"})
+                else:
+                    self._json_response({"error": "Stream manager not available"}, 503)
+                return
+            if self.path == "/api/v1/control/stream/start":
+                result, error, status = control_handler.set_stream_state("running")
+                if error:
+                    self._json_response({"error": error}, status)
+                else:
+                    self._json_response(result, status)
+                return
+            if self.path == "/api/v1/control/stream/stop":
+                result, error, status = control_handler.set_stream_state("stopped")
+                if error:
+                    self._json_response({"error": error}, status)
+                else:
+                    self._json_response(result, status)
+                return
+
+            self.send_error(404)
+
+    return ControlRequestHandler

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -29,7 +29,12 @@ import urllib.request
 
 from camera_streamer import led
 from camera_streamer.capture import CaptureManager
-from camera_streamer.control import DEFAULT_STREAM_STATE_PATH, VALID_STREAM_STATES
+from camera_streamer.control import (
+    DEFAULT_STREAM_STATE_PATH,
+    VALID_STREAM_STATES,
+    ControlHandler,
+)
+from camera_streamer.control_server import CameraControlServer
 from camera_streamer.discovery import DiscoveryService
 from camera_streamer.faults import (
     FAULT_NETWORK_MDNS_RESOLUTION_FAILED,
@@ -261,11 +266,13 @@ class CameraLifecycle:
         self._discovery = None
         self._stream = None
         self._status_server = None
+        self._control_server = None
         self._health = None
         self._heartbeat = None
         self._setup_server = None
         self._ota_agent = None
         self._pairing = PairingManager(config)
+        self._control_handler = None
         # Background server-name resolver (#199). Replaces the previous
         # one-shot ``gethostbyname`` warning. Started in ``_do_running``
         # once the CaptureManager exists (the resolver injects faults
@@ -320,6 +327,8 @@ class CameraLifecycle:
             self._ota_agent.stop()
         if self._stream:
             self._stream.stop()
+        if self._control_server:
+            self._control_server.stop()
         if self._status_server:
             self._status_server.stop()
         if self._discovery:
@@ -511,20 +520,34 @@ class CameraLifecycle:
                 desired,
             )
 
+        self._control_handler = ControlHandler(
+            self._config,
+            self._stream,
+            stream_state_path=self._stream_state_path,
+        )
+
         # Status HTTPS server (port 443)
         self._status_server = CameraStatusServer(
             self._config,
             self._stream,
+            control_handler=self._control_handler,
             wifi_interface=self._platform.wifi_interface,
             thermal_path=self._platform.thermal_path,
             pairing_manager=self._pairing,
-            stream_state_path=self._stream_state_path,
             # Capture manager flows into /api/status so the camera's
             # own status page can show a "no camera module detected"
             # banner. Set by _do_validating (the state before us).
             capture_manager=self._capture,
         )
         self._status_server.start()
+
+        # Dedicated control HTTPS listener (port 8443, mTLS required)
+        self._control_server = CameraControlServer(
+            self._config,
+            control_handler=self._control_handler,
+            stream_manager=self._stream,
+        )
+        self._control_server.start()
 
         # OTA update agent (port 8080)
         self._ota_agent = OTAAgent(self._config)
@@ -544,7 +567,7 @@ class CameraLifecycle:
             thermal_path=self._platform.thermal_path,
             vcgencmd_path=vcgencmd_path,
             throttle_path=throttle_path,
-            control_handler=self._status_server.control_handler,
+            control_handler=self._control_handler,
             # Surface hardware faults ("no camera module detected")
             # to the server so the dashboard can show the user.
             capture_manager=self._capture,

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -20,7 +20,7 @@ import threading
 import time
 
 from camera_streamer import ota_installer, wifi
-from camera_streamer.control import ControlHandler, parse_control_request
+from camera_streamer.control import parse_control_request
 from camera_streamer.factory_reset import FactoryResetService
 from camera_streamer.server_notifier import notify_config_change
 
@@ -34,6 +34,46 @@ LISTEN_PORT = 443
 SESSION_TIMEOUT = 7200  # 2 hours
 TLS_CERT_NAME = "status.crt"
 TLS_KEY_NAME = "status.key"
+CONTROL_API_PREFIX = "/api/v1/control/"
+STATUS_ROUTE_MATRIX = {
+    "HEAD": frozenset(
+        {
+            "/login",
+            "/logout",
+            "/pair",
+            "/",
+            "/status",
+            "/api/status",
+            "/api/networks",
+        }
+    ),
+    "GET": frozenset(
+        {
+            "/login",
+            "/logout",
+            "/pair",
+            "/",
+            "/status",
+            "/api/status",
+            "/api/networks",
+            "/api/ota/status",
+        }
+    ),
+    "PUT": frozenset({"/api/stream-config"}),
+    "POST": frozenset(
+        {
+            "/api/ota/upload",
+            "/api/ota/reboot",
+            "/login",
+            "/pair",
+            "/api/pair",
+            "/api/wifi",
+            "/api/factory-reset",
+            "/api/unpair",
+            "/api/password",
+        }
+    ),
+}
 
 # ---- Session store (in-memory) ----
 _sessions = {}
@@ -177,46 +217,13 @@ def _ensure_tls_material(config):
 
 
 def _wrap_https_server(server, config):
-    """Wrap the status server socket with TLS.
-
-    Uses ``CERT_OPTIONAL`` so browsers (Chrome/Edge) that don't have a
-    client cert can still reach the human-facing login + status pages,
-    while machine-facing ``/api/v1/control/*`` requests that DO present
-    a client cert have it validated against the paired CA. The control
-    handler itself (``_require_mtls``) then enforces the presence + CA
-    signature — no cert, no call. See ADR-0022 + issue #112.
-
-    Prior behaviour was CERT_NONE with ``_require_mtls`` falling back to
-    a source-IP check against ``config.server_ip``. That let anyone on
-    the same LAN who could spoof / inherit the server IP call machine
-    endpoints. Now the peer must hold a CA-signed client cert.
-    """
+    """Wrap the human-admin status server socket with browser-friendly TLS."""
     # REQ: SWR-013; RISK: RISK-002; SEC: SC-001; TEST: TC-004
     cert_path, key_path = _ensure_tls_material(config)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(cert_path, key_path)
     ctx.check_hostname = False
-
-    ca_path = os.path.join(config.certs_dir, "ca.crt")
-    if os.path.isfile(ca_path):
-        ctx.load_verify_locations(ca_path)
-        # CERT_OPTIONAL: ask for a client cert. If the peer sends one,
-        # the TLS layer validates it against ca.crt before the HTTP
-        # handler runs. If the peer sends nothing, the connection still
-        # completes (browsers need this) and the HTTP handler decides
-        # whether to allow the call based on the path.
-        ctx.verify_mode = ssl.CERT_OPTIONAL
-        log.info("TLS client-cert validation enabled (CA: %s)", ca_path)
-    else:
-        # Pre-pairing bring-up: no CA yet. The status server runs over
-        # plain TLS; control endpoints stay locked because no peer can
-        # present a CA-signed cert.
-        ctx.verify_mode = ssl.CERT_NONE
-        log.warning(
-            "CA not present at %s — control-endpoint mTLS cannot be enforced "
-            "until the camera is paired",
-            ca_path,
-        )
+    ctx.verify_mode = ssl.CERT_NONE
 
     server.socket = ctx.wrap_socket(server.socket, server_side=True)
     return server
@@ -323,6 +330,7 @@ class CameraStatusServer:
         self,
         config,
         stream_manager=None,
+        control_handler=None,
         wifi_interface="wlan0",
         thermal_path=None,
         pairing_manager=None,
@@ -338,20 +346,14 @@ class CameraStatusServer:
         # ``hardware_ok`` + ``hardware_error`` so the camera's own
         # status page can show a "no camera module detected" banner.
         self._capture = capture_manager
-        # Let ControlHandler pick the default path when caller didn't override
-        # so tests and production share the same default (ADR-0017).
-        if stream_state_path is None:
-            self._control = ControlHandler(config, stream_manager)
-        else:
-            self._control = ControlHandler(
-                config, stream_manager, stream_state_path=stream_state_path
-            )
+        _ = stream_state_path  # Retained for source-level compatibility.
+        self._control = control_handler
         self._server = None
         self._thread = None
 
     @property
     def control_handler(self):
-        """Return the internal ControlHandler (for lifecycle wiring)."""
+        """Return the injected local stream-config service, if available."""
         return self._control
 
     def start(self):
@@ -498,31 +500,10 @@ def _make_status_handler(
         def log_message(self, format, *args):
             log.debug("Status HTTPS: " + format % args)
 
-        def _has_mtls_client_cert(self):
-            """True iff the peer presented a client cert validated by OpenSSL.
-
-            The TLS layer (``CERT_OPTIONAL`` + ``load_verify_locations``)
-            already validated any cert the peer sent against the paired
-            CA before the HTTP handler runs — so ``getpeercert()``
-            returning a non-empty dict is proof of valid CA signature.
-            No peer cert → dict is empty → False. Issue #112 / #119.
-            Source-IP fallback was removed: a LAN attacker who could
-            spoof ``config.server_ip`` could previously bypass auth.
-            """
-            try:
-                peer_cert = self.request.getpeercert()
-            except (AttributeError, ValueError):
-                return False
-            return bool(peer_cert)
-
-        def _require_mtls(self):
-            """Require mTLS client certificate for control API endpoints."""
-            if self._has_mtls_client_cert():
-                return True
-            self._json_response({"error": "Client certificate required"}, 401)
-            return False
-
         def do_HEAD(self):
+            if self.path.startswith(CONTROL_API_PREFIX):
+                self.send_error(404)
+                return
             if self.path == "/login":
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html")
@@ -560,7 +541,7 @@ def _make_status_handler(
             return _check_session(token)
 
         def _require_auth(self):
-            """Require session auth OR mTLS for non-control API paths."""
+            """Require a valid browser session for protected human/admin paths."""
             if self._is_authenticated():
                 return True
             if self.path.startswith("/api/"):
@@ -572,26 +553,8 @@ def _make_status_handler(
             return False
 
         def do_GET(self):
-            # Control API — mTLS auth
-            if self.path == "/api/v1/control/config":
-                if not self._require_mtls():
-                    return
-                self._json_response(control_handler.get_config())
-                return
-            if self.path == "/api/v1/control/capabilities":
-                if not self._require_mtls():
-                    return
-                self._json_response(control_handler.get_capabilities())
-                return
-            if self.path == "/api/v1/control/status":
-                if not self._require_mtls():
-                    return
-                self._json_response(control_handler.get_status())
-                return
-            if self.path == "/api/v1/control/stream/state":
-                if not self._require_mtls():
-                    return
-                self._json_response(control_handler.get_stream_state())
+            if self.path.startswith(CONTROL_API_PREFIX):
+                self.send_error(404)
                 return
 
             if self.path == "/login":
@@ -632,20 +595,17 @@ def _make_status_handler(
             content_len = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(content_len) if content_len > 0 else b""
 
-            if self.path == "/api/v1/control/config":
-                if not self._require_mtls():
-                    return
-                params, request_id, err = parse_control_request(body)
-                if err:
-                    self._json_response({"error": err}, 400)
-                    return
-                result, error, status = control_handler.set_config(params, request_id)
-                if error:
-                    self._json_response({"error": error}, status)
-                else:
-                    self._json_response(result, status)
-            elif self.path == "/api/stream-config":
+            if self.path.startswith(CONTROL_API_PREFIX):
+                self.send_error(404)
+                return
+
+            if self.path == "/api/stream-config":
                 if not self._require_auth():
+                    return
+                if control_handler is None:
+                    self._json_response(
+                        {"error": "Local stream control unavailable"}, 503
+                    )
                     return
                 params, _, err = parse_control_request(body)
                 if err:
@@ -693,35 +653,8 @@ def _make_status_handler(
             content_len = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(content_len) if content_len > 0 else b""
 
-            # Control API — restart stream
-            if self.path == "/api/v1/control/restart-stream":
-                if not self._require_mtls():
-                    return
-                if stream_manager:
-                    ok = stream_manager.restart()
-                    self._json_response({"restarted": ok, "status": "ok"})
-                else:
-                    self._json_response({"error": "Stream manager not available"}, 503)
-                return
-
-            # Control API — on-demand stream start/stop (ADR-0017)
-            if self.path == "/api/v1/control/stream/start":
-                if not self._require_mtls():
-                    return
-                result, error, status = control_handler.set_stream_state("running")
-                if error:
-                    self._json_response({"error": error}, status)
-                else:
-                    self._json_response(result, status)
-                return
-            if self.path == "/api/v1/control/stream/stop":
-                if not self._require_mtls():
-                    return
-                result, error, status = control_handler.set_stream_state("stopped")
-                if error:
-                    self._json_response({"error": error}, status)
-                else:
-                    self._json_response(result, status)
+            if self.path.startswith(CONTROL_API_PREFIX):
+                self.send_error(404)
                 return
 
             if self.path == "/login":

--- a/app/camera/config/nftables-camera.conf
+++ b/app/camera/config/nftables-camera.conf
@@ -25,6 +25,12 @@ table inet filter {
         # OTA update endpoint from server only
         tcp dport 8080 ip saddr @server_ip accept
 
+        # Human-admin HTTPS surface
+        tcp dport 443 accept
+
+        # Server-only control API
+        tcp dport 8443 ip saddr @server_ip accept
+
         # mDNS (discovery)
         udp dport 5353 accept
 

--- a/app/camera/tests/contracts/test_api_contracts.py
+++ b/app/camera/tests/contracts/test_api_contracts.py
@@ -21,6 +21,8 @@ from urllib.request import Request, urlopen
 import pytest
 
 from camera_streamer.config import ConfigManager
+from camera_streamer.control import ControlHandler
+from camera_streamer.sensor_info import capabilities_for_testing
 from camera_streamer.status_server import CameraStatusServer
 from camera_streamer.wifi_setup import WifiSetupServer
 
@@ -170,6 +172,14 @@ def _head(path, scheme="http"):
         kwargs["context"] = TLS_CONTEXT
     with urlopen(req, **kwargs) as resp:
         return resp.status
+
+
+def _make_control_handler(config):
+    return ControlHandler(
+        config,
+        None,
+        sensor_capabilities=capabilities_for_testing("ov5647"),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -567,7 +577,10 @@ class TestStatusServerStreamConfigContract:
 
     def test_requires_auth(self, noauth_config):
         """Without password, /api/stream-config works without auth."""
-        server = CameraStatusServer(noauth_config)
+        server = CameraStatusServer(
+            noauth_config,
+            control_handler=_make_control_handler(noauth_config),
+        )
         server.start()
         try:
             data, status = _json_put(
@@ -581,7 +594,10 @@ class TestStatusServerStreamConfigContract:
 
     def test_error_on_invalid_param(self, noauth_config):
         """Invalid param returns {error}."""
-        server = CameraStatusServer(noauth_config)
+        server = CameraStatusServer(
+            noauth_config,
+            control_handler=_make_control_handler(noauth_config),
+        )
         server.start()
         try:
             data, status = _json_put(

--- a/app/camera/tests/integration/test_lifecycle.py
+++ b/app/camera/tests/integration/test_lifecycle.py
@@ -226,6 +226,36 @@ class TestPairingRegistration:
         assert request.full_url == "https://rpi-divinu.local/api/v1/pair/register"
 
 
+class TestPairingListenerWiring:
+    """PAIRING state should expose only the human listener."""
+
+    @patch("camera_streamer.lifecycle.CameraControlServer")
+    @patch("camera_streamer.lifecycle.CameraStatusServer")
+    @patch("camera_streamer.lifecycle.time.sleep")
+    @patch("camera_streamer.lifecycle.led")
+    def test_pairing_only_starts_status_listener(
+        self, mock_led, mock_sleep, MockStatus, MockControlServer
+    ):
+        config = _make_config()
+        platform = _make_platform()
+
+        shutdown_calls = [0]
+
+        def shutdown():
+            shutdown_calls[0] += 1
+            return shutdown_calls[0] > 1
+
+        lc = CameraLifecycle(config, platform, shutdown)
+        lc._pairing = MagicMock()
+        lc._pairing.is_paired = False
+
+        result = lc._do_pairing()
+
+        assert result is False
+        MockStatus.return_value.start.assert_called_once()
+        MockControlServer.assert_not_called()
+
+
 class TestValidating:
     """Test VALIDATING state — camera hardware check."""
 
@@ -267,14 +297,18 @@ class TestRunning:
 
     @patch("camera_streamer.lifecycle.led")
     @patch("camera_streamer.lifecycle.HealthMonitor")
+    @patch("camera_streamer.lifecycle.CameraControlServer")
     @patch("camera_streamer.lifecycle.CameraStatusServer")
+    @patch("camera_streamer.lifecycle.ControlHandler")
     @patch("camera_streamer.lifecycle.StreamManager")
     @patch("camera_streamer.lifecycle.DiscoveryService")
     def test_starts_all_services(
         self,
         MockDiscovery,
         MockStream,
+        MockControlHandler,
         MockStatus,
+        MockControlServer,
         MockHealth,
         mock_led,
         tmp_path,
@@ -302,17 +336,28 @@ class TestRunning:
         assert result is True
         MockDiscovery.return_value.start.assert_called_once()
         MockStream.return_value.start.assert_called_once()
+        MockControlHandler.assert_called_once()
         MockStatus.return_value.start.assert_called_once()
+        MockControlServer.return_value.start.assert_called_once()
         MockHealth.return_value.start.assert_called_once()
         mock_led.connected.assert_called_once()
 
     @patch("camera_streamer.lifecycle.led")
     @patch("camera_streamer.lifecycle.HealthMonitor")
+    @patch("camera_streamer.lifecycle.CameraControlServer")
     @patch("camera_streamer.lifecycle.CameraStatusServer")
+    @patch("camera_streamer.lifecycle.ControlHandler")
     @patch("camera_streamer.lifecycle.StreamManager")
     @patch("camera_streamer.lifecycle.DiscoveryService")
     def test_skips_streaming_when_unconfigured(
-        self, MockDiscovery, MockStream, MockStatus, MockHealth, mock_led
+        self,
+        MockDiscovery,
+        MockStream,
+        MockControlHandler,
+        MockStatus,
+        MockControlServer,
+        MockHealth,
+        mock_led,
     ):
         config = _make_config(is_configured=False)
         platform = _make_platform()
@@ -323,18 +368,24 @@ class TestRunning:
         lc._do_running()
 
         MockStream.return_value.start.assert_not_called()
+        MockControlHandler.assert_called_once()
+        MockControlServer.return_value.start.assert_called_once()
 
     @patch("camera_streamer.lifecycle._ServerResolver")
     @patch("camera_streamer.lifecycle.led")
     @patch("camera_streamer.lifecycle.HealthMonitor")
+    @patch("camera_streamer.lifecycle.CameraControlServer")
     @patch("camera_streamer.lifecycle.CameraStatusServer")
+    @patch("camera_streamer.lifecycle.ControlHandler")
     @patch("camera_streamer.lifecycle.StreamManager")
     @patch("camera_streamer.lifecycle.DiscoveryService")
     def test_starts_server_resolver(
         self,
         MockDiscovery,
         MockStream,
+        MockControlHandler,
         MockStatus,
+        MockControlServer,
         MockHealth,
         mock_led,
         MockResolver,
@@ -358,14 +409,18 @@ class TestRunning:
     @patch("camera_streamer.lifecycle._ServerResolver")
     @patch("camera_streamer.lifecycle.led")
     @patch("camera_streamer.lifecycle.HealthMonitor")
+    @patch("camera_streamer.lifecycle.CameraControlServer")
     @patch("camera_streamer.lifecycle.CameraStatusServer")
+    @patch("camera_streamer.lifecycle.ControlHandler")
     @patch("camera_streamer.lifecycle.StreamManager")
     @patch("camera_streamer.lifecycle.DiscoveryService")
     def test_does_not_start_resolver_when_unconfigured(
         self,
         MockDiscovery,
         MockStream,
+        MockControlHandler,
         MockStatus,
+        MockControlServer,
         MockHealth,
         mock_led,
         MockResolver,
@@ -383,14 +438,18 @@ class TestRunning:
 
     @patch("camera_streamer.lifecycle.led")
     @patch("camera_streamer.lifecycle.HealthMonitor")
+    @patch("camera_streamer.lifecycle.CameraControlServer")
     @patch("camera_streamer.lifecycle.CameraStatusServer")
+    @patch("camera_streamer.lifecycle.ControlHandler")
     @patch("camera_streamer.lifecycle.StreamManager")
     @patch("camera_streamer.lifecycle.DiscoveryService")
     def test_skips_streaming_when_desired_state_stopped(
         self,
         MockDiscovery,
         MockStream,
+        MockControlHandler,
         MockStatus,
+        MockControlServer,
         MockHealth,
         mock_led,
         tmp_path,
@@ -426,6 +485,7 @@ class TestShutdown:
 
         lc._health = MagicMock()
         lc._stream = MagicMock()
+        lc._control_server = MagicMock()
         lc._status_server = MagicMock()
         lc._discovery = MagicMock()
         # The boot-time server-name resolver (#199) joins on shutdown
@@ -438,9 +498,25 @@ class TestShutdown:
         assert lc.state == State.SHUTDOWN
         lc._health.stop.assert_called_once()
         lc._stream.stop.assert_called_once()
+        lc._control_server.stop.assert_called_once()
         lc._status_server.stop.assert_called_once()
         lc._discovery.stop.assert_called_once()
         lc._server_resolver.stop.assert_called_once()
+
+    def test_stops_control_listener_before_status_listener(self):
+        config = _make_config()
+        platform = _make_platform()
+        lc = CameraLifecycle(config, platform, lambda: False)
+
+        parent = MagicMock()
+        lc._control_server = parent.control
+        lc._status_server = parent.status
+
+        lc.shutdown()
+
+        assert parent.method_calls.index(
+            ("control.stop", (), {})
+        ) < parent.method_calls.index(("status.stop", (), {}))
 
     def test_handles_none_services(self):
         """Shutdown should work even if services were never started."""
@@ -459,7 +535,9 @@ class TestFullLifecycle:
     @patch("camera_streamer.lifecycle.led")
     @patch("camera_streamer.lifecycle.LedController")
     @patch("camera_streamer.lifecycle.HealthMonitor")
+    @patch("camera_streamer.lifecycle.CameraControlServer")
     @patch("camera_streamer.lifecycle.CameraStatusServer")
+    @patch("camera_streamer.lifecycle.ControlHandler")
     @patch("camera_streamer.lifecycle.StreamManager")
     @patch("camera_streamer.lifecycle.DiscoveryService")
     @patch("camera_streamer.lifecycle.CaptureManager")
@@ -470,7 +548,9 @@ class TestFullLifecycle:
         MockCapture,
         MockDiscovery,
         MockStream,
+        MockControlHandler,
         MockStatus,
+        MockControlServer,
         MockHealth,
         MockLedCtrl,
         mock_led,

--- a/app/camera/tests/integration/test_listener_separation.py
+++ b/app/camera/tests/integration/test_listener_separation.py
@@ -1,0 +1,222 @@
+# REQ: SWR-048; RISK: RISK-009; SEC: SC-009; TEST: TC-045
+"""Integration tests for the camera human/control listener split."""
+
+import shutil
+import subprocess
+from pathlib import Path
+from shutil import copyfile
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import pytest
+
+from camera_streamer.control import ControlHandler
+from camera_streamer.control_server import CameraControlServer
+from camera_streamer.sensor_info import capabilities_for_testing
+from camera_streamer.status_server import CameraStatusServer
+
+HUMAN_PORT = 18443
+CONTROL_PORT = 18444
+
+
+def _ssl_context(cert_path="", key_path=""):
+    import ssl
+
+    ctx = ssl._create_unverified_context()
+    if cert_path and key_path:
+        ctx.load_cert_chain(cert_path, key_path)
+    return ctx
+
+
+def _write_test_mtls_material(tmp_path: Path) -> dict[str, str]:
+    openssl = shutil.which("openssl")
+    if openssl is None:
+        pytest.skip("openssl CLI unavailable")
+
+    ca_key = tmp_path / "ca.key"
+    ca_crt = tmp_path / "ca.crt"
+    client_key = tmp_path / "client.key"
+    client_csr = tmp_path / "client.csr"
+    client_crt = tmp_path / "client.crt"
+    server_key = tmp_path / "server.key"
+    server_crt = tmp_path / "server.crt"
+
+    commands = [
+        [
+            openssl,
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(ca_key),
+            "-out",
+            str(ca_crt),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=Camera Test CA",
+        ],
+        [
+            openssl,
+            "req",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(client_key),
+            "-out",
+            str(client_csr),
+            "-nodes",
+            "-subj",
+            "/CN=paired-server",
+        ],
+        [
+            openssl,
+            "x509",
+            "-req",
+            "-in",
+            str(client_csr),
+            "-CA",
+            str(ca_crt),
+            "-CAkey",
+            str(ca_key),
+            "-CAcreateserial",
+            "-out",
+            str(client_crt),
+            "-days",
+            "1",
+            "-sha256",
+        ],
+        [
+            openssl,
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(server_key),
+            "-out",
+            str(server_crt),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+            "-addext",
+            "subjectAltName=DNS:localhost,IP:127.0.0.1",
+        ],
+    ]
+
+    for command in commands:
+        subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+
+    return {
+        "ca_crt": str(ca_crt),
+        "client_crt": str(client_crt),
+        "client_key": str(client_key),
+        "server_crt": str(server_crt),
+        "server_key": str(server_key),
+    }
+
+
+@pytest.fixture
+def split_listeners(camera_config, monkeypatch, tmp_path):
+    material = _write_test_mtls_material(tmp_path)
+    copyfile(material["ca_crt"], Path(camera_config.certs_dir) / "ca.crt")
+
+    monkeypatch.setattr("camera_streamer.status_server.LISTEN_PORT", HUMAN_PORT)
+    monkeypatch.setattr(
+        "camera_streamer.control_server.CONTROL_LISTEN_PORT", CONTROL_PORT
+    )
+    monkeypatch.setattr(
+        "camera_streamer.status_server._ensure_tls_material",
+        lambda _config: (material["server_crt"], material["server_key"]),
+    )
+
+    control_handler = ControlHandler(
+        camera_config,
+        None,
+        sensor_capabilities=capabilities_for_testing("ov5647"),
+    )
+    status_server = CameraStatusServer(
+        camera_config,
+        control_handler=control_handler,
+    )
+    control_server = CameraControlServer(
+        camera_config,
+        control_handler=control_handler,
+    )
+
+    assert status_server.start() is True
+    assert control_server.start() is True
+
+    try:
+        yield {
+            "client_crt": material["client_crt"],
+            "client_key": material["client_key"],
+        }
+    finally:
+        control_server.stop()
+        status_server.stop()
+
+
+class TestListenerSeparation:
+    def test_control_path_on_human_listener_returns_404_without_client_cert(
+        self, split_listeners
+    ):
+        request = Request(f"https://127.0.0.1:{HUMAN_PORT}/api/v1/control/config")
+
+        with pytest.raises(HTTPError) as excinfo:
+            urlopen(request, context=_ssl_context(), timeout=5)
+
+        assert excinfo.value.code == 404
+
+    def test_control_path_on_human_listener_returns_404_with_client_cert(
+        self, split_listeners
+    ):
+        request = Request(f"https://127.0.0.1:{HUMAN_PORT}/api/v1/control/config")
+
+        with pytest.raises(HTTPError) as excinfo:
+            urlopen(
+                request,
+                context=_ssl_context(
+                    split_listeners["client_crt"], split_listeners["client_key"]
+                ),
+                timeout=5,
+            )
+
+        assert excinfo.value.code == 404
+
+    def test_human_path_on_control_listener_requires_mtls(self, split_listeners):
+        request = Request(f"https://127.0.0.1:{CONTROL_PORT}/login")
+
+        with pytest.raises(URLError) as excinfo:
+            urlopen(request, context=_ssl_context(), timeout=5)
+
+        assert (
+            "certificate" in str(excinfo.value).lower()
+            or "ssl" in str(excinfo.value).lower()
+        )
+
+    def test_human_path_on_control_listener_returns_404_with_client_cert(
+        self, split_listeners
+    ):
+        request = Request(f"https://127.0.0.1:{CONTROL_PORT}/login")
+
+        with pytest.raises(HTTPError) as excinfo:
+            urlopen(
+                request,
+                context=_ssl_context(
+                    split_listeners["client_crt"], split_listeners["client_key"]
+                ),
+                timeout=5,
+            )
+
+        assert excinfo.value.code == 404

--- a/app/camera/tests/integration/test_listener_separation.py
+++ b/app/camera/tests/integration/test_listener_separation.py
@@ -2,7 +2,9 @@
 """Integration tests for the camera human/control listener split."""
 
 import shutil
+import ssl
 import subprocess
+from http.client import RemoteDisconnected
 from pathlib import Path
 from shutil import copyfile
 from urllib.error import HTTPError, URLError
@@ -20,8 +22,6 @@ CONTROL_PORT = 18444
 
 
 def _ssl_context(cert_path="", key_path=""):
-    import ssl
-
     ctx = ssl._create_unverified_context()
     if cert_path and key_path:
         ctx.load_cert_chain(cert_path, key_path)
@@ -30,6 +30,14 @@ def _ssl_context(cert_path="", key_path=""):
 
 def _write_test_mtls_material(tmp_path: Path) -> dict[str, str]:
     openssl = shutil.which("openssl")
+    if openssl is None:
+        for candidate in (
+            r"C:\Program Files\Git\usr\bin\openssl.exe",
+            r"C:\Program Files\Git\mingw64\bin\openssl.exe",
+        ):
+            if Path(candidate).is_file():
+                openssl = candidate
+                break
     if openssl is None:
         pytest.skip("openssl CLI unavailable")
 
@@ -197,11 +205,12 @@ class TestListenerSeparation:
     def test_human_path_on_control_listener_requires_mtls(self, split_listeners):
         request = Request(f"https://127.0.0.1:{CONTROL_PORT}/login")
 
-        with pytest.raises(URLError) as excinfo:
+        with pytest.raises((RemoteDisconnected, URLError, ssl.SSLError)) as excinfo:
             urlopen(request, context=_ssl_context(), timeout=5)
 
         assert (
             "certificate" in str(excinfo.value).lower()
+            or "closed connection" in str(excinfo.value).lower()
             or "ssl" in str(excinfo.value).lower()
         )
 

--- a/app/camera/tests/integration/test_status_server.py
+++ b/app/camera/tests/integration/test_status_server.py
@@ -255,7 +255,9 @@ class TestTlsHelpers:
             assert all(not path.startswith(CONTROL_API_PREFIX) for path in routes)
 
     def test_status_server_source_does_not_instantiate_control_handler(self):
-        source = Path("app/camera/camera_streamer/status_server.py").read_text()
+        source = (
+            Path(__file__).resolve().parents[2] / "camera_streamer" / "status_server.py"
+        ).read_text()
         assert "ControlHandler(" not in source
 
 

--- a/app/camera/tests/integration/test_status_server.py
+++ b/app/camera/tests/integration/test_status_server.py
@@ -2,6 +2,7 @@
 """Tests for camera_streamer.status_server — session management + system helpers."""
 
 import os
+import ssl
 import time
 from pathlib import Path
 from subprocess import CalledProcessError, TimeoutExpired
@@ -10,7 +11,9 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from camera_streamer.status_server import (
+    CONTROL_API_PREFIX,
     SESSION_TIMEOUT,
+    STATUS_ROUTE_MATRIX,
     TLS_CERT_NAME,
     TLS_KEY_NAME,
     CameraStatusServer,
@@ -243,7 +246,17 @@ class TestTlsHelpers:
 
         assert wrapped is mock_server
         ctx.load_cert_chain.assert_called_once_with("cert.pem", "key.pem")
+        assert ctx.verify_mode == ssl.CERT_NONE
+        ctx.load_verify_locations.assert_not_called()
         ctx.wrap_socket.assert_called_once_with(original_socket, server_side=True)
+
+    def test_status_routes_exclude_control_prefix(self):
+        for routes in STATUS_ROUTE_MATRIX.values():
+            assert all(not path.startswith(CONTROL_API_PREFIX) for path in routes)
+
+    def test_status_server_source_does_not_instantiate_control_handler(self):
+        source = Path("app/camera/camera_streamer/status_server.py").read_text()
+        assert "ControlHandler(" not in source
 
 
 # ---- System info helpers ----

--- a/app/camera/tests/unit/test_control_server.py
+++ b/app/camera/tests/unit/test_control_server.py
@@ -1,0 +1,54 @@
+# REQ: SWR-048; RISK: RISK-009; SEC: SC-009; TEST: TC-045
+"""Unit tests for the dedicated camera control listener."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from camera_streamer.control_server import (
+    CONTROL_API_PREFIX,
+    CONTROL_ROUTE_MATRIX,
+    CameraControlServer,
+    _wrap_https_server,
+)
+
+
+@pytest.fixture
+def tls_config(tmp_path):
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+    cfg = MagicMock()
+    cfg.certs_dir = str(certs_dir)
+    return cfg
+
+
+class TestControlTls:
+    @patch("camera_streamer.control_server.ssl.SSLContext")
+    @patch("camera_streamer.control_server.status_server_module._ensure_tls_material")
+    def test_wrap_https_server_requires_mtls(
+        self, mock_ensure_tls_material, mock_ssl_context, tls_config
+    ):
+        ca_path = Path(tls_config.certs_dir) / "ca.crt"
+        ca_path.write_text("CA")
+        mock_ensure_tls_material.return_value = ("server.crt", "server.key")
+        server = MagicMock()
+        original_socket = server.socket
+        ctx = MagicMock()
+        mock_ssl_context.return_value = ctx
+
+        wrapped = _wrap_https_server(server, tls_config)
+
+        assert wrapped is server
+        ctx.load_cert_chain.assert_called_once_with("server.crt", "server.key")
+        ctx.load_verify_locations.assert_called_once_with(str(ca_path))
+        assert ctx.verify_mode.name == "CERT_REQUIRED"
+        ctx.wrap_socket.assert_called_once_with(original_socket, server_side=True)
+
+    def test_start_skips_when_pairing_ca_missing(self, tls_config):
+        server = CameraControlServer(tls_config, control_handler=MagicMock())
+        assert server.start() is False
+
+    def test_control_routes_stay_under_control_prefix(self):
+        for routes in CONTROL_ROUTE_MATRIX.values():
+            assert all(path.startswith(CONTROL_API_PREFIX) for path in routes)

--- a/app/server/monitor/services/camera_control_client.py
+++ b/app/server/monitor/services/camera_control_client.py
@@ -2,8 +2,8 @@
 """
 Camera control client — pushes configuration to cameras via their control API.
 
-Uses server mTLS credentials to authenticate with the camera's HTTPS
-status server. The camera verifies the server certificate against the
+Uses server mTLS credentials to authenticate with the camera's dedicated
+control listener. The camera verifies the server certificate against the
 CA established during pairing (ADR-0009, ADR-0015).
 
 Design patterns:
@@ -22,6 +22,7 @@ log = logging.getLogger("monitor.camera_control_client")
 
 # Timeout for control API requests (seconds)
 REQUEST_TIMEOUT = 15
+CONTROL_PORT = 8443
 
 
 class CameraControlClient:
@@ -32,16 +33,17 @@ class CameraControlClient:
             server.crt, server.key, and ca.crt.
     """
 
-    def __init__(self, certs_dir):
+    def __init__(self, certs_dir, control_port=CONTROL_PORT):
         self._certs_dir = certs_dir
+        self._control_port = control_port
 
     def _ssl_context(self):
         """Build an SSL context with server mTLS credentials.
 
         The server presents its certificate (signed by the CA) to the
         camera, which verifies it against ca.crt received during pairing.
-        We disable hostname verification because the camera's status
-        server uses a self-signed cert with its own hostname.
+        We disable hostname verification because the camera listener
+        presents a self-signed device certificate.
         """
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.check_hostname = False
@@ -140,7 +142,7 @@ class CameraControlClient:
 
         Returns (response_dict, error_string). Error is empty on success.
         """
-        url = f"https://{camera_ip}{path}"
+        url = f"https://{camera_ip}:{self._control_port}{path}"
         data = None
         if body is not None:
             data = json.dumps(body).encode()
@@ -169,8 +171,27 @@ class CameraControlClient:
             log.warning("Control request %s %s failed: %s", method, url, err_msg)
             return None, err_msg
         except urllib.error.URLError as e:
+            if _is_control_port_unreachable(e.reason):
+                err_msg = "camera control port unreachable (firmware mismatch?)"
+                log.warning(
+                    "Control request %s %s unreachable: %s", method, url, err_msg
+                )
+                return None, err_msg
             log.warning("Control request %s %s unreachable: %s", method, url, e.reason)
             return None, f"Camera unreachable: {e.reason}"
         except (OSError, json.JSONDecodeError) as e:
             log.warning("Control request %s %s error: %s", method, url, e)
             return None, str(e)
+
+
+def _is_control_port_unreachable(reason) -> bool:
+    """Detect the "new port not listening yet" upgrade-mismatch case."""
+    if isinstance(reason, ConnectionRefusedError):
+        return True
+    if isinstance(reason, OSError) and getattr(reason, "errno", None) in {
+        111,
+        61,
+        10061,
+    }:
+        return True
+    return "connection refused" in str(reason).lower()

--- a/app/server/tests/unit/test_camera_control_client.py
+++ b/app/server/tests/unit/test_camera_control_client.py
@@ -1,9 +1,12 @@
 # REQ: SWR-039, SWR-065, SWR-066; RISK: RISK-007, RISK-015; SEC: SC-002, SC-012; TEST: TC-037, TC-054
 """Unit tests for CameraControlClient (ADR-0015)."""
 
+import urllib.error
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from monitor.services.camera_control_client import CameraControlClient
+from monitor.services.camera_control_client import CONTROL_PORT, CameraControlClient
 
 
 @pytest.fixture
@@ -18,6 +21,12 @@ class TestCameraControlClientUnit:
 
     def test_init_stores_certs_dir(self, client, data_dir):
         assert client._certs_dir == str(data_dir / "certs")
+        assert client._control_port == CONTROL_PORT
+
+    def test_init_allows_custom_control_port(self, data_dir):
+        certs_dir = data_dir / "certs"
+        custom = CameraControlClient(str(certs_dir), control_port=9443)
+        assert custom._control_port == 9443
 
     def test_ssl_context_no_certs(self, client):
         """SSL context works even without cert files."""
@@ -62,6 +71,46 @@ class TestCameraControlClientUnit:
         result, err = client.get_stream_state("192.168.99.99")
         assert result is None
         assert err
+
+    @patch("monitor.services.camera_control_client.urllib.request.urlopen")
+    def test_request_uses_default_control_port(self, mock_urlopen, client):
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = b"{}"
+        mock_urlopen.return_value = response
+
+        result, err = client.get_config("10.0.0.1")
+
+        assert err == ""
+        assert result == {}
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == "https://10.0.0.1:8443/api/v1/control/config"
+
+    @patch("monitor.services.camera_control_client.urllib.request.urlopen")
+    def test_request_uses_custom_control_port(self, mock_urlopen, data_dir):
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = b"{}"
+        mock_urlopen.return_value = response
+        client = CameraControlClient(str(data_dir / "certs"), control_port=9443)
+
+        result, err = client.get_config("10.0.0.1")
+
+        assert err == ""
+        assert result == {}
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == "https://10.0.0.1:9443/api/v1/control/config"
+
+    @patch("monitor.services.camera_control_client.urllib.request.urlopen")
+    def test_connection_refused_returns_firmware_mismatch_error(
+        self, mock_urlopen, client
+    ):
+        mock_urlopen.side_effect = urllib.error.URLError(
+            ConnectionRefusedError(111, "Connection refused")
+        )
+
+        result, err = client.get_config("10.0.0.1")
+
+        assert result is None
+        assert err == "camera control port unreachable (firmware mismatch?)"
 
 
 class TestStreamControlEndpoints:

--- a/docs/history/adr/0009-camera-pairing-mtls.md
+++ b/docs/history/adr/0009-camera-pairing-mtls.md
@@ -208,8 +208,10 @@ After pairing, all camera-server channels use mTLS:
 - Server presents `server.crt` when pushing updates
 - Same CA trust chain
 
-**Health/status polling:**
-- Server polls camera health endpoint over HTTPS with mTLS
+**Server-to-camera control:**
+- Server calls the camera control API over HTTPS on port 8443 with mTLS
+- The human-admin listener remains on port 443 and does not require a client cert
+- Camera nftables permits port 8443 only from the paired server IP while leaving port 443 for human-admin access
 - Same certs, same trust chain
 
 ---

--- a/docs/history/adr/0015-server-camera-control-channel.md
+++ b/docs/history/adr/0015-server-camera-control-channel.md
@@ -56,17 +56,24 @@ Since we use `libcamera-vid` (CLI, not picamera2 library), all parameter changes
 
 ## Decision
 
-### 1. Protocol: HTTP REST on the existing camera HTTPS server
+### 1. Protocol: HTTP REST on dedicated camera control listener
 
-Add new API endpoints to the camera's existing status server (`status_server.py`, port 443). The server (RPi 4B) pushes configuration by making HTTPS requests to the camera. No new protocols, no broker, no additional ports.
+Keep HTTP REST, but split the camera HTTPS surface into two listeners:
+
+- `:443` human-admin status UI (`status_server.py`)
+- `:8443` server-only control API (`control_server.py`)
+
+The server (RPi 4B) pushes configuration to `https://<camera-ip>:8443/api/v1/control/*`.
+No new protocols or brokers are introduced; the only runtime change is a
+second stdlib HTTPS listener inside the existing camera process.
 
 **Why this is the right choice:**
 
 - Camera already runs an HTTPS server with session auth and self-signed TLS
 - Both devices are on the same LAN with sub-millisecond latency
 - The ESPHome pattern (hub connects to device's server) maps directly to our architecture
-- Adding REST endpoints to `status_server.py` costs zero new infrastructure
-- mTLS can be layered on for the control channel (server presents its cert, camera verifies against CA)
+- A second stdlib listener is cheap on the Zero 2W and removes auth-policy coupling
+- The control listener can require mTLS at the TLS layer (`CERT_REQUIRED`) without affecting browser UX on `:443`
 
 ### 2. Authentication: mTLS with server certificate verification
 
@@ -74,22 +81,23 @@ The control channel uses **mutual TLS** — the same trust infrastructure establ
 
 - **Server → Camera requests:** Server presents its `server.crt` (signed by server CA). Camera verifies against `ca.crt` received during pairing.
 - **No session cookies needed:** Certificate identity replaces username/password for machine-to-machine calls.
-- **Human admin access** (via camera status page) continues using password + session cookies on the same server.
-
-This means the camera's HTTPS server accepts two authentication methods:
-1. **Session cookie** — for human admin via browser (existing)
-2. **mTLS client certificate** — for server control channel (new)
+- **Human admin access** (via camera status page) continues using password + session cookies on `:443`.
 
 Request routing:
 
 ```
-Camera HTTPS (port 443)
-  ├── /login, /, /status, /api/status, /api/wifi, /api/password
-  │     → session cookie auth (human admin, existing)
-  ├── /pair
-  │     → PIN auth (pairing ceremony, existing)
-  └── /api/v1/control/*
-        → mTLS auth (server only, new)
+Camera HTTPS surfaces
+  :443
+    ├── /login, /, /status, /api/status, /api/wifi, /api/password
+    │     → session cookie auth (human admin)
+    ├── /pair
+    │     → PIN auth (pairing ceremony)
+    └── /api/v1/control/*
+          → 404 (not routed on the human listener)
+
+  :8443
+    └── /api/v1/control/*
+          → mTLS auth (server only)
 ```
 
 ### 3. Camera-side API endpoints
@@ -192,7 +200,7 @@ Camera configuration has a single source of truth: **the camera itself**. The se
 ```
 Admin changes resolution on dashboard
   → Server saves desired state to cameras.json
-  → Server pushes PUT /api/v1/control/config to camera
+  → Server pushes PUT /api/v1/control/config to camera on :8443
   → Camera validates, applies, persists to camera.conf
   → Camera responds with applied config
   → Server updates cameras.json with confirmed state
@@ -232,24 +240,23 @@ class ControlHandler:
         self._rate_limit_seconds = 5
 ```
 
-Integration into `status_server.py`:
+Integration into `control_server.py`:
 
 ```python
-# In StatusHandler.do_GET / do_PUT:
-if self.path.startswith("/api/v1/control/"):
-    if not self._require_mtls():  # verify client cert
-        return
-    # Route to ControlHandler
+# In ControlRequestHandler.do_GET / do_PUT:
+if not self._require_mtls():
+    return
+# Route to ControlHandler
 ```
 
-mTLS verification in the camera's HTTPS server:
+mTLS verification in the dedicated control listener:
 
 ```python
 def _require_mtls(self):
     """Verify the request comes from a client with a cert signed by our CA."""
     # ssl.SSLSocket.getpeercert() returns cert info if client presented one
-    # Camera's SSL context needs: ctx.verify_mode = ssl.CERT_OPTIONAL
-    # (CERT_OPTIONAL so browser clients without certs still work on other endpoints)
+    # Control listener TLS context uses ctx.verify_mode = ssl.CERT_REQUIRED
+    # so no-cert clients fail the handshake before HTTP.
     peer_cert = self.request.getpeercert()
     if not peer_cert:
         self._json_response({"error": "Client certificate required"}, 401)
@@ -260,11 +267,15 @@ def _require_mtls(self):
 
 ### 9. Network and firewall considerations
 
-The camera's nftables firewall (ADR-0009) already allows inbound HTTPS (port 443) from the server IP. No firewall changes needed.
+The camera's nftables firewall now exposes:
+
+- `tcp dport 443 accept` for the human-admin HTTPS surface
+- `tcp dport 8443 ip saddr $SERVER_IP accept` for the server-only control API
 
 ```
-# Existing camera nftables rule:
-tcp dport 443 ip saddr $SERVER_IP accept  # status page + control API
+# Camera nftables rules:
+tcp dport 443 accept
+tcp dport 8443 ip saddr $SERVER_IP accept
 ```
 
 ### 10. Parameter validation rules
@@ -330,7 +341,7 @@ Strongly typed APIs with code generation. But: adds protobuf dependency, `grpcio
 
 ### Positive
 
-- **Zero new infrastructure** — reuses existing HTTPS server, mTLS certs, port 443
+- **Zero new infrastructure** — reuses stdlib HTTPS listeners and existing mTLS certs
 - **Familiar pattern** — REST API consistent with existing camera and server endpoints
 - **Strong auth** — mTLS means only the paired server can control the camera
 - **Auditable** — every change logged on both sides
@@ -341,7 +352,7 @@ Strongly typed APIs with code generation. But: adds protobuf dependency, `grpcio
 
 - **~2-5s stream gap on parameter changes** — unavoidable with libcamera-vid CLI (mitigated: users expect brief interruption when changing resolution)
 - **Camera must be reachable** — server needs network path to camera IP (already true for health checks; blocked if camera is offline → config_sync="pending")
-- **Two auth methods on one server** — session cookies (humans) + mTLS (server). Adds routing complexity in `status_server.py` (mitigated: clear URL prefix separation `/api/v1/control/*`)
+- **Two listeners instead of one** — slightly more sockets/threads, but with cleaner trust boundaries and simpler routing
 - **Server stores cached copy** — config can drift if camera is modified directly via its status page (mitigated: server refreshes from camera on health check cycle)
 
 ## Implementation Plan
@@ -349,8 +360,8 @@ Strongly typed APIs with code generation. But: adds protobuf dependency, `grpcio
 ### Phase 1 (this PR)
 
 1. Add `control.py` module to camera with parameter validation and stream restart logic
-2. Add mTLS verification to camera's HTTPS server (CERT_OPTIONAL mode)
-3. Add `/api/v1/control/config`, `/api/v1/control/capabilities`, `/api/v1/control/status` endpoints
+2. Add dedicated `control_server.py` listener with mTLS-required TLS (`CERT_REQUIRED`)
+3. Add `/api/v1/control/config`, `/api/v1/control/capabilities`, `/api/v1/control/status` endpoints on `:8443`
 4. Add `CameraControlClient` to server
 5. Wire `CameraService.update()` to push config to camera after saving
 6. Add `config_sync` field to Camera model ("synced", "pending", "error")
@@ -369,7 +380,8 @@ Strongly typed APIs with code generation. But: adds protobuf dependency, `grpcio
 | File | Change |
 |------|--------|
 | `app/camera/camera_streamer/control.py` | **New** — ControlHandler, validation, capabilities |
-| `app/camera/camera_streamer/status_server.py` | Add mTLS support, route `/api/v1/control/*` |
+| `app/camera/camera_streamer/control_server.py` | **New** — dedicated mTLS control listener on `:8443` |
+| `app/camera/camera_streamer/status_server.py` | Human-admin listener only; control paths return 404 |
 | `app/camera/camera_streamer/stream.py` | Add `restart()` method |
 | `app/camera/camera_streamer/config.py` | Add bitrate, h264_profile, rotation, flip params to DEFAULTS |
 | `app/server/monitor/services/camera_control_client.py` | **New** — HTTP client with mTLS |

--- a/docs/history/adr/0016-camera-health-heartbeat-protocol.md
+++ b/docs/history/adr/0016-camera-health-heartbeat-protocol.md
@@ -124,7 +124,8 @@ flag prevents a ping-pong notification back to the server.
 ### Server → Camera: On-demand Status Query
 
 `CameraControlClient.get_status(camera_ip)` calls
-`GET /api/v1/control/status` on the camera's status server (mTLS auth).
+`GET /api/v1/control/status` on the camera's dedicated control listener
+(`https://<camera-ip>:8443`, mTLS auth).
 
 Returns:
 ```json

--- a/docs/history/specs/113-camera-admin-control-split.md
+++ b/docs/history/specs/113-camera-admin-control-split.md
@@ -1,0 +1,606 @@
+# Feature Spec: Split Camera Human-Admin Surface From Machine Control Surface
+
+Tracking issue: #113. Branch: `feature/113-camera-admin-control-split`.
+
+## Title
+
+Split the camera's HTTPS surface so the human-admin status page and the
+server-only `/api/v1/control/*` API run on **separate listeners** with
+independent TLS and auth policies.
+
+## Goal
+
+Restate of issue #113. Today the camera's status server (port 443,
+`app/camera/camera_streamer/status_server.py`) hosts two trust models on
+one listener:
+
+- browser-driven admin pages (`/`, `/login`, `/api/wifi`,
+  `/api/password`, `/api/factory-reset`, `/api/unpair`,
+  `/api/ota/upload`, `/api/ota/reboot`, `/api/stream-config`, `/pair`)
+  authenticated by a session cookie or, for `/pair`, a 6-digit PIN
+- server-driven control endpoints (`/api/v1/control/config`,
+  `/.../capabilities`, `/.../status`, `/.../restart-stream`,
+  `/.../stream/{state,start,stop}`) authenticated by mTLS
+
+The unified listener is the reason the TLS context runs in
+`ssl.CERT_OPTIONAL` (browsers can't be required to present a client
+cert), and the reason `_require_mtls` and `_require_auth` have to coexist
+inside the same handler. Both are working today, but they share a
+listener for compatibility, not by design — every future control-plane
+or auth-hardening change has to re-prove that browser ergonomics
+haven't loosened the machine path, and vice versa.
+
+This spec gives each surface its own listener, its own TLS context, and
+its own URL space, so:
+
+- the human path can never accidentally accept a control call (and the
+  control path can never accidentally accept a session cookie)
+- the control listener can run `ssl.CERT_REQUIRED` — TLS itself fails
+  for any peer that doesn't present a valid CA-signed client cert, with
+  no in-handler fallback to second-guess
+- future control features (PTZ, image controls, fleet ops) and future
+  human features (richer admin UI, OTA UX) evolve independently
+- "no cross-access" is enforced by listener boundaries instead of by
+  per-route convention
+
+This issue is architecture-maintainability work. It does not add a
+user-facing feature, does not change the control parameter set
+(ADR-0015 §4 is preserved as-is), does not weaken pairing
+(ADR-0009/PIN), and does not relitigate ADR-0022 (no new pre-auth
+surface; the existing `/pair` page stays exactly where it is).
+
+## Context
+
+Existing code this change builds on, not replaces:
+
+- `app/camera/camera_streamer/status_server.py:33` — `LISTEN_PORT = 443`
+  and the unified `StatusHandler`. The handler currently routes both
+  human paths (via `_require_auth`) and `/api/v1/control/*` paths (via
+  `_require_mtls`) on the same listener.
+- `app/camera/camera_streamer/status_server.py:179` — `_wrap_https_server`
+  loads `ca.crt` and sets `ctx.verify_mode = ssl.CERT_OPTIONAL` so that
+  a browser without a client cert can still load `/login`. That mode is
+  the literal source of the cross-surface coupling described in #113.
+- `app/camera/camera_streamer/status_server.py:574` — `do_GET` /
+  `do_PUT` / `do_POST` route every path through one
+  `BaseHTTPRequestHandler` subclass. The control branches (`/api/v1/
+  control/*`) and the human branches share method dispatchers.
+- `app/camera/camera_streamer/control.py:111` — `ControlHandler` owns
+  parameter validation, request-id replay protection, the rate limit
+  (5 s, `RATE_LIMIT_SECONDS`), and the persisted desired stream state.
+  It is **stateful** and there must be exactly one instance per camera
+  process (see `_last_request_id`, `_last_change_time`,
+  `stream_state_path`).
+- `app/server/monitor/services/camera_control_client.py:38` — the
+  server-side client that calls the camera's control API. It builds
+  `https://{camera_ip}{path}` against port 443 today
+  (`urllib.request.urlopen` defaults). It carries server.crt /
+  server.key but pins `ctx.verify_mode = ssl.CERT_NONE` because the
+  camera's status cert is self-signed; that is **out of scope here** and
+  belongs to issue #119, which lands separately.
+- `app/camera/camera_streamer/lifecycle.py:514` — start/stop wiring for
+  the status server inside the camera lifecycle state machine. Any new
+  listener must plug in here so the lifecycle owns it (and tears it
+  down on shutdown / factory reset).
+- `meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb`
+  references `config/nftables-camera.conf` (recipe path; the file lives
+  in the recipe's WORKDIR overlay). The new control port must be added
+  to that ruleset, allowed only from the paired server IP, with the
+  same restriction shape as the existing 443 rule.
+- ADR-0015 §1–§3 — the chosen pattern was "HTTP REST on the existing
+  camera HTTPS server" with two auth methods on one listener. This
+  spec **revises §3 of ADR-0015 only**: keep HTTP REST + mTLS, but
+  split onto two listeners. Camera-side parameter set (§4),
+  controllable parameters (§4), config sync model (§6), security
+  hardening (§7), and bidirectional sync (§8) are unchanged.
+- ADR-0022 — no new pre-auth surface. The split adds zero new
+  pre-auth paths. The control listener has no pre-auth path at all
+  (CERT_REQUIRED rejects the TLS handshake before any HTTP route).
+- Issue #119 (open in `ready-for-design`) covers tightening the
+  control-channel auth direction (server verifies camera cert,
+  remove IP-fallback). #119 is intentionally complementary, not
+  blocking. After #113 lands, #119's "remove IP fallback" task is
+  effectively done on the camera side because there is no IP fallback
+  in the control listener; #119 still needs to harden the server's
+  outbound `CERT_NONE`.
+
+## User-Facing Behavior
+
+### Primary path — admin (browser)
+
+1. Operator points a browser at `https://camera.local/` (or its IP).
+2. Self-signed cert warning appears once (unchanged from today).
+3. After the cert acceptance, the browser receives the existing login
+   page from port 443. **No client-cert prompt.** The TLS context on
+   port 443 runs `verify_mode = ssl.CERT_NONE` — the human listener
+   does not request, validate, or even peek at a client certificate.
+4. Login → status page → WiFi change / password change / OTA upload /
+   factory reset / pair flow — all behave exactly as today. Pairing
+   (`/pair`, `/api/pair`) stays on this listener (PIN-authenticated as
+   in ADR-0009; no behavior change).
+5. Any request for `/api/v1/control/*` on port 443 returns **404
+   (Not Found)** — that namespace is unrouted on the human listener.
+   Tests assert this explicitly.
+
+### Primary path — server (machine)
+
+1. The server's `CameraControlClient` opens an HTTPS connection to
+   `https://{camera_ip}:8443/api/v1/control/...`.
+2. The TLS handshake runs in `verify_mode = ssl.CERT_REQUIRED` on the
+   camera. The camera's TLS layer demands a client certificate signed
+   by `/data/certs/ca.crt`. If absent or signed by another CA, the
+   handshake fails with TLS alert `bad_certificate` (or
+   `certificate_required`). The HTTP handler is never reached.
+3. With the cert valid, the request enters `ControlHandler` exactly as
+   today: parameter validation, replay protection, rate limit,
+   audit log. No change to `ControlHandler` semantics.
+4. Any request for human-admin paths (`/`, `/login`, `/api/wifi`,
+   `/api/password`, `/api/factory-reset`, `/api/unpair`,
+   `/api/ota/*`, `/pair`, `/api/pair`, `/api/stream-config`) on port
+   8443 returns **404** — that namespace is unrouted on the control
+   listener.
+5. The pre-pairing case (no `ca.crt` on disk yet) keeps the control
+   listener **bound but un-startable** — the constructor logs
+   "control listener disabled until pairing" and the listener thread
+   does not start. Port 8443 is closed, `connect()` is refused at the
+   TCP layer. After pairing writes `ca.crt`, the lifecycle starts the
+   control listener (see Module / file impact list).
+
+### Failure states (must be designed, not just unit-tested)
+
+- **Browser hits the control port** (`https://camera.local:8443/`) →
+  TLS handshake fails because the browser presents no client cert.
+  The browser shows its generic SSL error. We do NOT add a
+  human-readable HTML response — exposing a 4xx page on the control
+  port would re-introduce a non-mTLS surface there.
+- **Server hits the human port** with mTLS credentials → handshake
+  succeeds (CERT_NONE is permissive), control paths return 404. The
+  server's control client logs the 404 and the camera-side audit log
+  records nothing (the human handler does not touch
+  `ControlHandler`). Acceptance test covers it.
+- **Server upgrades, camera does not** (mismatched OTA window) →
+  control client tries `:8443`, gets `connection refused` (camera
+  still listening only on `:443` for control). Server marks
+  `config_sync = pending` and surfaces a "camera firmware older than
+  server, please reboot for OTA" hint on the dashboard. The fallback
+  is **deliberately one-shot and observable**: the client does not
+  silently retry on `:443` for control, because retrying on the
+  human port is exactly what this issue is asking us to stop doing.
+- **Camera upgrades, server does not** → server still hits `:443`
+  for control. The new camera firmware returns 404 on the human
+  listener for `/api/v1/control/*`. Server marks `config_sync =
+  pending`. Fixed by upgrading the server.
+- **Operator's nftables not refreshed** (post-OTA, ruleset stale) →
+  port 8443 inbound from server IP is dropped at the firewall;
+  control client times out. Smoke-test row covers it; OTA recipe
+  installs the updated `nftables-camera.conf` so this should not
+  happen on the deployed image.
+- **Two control requests in flight** crossing 5 s rate limit →
+  unchanged from today. `ControlHandler` is the single instance
+  (shared between listener threads if both pointed at it; the spec
+  pins this to one listener so no shared-instance question arises).
+- **Pre-pairing browser admin** (operator viewing status before
+  pairing) → only `:443` runs; `:8443` is bound only after `ca.crt`
+  exists. Operator sees the same status page they see today.
+- **Factory reset deletes `ca.crt`** → control listener
+  shutdown is part of the unpair / factory-reset flow; the lifecycle
+  state machine tears down both servers, recreates `:443`, and leaves
+  `:8443` un-started until the next pairing. AC-7 covers this.
+
+## Acceptance Criteria
+
+Each bullet is testable; verification mechanism noted in brackets.
+
+- AC-1: With the camera in the post-pairing RUNNING state, port 443 is
+  bound and serves `/login` over HTTPS with no client-cert request
+  (TLS context `CERT_NONE`).
+  **[unit: `app/camera/tests/test_status_server.py` against the wrapped
+  socket; `ctx.verify_mode == ssl.CERT_NONE`]**
+- AC-2: With the camera in the post-pairing RUNNING state, port 8443
+  is bound and the TLS context is `CERT_REQUIRED` and validates against
+  `/data/certs/ca.crt`.
+  **[unit: new `app/camera/tests/test_control_server.py`]**
+- AC-3: A request to `https://camera/api/v1/control/config` on port
+  443 returns 404 regardless of whether the caller presents a client
+  cert. The same path on port 8443 with the paired server cert
+  succeeds and returns the current config.
+  **[contract: paired-cert harness from existing
+  `test_status_server.py` mTLS suite]**
+- AC-4: A request to `https://camera/login` on port 8443 fails the
+  TLS handshake when the caller presents no client cert. With a valid
+  client cert, the same path returns 404 (not the login page).
+  **[integration: `test_listener_separation.py` — TLS error class
+  asserted on no-cert path; 404 asserted on with-cert path]**
+- AC-5: Pre-pairing (no `ca.crt`), only port 443 is open. Port 8443
+  refuses TCP connections.
+  **[unit: lifecycle test that asserts `_status_server.start()` is
+  called but `_control_server.start()` is not, and a TCP connect to
+  `:8443` fails with `ConnectionRefusedError`]**
+- AC-6: After pairing, the lifecycle starts both listeners. After
+  unpair / factory reset, both listeners stop and `:8443` becomes
+  unbindable; `:443` rebinds (post-reset state is "human listener only,
+  control disabled").
+  **[lifecycle integration test reusing
+  `test_lifecycle_state_machine.py` patterns]**
+- AC-7: `ControlHandler` is instantiated exactly once per camera
+  process and is wired into the control listener only; the human
+  listener has no reference to it. (Static check: `grep -n
+  "ControlHandler" status_server.py` returns no constructor call.)
+  **[unit + lint test that fails on the constructor occurrence]**
+- AC-8: Server's `CameraControlClient` builds URLs with explicit port
+  8443 (default) and the constant is overridable via constructor
+  argument (so tests can target an ephemeral port).
+  **[unit: `app/server/tests/test_camera_control_client.py`]**
+- AC-9: When the server hits `:8443` and gets `ConnectionRefusedError`
+  (mismatched-firmware case), `CameraService.update()` records
+  `config_sync = pending` and the dashboard surface (existing) shows
+  the pending state. The client does **not** fall back to `:443`.
+  **[integration: mocked socket layer that refuses 8443]**
+- AC-10: nftables ruleset (`nftables-camera.conf`) allows tcp dport
+  8443 only from the paired server IP; default-drop applies otherwise.
+  Existing 443 rule is unchanged.
+  **[unit: textual assertion of the ruleset; smoke-test row that
+  scans 8443 from a non-server IP and confirms drop]**
+- AC-11: All existing `test_status_server.py` mTLS tests are split
+  into two files (admin tests still run against the human listener,
+  control tests run against the new control listener). No test
+  regresses; the contract test harness path-coverage matrix shows
+  every existing endpoint mapped to exactly one listener.
+  **[CI: `pytest app/camera/tests/ -v` green]**
+- AC-12: A negative test asserts that NO `/api/v1/control/*` route is
+  registered in the human handler, and NO human-admin route is
+  registered in the control handler. (Walk both handlers' dispatch
+  tables; assert disjoint sets.)
+  **[contract test, runs in CI and prevents regressions on future
+  PRs]**
+- AC-13: Hardware verification: on a deployed image, an admin can
+  log in over `:443` from a browser; the server can push a config
+  change over `:8443`; an attempt to call `:443/api/v1/control/config`
+  with the server's mTLS cert returns 404.
+  **[hardware verification + new smoke-test row in
+  `scripts/smoke-test.sh`]**
+- AC-14: Audit log behavior is unchanged on the camera. Control
+  operations still log to `/data/logs/control.log` with the existing
+  fields (timestamp, parameter, old → new, requester cert CN). No new
+  audit events are introduced.
+  **[unit on `audit`/`control.py` log emit; contract assertion]**
+- AC-15: Documentation update: ADR-0015 §3 (request routing diagram)
+  is updated to reflect the split; ADR-0009 §nftables note gains a
+  line about the additional rule. ADR-0022 is **not** modified
+  (no new pre-auth surface introduced).
+  **[doc-link checker passes; PR description cites ADR-0015 + ADR-0022
+  with one-line summary of what changed and what didn't]**
+
+## Non-Goals
+
+- Renaming `status_server.py` → `admin_server.py` or splitting the
+  module file. The two listener objects can live inside
+  `status_server.py` (or with the control listener factored into a
+  thin sibling, Implementer's call) without renaming. Renaming is
+  churn out of proportion to the maintainability win.
+- Tightening the server-side outbound `CERT_NONE` (camera_control_client
+  uses `verify_mode = ssl.CERT_NONE` because the camera's status cert
+  is self-signed). That belongs to issue #119 and lands separately.
+  This spec does **not** make #119 worse — the new control listener
+  presents the same self-signed status cert as today, so the server
+  side's verification posture is unchanged.
+- Adding new control endpoints. The set is exactly what
+  `ControlHandler` exposes today (per ADR-0015 §4 and ADR-0017 stream
+  state).
+- Adding new human-admin endpoints.
+- Switching from Python's `http.server` to a framework (Flask, etc.)
+  on the camera. ADR-0006 (modular monolith) and the Zero 2W's RAM
+  budget say no.
+- Adding a reverse proxy (nginx, caddy) on the camera. Same reason.
+- Removing the PIN-authenticated `/pair` page or moving it to a third
+  port. It stays where it is — pre-auth-by-design, scoped to the
+  pairing ceremony, ADR-0009.
+- Changing the RTSPS streaming port (8554) or any other port not
+  named here.
+- Changing the camera's mDNS advertisement set. Only `:443` is
+  advertised (so a browser-based `camera.local` discovery path keeps
+  working). The server learns the control endpoint from pairing
+  metadata, not mDNS.
+- Persisting any new state on `/data`. The split is purely a runtime
+  / process-shape change.
+
+## Module / File Impact List
+
+New code (camera-side):
+
+- `app/camera/camera_streamer/control_server.py` — thin module owning
+  the second `http.server.HTTPServer` on `:8443`, its TLS context
+  (`ssl.CERT_REQUIRED`), and a `ControlHandler`-only request handler.
+  No human-admin routes registered. Constructor takes the
+  `ControlHandler` instance (never instantiates one). Implements
+  `start()` / `stop()` mirroring `CameraStatusServer`.
+- `app/camera/camera_streamer/control_handler_http.py` (or kept inline
+  in `control_server.py`) — the `BaseHTTPRequestHandler` subclass that
+  dispatches `/api/v1/control/*` GET/PUT/POST requests to the shared
+  `ControlHandler` instance, with the existing
+  `parse_control_request` + JSON response helpers reused.
+- New constant `CONTROL_LISTEN_PORT = 8443` lives in `control_server.py`
+  with a comment pointing back to this spec and ADR-0015 §3.
+
+Modified code (camera-side):
+
+- `app/camera/camera_streamer/status_server.py`:
+  - Remove all `/api/v1/control/*` route branches from `do_GET`,
+    `do_PUT`, `do_POST`.
+  - Remove `_require_mtls` and `_has_mtls_client_cert` from the human
+    handler.
+  - In `_wrap_https_server`, change `ctx.verify_mode = ssl.CERT_OPTIONAL`
+    to `ssl.CERT_NONE`. Drop the `load_verify_locations(ca_path)` call
+    on the human listener (the human listener has no use for the CA).
+  - `CameraStatusServer.__init__` no longer instantiates
+    `ControlHandler`. Instead, the lifecycle injects the shared
+    `ControlHandler` into both servers explicitly. (The
+    `control_handler` property remains for backward compatibility but
+    is now sourced from the lifecycle, not constructed inside.)
+  - The `/api/stream-config` endpoint stays on `:443` (it's the human
+    admin path that lets the operator change stream settings from the
+    camera's own status page) and continues to delegate to the shared
+    `ControlHandler` with `origin="local"` exactly as today.
+- `app/camera/camera_streamer/lifecycle.py:514` — wire the
+  `ControlServer` start/stop alongside the existing `CameraStatusServer`
+  start/stop. Both are members of the lifecycle. Order:
+  1. After pairing (`ca.crt` present) → start human + control listeners
+  2. On unpair / factory reset → stop control listener first, then
+     human, then drop `ca.crt`
+  3. On shutdown → stop both
+- `app/camera/camera_streamer/control.py` — no functional change.
+  Add a comment at the top citing this spec for the listener-split
+  rationale; the parameter table, validation, audit, rate limit, and
+  stream state file remain authoritative.
+
+Modified code (server-side):
+
+- `app/server/monitor/services/camera_control_client.py`:
+  - Add `CONTROL_PORT = 8443` constant at module top.
+  - `_request()` builds `https://{camera_ip}:{self._control_port}{path}`.
+  - Constructor takes optional `control_port=CONTROL_PORT` for tests.
+  - On `ConnectionRefusedError` / `URLError(connection refused)`,
+    return a distinct error string `"camera control port unreachable
+    (firmware mismatch?)"` so `CameraService` can surface a useful
+    operator hint. **No fallback to `:443`.**
+
+Modified code (firmware build):
+
+- `meta-home-monitor/recipes-camera/camera-streamer/files/config/nftables-camera.conf`
+  (referenced from the recipe at
+  `meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb:25`)
+  — add `tcp dport 8443 ip saddr $SERVER_IP accept` mirroring the
+  existing 443 rule. Default-drop policy is unchanged.
+- The `monitor-server` recipe does **not** need a firewall change
+  (the server is the originator of the connection).
+
+Tests (new):
+
+- `app/camera/tests/test_control_server.py` — TLS context assertions,
+  start/stop wiring, 404 on human paths, mTLS handshake required.
+- `app/camera/tests/test_listener_separation.py` — cross-access
+  matrix: human path on `:8443` → 404; control path on `:443` → 404.
+  Same matrix re-run with mTLS cert presented to `:443` (still 404).
+- `app/camera/tests/test_lifecycle_listeners.py` — pre-pairing /
+  post-pairing / unpair listener state.
+- `app/server/tests/test_camera_control_client.py` (extend) — port
+  8443 default, custom port via constructor, no-fallback on
+  connection refused, distinct error string on mismatch.
+
+Tests (modified):
+
+- `app/camera/tests/test_status_server.py` — keep all admin-side
+  cases; remove or move all `/api/v1/control/*` cases to
+  `test_control_server.py` (no test regresses; contract surface is
+  the same).
+
+Smoke-test additions (`scripts/smoke-test.sh`):
+
+- "browser admin can log in over `:443` and change WiFi"
+- "server pushes config over `:8443` and stream restarts"
+- "calling `:443/api/v1/control/config` with a valid client cert
+  returns 404"
+- "scanning `:8443` from a non-server LAN IP times out / drops"
+
+Dependencies:
+
+- No new Python packages. No new system packages. No Yocto recipe
+  additions beyond the firewall config edit.
+
+Out-of-tree:
+
+- No `app/server/` model change. No `Camera` field added.
+- No mDNS service-name change. The camera continues to advertise
+  `_https._tcp` on `:443`.
+
+## Validation Plan
+
+Pulled from `docs/ai/validation-and-release.md`:
+
+| Area touched | Required validation |
+|--------------|---------------------|
+| Camera Python | `pytest app/camera/tests/ -v`, `ruff check .`, `ruff format --check .` |
+| Server Python (control client) | `pytest app/server/tests/test_camera_control_client.py -v` plus full `app/server/tests/` for safety |
+| Auth or security path | full camera + server suite + smoke; change touches `**/auth/**`-adjacent code (mTLS context) |
+| API contract | new contract test files for the cross-access matrix; existing control-API contract tests preserved |
+| Yocto / firewall | rebuild camera image; `bitbake -c devshell camera-streamer` not required, but the recipe diff is reviewed; smoke-test row exercises the rule |
+| Requirements / risk / security / traceability | `python tools/traceability/check_traceability.py`; `python scripts/ai/check_doc_links.py` |
+| Hardware behavior | deploy + `scripts/smoke-test.sh` rows above; manual browser test on `:443`; manual server-driven config push on `:8443` |
+
+## Risk
+
+ISO 14971-lite framing. Hazards specific to this change:
+
+| ID | Hazard | Severity | Probability | Risk control |
+|----|--------|----------|-------------|--------------|
+| HAZ-113-1 | Mismatched OTA window: server upgraded before camera (or vice versa) → control plane silently breaks because the port is wrong. | Moderate (operational) | Medium | RC-113-1: server's `CameraControlClient` returns a distinct, operator-visible error on `:8443` connection-refused; `CameraService` raises `config_sync = pending` and the dashboard already surfaces that state. No silent fallback to `:443`. Atomic OTA bundle (ADR-0014/0020) keeps server and camera firmware in lockstep on a normal upgrade. |
+| HAZ-113-2 | Browser starts prompting users for a client cert on `:443`. | Minor (UX) | Low | RC-113-2: human listener's TLS context is now `CERT_NONE` (no client-cert request at all). Removing `load_verify_locations` on `:443` is what makes this guarantee structural rather than convention. AC-1 pins it. |
+| HAZ-113-3 | Operator's `nftables` ruleset stale after OTA → control plane unreachable. | Moderate (operational) | Low | RC-113-3: OTA recipe installs the updated `nftables-camera.conf`; smoke-test row scans `:8443` reachability post-deploy; the camera's status page displays a "control plane unreachable from server" banner if the heartbeat layer has been silent for >2 health intervals. |
+| HAZ-113-4 | Future PR adds a new control endpoint to the wrong listener (the human one), regressing the split. | Moderate (security) | Medium (humans drift over time) | RC-113-4: AC-12 contract test (path-coverage disjoint-set check) runs in CI; any new route registered on the wrong handler fails the test. PR template adds a one-line check "if you added a `/api/v1/control/*` route, did you add it to the control listener?" |
+| HAZ-113-5 | The control listener starts before `ca.crt` is on disk (e.g., a race during pairing), TLS context construction fails noisily, lifecycle wedges. | Moderate (operational) | Low | RC-113-5: lifecycle gates control-listener start on `os.path.isfile(ca_path)` (mirrors the existing pre-pairing log line). Failure mode is "control listener disabled until pairing", logged once, retried by the lifecycle on the next state transition. |
+| HAZ-113-6 | Adding a second listener uses more file descriptors / sockets / threads on the constrained Zero 2W. | Minor | Low | RC-113-6: each Python `HTTPServer` is one socket + one thread (the existing pattern). Memory footprint delta is well under 5 MB. Hardware verification row in AC-13 confirms post-deploy. |
+| HAZ-113-7 | `/api/stream-config` (the human-admin form that lets the operator change stream settings from the camera's status page) bypasses the new mTLS-only control listener and writes the same camera.conf the control listener writes. | Minor (security) | Low | RC-113-7: this is intentional — `/api/stream-config` is session-cookie-gated (admin password) and shares the *same* `ControlHandler` instance, with `origin="local"`. The two paths converge on `ControlHandler` exactly as today; ADR-0015 §8 (bidirectional sync) covers the ping-pong prevention. Spec calls this out explicitly so a future reviewer doesn't try to "fix" it. |
+
+Reference `docs/risk/` for the existing camera-domain risk register;
+this spec adds rows; it does not redefine risk policy.
+
+## Security
+
+Threat-model deltas (Implementer fills concrete `THREAT-` / `SC-` IDs):
+
+- **Strengthens** the machine-control trust boundary: `CERT_REQUIRED`
+  on the control listener means a peer without a CA-signed client
+  cert cannot complete the TLS handshake. Today the same defense lives
+  one layer deeper (in `_require_mtls`'s `getpeercert()` check); after
+  the split, the defense is at the TLS layer itself, which is the
+  stricter and easier-to-audit position.
+- **Removes** the `CERT_OPTIONAL` mode from the camera's HTTPS
+  surface entirely. There is no listener that asks-for-but-doesn't-
+  require a client cert. This eliminates the class of bug where a
+  future code path forgets `_require_mtls()` and silently accepts a
+  no-cert call.
+- **Does not add a pre-auth surface.** The human listener already had
+  `/login`, `/pair`, and the static error pages reachable pre-auth.
+  After the split, that set is unchanged. The control listener has no
+  pre-auth surface (TLS terminates the connection before any HTTP
+  layer runs).
+- **Sensitive paths touched:** `**/auth/**` (yes — `_require_mtls`
+  removed from the admin handler; the same predicate moves into the
+  control handler), `**/secrets/**` (no), `**/.github/workflows/**`
+  (no), camera lifecycle (`lifecycle.py`, sensitive — yes), pairing
+  flow (no — `/pair` stays on `:443`), OTA flow (no — `/api/ota/*`
+  stays on `:443`). Per `docs/ai/roles/architect.md` these sensitive
+  paths are flagged here for extra review.
+- **Audit:** no new audit events. Existing `control.log` is unchanged.
+  No human-admin event names change.
+- **Rate limit / lockout:** `ControlHandler.RATE_LIMIT_SECONDS = 5`
+  is preserved as the single source of truth for control-plane rate
+  limiting. The human-admin rate limit (`auth.py` server-side
+  patterns; on the camera, login rate limit lives in
+  `status_server.py`) is unchanged.
+- **Defense in depth:** nftables `tcp dport 8443 ip saddr $SERVER_IP
+  accept` keeps the network-layer guard. mTLS keeps the TLS-layer
+  guard. `ControlHandler`'s parameter validation keeps the
+  application-layer guard. The split removes one *coupling* (CERT_OPTIONAL)
+  and adds zero new authentication primitives.
+- **No backdoor introduced.** ADR-0022 is not weakened. No new
+  pre-auth path; no recovery / bypass surface; no in-handler "if
+  source IP matches server" fallback (that was already removed in
+  #112 / #119 and is **not** reintroduced anywhere in this spec).
+
+## Traceability
+
+Implementation annotations map issue #113 onto the existing controlled
+traceability catalogue:
+
+- Listener separation and TLS hardening: `SWR-013`, `SWR-039`,
+  `RISK-002`, `RISK-007`, `SC-001`, `SC-002`, verified by `TC-004`,
+  `TC-037`.
+- Cross-access prevention (path-coverage disjoint set): `SWR-039`,
+  `RISK-007`, `SC-002`, verified by new contract test wired into
+  `TC-037`.
+- Server outbound control-port migration: `SWR-039`, `RISK-007`,
+  verified through extended `app/server/tests/test_camera_control_client.py`
+  rolling under `TC-037`.
+- Camera lifecycle wiring (start/stop ordering, pre-pairing gate):
+  `SWR-013`, `RISK-002`, verified by lifecycle integration tests in
+  `TC-004` family.
+- Yocto firewall rule: `SWR-049` (production hardening), `RC-018`
+  (risk-control-verification.md), `RISK-018`/`RISK-019`, verified
+  by `TC-044` / `TC-047`.
+
+The `HAZ-113-*` / `RC-113-*` rows in this spec remain issue-local
+design records. They roll up to the controlled IDs above rather than
+introducing new global traceability IDs in this implementation slice.
+
+## Deployment Impact
+
+- Yocto rebuild needed: **yes**, for the camera image — the firewall
+  config file changes (one-line addition). Recipe (`camera-streamer_1.0.bb`)
+  itself is unchanged. No new packagegroup. No layer-class change.
+- Server image: no Yocto change.
+- OTA path: standard combined OTA bundle (server + camera together
+  per ADR-0014/0020). The split is wire-compatible only when both
+  ends are upgraded; the operator-visible mismatched-window behavior
+  is described in HAZ-113-1.
+- Hardware verification: yes — required. Browser admin on `:443`,
+  server-driven config push on `:8443`, and the negative-cross test
+  (`:443` + mTLS cert returns 404).
+- Default state on upgrade: control listener auto-starts on the
+  upgraded camera *if* `ca.crt` exists (i.e., camera is paired).
+  Pre-paired cameras are unchanged behaviorally; only `:443` runs
+  until pairing.
+- No data-migration step. No `users.json` / `cameras.json` schema
+  change. No reboot-required state transition.
+
+## Open Questions
+
+(None of these are blocking; design proceeds. Implementer captures
+answers in PR description.)
+
+- OQ-1: Confirm port 8443 is not used by anything else on the camera
+  image. Quick check: `ss -tlnp` on a running camera, plus a
+  `bitbake-layers show-recipes` scan for `:8443` in installed
+  recipes. If conflict, choose 8444 — port number is incidental,
+  callout is "well-known alternate HTTPS, easy to remember."
+- OQ-2: Whether to factor the new control listener into its own
+  module (`control_server.py`) or keep both `HTTPServer` instances
+  inside `status_server.py` with one new class. **Recommendation:
+  separate module** — the names already say what they're for, and
+  it makes AC-12's path-coverage disjoint-set check trivial to
+  implement (two distinct dispatch tables in two files).
+- OQ-3: Should `CameraControlClient`'s constructor take a
+  `control_port` argument (per AC-8), or read it from a config /
+  settings entry? **Recommendation: constructor argument with a
+  module-level default.** Adding a `Settings` field for the port is
+  speculative configuration we don't need yet; the constant is fine.
+- OQ-4: Documentation update to ADR-0015 §3 — done in this PR or in
+  a follow-up ADR-0015 supplement? **Recommendation: this PR**, as
+  a minimal §3 patch + a "Revised by issue #113" note at the top.
+  Larger architectural commentary belongs in a future ADR if the
+  pattern recurs.
+- OQ-5: Should the camera's mDNS advertisement gain a second SRV
+  record for `:8443` (so the server can discover the control port)?
+  **Recommendation: no.** The server learns the camera's IP during
+  pairing and the control port is a constant. Adding mDNS for the
+  control listener creates a discovery surface for an endpoint that
+  shouldn't be discovered. Filed under "ideas we don't need" so a
+  future reader can see we considered it.
+
+(No question is blocking; if OQ-1 finds a port conflict, the
+Implementer picks the next free port and updates the constants. No
+spec edit required.)
+
+## Implementation Guardrails
+
+- Preserve modular monolith (ADR-0006): no new daemon, no new process.
+  Two `http.server.HTTPServer` instances inside the same camera-streamer
+  Python process.
+- Preserve service-layer pattern (ADR-0003): `ControlHandler` stays
+  the single business-logic owner for control operations; the new
+  HTTP handler is a thin adapter exactly like the existing one in
+  `status_server.py`.
+- Preserve ADR-0009 / ADR-0015 trust model: same mTLS, same CA, same
+  cert files, same `ControlHandler` parameter set. Listener split is
+  a runtime-shape change, not a trust-model change.
+- Preserve ADR-0022: no new pre-auth surface, no recovery / bypass
+  primitive, no documented "alternate way in." This PR cites
+  ADR-0022 in its description with the explicit one-liner "this PR
+  adds zero new pre-auth surfaces."
+- Do **not** remove `_require_mtls` from `control.py` or its test
+  scaffolding — the predicate moves from `status_server.py`'s human
+  handler to the new control handler so the application-layer
+  defense (`getpeercert()` check + CN match if added later) stays
+  available even if the TLS layer's `CERT_REQUIRED` is ever
+  loosened.
+- Do **not** add a fallback path in `CameraControlClient` that
+  retries control calls on `:443` after `:8443` fails. Silent
+  fallback is exactly the maintainability hazard #113 is
+  closing.
+- Tests + docs ship in the same PR as code, per
+  `engineering-standards`. PR description must include:
+  the ADR-0015 §3 diff, the ADR-0022 one-liner, the firewall rule
+  change summary, and the cross-access matrix output.
+- The PR description should propose updating the issue title to make
+  clear that this is the **listener split**, not a broader auth
+  rework — to avoid scope creep with #119.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -267,6 +267,7 @@ if [ -n "$CAMERA_IP" ]; then
     echo ""
     echo "[8/8] Camera node: ${CAMERA_IP}"
     CAM_URL="https://${CAMERA_IP}"
+    CAM_CONTROL_URL="https://${CAMERA_IP}:8443"
     CAM_CURL=(curl -sk --connect-timeout 5 --max-time 10)
 
     # --- Reachability ---
@@ -341,6 +342,38 @@ if [ -n "$CAMERA_IP" ]; then
         CAM_STREAM=$(echo "$CAM_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('streaming','?'))" 2>/dev/null) || CAM_STREAM="?"
         CAM_TEMP=$(echo "$CAM_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cpu_temp','?'))" 2>/dev/null) || CAM_TEMP="?"
         echo -e "  ${YELLOW}INFO${NC} Camera: id=${CAM_ID}, streaming=${CAM_STREAM}, cpu_temp=${CAM_TEMP}"
+    fi
+
+    if "${CAM_CURL[@]}" -o /dev/null "${CAM_CONTROL_URL}/api/v1/control/status" 2>/dev/null; then
+        fail "Camera control port unexpectedly accepted a no-cert client"
+    else
+        pass "Camera control port rejects a no-cert client"
+    fi
+
+    if [ -n "${SMOKE_CAMERA_CONTROL_CERT:-}" ] && [ -n "${SMOKE_CAMERA_CONTROL_KEY:-}" ]; then
+        CAM_MTLS_CURL=(
+            curl -sk --connect-timeout 5 --max-time 10
+            --cert "${SMOKE_CAMERA_CONTROL_CERT}"
+            --key "${SMOKE_CAMERA_CONTROL_KEY}"
+        )
+
+        CAM_CONTROL_STATUS=$("${CAM_MTLS_CURL[@]}" -o /dev/null -w "%{http_code}" \
+            "${CAM_CONTROL_URL}/api/v1/control/config" 2>/dev/null) || true
+        if [ "$CAM_CONTROL_STATUS" = "200" ]; then
+            pass "Camera control API reachable on :8443 with mTLS"
+        else
+            fail "Camera control API on :8443 expected 200, got ${CAM_CONTROL_STATUS:-000}"
+        fi
+
+        CAM_HUMAN_CONTROL_STATUS=$("${CAM_MTLS_CURL[@]}" -o /dev/null -w "%{http_code}" \
+            "${CAM_URL}/api/v1/control/config" 2>/dev/null) || true
+        if [ "$CAM_HUMAN_CONTROL_STATUS" = "404" ]; then
+            pass "Camera human listener returns 404 for control path"
+        else
+            fail "Camera human listener expected 404 for control path, got ${CAM_HUMAN_CONTROL_STATUS:-000}"
+        fi
+    else
+        skip "Camera mTLS control-path checks skipped (set SMOKE_CAMERA_CONTROL_CERT and SMOKE_CAMERA_CONTROL_KEY)"
     fi
 else
     if [ -z "${3:-}" ]; then


### PR DESCRIPTION
Closes #113

## Summary
This change splits the camera HTTPS surface into two listeners so browser-admin traffic stays on `:443` and the server-only control API moves to `:8443` with independent TLS and auth policies. Human/admin routes can no longer serve control calls, the control listener can enforce `ssl.CERT_REQUIRED`, ADR-0015's routing model is updated to reflect the split, and ADR-0022 remains unchanged because this adds no new pre-auth surface.

## Spec
`docs/history/specs/113-camera-admin-control-split.md`

## Validation evidence
- `pytest app/camera/tests/ -v --cov=app/camera --cov-fail-under=80`: PASS
- `pytest app/server/tests/ -v --cov=app/server --cov-fail-under=85`: PASS
- `python tools/docs/check_doc_map.py`: PASS
- `python scripts/ai/validate_repo_ai_setup.py`: PASS
- `python scripts/ai/check_doc_links.py`: PASS
- `python scripts/ai/check_shell_scripts.py`: PASS
- `python scripts/check_version_consistency.py`: PASS
- `python scripts/check_versioning_design.py`: PASS
- `python tools/traceability/check_traceability.py`: PASS
- `python -m pre_commit run --all-files`: PASS
- `ruff check .`: PASS
- `ruff format --check .`: PASS
- `C:\Program Files\Git\bin\bash.exe -n scripts/smoke-test.sh`: PASS
- `shellcheck scripts/smoke-test.sh`: PASS
- coverage: server 93.57% / camera 88.65%
- skipped: `bitbake -p` (Windows host has no Yocto SDK; Yocto/firewall verification still needed in a Linux build environment before merge)
- skipped: deployed hardware verification (required for browser admin on `:443`, control calls on `:8443`, and the negative cross-access smoke rows)

## Deployment impact
- Camera image rebuild required because the camera firewall config changes to admit `:8443` only from the paired server IP.
- Server image does not need a Yocto change, but rollout still needs server and camera updated together because the control client now targets `:8443`.
- Hardware verification remains required for browser admin on `:443`, control-plane calls on `:8443`, and the negative cross-access smoke cases.

## Traceability
- Listener separation and TLS hardening: `SWR-013`, `SWR-039`, `RISK-002`, `RISK-007`, `SC-001`, `SC-002`, verified by `TC-004` and `TC-037`.
- Cross-access prevention: `SWR-039`, `RISK-007`, `SC-002`, verified by the new contract coverage under `TC-037`.
- Control-port migration on the server: `SWR-039`, `RISK-007`, verified through the extended `app/server/tests/unit/test_camera_control_client.py` coverage.
- Lifecycle start/stop ordering: `SWR-013`, `RISK-002`, verified by lifecycle integration tests in the `TC-004` family.
- Firewall rule update: `SWR-049`, `RC-018`, `RISK-018`, `RISK-019`; `TC-044` / `TC-047` still need the skipped Yocto/hardware follow-up.

## Out of scope
- No server-side certificate verification hardening beyond the listener split; the outbound `CERT_NONE` follow-up stays with issue `#119`.
- No new control or human-admin endpoints, no reverse proxy/framework swap, and no port changes outside the new control listener.
- No mDNS discovery expansion, no new persisted state, and no pairing/PIN flow redesign.