### PR TITLE
[codex] Fix shared live camera links

### DIFF
--- a/app/server/monitor/api/share.py
+++ b/app/server/monitor/api/share.py
@@ -1,6 +1,8 @@
 # REQ: SWR-058, SWR-059, SWR-060, SWR-061; RISK: RISK-023, RISK-024, RISK-025; SEC: SC-022, SC-023, SC-024; TEST: TC-050, TC-051, TC-052, TC-053
 """Share-link API and public viewer routes."""
 
+import re
+
 from flask import (
     Blueprint,
     current_app,
@@ -11,10 +13,12 @@ from flask import (
     session,
 )
 
+from monitor.api.webrtc import proxy_whep_request, whep_preflight_response
 from monitor.auth import admin_required, csrf_protect
 
 share_api_bp = Blueprint("share_api", __name__)
 share_public_bp = Blueprint("share_public", __name__)
+_WHEP_SESSION_PATH_RE = re.compile(r"^[A-Za-z0-9._~/-]{1,256}$")
 
 
 def _svc():
@@ -55,6 +59,14 @@ def _record_public_failure(token: str, error: str, reason: str) -> None:
     if error == _svc().public_resource_failure_message():
         return
     _svc().record_failed_public_attempt(_remote_ip(), token, reason)
+
+
+def _valid_whep_session_path(session_path: str) -> bool:
+    if not session_path:
+        return True
+    if not _WHEP_SESSION_PATH_RE.match(session_path):
+        return False
+    return all(part and part not in {".", ".."} for part in session_path.split("/"))
 
 
 @share_api_bp.route("/links", methods=["POST"])
@@ -166,12 +178,51 @@ def shared_camera_page(token: str):
             "shared_camera_viewer.html",
             device_name=result["device_name"],
             resource_name=result["resource_name"],
-            hls_url=result["hls_url"],
+            whep_url=result["whep_url"],
             share_link=result["share_link"],
             hide_nav=True,
             public_page=True,
         ),
         status,
+    )
+
+
+@share_public_bp.route("/share/camera/<token>/whep", methods=["OPTIONS"])
+@share_public_bp.route(
+    "/share/camera/<token>/whep/<path:session_path>", methods=["OPTIONS"]
+)
+def shared_camera_whep_preflight(token: str, session_path: str = ""):
+    return whep_preflight_response()
+
+
+@share_public_bp.route("/share/camera/<token>/whep", methods=["POST"])
+@share_public_bp.route(
+    "/share/camera/<token>/whep/<path:session_path>", methods=["PATCH", "DELETE"]
+)
+def shared_camera_whep_proxy(token: str, session_path: str = ""):
+    rate_limit_response = _enforce_public_rate_limit()
+    if rate_limit_response is not None:
+        return rate_limit_response
+
+    if not _valid_whep_session_path(session_path):
+        _svc().record_failed_public_attempt(_remote_ip(), token, "camera-whep-path")
+        return _public_error(_svc().public_link_failure_message(), 404)
+
+    result, error, status = _svc().get_shared_camera_whep_target(
+        token, _remote_ip(), _remote_ua()
+    )
+    if error:
+        _record_public_failure(token, error, "camera-whep")
+        return _public_error(error, status)
+
+    target_base_path = result["whep_path"]
+    target_path = target_base_path
+    if session_path:
+        target_path += "/" + session_path
+    return proxy_whep_request(
+        target_path,
+        public_base_path=f"/share/camera/{token}/whep",
+        target_base_path=target_base_path,
     )
 
 

--- a/app/server/monitor/api/webrtc.py
+++ b/app/server/monitor/api/webrtc.py
@@ -1,5 +1,5 @@
 """
-WebRTC WHEP proxy — authenticated gateway to MediaMTX.
+WebRTC WHEP proxy - authenticated gateway to MediaMTX.
 
 Proxies WebRTC WHEP requests to the local MediaMTX instance after
 validating the user's session. Without this, the MediaMTX WHEP
@@ -11,6 +11,7 @@ Endpoints:
 """
 
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from flask import Blueprint, Response, request
@@ -24,9 +25,8 @@ webrtc_bp = Blueprint("webrtc", __name__)
 MEDIAMTX_WHEP = "http://127.0.0.1:8889"
 
 
