### PR TITLE
Fix USB storage activation flow

### DIFF
--- a/app/server/config/monitor-privileged-helper.service
+++ b/app/server/config/monitor-privileged-helper.service
@@ -19,11 +19,14 @@ RuntimeDirectory=monitor
 RuntimeDirectoryMode=0750
 
 # This helper is intentionally root, but its socket accepts only allowlisted
-# JSON operations from the monitor group. Do not enable ProtectSystem here:
-# USB mounts must occur in the host mount namespace so nginx and the
-# unprivileged Flask process see the selected recording disk.
+# JSON operations from the monitor group. Do not enable filesystem namespacing
+# here: USB mounts must occur in the host mount namespace so nginx and the
+# unprivileged Flask process see the selected recording disk. ProtectHome and
+# PrivateMounts would make the helper report success for mounts that the app
+# cannot see.
 CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_CHOWN CAP_FOWNER CAP_SYS_TIME CAP_SYS_BOOT CAP_NET_ADMIN CAP_NET_RAW
-ProtectHome=true
+ProtectHome=false
+PrivateMounts=false
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true

--- a/app/server/monitor/services/privileged_helper.py
+++ b/app/server/monitor/services/privileged_helper.py
@@ -28,6 +28,11 @@ try:
 except ImportError:  # pragma: no cover - non-POSIX development hosts
     grp = None
 
+try:
+    import pwd
+except ImportError:  # pragma: no cover - non-POSIX development hosts
+    pwd = None
+
 log = logging.getLogger("monitor.privileged-helper")
 
 MAX_REQUEST_BYTES = 8192
