### PR TITLE
fix(camera): non-recursive throttle-state probe (sysfs symlink loop)

### DIFF
--- a/app/camera/camera_streamer/platform.py
+++ b/app/camera/camera_streamer/platform.py
@@ -196,15 +196,40 @@ def _probe_vcgencmd_path() -> str | None:
 
 
 def _probe_throttle_path() -> str | None:
-    """Find a Raspberry Pi throttle-state sysfs file if present."""
-    patterns = (
-        "/sys/devices/platform/soc/**/throttled",
-        "/sys/devices/platform/soc/**/get_throttled",
-    )
-    for pattern in patterns:
-        for path in sorted(glob.glob(pattern, recursive=True)):
-            if os.path.isfile(path):
-                return path
+    """Find a Raspberry Pi throttle-state sysfs file if present.
+
+    `os.walk(followlinks=False)` is mandatory: `/sys/devices/platform/soc/`
+    on some SoCs (Pi Zero 2W with bcm2835 serial driver, see hardware
+    test 2026-05-05) contains symlink loops via the
+    `<dev>/driver/<dev>/driver/...` chain. The previous implementation
+    used `glob.glob(pattern, recursive=True)`, which DOES follow
+    symlinks for the `**` token (per the Python 3.12 docs) and
+    therefore spun forever in a CPU-bound loop, hanging the lifecycle
+    boot at "Config loaded" before any thread could start.
+
+    A bounded directory walk that refuses to descend into symlinks
+    cannot loop, and on this SoC family the real throttle-state files
+    live at depth ≤ 4 from the soc/ root, well within the practical
+    walk budget. We additionally cap the directory count so a future
+    SoC with thousands of subnodes can't degrade boot latency.
+    """
+    targets = ("throttled", "get_throttled")
+    soc_root = "/sys/devices/platform/soc"
+    if not os.path.isdir(soc_root):
+        return None
+    # Cap walked directories — defence in depth in case some future
+    # kernel adds a non-loop sysfs forest large enough to slow boot.
+    max_dirs = 2000
+    for walked, (dirpath, _dirnames, filenames) in enumerate(
+        os.walk(soc_root, followlinks=False), start=1
+    ):
+        if walked > max_dirs:
+            break
+        for name in targets:
+            if name in filenames:
+                candidate = os.path.join(dirpath, name)
+                if os.path.isfile(candidate):
+                    return candidate
     return None
 
 

--- a/app/camera/tests/unit/test_platform.py
+++ b/app/camera/tests/unit/test_platform.py
@@ -193,14 +193,77 @@ class TestProbing:
     def test_probe_vcgencmd_path(self, mock_which):
         assert _probe_vcgencmd_path() == "/usr/bin/vcgencmd"
 
-    @patch("glob.glob", return_value=["/sys/devices/platform/soc/test/throttled"])
+    @patch("os.path.isdir", return_value=True)
+    @patch(
+        "os.walk",
+        return_value=[
+            ("/sys/devices/platform/soc/firmware", [], ["throttled"]),
+        ],
+    )
     @patch("os.path.isfile", return_value=True)
-    def test_probe_throttle_path_found(self, mock_isfile, mock_glob):
-        assert _probe_throttle_path() == "/sys/devices/platform/soc/test/throttled"
+    def test_probe_throttle_path_found(self, mock_isfile, mock_walk, mock_isdir):
+        # os.path.join uses the host separator (backslash on Windows,
+        # forward slash on Linux) — test against the joined form so
+        # both CI and local Windows runs agree.
+        expected = os.path.join("/sys/devices/platform/soc/firmware", "throttled")
+        assert _probe_throttle_path() == expected
 
-    @patch("glob.glob", return_value=[])
-    def test_probe_throttle_path_none(self, mock_glob):
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.walk", return_value=[])
+    def test_probe_throttle_path_none(self, mock_walk, mock_isdir):
         assert _probe_throttle_path() is None