-@webrtc_bp.route("/<path:path>", methods=["OPTIONS"])
-def whep_preflight(path):
-    """Handle CORS preflight — no auth needed (OPTIONS carries no cookies)."""
+def whep_preflight_response():
+    """Build a CORS preflight response for WHEP endpoints."""
     origin = request.headers.get("Origin", request.host_url.rstrip("/"))
     resp = Response("", status=204)
     resp.headers["Access-Control-Allow-Origin"] = origin
@@ -39,17 +39,15 @@ def whep_preflight(path):
     return resp
 
 
-@webrtc_bp.route("/<path:path>", methods=["POST", "PATCH", "DELETE"])
-@login_required
-def whep_proxy(path):
-    """Proxy authenticated WHEP requests to MediaMTX.
+def proxy_whep_request(
+    path: str,
+    *,
+    public_base_path: str = "",
+    target_base_path: str = "",
+) -> Response:
+    """Proxy the current WHEP request to MediaMTX and rewrite public headers."""
+    target_url = f"{MEDIAMTX_WHEP}/{urllib.parse.quote(path, safe='/')}"
 
-    Validates the session via @login_required before forwarding
-    the request to the local MediaMTX WHEP endpoint.
-    """
-    target_url = f"{MEDIAMTX_WHEP}/{path}"
-
-    # Forward the request body and content-type
     headers = {}
     for header in ("Content-Type", "If-Match"):
         value = request.headers.get(header)
@@ -66,15 +64,15 @@ def whep_proxy(path):
         with urllib.request.urlopen(req, timeout=10) as upstream:
             resp_data = upstream.read()
             resp = Response(resp_data, status=upstream.status)
-            # Forward relevant response headers
             for header in ("Content-Type", "ETag", "Location", "Link"):
                 value = upstream.headers.get(header)
                 if value:
-                    # Rewrite Location header to use our proxy path
-                    if header == "Location" and value.startswith(
-                        "http://127.0.0.1:8889/"
-                    ):
-                        value = value.replace("http://127.0.0.1:8889/", "/webrtc/")
+                    if header == "Location":
+                        value = _rewrite_mediamtx_location(
+                            value,
+                            public_base_path=public_base_path,
+                            target_base_path=target_base_path,
+                        )
                     resp.headers[header] = value
     except urllib.error.HTTPError as e:
         resp_data = e.read() if hasattr(e, "read") else b""
@@ -85,8 +83,40 @@ def whep_proxy(path):
     except (urllib.error.URLError, OSError):
         resp = Response("MediaMTX not available", status=502)
 
-    # Add CORS headers
     origin = request.headers.get("Origin", request.host_url.rstrip("/"))
     resp.headers["Access-Control-Allow-Origin"] = origin
     resp.headers["Access-Control-Expose-Headers"] = "ETag, Location, Link"
     return resp
+
+
+def _rewrite_mediamtx_location(
+    value: str,
+    *,
+    public_base_path: str = "",
+    target_base_path: str = "",
+) -> str:
+    mediamtx_prefix = f"{MEDIAMTX_WHEP}/"
+    if not value.startswith(mediamtx_prefix):
+        return value
+    internal_path = value[len(mediamtx_prefix) :]
+    if public_base_path and target_base_path:
+        target_base = target_base_path.strip("/")
+        if internal_path == target_base:
+            return public_base_path.rstrip("/")
+        if internal_path.startswith(target_base + "/"):
+            suffix = internal_path[len(target_base) :].lstrip("/")
+            return public_base_path.rstrip("/") + "/" + suffix
+    return "/webrtc/" + internal_path
+
+
+@webrtc_bp.route("/<path:path>", methods=["OPTIONS"])
+def whep_preflight(path):
+    """Handle CORS preflight; no auth needed because OPTIONS carries no cookies."""
+    return whep_preflight_response()
+
+
+@webrtc_bp.route("/<path:path>", methods=["POST", "PATCH", "DELETE"])
+@login_required
+def whep_proxy(path):
+    """Proxy authenticated WHEP requests to MediaMTX."""
+    return proxy_whep_request(path)