@@ -104,13 +109,41 @@ def _run_command(
 
 
 def _op_usb_mount(payload: dict[str, Any]) -> dict[str, Any]:
+    mount_point = _validate_mount_point(payload.get("mount_point"))
     ok, err = usb.mount_device(
         _validate_device_path(payload.get("device_path")),
-        _validate_mount_point(payload.get("mount_point")),
+        mount_point,
     )
     if not ok:
         raise HelperRequestError(err or "mount failed")
+    _ensure_monitor_can_write_mount(mount_point)
     return {}
+
+
+def _ensure_monitor_can_write_mount(mount_point: str) -> None:
+    """Make a helper-mounted USB root writable by ``monitor``.
+
+    The helper runs as root, so ``usb.mount_device`` cannot infer the Flask
+    service UID from ``os.getuid()``. Without this correction ext4 USB drives
+    mount as root-owned and the unprivileged app cannot create the recordings
+    folder, causing the Storage tab's "Use" action to fail after a successful
+    mount.
+    """
+    if pwd is None or grp is None:
+        return
+    try:
+        uid = pwd.getpwnam("monitor").pw_uid
+        gid = grp.getgrnam("monitor").gr_gid
+        os.chown(mount_point, uid, gid)
+        os.chmod(mount_point, 0o775)
+        recordings_dir = posixpath.join(mount_point, usb.RECORDINGS_FOLDER)
+        os.makedirs(recordings_dir, exist_ok=True)
+        os.chown(recordings_dir, uid, gid)
+        os.chmod(recordings_dir, 0o775)
+    except (KeyError, PermissionError, OSError) as exc:
+        raise HelperRequestError(
+            f"USB mounted but {mount_point} is not writable by monitor: {exc}"
+        ) from exc
 
 
 def _op_usb_unmount(payload: dict[str, Any]) -> dict[str, Any]:

--- a/app/server/monitor/services/storage_service.py
+++ b/app/server/monitor/services/storage_service.py
@@ -62,8 +62,13 @@ class StorageService:
         """
         devices = usb.detect_devices()
         rec_dir = self._active_recordings_dir()
+        configured_device = self._configured_usb_device()
         for d in devices:
-            d["in_use"] = bool(rec_dir) and self._device_backs_dir(d, rec_dir)
+            is_active = bool(rec_dir) and self._device_backs_dir(d, rec_dir)
+            is_configured = bool(configured_device) and d.get("path") == configured_device
+            d["in_use"] = is_active
+            d["configured"] = is_configured
+            d["configured_inactive"] = is_configured and not is_active
         return devices
 
     def _active_recordings_dir(self) -> str:
@@ -73,6 +78,14 @@ class StorageService:
         if not isinstance(rec_dir, str) or not rec_dir:
             return ""
         return rec_dir
+
+    def _configured_usb_device(self) -> str:
+        try:
+            settings = self._store.get_settings()
+        except Exception:
+            return ""
+        value = getattr(settings, "usb_device", "")
+        return value if isinstance(value, str) else ""
 
     @staticmethod
     def _device_backs_dir(device: dict, rec_dir: str) -> bool:
@@ -129,7 +142,16 @@ class StorageService:
             return None, f"Failed to mount: {err}", 500
 
         # Create recordings folder
-        rec_dir = usb.prepare_recordings_dir()
+        try:
+            rec_dir = usb.prepare_recordings_dir()
+        except OSError as exc:
+            log.exception("Failed to prepare USB recordings directory")
+            return (
+                None,
+                "USB mounted, but the recordings folder could not be prepared. "
+                f"Check permissions on {usb.DEFAULT_MOUNT_POINT}: {exc}",
+                500,
+            )
 
         # Switch storage manager
         if self._storage_manager:

--- a/app/server/monitor/services/storage_service.py
+++ b/app/server/monitor/services/storage_service.py
@@ -65,7 +65,9 @@ class StorageService:
         configured_device = self._configured_usb_device()
         for d in devices:
             is_active = bool(rec_dir) and self._device_backs_dir(d, rec_dir)
-            is_configured = bool(configured_device) and d.get("path") == configured_device
+            is_configured = (
+                bool(configured_device) and d.get("path") == configured_device
+            )
             d["in_use"] = is_active
             d["configured"] = is_configured
             d["configured_inactive"] = is_configured and not is_active

--- a/app/server/monitor/static/js/app.js
+++ b/app/server/monitor/static/js/app.js
@@ -60,13 +60,32 @@
                 return Promise.reject(new Error('Authentication required'));
             }
 
-            return resp.json().then(function(data) {
+            return _readResponseBody(resp).then(function(data) {
                 if (!resp.ok) {
                     var msg = data.error || data.message || 'Request failed';
                     return Promise.reject(new Error(msg));
                 }
                 return data;
             });
+        });
+    }
+
+    function _readResponseBody(resp) {
+        var contentType = (resp.headers.get('Content-Type') || '').toLowerCase();
+        if (contentType.indexOf('application/json') !== -1) {
+            return resp.json().catch(function() {
+                return { error: 'Invalid JSON response from server' };
+            });
+        }
+        return resp.text().then(function(text) {
+            var message = text.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+            if (!message) {
+                message = resp.statusText || 'Request failed';
+            }
+            if (message.length > 180) {
+                message = message.slice(0, 177) + '...';
+            }
+            return { error: message };
         });
     }
 

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -1415,6 +1415,7 @@
                             <div style="font-weight:500;">
                                 <span x-text="d.model"></span>
                                 <span x-show="d.in_use" class="badge badge--ok" style="margin-left:8px;">In use</span>
+                                <span x-show="d.configured_inactive" class="badge badge--warn" style="margin-left:8px;">Configured</span>
                             </div>
                             <div class="text-small text-muted">
                                 <span x-text="d.path"></span> &middot;
@@ -1422,10 +1423,13 @@
                                 <span x-text="d.fstype || 'unformatted'"></span>
                                 <span x-show="d.supported" style="color:#4ade80;"> Compatible</span>
                                 <span x-show="!d.supported" style="color:#f87171;"> Needs format</span>
+                                <span x-show="d.configured_inactive"> &middot; not active right now</span>
                             </div>
                         </div>
                         <div style="display:flex; gap:6px; flex-wrap:wrap; align-items:center;">
-                            <button x-show="d.supported && !d.in_use" class="btn btn--primary btn--small" @click="selectUsb(d.path)">Use</button>
+                            <button x-show="d.supported && !d.in_use" class="btn btn--primary btn--small" @click="selectUsb(d)">
+                                <span x-text="d.configured_inactive ? 'Reconnect' : 'Use'"></span>
+                            </button>
                             <span x-show="d.in_use" class="text-small text-muted">Active</span>
                             <!-- Issue #107: Reformat available for all device states.
                                  In-use drives auto-eject first via showFormat(). -->
@@ -3905,8 +3909,13 @@ function settingsPage() {
             this.storage.scanning = false;
         },
 
-        async selectUsb(path) {
-            if (!confirm('Use this USB device for recordings?')) return;
+        async selectUsb(device) {
+            var path = (typeof device === 'string') ? device : (device && device.path);
+            if (!path) return;
+            var prompt = device && device.configured_inactive
+                ? 'Reconnect the configured USB drive and use it for recordings?'
+                : 'Use this USB device for recordings?';
+            if (!confirm(prompt)) return;
             try {
                 var data = await window.HM.api.post('/api/v1/storage/select', { device_path: path });
                 window.HM.toast(data.message || 'USB storage active', 'success');

--- a/app/server/tests/integration/test_api_storage.py
+++ b/app/server/tests/integration/test_api_storage.py
@@ -180,6 +180,32 @@ class TestSelectDevice:
         assert response.status_code == 500
         assert "Failed to mount" in response.get_json()["error"]
 
+    @patch(USB_PATCH)
+    def test_prepare_recordings_failure_returns_json_error(
+        self, mock_usb, logged_in_client
+    ):
+        client = logged_in_client()
+        device = _make_device("/dev/sda1")
+        mock_usb.detect_devices.return_value = [device]
+        mock_usb.mount_device.return_value = (True, None)
+        mock_usb.prepare_recordings_dir.side_effect = PermissionError(
+            "permission denied"
+        )
+        mock_usb.DEFAULT_MOUNT_POINT = "/mnt/recordings"
+
+        response = client.post(
+            "/api/v1/storage/select",
+            json={
+                "device_path": "/dev/sda1",
+            },
+        )
+
+        assert response.status_code == 500
+        assert response.is_json
+        assert "recordings folder could not be prepared" in response.get_json()[
+            "error"
+        ]
+
     def test_requires_admin(self, logged_in_client):
         client = logged_in_client("viewer")
         response = client.post(

--- a/app/server/tests/integration/test_api_storage.py
+++ b/app/server/tests/integration/test_api_storage.py
@@ -202,9 +202,7 @@ class TestSelectDevice:
 
         assert response.status_code == 500
         assert response.is_json
-        assert "recordings folder could not be prepared" in response.get_json()[
-            "error"
-        ]
+        assert "recordings folder could not be prepared" in response.get_json()["error"]
 
     def test_requires_admin(self, logged_in_client):
         client = logged_in_client("viewer")

--- a/app/server/tests/unit/test_privileged_helper.py
+++ b/app/server/tests/unit/test_privileged_helper.py
@@ -123,9 +123,7 @@ def test_helper_mount_ownership_covers_recordings_folder():
         f"/mnt/recordings/{helper.usb.RECORDINGS_FOLDER}", exist_ok=True
     )
     chown.assert_any_call("/mnt/recordings", 996, 994)
-    chown.assert_any_call(
-        f"/mnt/recordings/{helper.usb.RECORDINGS_FOLDER}", 996, 994
-    )
+    chown.assert_any_call(f"/mnt/recordings/{helper.usb.RECORDINGS_FOLDER}", 996, 994)
     chmod.assert_any_call("/mnt/recordings", 0o775)
     chmod.assert_any_call(f"/mnt/recordings/{helper.usb.RECORDINGS_FOLDER}", 0o775)
 

--- a/app/server/tests/unit/test_privileged_helper.py
+++ b/app/server/tests/unit/test_privileged_helper.py
@@ -73,6 +73,7 @@ def test_usb_mount_delegates_to_usb_module():
             return_value=[{"path": "/dev/sda1"}],
         ),
         patch.object(helper.usb, "mount_device", return_value=(True, "")) as mount,
+        patch.object(helper, "_ensure_monitor_can_write_mount") as ensure_writable,
     ):
         data = helper.handle_request(
             b'{"operation":"usb.mount","payload":{"device_path":"/dev/sda1"}}'
@@ -80,6 +81,53 @@ def test_usb_mount_delegates_to_usb_module():
 
     assert data == {}
     mount.assert_called_once_with("/dev/sda1", helper.usb.DEFAULT_MOUNT_POINT)
+    ensure_writable.assert_called_once_with(helper.usb.DEFAULT_MOUNT_POINT)
+
+
+def test_usb_mount_fails_when_helper_cannot_make_mount_writable():
+    with (
+        patch.object(
+            helper.usb,
+            "detect_devices",
+            return_value=[{"path": "/dev/sda1"}],
+        ),
+        patch.object(helper.usb, "mount_device", return_value=(True, "")),
+        patch.object(
+            helper,
+            "_ensure_monitor_can_write_mount",
+            side_effect=helper.HelperRequestError("not writable"),
+        ),
+        pytest.raises(helper.HelperRequestError, match="not writable"),
+    ):
+        helper.handle_request(
+            b'{"operation":"usb.mount","payload":{"device_path":"/dev/sda1"}}'
+        )
+
+
+def test_helper_mount_ownership_covers_recordings_folder():
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value.pw_uid = 996
+    fake_grp = MagicMock()
+    fake_grp.getgrnam.return_value.gr_gid = 994
+
+    with (
+        patch.object(helper, "pwd", fake_pwd),
+        patch.object(helper, "grp", fake_grp),
+        patch.object(helper.os, "chown", create=True) as chown,
+        patch.object(helper.os, "chmod") as chmod,
+        patch.object(helper.os, "makedirs") as makedirs,
+    ):
+        helper._ensure_monitor_can_write_mount("/mnt/recordings")
+
+    makedirs.assert_called_once_with(
+        f"/mnt/recordings/{helper.usb.RECORDINGS_FOLDER}", exist_ok=True
+    )
+    chown.assert_any_call("/mnt/recordings", 996, 994)
+    chown.assert_any_call(
+        f"/mnt/recordings/{helper.usb.RECORDINGS_FOLDER}", 996, 994
+    )
+    chmod.assert_any_call("/mnt/recordings", 0o775)
+    chmod.assert_any_call(f"/mnt/recordings/{helper.usb.RECORDINGS_FOLDER}", 0o775)
 
 
 def test_usb_unmount_and_format_delegate_to_usb_module():

--- a/app/server/tests/unit/test_svc_storage.py
+++ b/app/server/tests/unit/test_svc_storage.py
@@ -11,7 +11,12 @@ USB_PATCH = "monitor.services.storage_service.usb"
 
 
 def _make_device(
-    path="/dev/sda1", model="USB Stick", size="32G", fstype="ext4", supported=True
+    path="/dev/sda1",
+    model="USB Stick",
+    size="32G",
+    fstype="ext4",
+    supported=True,
+    mountpoint="",
 ):
     return {
         "path": path,
@@ -19,6 +24,7 @@ def _make_device(
         "size": size,
         "fstype": fstype,
         "supported": supported,
+        "mountpoint": mountpoint,
     }
 
 
@@ -60,6 +66,34 @@ class TestListDevices:
         result = svc.list_devices()
         assert len(result) == 1
         mock_usb.detect_devices.assert_called_once()
+
+    @patch(USB_PATCH)
+    def test_marks_configured_but_inactive_usb(self, mock_usb, svc, deps):
+        sm, store, _ = deps
+        sm.recordings_dir = "/data/recordings"
+        store.get_settings.return_value.usb_device = "/dev/sda1"
+        mock_usb.detect_devices.return_value = [_make_device(mountpoint="")]
+
+        result = svc.list_devices()
+
+        assert result[0]["configured"] is True
+        assert result[0]["configured_inactive"] is True
+        assert result[0]["in_use"] is False
+
+    @patch(USB_PATCH)
+    def test_marks_mounted_configured_usb_as_in_use(self, mock_usb, svc, deps):
+        sm, store, _ = deps
+        sm.recordings_dir = "/mnt/recordings/home-monitor-recordings"
+        store.get_settings.return_value.usb_device = "/dev/sda1"
+        mock_usb.detect_devices.return_value = [
+            _make_device(mountpoint="/mnt/recordings")
+        ]
+
+        result = svc.list_devices()
+
+        assert result[0]["configured"] is True
+        assert result[0]["configured_inactive"] is False
+        assert result[0]["in_use"] is True
 
 
 class TestSelectDevice:
@@ -107,6 +141,24 @@ class TestSelectDevice:
         assert result["recordings_dir"] == "/mnt/usb/recordings"
         sm.set_recordings_dir.assert_called_once_with("/mnt/usb/recordings")
         audit.log_event.assert_called_once()
+
+    @patch(USB_PATCH)
+    def test_prepare_recordings_permission_failure_returns_clean_error(
+        self, mock_usb, svc
+    ):
+        mock_usb.detect_devices.return_value = [_make_device()]
+        mock_usb.mount_device.return_value = (True, None)
+        mock_usb.prepare_recordings_dir.side_effect = PermissionError(
+            "permission denied"
+        )
+        mock_usb.DEFAULT_MOUNT_POINT = "/mnt/recordings"
+
+        result, err, status = svc.select_device("/dev/sda1")
+
+        assert result is None
+        assert status == 500
+        assert "recordings folder could not be prepared" in err
+        assert "permission denied" in err
 
     @patch(USB_PATCH)
     def test_saves_usb_config(self, mock_usb, svc, deps):

--- a/app/server/tests/unit/test_systemd_privilege_boundary.py
+++ b/app/server/tests/unit/test_systemd_privilege_boundary.py
@@ -45,6 +45,8 @@ def test_helper_unit_is_the_only_root_service_in_boundary():
         "/usr/bin/python3 -m monitor.services.privileged_helper"
     ]
     assert "CAP_SYS_ADMIN" in data["CapabilityBoundingSet"][0]
+    assert data["ProtectHome"] == ["false"]
+    assert data["PrivateMounts"] == ["false"]
 
 
 def test_yocoto_recipe_installs_helper_unit():


### PR DESCRIPTION
## Summary
- keep the privileged helper in the host mount namespace so USB mounts are visible to the dashboard
- make helper-mounted USB roots and recording folders writable by the monitor service user
- mark configured-but-inactive USB drives in the Storage UI and avoid raw JSON parser errors for non-JSON responses
- return clean JSON when USB recording folder preparation fails

## Validation
- pytest app/server/tests/unit/test_svc_storage.py app/server/tests/integration/test_api_storage.py app/server/tests/unit/test_privileged_helper.py app/server/tests/unit/test_systemd_privilege_boundary.py -q
- ruff check app/server/monitor/services/storage_service.py app/server/monitor/services/privileged_helper.py app/server/tests/unit/test_svc_storage.py app/server/tests/integration/test_api_storage.py app/server/tests/unit/test_privileged_helper.py app/server/tests/unit/test_systemd_privilege_boundary.py
- scripts/smoke-test.sh 192.168.1.244 otatest1234 192.168.1.148 1234

## Live verification
- hot-deployed to 192.168.1.244
- /dev/sda1 selected successfully
- /mnt/recordings is mounted from /dev/sda1
- monitor user can write to /mnt/recordings/home-monitor-recordings