+
+    @patch("os.path.isdir", return_value=False)
+    def test_probe_throttle_path_no_soc_root(self, mock_isdir):
+        """Non-Pi platforms (no /sys/devices/platform/soc) → return None
+        without ever invoking the walk."""
+        assert _probe_throttle_path() is None
+
+    def test_probe_throttle_path_does_not_follow_symlinks(self):
+        """Symlink loops in /sys/devices/platform/soc must not hang the
+        probe. The bug that prompted this guard: Pi Zero 2W's
+        bcm2835 serial driver has a `<dev>/driver/<dev>/...`
+        self-referential chain in sysfs; the prior `glob.glob(pattern,
+        recursive=True)` followed it forever (Python 3.12 docs: ** does
+        follow symlinks) and pinned the camera-streamer at boot for
+        minutes before systemd's watchdog killed it.
+        """
+        # The fix is structural — os.walk is called with
+        # followlinks=False. Verify the call shape directly so
+        # future refactors can't silently re-enable it.
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.walk", return_value=[]) as mock_walk,
+        ):
+            _probe_throttle_path()
+        assert mock_walk.call_count == 1
+        # os.walk(top, topdown=True, onerror=None, followlinks=False)
+        # — followlinks may be passed positionally or as a kwarg.
+        kwargs = mock_walk.call_args.kwargs
+        if "followlinks" in kwargs:
+            assert kwargs["followlinks"] is False
+        else:
+            args = mock_walk.call_args.args
+            # If passed positionally, the 4th arg is followlinks.
+            assert len(args) < 4 or args[3] is False, (
+                f"os.walk called with followlinks=True: args={args}"
+            )
+
+    def test_probe_throttle_path_caps_walked_directories(self):
+        """Even on a non-loop sysfs forest, the probe must not walk
+        unbounded — defence against future SoCs with thousands of
+        nodes adding seconds to boot."""
+
+        def fake_walk(*_args, **_kwargs):
+            # Simulate a giant sysfs that keeps yielding empty dirs.
+            for i in range(10_000):
+                yield (f"/sys/devices/platform/soc/dir{i}", [], [])
+
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.walk", side_effect=fake_walk),
+        ):
+            assert _probe_throttle_path() is None
 
     @patch(
         "os.path.isdir",


### PR DESCRIPTION
## Summary

- Hardware test on `rpi-divinu-cam-a5cf` (Pi Zero 2W) right after the #242 throttle-state work merged: `camera-streamer.service` stayed `active` but the process was stuck on a single thread spinning at 100% CPU. Journal cut off at "Config loaded" — no heartbeat, no streaming pipeline. `strace` showed the process walking sysfs forever through `/sys/devices/platform/soc/3f215040.serial/.../driver/<dev>/driver/<dev>/...` — the bcm2835 serial driver has self-referential symlinks in the sysfs node tree.
- Root cause: `glob.glob(pattern, recursive=True)` follows symlinks per the Python 3.12 docs ("the `**` token will match files, directories, subdirectories **and symbolic links to directories**"). The `_probe_throttle_path` function in `platform.py` used this pattern over `/sys/devices/platform/soc/**/throttled`.
- Switch to `os.walk(soc_root, followlinks=False)` filtered by filename. A bounded symlink-safe scan; finds the same `throttled` / `get_throttled` files on a healthy SoC and refuses to descend into loops on a quirky one. A 2000-directory cap defends against future SoCs with very wide trees.
- Bonus: setting `CAMERA_THROTTLED_PATH=` in the systemd unit DOESN'T help — `os.environ.get(key, default)` evaluates the default eagerly so `_probe_throttle_path()` runs regardless of the env var. The structural fix in this commit is the only path that helps.

## Test plan
- [x] 5 new `_probe_throttle_path` tests: walk yields expected path; empty walk → None; non-Pi platforms short-circuit; `followlinks=False` contract asserted (positional or keyword); 10 000-directory fake forest terminates via the cap.
- [x] Existing 30 platform tests still pass (the two `glob.glob` tests rewritten to mock `os.walk`).
- [x] Full camera unit suite: 499 passed (excluding the pre-existing Windows-only `test_lifecycle_resolver` flake).
- [x] `ruff check` + `ruff format --check` clean.
- [x] **Live verification on `rpi-divinu-cam-a5cf`**: pre-fix → 1 thread, hung at "Config loaded". Post hot-patch → 17 threads, ffmpeg streaming, heartbeat HTTP 200, `throttle_state` populated on `cameras.json` (per-heartbeat path uses vcgencmd directly so the sysfs probe only ran at startup, and now completes promptly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)