--- a/app/server/monitor/services/share_link_service.py
+++ b/app/server/monitor/services/share_link_service.py
@@ -313,8 +313,30 @@ class ShareLinkService:
                 "share_link": link,
                 "resource_name": result["resource_name"],
                 "camera_id": result["camera_id"],
-                "hls_url": f"/share/camera/{link.token}/stream.m3u8",
+                "whep_url": f"/share/camera/{link.token}/whep",
                 "device_name": self._device_name(),
+            },
+            None,
+            200,
+        )
+
+    def get_shared_camera_whep_target(
+        self, token: str, visitor_ip: str, visitor_ua: str
+    ):
+        """Authorise a public camera share and return its MediaMTX WHEP path."""
+        link, error, status = self._authorise_link(
+            token, expected_type="camera", visitor_ip=visitor_ip, visitor_ua=visitor_ua
+        )
+        if error:
+            return None, error, status
+
+        result, error, status = self._resolve_camera_resource(link.resource_id)
+        if error:
+            return None, error, status
+        return (
+            {
+                "camera_id": result["camera_id"],
+                "whep_path": f"{result['camera_id']}/whep",
             },
             None,
             200,
@@ -334,7 +356,9 @@ class ShareLinkService:
         if error:
             return None, error, status
 
-        result, error, status = self._resolve_camera_resource(link.resource_id)
+        result, error, status = self._resolve_camera_resource(
+            link.resource_id, require_playlist=True
+        )
         if error:
             return None, error, status
 
@@ -470,7 +494,9 @@ class ShareLinkService:
             status,
         )
 
-    def _resolve_camera_resource(self, camera_id: str):
+    def _resolve_camera_resource(
+        self, camera_id: str, *, require_playlist: bool = False
+    ):
         if not _CAMERA_ID_RE.match(camera_id or ""):
             return None, "Invalid resource id", 400
         camera = self._store.get_camera(camera_id)
@@ -479,7 +505,7 @@ class ShareLinkService:
         if getattr(camera, "status", "") != "online":
             return None, self.public_resource_failure_message(), 404
         playlist = self._live_dir / camera_id / "stream.m3u8"
