### PR TITLE
[codex] Fix dashboard settings and tailscale status

### DIFF
--- a/app/server/monitor/api/system.py
+++ b/app/server/monitor/api/system.py
@@ -362,8 +362,13 @@ def tailscale_status():
 
     # Merge persisted config (never expose the auth key value)
     settings = current_app.store.get_settings()
+    effective_enabled = (
+        bool(settings.tailscale_enabled)
+        or bool(status.get("daemon_enabled"))
+        or status.get("state") == "connected"
+    )
     status["config"] = {
-        "enabled": settings.tailscale_enabled,
+        "enabled": effective_enabled,
         "auto_connect": settings.tailscale_auto_connect,
         "accept_routes": settings.tailscale_accept_routes,
         "ssh": settings.tailscale_ssh,

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -63,17 +63,6 @@
     </a>
 </div>
 
-<div id="dashboard-server-address" class="card mb-16" hidden style="padding:16px;">
-    <div class="section-header" style="margin-bottom:10px;">Server address</div>
-    <a data-role="server-url" href="" class="form-input"
-       style="display:block;text-decoration:none;font-family:var(--font-mono, monospace);word-break:break-word;"></a>
-    <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:12px;">
-        <button data-role="copy-url" type="button" class="btn btn--secondary btn--small">Copy</button>
-        <a data-role="help-link" href="" class="text-small text-muted">Help</a>
-    </div>
-    <div data-role="server-meta" class="text-small text-muted" style="margin-top:10px;"></div>
-</div>
-
 <!--
   Tier 3 (slice 2) — Recent events feed
   Reverse-chronological clip list across every camera. Clicking a row
@@ -453,9 +442,14 @@
                 </div>
                 <div class="form-group">
                     <label>Resolution</label>
-                    <select class="form-input" x-model="editForm.resolution" @change="onResolutionChange()">
+                    <select class="form-input"
+                            x-model="editForm.resolution"
+                            x-effect="$el.value = editForm.resolution"
+                            @change="onResolutionChange()">
                         <template x-for="opt in editForm.resolutionOptions" :key="opt.value">
-                            <option :value="opt.value" x-text="opt.label"></option>
+                            <option :value="opt.value"
+                                    :selected="opt.value === editForm.resolution"
+                                    x-text="opt.label"></option>
                         </template>
                     </select>
                 </div>
@@ -625,8 +619,6 @@
 
 {% block scripts %}
 <script>
-window.HM.networkFallback.mount('dashboard-server-address', '/help/network-fallback');
-
 function dashboardPage() {
     return {
         // --- ADR-0018 Tier-1 + Tier-2 + Tier-3 state ---

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -2945,7 +2945,7 @@ function settingsPage() {
         async exportDiagnostics() {
             this.diagnostics.exporting = true;
             this.diagnostics.error = '';
-            this.diagnostics.status = 'Collecting logs, config, and host state...';
+            this.diagnostics.status = 'Preparing diagnostics download...';
             if (this.diagnostics.slowTimer) {
                 clearTimeout(this.diagnostics.slowTimer);
             }
@@ -2955,43 +2955,34 @@ function settingsPage() {
                 }
             }, 30000);
             try {
-                var resp = await fetch('/api/v1/system/diagnostics/export', {
-                    method: 'POST',
-                    credentials: 'same-origin',
-                    headers: {
-                        'X-CSRF-Token': window.HM.auth.getCsrfToken() || '',
-                    },
-                });
-                if (!resp.ok) {
-                    var payload = {};
-                    try {
-                        payload = await resp.json();
-                    } catch (_) {
-                        payload = {};
-                    }
-                    var message = payload.error || 'Diagnostics export failed';
-                    if (resp.status === 429 && payload.retry_after_seconds) {
-                        message = 'Diagnostics export busy. Try again in ' + payload.retry_after_seconds + 's.';
-                    } else if (payload.detail) {
-                        message = payload.detail;
-                    }
-                    throw new Error(message);
+                if (!window.HM.auth.getCsrfToken()) {
+                    await window.HM.auth.getMe();
+                }
+                var csrfToken = window.HM.auth.getCsrfToken() || '';
+                if (!csrfToken) {
+                    throw new Error('Session expired. Refresh the page and try again.');
                 }
 
-                var blob = await resp.blob();
-                var disposition = resp.headers.get('Content-Disposition') || '';
-                var match = disposition.match(/filename="?([^";]+)"?/);
-                var filename = match ? match[1] : 'hm-diagnostics.tar.gz';
-                var url = window.URL.createObjectURL(blob);
-                var link = document.createElement('a');
-                link.href = url;
-                link.download = filename;
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-                window.URL.revokeObjectURL(url);
-                this.diagnostics.status = 'Diagnostics bundle downloaded.';
-                window.HM.toast('Diagnostics downloaded', 'success');
+                var form = document.createElement('form');
+                form.method = 'POST';
+                form.action = '/api/v1/system/diagnostics/export';
+                form.style.display = 'none';
+
+                var csrf = document.createElement('input');
+                csrf.type = 'hidden';
+                csrf.name = 'csrf_token';
+                csrf.value = csrfToken;
+                form.appendChild(csrf);
+
+                document.body.appendChild(form);
+                form.submit();
+                setTimeout(function() {
+                    if (form.parentNode) {
+                        form.parentNode.removeChild(form);
+                    }
+                }, 5000);
+                this.diagnostics.status = 'Diagnostics export started. Check your downloads.';
+                window.HM.toast('Diagnostics export started', 'success');
             } catch (e) {
                 this.diagnostics.error = e.message || 'Diagnostics export failed';
                 this.diagnostics.status = '';

--- a/app/server/tests/integration/test_api_system.py
+++ b/app/server/tests/integration/test_api_system.py
@@ -198,6 +198,22 @@ class TestTailscaleEndpoints:
         assert "enabled" in data["config"]
         assert "has_auth_key" in data["config"]
 
+    def test_get_status_reflects_running_daemon_as_enabled(self, app, logged_in_client):
+        settings = app.store.get_settings()
+        settings.tailscale_enabled = False
+        app.store.save_settings(settings)
+        app.tailscale_service = MagicMock()
+        app.tailscale_service.get_status.return_value = {
+            "state": "connected",
+            "daemon_enabled": True,
+        }
+
+        client = logged_in_client()
+        resp = client.get("/api/v1/system/tailscale")
+
+        assert resp.status_code == 200
+        assert resp.get_json()["config"]["enabled"] is True
+
     def test_connect_requires_admin(self, logged_in_client):
         client = logged_in_client("viewer")
         assert client.post("/api/v1/system/tailscale/connect").status_code == 403

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -125,7 +125,9 @@ class TestProtectedPages:
         response = client.get("/dashboard")
         assert response.status_code == 200
         body = response.get_data(as_text=True)
-        assert "dashboard-server-address" in body
+        assert "dashboard-server-address" not in body
+        assert "Server address" not in body
+        assert "networkFallback.mount" not in body
         assert 'data-role="server-qr"' not in body
         assert "qrcode.min.js" not in body
 
@@ -136,6 +138,19 @@ class TestProtectedPages:
             sess["role"] = "admin"
         response = client.get("/live")
         assert response.status_code == 200
+
+    def test_settings_uses_native_form_for_diagnostics_export(self, client):
+        with client.session_transaction() as sess:
+            sess["user_id"] = "user-001"
+            sess["username"] = "admin"
+            sess["role"] = "admin"
+        response = client.get("/settings")
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert "form.action = '/api/v1/system/diagnostics/export'" in body
+        assert "form.submit()" in body
+        assert "fetch('/api/v1/system/diagnostics/export'" not in body
+        assert "hm-diagnostics.tar.gz" not in body
 
     def test_recordings_renders_when_authenticated(self, client):
         with client.session_transaction() as sess:
@@ -563,6 +578,8 @@ class TestDashboardSensorAwareSettings:
         # New dynamic dropdown markup is present.
         assert 'x-for="opt in editForm.resolutionOptions"' in body
         assert ':value="opt.value"' in body
+        assert 'x-effect="$el.value = editForm.resolution"' in body
+        assert ':selected="opt.value === editForm.resolution"' in body
         # Sensor label row is present (hidden when empty).
         assert "editForm.sensorLabel" in body
         # Mismatch banner is present.


### PR DESCRIPTION
## Summary

- Remove the dashboard Server Address panel and its network fallback mount so the dashboard no longer repeats server address information after login.
- Make the camera settings resolution dropdown stay bound to the camera's current resolution, including custom/current modes.
- Switch diagnostics export to a native POST form download path so browser fetch/blob failures do not block export.
- Reflect an already-running or systemd-enabled Tailscale daemon as enabled in the settings API.

## Validation

- `pytest app/server/tests/integration/test_views.py app/server/tests/integration/test_api_diagnostics_export.py app/server/tests/integration/test_api_system.py::TestTailscaleEndpoints app/server/tests/contracts/test_api_contracts.py::TestTailscaleStatusContract -q`
- `ruff check app/server/monitor/api/system.py app/server/tests/integration/test_api_system.py app/server/tests/integration/test_views.py app/server/tests/integration/test_api_diagnostics_export.py`
- `ruff format --check app/server/monitor/api/system.py app/server/tests/integration/test_api_system.py app/server/tests/integration/test_views.py app/server/tests/integration/test_api_diagnostics_export.py`

## Device Check

Deployed and checked on the server at `192.168.1.245`; Tailscale is connected with IP `100.118.180.85`, and the persisted auto-connect setting reflects user changes.