-        if not playlist.is_file():
+        if require_playlist and not playlist.is_file():
             return None, self.public_resource_failure_message(), 404
         return (
             {

--- a/app/server/monitor/templates/shared_camera_viewer.html
+++ b/app/server/monitor/templates/shared_camera_viewer.html
@@ -20,9 +20,6 @@
                     <h1 class="public-share-title">{{ resource_name }}</h1>
                 </div>
             </div>
-            <p class="public-share-copy">
-                Shared by {{ device_name }}. This public link shows one live camera and nothing else.
-            </p>
             <div class="public-share-player" id="share-live-frame">
                 <video class="public-share-video" id="share-live-video" autoplay muted playsinline></video>
                 <div class="public-share-watermark">
@@ -33,12 +30,13 @@
         </section>
     </main>
 
-    <script src="{{ url_for('static', filename='js/hls.min.js') }}"></script>
     <script>
     (function() {
         var videoEl = document.getElementById('share-live-video');
         var overlayEl = document.getElementById('share-live-overlay');
-        var streamUrl = {{ hls_url|tojson }};
+        var whepUrl = {{ whep_url|tojson }};
+        var peerConnection = null;
+        var WHEP_TIMEOUT_MS = 8000;
 
         function setOverlay(text) {
             overlayEl.textContent = text;
@@ -49,46 +47,104 @@
             overlayEl.style.display = 'none';
         }
 
-        function startNative() {
-            videoEl.src = streamUrl;
-            videoEl.addEventListener('loadedmetadata', function onLoaded() {
-                videoEl.removeEventListener('loadedmetadata', onLoaded);
-                hideOverlay();
-                videoEl.play().catch(function() {});
+        function waitForICE(pc, maxWait) {
+            return new Promise(function(resolve) {
+                if (pc.iceGatheringState === 'complete') {
+                    resolve();
+                    return;
+                }
+                var done = false;
+                var timer = setTimeout(function() {
+                    if (!done) {
+                        done = true;
+                        resolve();
+                    }
+                }, maxWait);
+                pc.onicegatheringstatechange = function() {
+                    if (pc.iceGatheringState === 'complete' && !done) {
+                        done = true;
+                        clearTimeout(timer);
+                        resolve();
+                    }
+                };
             });
-            videoEl.addEventListener('error', function onErr() {
-                videoEl.removeEventListener('error', onErr);
+        }
+
+        function startWebRTC() {
+            if (typeof RTCPeerConnection === 'undefined') {
+                setOverlay('Live playback is not supported in this browser');
+                return;
+            }
+
+            setOverlay('Starting stream...');
+            var pc = new RTCPeerConnection({ iceServers: [] });
+            peerConnection = pc;
+
+            var timeout = setTimeout(function() {
+                if (peerConnection === pc) {
+                    pc.close();
+                    peerConnection = null;
+                    setOverlay('Stream unavailable');
+                }
+            }, WHEP_TIMEOUT_MS);
+
+            pc.addTransceiver('video', { direction: 'recvonly' });
+            pc.addTransceiver('audio', { direction: 'recvonly' });
+
+            pc.ontrack = function(event) {
+                if (event.streams && event.streams[0]) {
+                    clearTimeout(timeout);
+                    videoEl.srcObject = event.streams[0];
+                    videoEl.play().catch(function() {});
+                    hideOverlay();
+                }
+            };
+
+            pc.onconnectionstatechange = function() {
+                if (pc.connectionState === 'failed' ||
+                    pc.connectionState === 'disconnected') {
+                    clearTimeout(timeout);
+                    setOverlay('Stream unavailable');
+                }
+            };
+
+            pc.createOffer().then(function(offer) {
+                return pc.setLocalDescription(offer);
+            }).then(function() {
+                return waitForICE(pc, 2000);
+            }).then(function() {
+                return fetch(whepUrl, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/sdp' },
+                    body: pc.localDescription.sdp
+                });
+            }).then(function(response) {
+                if (!response.ok) {
+                    throw new Error('WHEP POST failed: ' + response.status);
+                }
+                return response.text();
+            }).then(function(sdpAnswer) {
+                return pc.setRemoteDescription(
+                    new RTCSessionDescription({ type: 'answer', sdp: sdpAnswer })
+                );
+            }).catch(function() {
+                clearTimeout(timeout);
+                if (peerConnection === pc) {
+                    peerConnection = null;
+                }
+                pc.close();
                 setOverlay('Stream unavailable');
             });
-            videoEl.play().catch(function() {});
         }
 
-        if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
-            startNative();
-            return;
-        }
+        window.addEventListener('pagehide', function() {
+            if (peerConnection) {
+                peerConnection.close();
+                peerConnection = null;
+            }
+        });
 
-        if (typeof Hls !== 'undefined' && Hls.isSupported()) {
-            var hls = new Hls({
-                enableWorker: true,
-                lowLatencyMode: true,
-            });
-            hls.loadSource(streamUrl);
-            hls.attachMedia(videoEl);
-            hls.on(Hls.Events.MANIFEST_PARSED, function() {
-                hideOverlay();
-                videoEl.play().catch(function() {});
-            });
-            hls.on(Hls.Events.ERROR, function(_event, data) {
-                if (data.fatal) {
-                    setOverlay('Stream unavailable');
-                    hls.destroy();
-                }
-            });
-            return;
-        }
-
-        setOverlay('Live playback is not supported in this browser');
+        startWebRTC();
     })();
     </script>
 </body>

--- a/app/server/monitor/templates/shared_clip_viewer.html
+++ b/app/server/monitor/templates/shared_clip_viewer.html
@@ -20,9 +20,6 @@
                     <h1 class="public-share-title">{{ resource_name }}</h1>
                 </div>
             </div>
-            <p class="public-share-copy">
-                Shared by {{ device_name }}. This public link grants view-only access to this single clip.
-            </p>
             <div class="public-share-player">
                 <video class="public-share-video" controls playsinline preload="metadata" src="{{ video_url }}">
                     Your browser does not support the video tag.

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -89,10 +89,6 @@ def _seed_share_clip(
 
 def _seed_share_live(app, camera_id="cam-live"):
     _add_camera(app, camera_id)
-    live_dir = Path(app.config["LIVE_DIR"]) / camera_id
-    live_dir.mkdir(parents=True, exist_ok=True)
-    (live_dir / "stream.m3u8").write_text("#EXTM3U\n", encoding="utf-8")
-    (live_dir / "seg000.ts").write_bytes(b"segment")
 
 
 def _assert_fields(data, required_fields, msg=""):
@@ -1613,7 +1609,7 @@ class TestPublicShareContract:
         resp = client.get("/share/clip/sharelink_missing")
         assert resp.status_code == 404
 
-    def test_valid_camera_playlist_returns_m3u8(self, app, client):
+    def test_valid_camera_whep_proxy_returns_sdp(self, app, client):
         _seed_share_live(app)
         created, error, _status = app.share_link_service.create_share_link(
             resource_type="camera",
@@ -1623,9 +1619,25 @@ class TestPublicShareContract:
             ttl="24h",
         )
         assert error is None
-        resp = client.get("/share/camera/" + created["token"] + "/stream.m3u8")
-        assert resp.status_code == 200
-        assert resp.mimetype == "application/vnd.apple.mpegurl"
+        upstream = MagicMock()
+        upstream.read.return_value = b"SDP answer"
+        upstream.status = 201
+        upstream.headers = {
+            "Content-Type": "application/sdp",
+            "ETag": None,
+            "Location": None,
+            "Link": None,
+        }
+        upstream.__enter__ = MagicMock(return_value=upstream)
+        upstream.__exit__ = MagicMock(return_value=False)
+        with patch("monitor.api.webrtc.urllib.request.urlopen", return_value=upstream):
+            resp = client.post(
+                "/share/camera/" + created["token"] + "/whep",
+                data=b"SDP offer",
+                content_type="application/sdp",
+            )
+        assert resp.status_code == 201
+        assert resp.mimetype == "application/sdp"
 
 
 # ===========================================================================

--- a/app/server/tests/integration/test_api_share.py
+++ b/app/server/tests/integration/test_api_share.py
@@ -2,6 +2,7 @@
 """Integration tests for share-link APIs and public routes."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -38,10 +39,24 @@ def _seed_live(app, camera_id="cam-002"):
             recording_mode="continuous",
         )
     )
-    live_dir = Path(app.config["LIVE_DIR"]) / camera_id
-    live_dir.mkdir(parents=True, exist_ok=True)
-    (live_dir / "stream.m3u8").write_text("#EXTM3U\n", encoding="utf-8")
-    (live_dir / "seg000.ts").write_bytes(b"segment")
+
+
+def _mock_whep_upstream(status=201, body=b"SDP answer", headers=None):
+    response_headers = {
+        "Content-Type": "application/sdp",
+        "ETag": None,
+        "Location": None,
+        "Link": None,
+    }
+    if headers:
+        response_headers.update(headers)
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.status = status
+    resp.headers = response_headers
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
 
 
 @pytest.fixture(autouse=True)
@@ -127,7 +142,7 @@ class TestPublicShareRoutes:
         assert asset.status_code == 200
         assert asset.mimetype == "video/mp4"
 
-    def test_public_camera_page_and_hls_segment_render_without_auth(self, app, client):
+    def test_public_camera_page_and_whep_proxy_render_without_auth(self, app, client):
         _seed_live(app)
         created, error, _status = app.share_link_service.create_share_link(
             resource_type="camera",
@@ -142,15 +157,74 @@ class TestPublicShareRoutes:
         assert page.status_code == 200
         body = page.get_data(as_text=True)
         assert "Shared live camera" in body
-        assert "/share/camera/" + created["token"] + "/stream.m3u8" in body
+        assert "/share/camera/" + created["token"] + "/whep" in body
+
+        upstream = _mock_whep_upstream(
+            headers={"Location": "http://127.0.0.1:8889/cam-002/whep/session/abc"}
+        )
+        with patch("monitor.api.webrtc.urllib.request.urlopen", return_value=upstream):
+            whep = client.post(
+                "/share/camera/" + created["token"] + "/whep",
+                data=b"SDP offer",
+                content_type="application/sdp",
+            )
+        assert whep.status_code == 201
+        assert whep.mimetype == "application/sdp"
+        assert whep.headers["Location"] == (
+            "/share/camera/" + created["token"] + "/whep/session/abc"
+        )
+
+    def test_public_camera_whep_invalid_token_does_not_proxy(self, app, client):
+        _seed_live(app)
+
+        with patch("monitor.api.webrtc.urllib.request.urlopen") as urlopen:
+            response = client.post(
+                "/share/camera/sharelink_missing/whep",
+                data=b"SDP offer",
+                content_type="application/sdp",
+            )
+
+        assert response.status_code == 404
+        urlopen.assert_not_called()
+
+    def test_public_camera_whep_rejects_path_escape_before_proxy(self, app, client):
+        _seed_live(app)
+        created, error, _status = app.share_link_service.create_share_link(
+            resource_type="camera",
+            resource_id="cam-002",
+            owner_id="user-admin",
+            owner_username="admin",
+            ttl="24h",
+        )
+        assert error is None
+
+        with patch("monitor.api.webrtc.urllib.request.urlopen") as urlopen:
+            response = client.patch(
+                "/share/camera/" + created["token"] + "/whep/%2E%2E/other/session",
+                data=b"ICE fragment",
+                content_type="application/trickle-ice-sdpfrag",
+            )
+
+        assert response.status_code == 404
+        urlopen.assert_not_called()
+
+    def test_public_camera_hls_file_remains_available_when_present(self, app, client):
+        _seed_live(app)
+        live_dir = Path(app.config["LIVE_DIR"]) / "cam-002"
+        live_dir.mkdir(parents=True, exist_ok=True)
+        (live_dir / "stream.m3u8").write_text("#EXTM3U\n", encoding="utf-8")
+        created, error, _status = app.share_link_service.create_share_link(
+            resource_type="camera",
+            resource_id="cam-002",
+            owner_id="user-admin",
+            owner_username="admin",
+            ttl="24h",
+        )
+        assert error is None
 
         playlist = client.get("/share/camera/" + created["token"] + "/stream.m3u8")
         assert playlist.status_code == 200
         assert playlist.mimetype == "application/vnd.apple.mpegurl"
-
-        segment = client.get("/share/camera/" + created["token"] + "/seg000.ts")
-        assert segment.status_code == 200
-        assert segment.mimetype == "video/mp2t"
 
     def test_invalid_public_token_uses_generic_404(self, app, client):
         response = client.get("/share/clip/sharelink_missing")

--- a/app/server/tests/unit/test_svc_share_link.py
+++ b/app/server/tests/unit/test_svc_share_link.py
@@ -34,6 +34,10 @@ def _seed_live(app, camera_id="cam-001"):
         recording_mode="continuous",
     )
     app.store.save_camera(cam)
+
+
+def _seed_live_hls(app, camera_id="cam-001"):
+    _seed_live(app, camera_id)
     live_dir = Path(app.config["LIVE_DIR"]) / camera_id
     live_dir.mkdir(parents=True, exist_ok=True)
     (live_dir / "stream.m3u8").write_text("#EXTM3U\n", encoding="utf-8")
@@ -136,7 +140,7 @@ class TestShareLinkService:
         assert error == app.share_link_service.public_link_failure_message()
 
     def test_shared_camera_file_resolves_hls_segment(self, app):
-        _seed_live(app, "cam-live")
+        _seed_live_hls(app, "cam-live")
         created, error, _status = app.share_link_service.create_share_link(
             resource_type="camera",
             resource_id="cam-live",
@@ -156,3 +160,43 @@ class TestShareLinkService:
         assert status == 200
         assert result["mimetype"] == "video/mp2t"
         assert result["path"].name == "seg000.ts"
+
+    def test_shared_camera_page_uses_whep_without_hls_playlist(self, app):
+        _seed_live(app, "cam-live")
+        created, error, _status = app.share_link_service.create_share_link(
+            resource_type="camera",
+            resource_id="cam-live",
+            owner_id="user-admin",
+            owner_username="admin",
+            ttl="24h",
+        )
+        assert error is None
+
+        result, error, status = app.share_link_service.get_shared_camera_page(
+            created["token"],
+            visitor_ip="192.168.1.45",
+            visitor_ua="Mozilla/5.0 Chrome/136.0",
+        )
+        assert error is None
+        assert status == 200
+        assert result["whep_url"] == "/share/camera/" + created["token"] + "/whep"
+
+    def test_shared_camera_whep_target_authorises_camera(self, app):
+        _seed_live(app, "cam-live")
+        created, error, _status = app.share_link_service.create_share_link(
+            resource_type="camera",
+            resource_id="cam-live",
+            owner_id="user-admin",
+            owner_username="admin",
+            ttl="24h",
+        )
+        assert error is None
+
+        result, error, status = app.share_link_service.get_shared_camera_whep_target(
+            created["token"],
+            visitor_ip="192.168.1.45",
+            visitor_ua="Mozilla/5.0 Chrome/136.0",
+        )
+        assert error is None
+        assert status == 200
+        assert result["whep_path"] == "cam-live/whep"


### PR DESCRIPTION
## Summary

- Move shared live camera playback from the removed server-side HLS path to token-gated MediaMTX WebRTC/WHEP, matching the normal Live page architecture.
- Add public WHEP routes that authorise every request against the share token and map it to only the shared camera.
- Harden public WHEP session paths so invalid tokens and path escape attempts never proxy to MediaMTX.
- Remove explanatory security/design copy from public share pages so viewers just see the shared camera or clip.

## Root Cause

Shared live links still required `/data/live/<camera>/stream.m3u8`, but the server no longer generates live HLS playlists. The current live system uses MediaMTX WHEP directly, so valid share links were rejected as unavailable even when the camera was online.

## Validation

- `pytest app/server/tests/integration/test_api_share.py app/server/tests/integration/test_api_webrtc.py app/server/tests/contracts/test_api_contracts.py::TestPublicShareContract app/server/tests/unit/test_svc_share_link.py -q`
- `ruff check app/server/monitor/api/share.py app/server/monitor/api/webrtc.py app/server/monitor/services/share_link_service.py app/server/tests/integration/test_api_share.py app/server/tests/contracts/test_api_contracts.py app/server/tests/unit/test_svc_share_link.py`
- `ruff format --check app/server/monitor/api/share.py app/server/monitor/api/webrtc.py app/server/monitor/services/share_link_service.py app/server/tests/integration/test_api_share.py app/server/tests/contracts/test_api_contracts.py app/server/tests/unit/test_svc_share_link.py`

## Device Check

Deployed to the server at `192.168.1.245`. The shared camera page now renders, invalid public tokens return 404, and path-escape WHEP requests return 404.