### PR TITLE
Fix first setup and factory reset recovery

### DIFF
--- a/app/camera/camera_streamer/factory_reset.py
+++ b/app/camera/camera_streamer/factory_reset.py
@@ -1,13 +1,13 @@
 # REQ: SWR-018; RISK: RISK-006; SEC: SC-006; TEST: TC-015
 """
-Factory reset service for camera — wipes config and returns to first-boot state.
+Factory reset service for camera: wipes config and returns to first-boot state.
 
-Mirrors the server's FactoryResetService pattern (ADR-0013):
+Mirrors the server reset pattern:
 - Constructor injection (config, data_dir)
-- WiFi credentials wiped via hotspot script's 'wipe' command
-- System reboot after reset (systemd re-evaluates ConditionPathExists)
+- WiFi credentials wiped via the hotspot script or root helper
+- System reboot after reset so systemd re-evaluates setup-hotspot conditions
 
-After reset: camera-hotspot.service starts (no .setup-done) → setup wizard.
+After reset: camera-hotspot.service starts (no .setup-done) and serves setup.
 """
 
 import logging
@@ -15,6 +15,8 @@ import os
 import shutil
 import subprocess
 import threading
+
+from camera_streamer import privileged
 
 log = logging.getLogger("camera-streamer.factory-reset")
 
@@ -49,19 +51,24 @@ class FactoryResetService:
         config_path = os.path.join(self._data_dir, "config", "camera.conf")
         self._safe_remove(config_path, errors)
 
-        # 3. Remove certificates (pairing data)
+        # 3. Preserve the operator-chosen setup hotspot password. A GUI
+        # factory reset is an authenticated admin action; keeping this
+        # credential avoids falling back to a public first-boot default and
+        # lets the same operator re-enter setup after reboot.
+
+        # 4. Remove certificates (pairing data)
         certs_dir = os.path.join(self._data_dir, "certs")
         self._safe_rmtree(certs_dir, errors)
 
-        # 4. Remove logs
+        # 5. Remove logs
         logs_dir = os.path.join(self._data_dir, "logs")
         self._safe_rmtree(logs_dir, errors)
 
-        # 5. Remove OTA staging
+        # 6. Remove OTA staging
         ota_dir = os.path.join(self._data_dir, "ota")
         self._safe_rmtree(ota_dir, errors)
 
-        # 6. Clear WiFi credentials via hotspot script (ADR-0013)
+        # 7. Clear WiFi credentials via hotspot script/root helper.
         self._clear_wifi(errors)
 
         if errors:
@@ -95,14 +102,43 @@ class FactoryResetService:
             errors.append(f"{path}: {exc}")
 
     def _clear_wifi(self, errors: list):
-        """Clear WiFi credentials via hotspot script + direct cleanup.
+        """Clear WiFi credentials via hotspot script plus direct /data cleanup.
 
-        The hotspot script's 'wipe' command handles nmcli deletion and
-        file cleanup. We also directly clean /data/network/ as a safety
-        net — nm-persist.sh bind-mounts this over /etc/NetworkManager/
-        system-connections/ on every boot, so it must be wiped too.
+        The hotspot script's wipe command handles NetworkManager deletion.
+        Direct /data cleanup is retained as a safety net because nm-persist.sh
+        restores connections from /data/network/system-connections/ on boot.
         """
-        # 1. Run hotspot script wipe (handles nmcli + /etc cleanup)
+        if privileged.should_use_helper():
+            try:
+                data = privileged.request("hotspot.wipe", timeout=35)
+            except privileged.PrivilegedHelperError as exc:
+                log.warning("Failed to wipe WiFi credentials via helper: %s", exc)
+                errors.append(f"wifi: {exc}")
+            else:
+                if int(data.get("returncode") or 0) != 0:
+                    output = str(data.get("stderr") or data.get("stdout") or "")
+                    output = output.strip()
+                    log.warning("WiFi wipe returned non-zero: %s", output)
+                    errors.append(f"wifi: {output}")
+                else:
+                    log.debug("WiFi credentials wiped via privileged helper")
+        else:
+            self._clear_wifi_without_helper(errors)
+
+        persist_dir = os.path.join(self._data_dir, "network", "system-connections")
+        self._wipe_dir_contents(persist_dir, "persistent WiFi", errors)
+
+        marker = os.path.join(self._data_dir, "network", ".wifi-wiped")
+        try:
+            os.makedirs(os.path.dirname(marker), exist_ok=True)
+            with open(marker, "w") as f:
+                f.write("1\n")
+            log.debug("WiFi wipe marker written: %s", marker)
+        except OSError as exc:
+            log.warning("Failed to write wifi wipe marker: %s", exc)
+            errors.append(f"wifi-marker: {exc}")
+
+    def _clear_wifi_without_helper(self, errors: list) -> None:
         try:
             if os.path.isfile(self._hotspot_script):
                 result = subprocess.run(
@@ -120,32 +156,15 @@ class FactoryResetService:
                     log.debug("WiFi credentials wiped via hotspot script")
             else:
                 log.debug(
-                    "Hotspot script not found at %s — skipping script wipe",
+                    "Hotspot script not found at %s; skipping script wipe",
                     self._hotspot_script,
                 )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
             log.warning("Failed to wipe WiFi credentials: %s", exc)
             errors.append(f"wifi: {exc}")
 
-        # 2. Always wipe /data/network/system-connections/ directly
-        #    (nm-persist.sh restores connections from here on every boot)
-        persist_dir = os.path.join(self._data_dir, "network", "system-connections")
-        self._wipe_dir_contents(persist_dir, "persistent WiFi", errors)
-
-        # 3. Write a marker so nm-persist.sh skips re-seeding from rootfs
-        #    (rootfs may have baked-in WiFi connections from dev builds)
-        marker = os.path.join(self._data_dir, "network", ".wifi-wiped")
-        try:
-            os.makedirs(os.path.dirname(marker), exist_ok=True)
-            with open(marker, "w") as f:
-                f.write("1\n")
-            log.debug("WiFi wipe marker written: %s", marker)
-        except OSError as exc:
-            log.warning("Failed to write wifi wipe marker: %s", exc)
-            errors.append(f"wifi-marker: {exc}")
-
     def _wipe_dir_contents(self, dirpath: str, label: str, errors: list):
-        """Remove all files in a directory (not the directory itself)."""
+        """Remove all files in a directory, not the directory itself."""
         if not os.path.isdir(dirpath):
             return
         for fname in os.listdir(dirpath):
@@ -159,24 +178,74 @@ class FactoryResetService:
                 errors.append(f"{label}: {exc}")
 
     def _schedule_reboot(self):
-        """Reboot the system after a 2-second delay.
-
-        A full reboot (not just service restart) is required so that
-        camera-hotspot.service ConditionPathExists re-evaluates
-        and starts the WiFi hotspot for first-boot setup.
-        """
-
-        def _do_reboot():
-            log.info("Rebooting system for factory reset...")
-            try:
-                subprocess.run(
-                    ["systemctl", "reboot"],
-                    capture_output=True,
-                    timeout=30,
-                )
-            except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-                log.error("System reboot failed: %s", exc)
-
-        timer = threading.Timer(2.0, _do_reboot)
+        """Recover into first-boot setup after a 2-second delay."""
+        timer = threading.Timer(2.0, self._run_post_reset_recovery)
         timer.daemon = True
         timer.start()
+
+    def _run_post_reset_recovery(self):
+        """Reboot after reset, or explicitly bring setup networking back."""
+        if self._attempt_reboot():
+            return
+        log.error("Factory reset reboot failed; starting setup hotspot fallback")
+        if not self._start_setup_hotspot():
+            log.critical(
+                "Factory reset could not reboot or start the setup hotspot; "
+                "operator intervention is required"
+            )
+
+    def _attempt_reboot(self) -> bool:
+        log.info("Rebooting system for factory reset...")
+        if privileged.should_use_helper():
+            try:
+                data = privileged.request("system.reboot", timeout=20)
+            except privileged.PrivilegedHelperError as exc:
+                log.error("Privileged reboot failed: %s", exc)
+                return False
+            return self._command_result_ok(data, "system.reboot")
+        ok, error = self._run_system_command(["systemctl", "reboot"], timeout=30)
+        if not ok:
+            log.error("System reboot failed: %s", error)
+        return ok
+
+    def _start_setup_hotspot(self) -> bool:
+        if privileged.should_use_helper():
+            try:
+                data = privileged.request("hotspot.start", timeout=95)
+            except privileged.PrivilegedHelperError as exc:
+                log.error("Privileged setup hotspot start failed: %s", exc)
+                return False
+            return self._command_result_ok(data, "hotspot.start")
+        ok, error = self._run_system_command(
+            ["systemctl", "restart", "camera-hotspot.service"],
+            timeout=90,
+        )
+        if not ok:
+            log.error("Setup hotspot restart failed: %s", error)
+        return ok
+
+    @staticmethod
+    def _run_system_command(cmd: list[str], *, timeout: int) -> tuple[bool, str]:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            return False, str(exc)
+        detail = (result.stderr or result.stdout or "").strip()
+        if result.returncode == 0:
+            return True, detail
+        return False, detail or f"exit {result.returncode}"
+
+    @staticmethod
+    def _command_result_ok(data: dict, label: str) -> bool:
+        returncode = int(data.get("returncode") or 0)
+        if returncode == 0:
+            return True
+        detail = str(data.get("stderr") or data.get("stdout") or "").strip()
+        log.error("%s failed: %s", label, detail or f"exit {returncode}")
+        return False

--- a/app/camera/camera_streamer/privileged.py
+++ b/app/camera/camera_streamer/privileged.py
@@ -1,0 +1,82 @@
+# REQ: SWR-018, SWR-050; RISK: RISK-006, RISK-018; SEC: SC-006, SC-019; TEST: TC-015, TC-044
+"""Client for the root-only camera privilege helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from typing import Any
+
+HELPER_SOCKET = os.environ.get(
+    "CAMERA_PRIVILEGED_HELPER_SOCKET",
+    "/run/camera/privileged-helper.sock",
+)
+HELPER_TIMEOUT_SECONDS = 35
+
+
+class PrivilegedHelperError(RuntimeError):
+    """Raised when the privileged helper is unavailable or rejects a request."""
+
+
+def should_use_helper() -> bool:
+    """Return True when the current process should use the root helper."""
+    if os.environ.get("CAMERA_DISABLE_PRIVILEGED_HELPER") == "1":
+        return False
+    return (
+        os.name == "posix"
+        and hasattr(os, "geteuid")
+        and os.geteuid() != 0
+        and "CAMERA_PRIVILEGED_HELPER_SOCKET" in os.environ
+    )
+
+
+def is_helper_available(socket_path: str = HELPER_SOCKET) -> bool:
+    return (
+        hasattr(socket, "AF_UNIX")
+        and os.path.exists(socket_path)
+        and os.path.exists(os.path.dirname(socket_path))
+    )
+
+
+def request(
+    operation: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout: int = HELPER_TIMEOUT_SECONDS,
+    socket_path: str = HELPER_SOCKET,
+) -> dict[str, Any]:
+    """Send an allowlisted operation to the root helper."""
+    if not is_helper_available(socket_path):
+        raise PrivilegedHelperError("privileged helper unavailable")
+
+    message = json.dumps(
+        {"operation": operation, "payload": payload or {}},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            sock.connect(socket_path)
+            sock.sendall(message + b"\n")
+            chunks: list[bytes] = []
+            while True:
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+    except OSError as exc:
+        raise PrivilegedHelperError(str(exc)) from exc
+
+    try:
+        response = json.loads(b"".join(chunks).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PrivilegedHelperError("invalid privileged helper response") from exc
+
+    if not isinstance(response, dict) or not response.get("ok"):
+        error = ""
+        if isinstance(response, dict):
+            error = str(response.get("error") or "")
+        raise PrivilegedHelperError(error or "privileged helper rejected request")
+    data = response.get("data") or {}
+    return data if isinstance(data, dict) else {}

--- a/app/camera/camera_streamer/privileged_helper.py
+++ b/app/camera/camera_streamer/privileged_helper.py
@@ -1,0 +1,244 @@
+# REQ: SWR-018, SWR-050; RISK: RISK-006, RISK-018; SEC: SC-006, SC-019; TEST: TC-015, TC-044
+"""Root-only allowlisted helper for camera appliance operations."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import subprocess
+from collections.abc import Callable
+from typing import Any
+
+from camera_streamer.privileged import HELPER_SOCKET
+
+try:
+    import grp
+except ImportError:  # pragma: no cover - non-POSIX development hosts
+    grp = None
+
+try:
+    import pwd
+except ImportError:  # pragma: no cover - non-POSIX development hosts
+    pwd = None
+
+log = logging.getLogger("camera-streamer.privileged-helper")
+
+MAX_REQUEST_BYTES = 8192
+REQUEST_TIMEOUT_SECONDS = 120
+SOCKET_GROUP = "camera"
+SETUP_HOTSPOT_PASSWORD_FILE = "/data/config/camera-hotspot.psk"
+BLOCKED_SETUP_HOTSPOT_PASSWORDS = {"homecamera", "homemonitor"}
+MIN_SETUP_HOTSPOT_PASSWORD_LENGTH = 12
+MAX_SETUP_HOTSPOT_PASSWORD_LENGTH = 63
+
+
+class HelperRequestError(ValueError):
+    """Raised when an operation is rejected before execution."""
+
+
+def _run_command(
+    cmd: list[str],
+    *,
+    timeout: int = 30,
+    nonzero_ok: bool = False,
+) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise HelperRequestError(f"{cmd[0]} not found") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HelperRequestError(f"{cmd[0]} timed out") from exc
+    except OSError as exc:
+        raise HelperRequestError(str(exc)) from exc
+
+    data = {
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+    if result.returncode != 0 and not nonzero_ok:
+        raise HelperRequestError(result.stderr.strip() or result.stdout.strip())
+    return data
+
+
+def _op_hotspot_wipe(payload: dict[str, Any]) -> dict[str, Any]:
+    return _run_command(
+        ["/opt/camera/scripts/camera-hotspot.sh", "wipe"],
+        timeout=30,
+        nonzero_ok=True,
+    )
+
+
+def _op_hotspot_start(payload: dict[str, Any]) -> dict[str, Any]:
+    return _run_command(
+        ["systemctl", "restart", "camera-hotspot.service"],
+        timeout=90,
+    )
+
+
+def _op_hotspot_stop(payload: dict[str, Any]) -> dict[str, Any]:
+    return _run_command(
+        ["/opt/camera/scripts/camera-hotspot.sh", "stop"],
+        timeout=30,
+        nonzero_ok=True,
+    )
+
+
+def _op_hotspot_connect(payload: dict[str, Any]) -> dict[str, Any]:
+    ssid = str(payload.get("ssid") or "").strip()
+    password = str(payload.get("password") or "")
+    if not ssid:
+        raise HelperRequestError("ssid required")
+    if not password:
+        raise HelperRequestError("wifi password required")
+    return _run_command(
+        ["/opt/camera/scripts/camera-hotspot.sh", "connect", ssid, password],
+        timeout=75,
+    )
+
+
+def _camera_identity() -> tuple[int, int] | None:
+    if pwd is None or grp is None:
+        return None
+    try:
+        uid = pwd.getpwnam(SOCKET_GROUP).pw_uid
+        gid = grp.getgrnam(SOCKET_GROUP).gr_gid
+    except KeyError as exc:
+        raise HelperRequestError("camera service account not found") from exc
+    return uid, gid
+
+
+def _validate_setup_hotspot_password(value: Any) -> str:
+    password = str(value or "").strip()
+    if password.lower() in BLOCKED_SETUP_HOTSPOT_PASSWORDS:
+        raise HelperRequestError("choose a new setup hotspot password")
+    if len(password) < MIN_SETUP_HOTSPOT_PASSWORD_LENGTH:
+        raise HelperRequestError(
+            "setup hotspot password must be at least "
+            f"{MIN_SETUP_HOTSPOT_PASSWORD_LENGTH} characters"
+        )
+    if len(password) > MAX_SETUP_HOTSPOT_PASSWORD_LENGTH:
+        raise HelperRequestError(
+            "setup hotspot password must be no more than "
+            f"{MAX_SETUP_HOTSPOT_PASSWORD_LENGTH} characters"
+        )
+    return password
+
+
+def _op_hotspot_set_password(payload: dict[str, Any]) -> dict[str, Any]:
+    password = _validate_setup_hotspot_password(payload.get("password"))
+    target = SETUP_HOTSPOT_PASSWORD_FILE
+    parent = os.path.dirname(target)
+    tmp_path = f"{target}.tmp"
+    identity = _camera_identity()
+
+    os.makedirs(parent, mode=0o700, exist_ok=True)
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as handle:
+            handle.write(password + "\n")
+        os.chmod(tmp_path, 0o600)
+        if identity is not None:
+            os.chown(tmp_path, identity[0], identity[1])
+        os.replace(tmp_path, target)
+        os.chmod(target, 0o600)
+        if identity is not None:
+            os.chown(target, identity[0], identity[1])
+    except OSError as exc:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise HelperRequestError(str(exc)) from exc
+    return {"returncode": 0, "path": target}
+
+
+def _op_system_reboot(payload: dict[str, Any]) -> dict[str, Any]:
+    return _run_command(["systemctl", "reboot"], timeout=15)
+
+
+OPERATIONS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
+    "hotspot.connect": _op_hotspot_connect,
+    "hotspot.set_password": _op_hotspot_set_password,
+    "hotspot.wipe": _op_hotspot_wipe,
+    "hotspot.start": _op_hotspot_start,
+    "hotspot.stop": _op_hotspot_stop,
+    "system.reboot": _op_system_reboot,
+}
+
+
+def _handle_request(raw: bytes) -> bytes:
+    if len(raw) > MAX_REQUEST_BYTES:
+        raise HelperRequestError("request too large")
+    try:
+        message = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HelperRequestError("invalid JSON") from exc
+
+    if not isinstance(message, dict):
+        raise HelperRequestError("request must be an object")
+    operation = str(message.get("operation") or "")
+    payload = message.get("payload") or {}
+    if not isinstance(payload, dict):
+        raise HelperRequestError("payload must be an object")
+    handler = OPERATIONS.get(operation)
+    if handler is None:
+        raise HelperRequestError("operation not allowed")
+    data = handler(payload)
+    return json.dumps({"ok": True, "data": data}, separators=(",", ":")).encode("utf-8")
+
+
+def _set_socket_permissions(socket_path: str) -> None:
+    os.chmod(socket_path, 0o660)
+    if grp is None:
+        return
+    try:
+        gid = grp.getgrnam(SOCKET_GROUP).gr_gid
+    except KeyError:
+        return
+    os.chown(socket_path, 0, gid)
+
+
+def serve(socket_path: str = HELPER_SOCKET) -> None:
+    os.makedirs(os.path.dirname(socket_path), mode=0o750, exist_ok=True)
+    try:
+        os.unlink(socket_path)
+    except FileNotFoundError:
+        pass
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(socket_path)
+        _set_socket_permissions(socket_path)
+        server.listen(8)
+        log.info("Camera privileged helper listening on %s", socket_path)
+        while True:
+            conn, _ = server.accept()
+            with conn:
+                conn.settimeout(REQUEST_TIMEOUT_SECONDS)
+                try:
+                    raw = conn.recv(MAX_REQUEST_BYTES + 1)
+                    response = _handle_request(raw.strip())
+                except Exception as exc:
+                    log.warning("Privileged helper request rejected: %s", exc)
+                    response = json.dumps(
+                        {"ok": False, "error": str(exc)},
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                conn.sendall(response + b"\n")
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    serve()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -1495,7 +1495,8 @@ details[open] summary {
     <p>
       Factory reset erases WiFi settings, pairing certificates, and the
       admin password. The camera reboots into setup mode with its own
-      hotspot called <span id="reset-ssid" class="inline-code">HomeCam-Setup</span>.
+      hotspot called <span id="reset-ssid" class="inline-code">HomeCam-Setup</span>
+      using the setup hotspot password chosen during setup.
       You'll need to redo the first-boot wizard.
     </p>
     <details>

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -27,7 +27,7 @@ import threading
 import time
 from pathlib import Path
 
-from camera_streamer import led, wifi
+from camera_streamer import led, privileged, wifi
 from camera_streamer.config import MIN_ADMIN_PASSWORD_LENGTH
 
 log = logging.getLogger("camera-streamer.wifi-setup")
@@ -38,6 +38,7 @@ CONNECT_DELAY = 3
 HOTSPOT_SCRIPT = "/opt/camera/scripts/camera-hotspot.sh"
 BLOCKED_SETUP_HOTSPOT_PASSWORDS = {"homecamera", "homemonitor"}
 MIN_SETUP_HOTSPOT_PASSWORD_LENGTH = 12
+MAX_SETUP_HOTSPOT_PASSWORD_LENGTH = 63
 
 # Template directory (adjacent to this module)
 _TEMPLATE_DIR = Path(__file__).parent / "templates"
@@ -212,6 +213,16 @@ class WifiSetupServer:
         network. If connection fails, the script restarts the AP.
         Returns (success, error_message).
         """
+        if privileged.should_use_helper():
+            try:
+                privileged.request(
+                    "hotspot.connect",
+                    {"ssid": ssid, "password": password},
+                    timeout=90,
+                )
+                return True, ""
+            except privileged.PrivilegedHelperError as e:
+                return False, str(e)
         try:
             result = subprocess.run(
                 [self._hotspot_script, "connect", ssid, password],
@@ -243,6 +254,21 @@ class WifiSetupServer:
                 "Setup hotspot password must be at least "
                 f"{MIN_SETUP_HOTSPOT_PASSWORD_LENGTH} characters"
             )
+        if len(password) > MAX_SETUP_HOTSPOT_PASSWORD_LENGTH:
+            raise ValueError(
+                "Setup hotspot password must be no more than "
+                f"{MAX_SETUP_HOTSPOT_PASSWORD_LENGTH} characters"
+            )
+        if privileged.should_use_helper():
+            try:
+                privileged.request(
+                    "hotspot.set_password",
+                    {"password": password},
+                    timeout=20,
+                )
+                return
+            except privileged.PrivilegedHelperError as exc:
+                raise OSError(str(exc)) from exc
         path = os.path.join(self._config.data_dir, "config", "camera-hotspot.psk")
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
@@ -285,28 +311,40 @@ class WifiSetupServer:
     def rescan(self):
         """Rescan by briefly dropping AP via hotspot script, scanning, then restarting."""
         log.info("Rescan requested — stopping hotspot briefly")
-        try:
-            subprocess.run(
-                [self._hotspot_script, "stop"],
-                capture_output=True,
-                timeout=10,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-            wifi.stop_hotspot()
+        if privileged.should_use_helper():
+            try:
+                privileged.request("hotspot.stop", timeout=30)
+            except privileged.PrivilegedHelperError as e:
+                log.warning("Privileged hotspot stop failed during rescan: %s", e)
+        else:
+            try:
+                subprocess.run(
+                    [self._hotspot_script, "stop"],
+                    capture_output=True,
+                    timeout=10,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                wifi.stop_hotspot()
 
         time.sleep(2)
         self._cached_networks = wifi.scan_networks(self._wifi_interface)
         log.info("Rescan found %d networks", len(self._cached_networks))
         time.sleep(1)
 
-        try:
-            subprocess.run(
-                [self._hotspot_script, "start"],
-                capture_output=True,
-                timeout=30,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-            wifi.start_hotspot(self._wifi_interface)
+        if privileged.should_use_helper():
+            try:
+                privileged.request("hotspot.start", timeout=90)
+            except privileged.PrivilegedHelperError as e:
+                log.warning("Privileged hotspot start failed during rescan: %s", e)
+        else:
+            try:
+                subprocess.run(
+                    [self._hotspot_script, "start"],
+                    capture_output=True,
+                    timeout=30,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                wifi.start_hotspot(self._wifi_interface)
 
         return self._cached_networks
 
@@ -443,16 +481,38 @@ def _make_handler(config, setup_server):
                             400,
                         )
                         return
+                    if (
+                        len(setup_hotspot_password.strip())
+                        > MAX_SETUP_HOTSPOT_PASSWORD_LENGTH
+                    ):
+                        self._json_response(
+                            {
+                                "error": "Setup hotspot password required "
+                                f"(max {MAX_SETUP_HOTSPOT_PASSWORD_LENGTH} characters)"
+                            },
+                            400,
+                        )
+                        return
 
-                    setup_server.save_and_connect(
-                        ssid,
-                        password,
-                        server_ip,
-                        server_port,
-                        admin_username=admin_username,
-                        admin_password=admin_password,
-                        setup_hotspot_password=setup_hotspot_password,
-                    )
+                    try:
+                        setup_server.save_and_connect(
+                            ssid,
+                            password,
+                            server_ip,
+                            server_port,
+                            admin_username=admin_username,
+                            admin_password=admin_password,
+                            setup_hotspot_password=setup_hotspot_password,
+                        )
+                    except ValueError as exc:
+                        self._json_response({"error": str(exc)}, 400)
+                        return
+                    except OSError as exc:
+                        log.warning("Failed to save setup settings: %s", exc)
+                        self._json_response(
+                            {"error": "Failed to save setup settings"}, 500
+                        )
+                        return
                     self._json_response(
                         {
                             "status": "connecting",

--- a/app/camera/config/camera-hotspot.sh
+++ b/app/camera/config/camera-hotspot.sh
@@ -45,7 +45,10 @@ get_hotspot_pass() {
 LED_PATH="/sys/class/leds/ACT"
 
 led_write() {
-    echo "$2" > "${LED_PATH}/$1" 2>/dev/null || true
+    TARGET="${LED_PATH}/$1"
+    if [ -w "$TARGET" ]; then
+        printf "%s\n" "$2" > "$TARGET" 2>/dev/null || true
+    fi
 }
 
 led_setup_mode() {
@@ -106,6 +109,9 @@ start_hotspot() {
         wifi.mode ap \
         wifi.band bg \
         wifi-sec.key-mgmt wpa-psk \
+        wifi-sec.proto rsn \
+        wifi-sec.pairwise ccmp \
+        wifi-sec.group ccmp \
         wifi-sec.psk "${HOTSPOT_PASS_VALUE}" \
         ipv4.method shared
 
@@ -211,8 +217,9 @@ wipe_wifi() {
     if [ -d "$NM_DIR" ]; then
         for CONN_FILE in "${NM_DIR}"/*; do
             if [ -f "$CONN_FILE" ]; then
-                rm -f "$CONN_FILE"
-                echo "  Removed file: $(basename "$CONN_FILE")"
+                rm -f "$CONN_FILE" 2>/dev/null \
+                    && echo "  Removed file: $(basename "$CONN_FILE")" \
+                    || echo "  Skipped read-only file: $(basename "$CONN_FILE")"
             fi
         done
     fi
@@ -232,13 +239,15 @@ wipe_wifi() {
 
     # Reset wpa_supplicant.conf to empty state
     WPA_CONF="/etc/wpa_supplicant.conf"
-    if [ -f "$WPA_CONF" ]; then
+    if [ -w "$WPA_CONF" ]; then
         cat > "$WPA_CONF" <<'WPAEOF'
 ctrl_interface=/var/run/wpa_supplicant
 ctrl_interface_group=0
 update_config=1
 WPAEOF
         echo "  Reset wpa_supplicant.conf"
+    elif [ -f "$WPA_CONF" ]; then
+        echo "  Skipped read-only wpa_supplicant.conf"
     fi
 
     echo "WiFi credentials wiped"

--- a/app/camera/config/camera-privileged-helper.service
+++ b/app/camera/config/camera-privileged-helper.service
@@ -1,0 +1,22 @@
+# REQ: SWR-018, SWR-050; RISK: RISK-006, RISK-018; SEC: SC-006, SC-019; TEST: TC-015, TC-044
+[Unit]
+Description=Home Monitor Camera Privileged Helper
+Documentation=https://github.com/vinu-dev/rpi-home-monitor
+After=local-fs.target
+Before=camera-streamer.service
+
+[Service]
+Type=simple
+User=root
+Group=camera
+RuntimeDirectory=camera
+RuntimeDirectoryMode=0750
+WorkingDirectory=/opt/camera
+Environment=PYTHONPATH=/opt/camera
+Environment=CAMERA_PRIVILEGED_HELPER_SOCKET=/run/camera/privileged-helper.sock
+ExecStart=/usr/bin/python3 -m camera_streamer.privileged_helper
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/app/camera/config/camera-streamer.service
+++ b/app/camera/config/camera-streamer.service
@@ -6,8 +6,8 @@ Description=Camera RTSP Streamer
 #   b) condition was false (already set up) — exits immediately.
 # Either way camera-streamer can start. Avoids waiting for
 # network-online.target which adds ~60-120s in hotspot/AP mode.
-After=avahi-daemon.service local-fs.target NetworkManager.service camera-hotspot.service sys-subsystem-net-devices-wlan0.device
-Wants=NetworkManager.service
+After=avahi-daemon.service local-fs.target NetworkManager.service camera-privileged-helper.service camera-hotspot.service sys-subsystem-net-devices-wlan0.device
+Wants=NetworkManager.service camera-privileged-helper.service
 
 [Service]
 Type=notify
@@ -27,6 +27,7 @@ Environment=PYTHONPATH=/opt/camera
 Environment=CAMERA_DATA_DIR=/data
 Environment=CAMERA_CONFIG_DIR=/data/config
 Environment=CAMERA_CERTS_DIR=/data/certs
+Environment=CAMERA_PRIVILEGED_HELPER_SOCKET=/run/camera/privileged-helper.sock
 
 # Security hardening
 NoNewPrivileges=true

--- a/app/camera/tests/contracts/test_api_contracts.py
+++ b/app/camera/tests/contracts/test_api_contracts.py
@@ -463,6 +463,36 @@ class TestSetupConnectContract:
 
     @patch("camera_streamer.wifi.scan_networks", return_value=[])
     @patch("camera_streamer.wifi.start_hotspot", return_value=True)
+    def test_save_failure_returns_json_error(
+        self, mock_hotspot, mock_scan, setup_config
+    ):
+        server = WifiSetupServer(setup_config)
+        server.start()
+        try:
+            with patch.object(
+                server,
+                "_save_setup_hotspot_password",
+                side_effect=OSError("read only"),
+            ):
+                data, status = _json_post(
+                    "/api/connect",
+                    {
+                        "ssid": "TestNet",
+                        "password": "pass123",
+                        "server_ip": "192.168.1.100",
+                        "admin_username": "admin",
+                        "admin_password": "testpass12345",
+                        "setup_hotspot_password": "CameraSetupPass123",
+                    },
+                )
+            assert status == 500
+            _assert_fields(data, {"error"})
+            assert "setup settings" in data["error"]
+        finally:
+            server.stop()
+
+    @patch("camera_streamer.wifi.scan_networks", return_value=[])
+    @patch("camera_streamer.wifi.start_hotspot", return_value=True)
     def test_error_fields(self, mock_hotspot, mock_scan, setup_config):
         server = WifiSetupServer(setup_config)
         server.start()

--- a/app/camera/tests/integration/test_wifi_setup.py
+++ b/app/camera/tests/integration/test_wifi_setup.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from camera_streamer import wifi
+from camera_streamer import privileged, wifi
 from camera_streamer.status_server import (
     SESSION_TIMEOUT,
     CameraStatusServer,
@@ -161,6 +161,34 @@ class TestWifiSetupServer:
         with pytest.raises(ValueError, match="new setup hotspot"):
             server._save_setup_hotspot_password("homecamera")
 
+    @patch("camera_streamer.wifi_setup.privileged.request")
+    @patch("camera_streamer.wifi_setup.privileged.should_use_helper", return_value=True)
+    def test_setup_hotspot_password_uses_privileged_helper(
+        self, mock_should_use_helper, mock_request, unconfigured_config
+    ):
+        server = WifiSetupServer(unconfigured_config)
+
+        server._save_setup_hotspot_password("CameraSetupPass123")
+
+        mock_request.assert_called_once_with(
+            "hotspot.set_password",
+            {"password": "CameraSetupPass123"},
+            timeout=20,
+        )
+
+    @patch(
+        "camera_streamer.wifi_setup.privileged.request",
+        side_effect=privileged.PrivilegedHelperError("helper denied"),
+    )
+    @patch("camera_streamer.wifi_setup.privileged.should_use_helper", return_value=True)
+    def test_setup_hotspot_password_reports_privileged_helper_error(
+        self, mock_should_use_helper, mock_request, unconfigured_config
+    ):
+        server = WifiSetupServer(unconfigured_config)
+
+        with pytest.raises(OSError, match="helper denied"):
+            server._save_setup_hotspot_password("CameraSetupPass123")
+
 
 class TestScanWifi:
     """Test WiFi scanning via wifi module."""
@@ -303,6 +331,38 @@ class TestSaveAndConnect:
         assert mgr.server_ip == "10.0.0.5"
         assert mgr.server_port == 9999
 
+    @patch("camera_streamer.wifi_setup.privileged.request")
+    @patch("camera_streamer.wifi_setup.privileged.should_use_helper", return_value=True)
+    def test_hotspot_connect_uses_privileged_helper(
+        self, mock_should_use_helper, mock_request, unconfigured_config
+    ):
+        server = WifiSetupServer(unconfigured_config)
+
+        ok, err = server._hotspot_connect("TestNet", "pass123")
+
+        assert ok is True
+        assert err == ""
+        mock_request.assert_called_once_with(
+            "hotspot.connect",
+            {"ssid": "TestNet", "password": "pass123"},
+            timeout=90,
+        )
+
+    @patch(
+        "camera_streamer.wifi_setup.privileged.request",
+        side_effect=privileged.PrivilegedHelperError("helper denied"),
+    )
+    @patch("camera_streamer.wifi_setup.privileged.should_use_helper", return_value=True)
+    def test_hotspot_connect_reports_privileged_helper_error(
+        self, mock_should_use_helper, mock_request, unconfigured_config
+    ):
+        server = WifiSetupServer(unconfigured_config)
+
+        ok, err = server._hotspot_connect("TestNet", "pass123")
+
+        assert ok is False
+        assert "helper denied" in err
+
 
 class TestRescan:
     """Test the rescan flow (drops AP briefly)."""
@@ -327,6 +387,27 @@ class TestRescan:
         assert networks[0]["ssid"] == "NewNet"
         # Cached networks should be updated
         assert server.get_cached_networks()[0]["ssid"] == "NewNet"
+
+    @patch("camera_streamer.wifi_setup.privileged.request")
+    @patch("camera_streamer.wifi_setup.privileged.should_use_helper", return_value=True)
+    @patch("camera_streamer.wifi.time.sleep")
+    @patch("camera_streamer.wifi.scan_networks")
+    def test_rescan_uses_privileged_helper_for_hotspot_lifecycle(
+        self,
+        mock_scan,
+        mock_sleep,
+        mock_should_use_helper,
+        mock_request,
+        unconfigured_config,
+    ):
+        mock_scan.return_value = [{"ssid": "NewNet", "signal": 75, "security": "WPA2"}]
+        server = WifiSetupServer(unconfigured_config)
+
+        networks = server.rescan()
+
+        assert networks == [{"ssid": "NewNet", "signal": 75, "security": "WPA2"}]
+        mock_request.assert_any_call("hotspot.stop", timeout=30)
+        mock_request.assert_any_call("hotspot.start", timeout=90)
 
 
 class TestWaitForWifi:

--- a/app/camera/tests/unit/test_factory_reset.py
+++ b/app/camera/tests/unit/test_factory_reset.py
@@ -18,6 +18,7 @@ def data_dir(tmp_path):
 
     # Config file
     (tmp_path / "config" / "camera.conf").write_text("[camera]\nid=cam-001\n")
+    (tmp_path / "config" / "camera-hotspot.psk").write_text("CameraSetupPass123\n")
 
     # Stamp file
     (tmp_path / ".setup-done").write_text("1\n")
@@ -56,6 +57,13 @@ class TestCameraFactoryReset:
     def test_reset_removes_config(self, mock_reboot, svc, data_dir):
         svc.execute_reset()
         assert not (data_dir / "config" / "camera.conf").exists()
+
+    @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
+    def test_reset_preserves_setup_hotspot_password(self, mock_reboot, svc, data_dir):
+        svc.execute_reset()
+        assert (data_dir / "config" / "camera-hotspot.psk").read_text() == (
+            "CameraSetupPass123\n"
+        )
 
     @patch("camera_streamer.factory_reset.FactoryResetService._schedule_reboot")
     def test_reset_removes_certs(self, mock_reboot, svc, data_dir):
@@ -140,3 +148,94 @@ class TestWifiWipeDelegation:
         svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
         msg, status = svc.execute_reset()
         assert status == 200
+
+
+class TestPostResetRecovery:
+    """Camera reset must not strand first-boot setup if reboot fails."""
+
+    @patch("camera_streamer.factory_reset.subprocess.run")
+    def test_attempt_reboot_checks_return_code(self, mock_run, config, tmp_path):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="denied")
+        svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
+
+        assert svc._attempt_reboot() is False
+
+        mock_run.assert_called_once_with(
+            ["systemctl", "reboot"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+    @patch("camera_streamer.factory_reset.privileged.request")
+    @patch("camera_streamer.factory_reset.privileged.should_use_helper")
+    def test_attempt_reboot_uses_privileged_helper(
+        self, mock_should_use_helper, mock_request, config, tmp_path
+    ):
+        mock_should_use_helper.return_value = True
+        mock_request.return_value = {"returncode": 0, "stdout": "", "stderr": ""}
+        svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
+
+        assert svc._attempt_reboot() is True
+
+        mock_request.assert_called_once_with("system.reboot", timeout=20)
+
+    def test_post_reset_recovery_starts_hotspot_when_reboot_fails(
+        self, config, tmp_path
+    ):
+        svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
+
+        with (
+            patch.object(svc, "_attempt_reboot", return_value=False) as reboot,
+            patch.object(svc, "_start_setup_hotspot", return_value=True) as hotspot,
+        ):
+            svc._run_post_reset_recovery()
+
+        reboot.assert_called_once()
+        hotspot.assert_called_once()
+
+    @patch("camera_streamer.factory_reset.subprocess.run")
+    def test_start_setup_hotspot_restarts_systemd(self, mock_run, config, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
+
+        assert svc._start_setup_hotspot() is True
+
+        mock_run.assert_called_once_with(
+            ["systemctl", "restart", "camera-hotspot.service"],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+        )
+
+    @patch("camera_streamer.factory_reset.privileged.request")
+    @patch("camera_streamer.factory_reset.privileged.should_use_helper")
+    def test_start_setup_hotspot_uses_privileged_helper(
+        self, mock_should_use_helper, mock_request, config, tmp_path
+    ):
+        mock_should_use_helper.return_value = True
+        mock_request.return_value = {"returncode": 0, "stdout": "", "stderr": ""}
+        svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
+
+        assert svc._start_setup_hotspot() is True
+
+        mock_request.assert_called_once_with("hotspot.start", timeout=95)
+
+
+class TestPrivilegedWifiWipe:
+    @patch("camera_streamer.factory_reset.privileged.request")
+    @patch("camera_streamer.factory_reset.privileged.should_use_helper")
+    def test_clear_wifi_uses_privileged_helper(
+        self, mock_should_use_helper, mock_request, config, tmp_path
+    ):
+        mock_should_use_helper.return_value = True
+        mock_request.return_value = {"returncode": 0, "stdout": "", "stderr": ""}
+        svc = FactoryResetService(config, str(tmp_path), hotspot_script="/nonexistent")
+        errors = []
+
+        svc._clear_wifi(errors)
+
+        mock_request.assert_called_once_with("hotspot.wipe", timeout=35)
+        assert errors == []

--- a/app/camera/tests/unit/test_privileged_helper.py
+++ b/app/camera/tests/unit/test_privileged_helper.py
@@ -1,0 +1,140 @@
+# REQ: SWR-018, SWR-050; RISK: RISK-006, RISK-018; SEC: SC-006, SC-019; TEST: TC-015, TC-044
+"""Unit tests for the camera privileged helper allowlist."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from camera_streamer import privileged_helper
+
+
+def test_hotspot_wipe_uses_camera_hotspot_script():
+    with patch("camera_streamer.privileged_helper.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        data = privileged_helper._op_hotspot_wipe({})
+
+    assert data["returncode"] == 0
+    mock_run.assert_called_once_with(
+        ["/opt/camera/scripts/camera-hotspot.sh", "wipe"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_hotspot_start_restarts_camera_hotspot_service():
+    with patch("camera_streamer.privileged_helper.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        data = privileged_helper._op_hotspot_start({})
+
+    assert data["returncode"] == 0
+    mock_run.assert_called_once_with(
+        ["systemctl", "restart", "camera-hotspot.service"],
+        capture_output=True,
+        text=True,
+        timeout=90,
+        check=False,
+    )
+
+
+def test_hotspot_stop_uses_camera_hotspot_script():
+    with patch("camera_streamer.privileged_helper.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        data = privileged_helper._op_hotspot_stop({})
+
+    assert data["returncode"] == 0
+    mock_run.assert_called_once_with(
+        ["/opt/camera/scripts/camera-hotspot.sh", "stop"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_hotspot_connect_uses_camera_hotspot_script():
+    with patch("camera_streamer.privileged_helper.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        data = privileged_helper._op_hotspot_connect(
+            {"ssid": "MysticNet2.4", "password": "secret-pass"}
+        )
+
+    assert data["returncode"] == 0
+    mock_run.assert_called_once_with(
+        [
+            "/opt/camera/scripts/camera-hotspot.sh",
+            "connect",
+            "MysticNet2.4",
+            "secret-pass",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=75,
+        check=False,
+    )
+
+
+def test_hotspot_connect_rejects_empty_payload():
+    with pytest.raises(privileged_helper.HelperRequestError, match="ssid required"):
+        privileged_helper._op_hotspot_connect({"password": "secret-pass"})
+
+
+def test_hotspot_set_password_writes_protected_file(tmp_path):
+    target = tmp_path / "config" / "camera-hotspot.psk"
+    mock_pwd = MagicMock()
+    mock_grp = MagicMock()
+    mock_pwd.getpwnam.return_value = MagicMock(pw_uid=321)
+    mock_grp.getgrnam.return_value = MagicMock(gr_gid=654)
+
+    with (
+        patch.object(privileged_helper, "SETUP_HOTSPOT_PASSWORD_FILE", str(target)),
+        patch.object(privileged_helper, "pwd", mock_pwd),
+        patch.object(privileged_helper, "grp", mock_grp),
+        patch.object(privileged_helper.os, "chown", create=True) as mock_chown,
+    ):
+        data = privileged_helper._op_hotspot_set_password(
+            {"password": "CameraSetupPass123"}
+        )
+
+    assert data == {"returncode": 0, "path": str(target)}
+    assert target.read_text(encoding="utf-8") == "CameraSetupPass123\n"
+    if os.name != "nt":
+        assert target.stat().st_mode & 0o777 == 0o600
+    mock_chown.assert_any_call(str(target), 321, 654)
+
+
+def test_hotspot_set_password_rejects_factory_default():
+    with pytest.raises(privileged_helper.HelperRequestError, match="new setup"):
+        privileged_helper._op_hotspot_set_password({"password": "homecamera"})
+
+
+def test_hotspot_set_password_rejects_short_password():
+    with pytest.raises(privileged_helper.HelperRequestError, match="at least 12"):
+        privileged_helper._op_hotspot_set_password({"password": "short"})
+
+
+def test_system_reboot_uses_systemctl_reboot():
+    with patch("camera_streamer.privileged_helper.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        data = privileged_helper._op_system_reboot({})
+
+    assert data["returncode"] == 0
+    mock_run.assert_called_once_with(
+        ["systemctl", "reboot"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def test_rejects_unknown_operation():
+    with pytest.raises(privileged_helper.HelperRequestError, match="not allowed"):
+        privileged_helper._handle_request(b'{"operation":"not.allowed","payload":{}}')

--- a/app/camera/tests/unit/test_systemd_hardening.py
+++ b/app/camera/tests/unit/test_systemd_hardening.py
@@ -38,6 +38,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 UNIT_FILE = REPO_ROOT / "app" / "camera" / "config" / "camera-streamer.service"
+DEPLOY_SCRIPT = REPO_ROOT / "scripts" / "deploy-dev-app.sh"
 
 # --- The contract --------------------------------------------------
 #
@@ -121,6 +122,40 @@ def test_unit_file_exists():
         f"camera-streamer.service not found at {UNIT_FILE}; "
         "did the recipe layout change?"
     )
+
+
+def test_dev_deploy_uses_checked_in_unit_file():
+    """The hot-deploy path must not carry a stale inline unit override."""
+    text = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    assert "app/camera/config/camera-streamer.service" in text
+    assert "cp '$CAMERA_STAGE/camera-streamer.service'" in text
+    assert "cat > /etc/systemd/system/camera-streamer.service" not in text
+    assert "ReadWritePaths=/data\n" not in text
+
+
+def test_dev_deploy_installs_gpio_trigger_service():
+    text = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    assert "app/server/config/gpio-trigger.sh" in text
+    assert "app/server/config/gpio-trigger.service" in text
+    assert "/opt/scripts/gpio-trigger.sh" in text
+    assert "systemctl enable gpio-trigger.service" in text
+
+
+def test_dev_deploy_installs_camera_privileged_helper():
+    text = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    assert "app/camera/config/camera-privileged-helper.service" in text
+    assert "cp '$CAMERA_STAGE/camera-privileged-helper.service'" in text
+    assert "systemctl restart camera-privileged-helper camera-streamer" in text
+
+
+def test_camera_streamer_uses_privileged_helper_socket():
+    text = UNIT_FILE.read_text(encoding="utf-8")
+
+    assert "camera-privileged-helper.service" in text
+    assert "CAMERA_PRIVILEGED_HELPER_SOCKET=/run/camera/privileged-helper.sock" in text
 
 
 @pytest.mark.parametrize(

--- a/app/server/config/gpio-trigger.sh
+++ b/app/server/config/gpio-trigger.sh
@@ -73,6 +73,8 @@ wipe_data() {
               "${CONFIG_DIR}/users.json" \
               "${CONFIG_DIR}/settings.json" \
               "${CONFIG_DIR}/.secret_key" \
+              "${CONFIG_DIR}/setup-hotspot.psk" \
+              "${CONFIG_DIR}/camera-hotspot.psk" \
               "${CONFIG_DIR}/camera.conf" 2>/dev/null || true
     fi
 

--- a/app/server/config/monitor-hotspot.sh
+++ b/app/server/config/monitor-hotspot.sh
@@ -46,7 +46,10 @@ get_hotspot_pass() {
 LED_PATH="/sys/class/leds/ACT"
 
 led_write() {
-    echo "$2" > "${LED_PATH}/$1" 2>/dev/null || true
+    TARGET="${LED_PATH}/$1"
+    if [ -w "$TARGET" ]; then
+        printf "%s\n" "$2" > "$TARGET" 2>/dev/null || true
+    fi
 }
 
 led_setup_mode() {
@@ -113,6 +116,9 @@ start_hotspot() {
         wifi.mode ap \
         wifi.band bg \
         wifi-sec.key-mgmt wpa-psk \
+        wifi-sec.proto rsn \
+        wifi-sec.pairwise ccmp \
+        wifi-sec.group ccmp \
         wifi-sec.psk "${HOTSPOT_PASS_VALUE}" \
         ipv4.method shared
 
@@ -227,8 +233,9 @@ wipe_wifi() {
     if [ -d "$NM_DIR" ]; then
         for CONN_FILE in "${NM_DIR}"/*; do
             if [ -f "$CONN_FILE" ]; then
-                rm -f "$CONN_FILE"
-                echo "  Removed file: $(basename "$CONN_FILE")"
+                rm -f "$CONN_FILE" 2>/dev/null \
+                    && echo "  Removed file: $(basename "$CONN_FILE")" \
+                    || echo "  Skipped read-only file: $(basename "$CONN_FILE")"
             fi
         done
     fi
@@ -248,13 +255,15 @@ wipe_wifi() {
 
     # Reset wpa_supplicant.conf to empty state
     WPA_CONF="/etc/wpa_supplicant.conf"
-    if [ -f "$WPA_CONF" ]; then
+    if [ -w "$WPA_CONF" ]; then
         cat > "$WPA_CONF" <<'WPAEOF'
 ctrl_interface=/var/run/wpa_supplicant
 ctrl_interface_group=0
 update_config=1
 WPAEOF
         echo "  Reset wpa_supplicant.conf"
+    elif [ -f "$WPA_CONF" ]; then
+        echo "  Skipped read-only wpa_supplicant.conf"
     fi
 
     echo "WiFi credentials wiped"

--- a/app/server/monitor/provisioning.py
+++ b/app/server/monitor/provisioning.py
@@ -9,7 +9,7 @@ Security notes:
 - Sensitive endpoints (wifi/save, admin, complete) are blocked once setup is done.
   This prevents a LAN attacker from calling /setup/admin to take over the device
   after the owner has completed initial setup.
-- Rate limiting (5 requests per IP per 60s) prevents automated probing during
+- Rate limiting (30 requests per IP per 60s) prevents automated probing during
   the brief first-boot window when setup is incomplete.
 """
 
@@ -39,7 +39,7 @@ provisioning_bp = Blueprint("provisioning", __name__)
 # gets its own fresh counters — prevents test state bleed.
 # Separate from the login rate limiter in auth.py.
 _SETUP_RATE_WINDOW = 60  # seconds
-_SETUP_RATE_MAX = 5  # max attempts per window per IP
+_SETUP_RATE_MAX = 30  # max attempts per window per IP
 
 
 def _get_setup_attempts() -> dict:
@@ -141,7 +141,10 @@ def set_admin_password():
 @_require_setup_incomplete
 def setup_complete():
     """Apply all settings and finish setup."""
-    result, err, status = current_app.provisioning_service.complete_setup()
+    data = request.get_json(silent=True) or {}
+    result, err, status = current_app.provisioning_service.complete_setup(
+        network_mode=data.get("network_mode", "wifi")
+    )
     if err:
         return jsonify({"error": err}), status
     return jsonify(result), status

--- a/app/server/monitor/services/backup_paths.py
+++ b/app/server/monitor/services/backup_paths.py
@@ -2,9 +2,10 @@
 """
 Shared path catalogue for server-side mutable configuration.
 
-Config backup/import and factory reset both operate on the same set of
-server-owned files. Keeping the path inventory in one place prevents
-those flows from silently drifting apart.
+Config backup/import and factory reset share this catalogue so their path
+inventory is explicit. Factory reset intentionally keeps the operator-chosen
+setup hotspot password: the authenticated admin reset path must not fall back
+to the public first-boot default.
 """
 
 from dataclasses import dataclass
@@ -38,6 +39,10 @@ class BackupPaths:
     @property
     def session_secret_file(self) -> Path:
         return self.config_dir / ".secret_key"
+
+    @property
+    def setup_hotspot_password_file(self) -> Path:
+        return self.config_dir / "setup-hotspot.psk"
 
     @property
     def motion_events_file(self) -> Path:

--- a/app/server/monitor/services/factory_reset_service.py
+++ b/app/server/monitor/services/factory_reset_service.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import threading
 
+from monitor.services import privileged
 from monitor.services.backup_paths import build_backup_paths
 
 log = logging.getLogger("monitor.services.factory_reset")
@@ -59,9 +60,10 @@ class FactoryResetService:
         stamp = os.path.join(self._data_dir, ".setup-done")
         self._safe_remove(stamp, errors)
 
-        # 2. Clear config files shared with backup/import. Keep the
-        # config directory itself so first-boot code can recreate
-        # defaults in place.
+        # 2. Clear resettable config files. Keep the config directory itself
+        # so first-boot code can recreate defaults in place. The setup
+        # hotspot password is intentionally preserved for authenticated GUI
+        # reset so the device does not fall back to a public first-boot PSK.
         for target in self._paths.resettable_config_files:
             self._safe_remove(str(target), errors)
 
@@ -182,27 +184,92 @@ class FactoryResetService:
         return None
 
     def _schedule_restart(self):
-        """Reboot the system after a 2-second delay.
+        """Recover into first-boot setup after a 2-second delay.
 
         A full reboot (not just service restart) is required so that
         the monitor-hotspot.service ConditionPathExists check re-evaluates
         and starts the WiFi hotspot for first-boot setup.
         """
-
-        def _do_restart():
-            log.info("Rebooting system for factory reset...")
-            try:
-                subprocess.run(
-                    ["systemctl", "reboot"],
-                    capture_output=True,
-                    timeout=30,
-                )
-            except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-                log.error("System reboot failed: %s", exc)
-
-        timer = threading.Timer(2.0, _do_restart)
+        timer = threading.Timer(2.0, self._run_post_reset_recovery)
         timer.daemon = True
         timer.start()
+
+    def _run_post_reset_recovery(self):
+        """Reboot after reset, or explicitly bring setup networking back."""
+        if self._attempt_reboot():
+            return
+        log.error("Factory reset reboot failed; starting setup hotspot fallback")
+        if not self._start_setup_hotspot():
+            log.critical(
+                "Factory reset could not reboot or start the setup hotspot; "
+                "operator intervention is required"
+            )
+
+    def _attempt_reboot(self) -> bool:
+        """Request a system reboot and return whether systemd accepted it."""
+        log.info("Rebooting system for factory reset...")
+        if privileged.should_use_helper():
+            try:
+                result = privileged.request("system.reboot", timeout=20)
+            except privileged.PrivilegedHelperError as exc:
+                log.error("Privileged reboot request failed: %s", exc)
+                return False
+            return self._command_result_ok(result, "privileged reboot")
+
+        ok, error = self._run_system_command(["systemctl", "reboot"], timeout=30)
+        if not ok:
+            log.error("System reboot failed: %s", error)
+        return ok
+
+    def _start_setup_hotspot(self) -> bool:
+        """Restart the setup hotspot service if reboot is unavailable."""
+        if privileged.should_use_helper():
+            try:
+                result = privileged.request("hotspot.start", timeout=90)
+            except privileged.PrivilegedHelperError as exc:
+                log.error("Privileged setup hotspot start failed: %s", exc)
+                return False
+            return self._command_result_ok(result, "privileged hotspot start")
+
+        ok, error = self._run_system_command(
+            ["systemctl", "restart", "monitor-hotspot.service"],
+            timeout=90,
+        )
+        if not ok:
+            log.error("Setup hotspot restart failed: %s", error)
+        return ok
+
+    @staticmethod
+    def _run_system_command(cmd: list[str], *, timeout: int) -> tuple[bool, str]:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            return False, str(exc)
+        return FactoryResetService._command_result_ok(result, " ".join(cmd)), (
+            (result.stderr or result.stdout or "").strip()
+        )
+
+    @staticmethod
+    def _command_result_ok(result, label: str) -> bool:
+        if isinstance(result, dict):
+            returncode = int(result.get("returncode", 0) or 0)
+            stderr = str(result.get("stderr", "") or "").strip()
+            stdout = str(result.get("stdout", "") or "").strip()
+        else:
+            returncode = getattr(result, "returncode", 1)
+            stderr = str(getattr(result, "stderr", "") or "").strip()
+            stdout = str(getattr(result, "stdout", "") or "").strip()
+        if returncode == 0:
+            return True
+        detail = stderr or stdout or f"exit {returncode}"
+        log.error("%s failed: %s", label, detail)
+        return False
 
     def _log_audit(self, event, requesting_user="", requesting_ip="", detail=""):
         """Write audit event, fail-silent."""

--- a/app/server/monitor/services/privileged_helper.py
+++ b/app/server/monitor/services/privileged_helper.py
@@ -220,6 +220,21 @@ def _op_hotspot_connect_wifi(payload: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _op_hotspot_stop(payload: dict[str, Any]) -> dict[str, Any]:
+    return _run_command(
+        ["/opt/monitor/scripts/monitor-hotspot.sh", "stop"],
+        timeout=20,
+        nonzero_ok=True,
+    )
+
+
+def _op_hotspot_start(payload: dict[str, Any]) -> dict[str, Any]:
+    return _run_command(
+        ["systemctl", "restart", "monitor-hotspot.service"],
+        timeout=90,
+    )
+
+
 def _op_hostname_set(payload: dict[str, Any]) -> dict[str, Any]:
     hostname = _as_text(payload.get("hostname"), max_len=63)
     if not HOSTNAME_RE.fullmatch(hostname):
@@ -301,7 +316,7 @@ def _op_ota_install(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _op_system_reboot(payload: dict[str, Any]) -> dict[str, Any]:
-    return _run_command(["reboot"], timeout=15, nonzero_ok=True)
+    return _run_command(["systemctl", "reboot"], timeout=15)
 
 
 OPERATIONS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
@@ -314,6 +329,8 @@ OPERATIONS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
     "time.restart_timesyncd": _op_time_restart_timesyncd,
     "network.connect_wifi": _op_network_connect_wifi,
     "hotspot.connect_wifi": _op_hotspot_connect_wifi,
+    "hotspot.stop": _op_hotspot_stop,
+    "hotspot.start": _op_hotspot_start,
     "hostname.set": _op_hostname_set,
     "tailscale.up": _op_tailscale_up,
     "tailscale.down": _op_tailscale_down,

--- a/app/server/monitor/services/provisioning_service.py
+++ b/app/server/monitor/services/provisioning_service.py
@@ -24,6 +24,9 @@ HOTSPOT_SCRIPT = "/opt/monitor/scripts/monitor-hotspot.sh"
 SERVER_HOSTNAME = "rpi-divinu"
 BLOCKED_SETUP_HOTSPOT_PASSWORDS = {"homemonitor", "homecamera"}
 MIN_SETUP_HOTSPOT_PASSWORD_LENGTH = 12
+NETWORK_MODE_WIFI = "wifi"
+NETWORK_MODE_ETHERNET = "ethernet"
+VALID_NETWORK_MODES = {NETWORK_MODE_WIFI, NETWORK_MODE_ETHERNET}
 
 
 # REQ: SWR-021, SWR-054; RISK: RISK-010; SEC: SC-010; TEST: TC-021
@@ -177,28 +180,36 @@ class ProvisioningService:
         from monitor.auth import hash_password
 
         admin.password_hash = hash_password(password)
+        admin.must_change_password = False
         self._store.save_user(admin)
 
         return "Admin password updated", 200
 
-    def complete_setup(self) -> tuple[dict | None, str, int]:
+    def complete_setup(
+        self, network_mode: str = NETWORK_MODE_WIFI
+    ) -> tuple[dict | None, str, int]:
         """Apply all settings and finish setup.
 
-        Connects to WiFi, writes stamp file, schedules hotspot shutdown.
+        Connects to WiFi or keeps the wired LAN path, writes the setup
+        stamp file, and stops the setup hotspot once provisioning is complete.
         Returns (result_dict, error_message, status_code).
         """
         if self.is_setup_complete():
             return None, "Setup already completed", 403
 
-        ssid = self._pending_wifi.get("ssid", "")
-        password = self._pending_wifi.get("password", "")
+        network_mode = str(network_mode or NETWORK_MODE_WIFI).strip().lower()
+        if network_mode not in VALID_NETWORK_MODES:
+            return None, "Network mode must be wifi or ethernet.", 400
 
-        if not ssid or not password:
-            return (
-                None,
-                "WiFi credentials not saved. Go back and enter WiFi details.",
-                400,
-            )
+        if network_mode == NETWORK_MODE_WIFI:
+            ssid = self._pending_wifi.get("ssid", "")
+            password = self._pending_wifi.get("password", "")
+            if not ssid or not password:
+                return (
+                    None,
+                    "WiFi credentials not saved. Go back and enter WiFi details.",
+                    400,
+                )
 
         if not os.path.isfile(self.setup_hotspot_password_path):
             return (
@@ -207,14 +218,21 @@ class ProvisioningService:
                 400,
             )
 
-        # Step 1: Connect to WiFi
-        log.info("Connecting to WiFi: SSID=%s", ssid)
-        ok, err = self._connect_wifi(ssid, password)
-        if not ok:
-            return None, err, 500
-
-        # Step 2: Get new IP address
-        ip_address = self._get_wifi_ip()
+        if network_mode == NETWORK_MODE_WIFI:
+            log.info("Connecting to WiFi: SSID=%s", ssid)
+            ok, err = self._connect_wifi(ssid, password)
+            if not ok:
+                return None, err, 500
+            ip_address = self._get_wifi_ip()
+        else:
+            log.info("Completing setup using wired Ethernet")
+            ip_address = self._get_ethernet_ip()
+            if not ip_address:
+                return (
+                    None,
+                    "Ethernet is not connected. Plug in Ethernet or choose WiFi.",
+                    400,
+                )
 
         # Step 3: Set hostname (ensures correct mDNS after factory reset)
         self._set_hostname(SERVER_HOSTNAME)
@@ -228,18 +246,22 @@ class ProvisioningService:
         self._pending_wifi["ssid"] = ""
         self._pending_wifi["password"] = ""
 
-        # Note: hotspot was already stopped by the 'connect' command
+        if network_mode == NETWORK_MODE_ETHERNET:
+            self._stop_hotspot()
+
+        # When WiFi mode is used, hotspot was stopped by the connect command
         # in _connect_wifi() — no separate stop needed (ADR-0013).
 
         mdns_address = f"{SERVER_HOSTNAME}.local"
 
-        log.info("Setup complete! WiFi IP: %s", ip_address or "unknown")
+        log.info("Setup complete via %s. IP: %s", network_mode, ip_address or "unknown")
 
         return (
             {
                 "message": "Setup complete",
                 "ip": ip_address,
                 "hostname": mdns_address,
+                "network_mode": network_mode,
             },
             "",
             200,
@@ -300,9 +322,45 @@ class ProvisioningService:
 
     def _get_wifi_ip(self) -> str:
         """Get the IP address assigned to wlan0."""
+        return self._get_device_ip("wlan0")
+
+    def _get_ethernet_ip(self) -> str:
+        """Return the first connected Ethernet IPv4 address, if known."""
+        for device in self._connected_ethernet_devices():
+            ip_address = self._get_device_ip(device)
+            if ip_address:
+                return ip_address
+        return ""
+
+    def _connected_ethernet_devices(self) -> list[str]:
+        """List connected Ethernet devices as reported by NetworkManager."""
         try:
             result = subprocess.run(
-                ["nmcli", "-t", "-f", "IP4.ADDRESS", "dev", "show", "wlan0"],
+                ["nmcli", "-t", "-f", "DEVICE,TYPE,STATE", "dev", "status"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return []
+        if result.returncode != 0:
+            return []
+
+        devices: list[str] = []
+        for line in result.stdout.strip().splitlines():
+            parts = line.split(":")
+            if len(parts) < 3:
+                continue
+            device, dev_type, state = [part.strip() for part in parts[:3]]
+            if device and dev_type == "ethernet" and state == "connected":
+                devices.append(device)
+        return devices
+
+    def _get_device_ip(self, device: str) -> str:
+        """Get the IPv4 address assigned to a NetworkManager device."""
+        try:
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "IP4.ADDRESS", "dev", "show", device],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -318,6 +376,33 @@ class ProvisioningService:
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
         return ""
+
+    def _stop_hotspot(self) -> None:
+        """Best-effort stop for the setup hotspot after Ethernet setup."""
+        if privileged.should_use_helper():
+            try:
+                data = privileged.request("hotspot.stop", timeout=20)
+            except privileged.PrivilegedHelperError as exc:
+                log.warning("Failed to stop setup hotspot via helper: %s", exc)
+                return
+            if int(data.get("returncode") or 0) != 0:
+                output = str(data.get("stderr") or data.get("stdout") or "").strip()
+                log.warning("Setup hotspot stop returned non-zero: %s", output)
+            return
+
+        try:
+            result = subprocess.run(
+                [HOTSPOT_SCRIPT, "stop"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            log.warning("Failed to stop setup hotspot: %s", exc)
+            return
+        if result.returncode != 0:
+            output = result.stderr.strip() or result.stdout.strip()
+            log.warning("Setup hotspot stop returned non-zero: %s", output)
 
     def _write_stamp_file(self) -> str:
         """Write the setup-done stamp file. Returns error message or empty string."""

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -491,7 +491,7 @@
         <div class="settings-section__title">Factory Reset</div>
         <div class="card">
             <p style="font-size:var(--text-sm); color:var(--color-text-muted); margin-bottom:var(--space-3);">
-                Wipe all configuration, users, certificates, and recordings. The server will restart and present the first-boot setup wizard.
+                Wipe all configuration, users, certificates, and recordings. The server will restart and present the first-boot setup wizard using the setup hotspot password chosen during setup.
             </p>
             <div class="form-group">
                 <label style="display:flex; align-items:center; gap:var(--space-2); cursor:pointer;">

--- a/app/server/monitor/templates/setup.html
+++ b/app/server/monitor/templates/setup.html
@@ -129,6 +129,43 @@
             background: #133a6a;
         }
 
+        .network-mode-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 10px;
+            margin-bottom: 16px;
+        }
+        .network-mode {
+            width: 100%;
+            padding: 14px;
+            border: 2px solid #2a3a5e;
+            border-radius: 8px;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            cursor: pointer;
+            text-align: left;
+            transition: border-color 0.2s, background 0.2s;
+        }
+        .network-mode strong,
+        .network-mode span {
+            display: block;
+        }
+        .network-mode span {
+            margin-top: 4px;
+            color: #8090b0;
+            font-size: 0.82rem;
+        }
+        .network-mode.selected {
+            border-color: #e94560;
+            background: #1e2440;
+        }
+        .network-setup-panel {
+            display: none;
+        }
+        .network-setup-panel.visible {
+            display: block;
+        }
+
         /* Inputs */
         .input-group {
             margin-bottom: 16px;
@@ -526,38 +563,55 @@
             </div>
             <div class="card">
                 <h1>Welcome to Home Monitor</h1>
-                <p>Your self-hosted security camera system. This wizard will help you connect your server to WiFi and secure your admin account.</p>
-                <p>You will need your WiFi network name and password.</p>
+                <p>Your self-hosted security camera system. This wizard will help you choose networking and secure your admin account.</p>
+                <p>Use wired Ethernet when available. WiFi setup is optional for the server.</p>
                 <button class="btn btn-primary" onclick="goToStep(1)">Get Started</button>
             </div>
         </div>
 
-        <!-- Step 1: WiFi (save only, don't connect) -->
+        <!-- Step 1: Network -->
         <div class="step" id="step-1">
             <div class="card">
                 <div class="step-label">Step 1 of 3</div>
-                <h2>Select WiFi Network</h2>
-                <p>Choose the WiFi network your server should connect to.</p>
+                <h2>Choose Network</h2>
+                <p>Keep the server wired, or connect it to WiFi.</p>
 
-                <div id="wifi-scan-loading" class="scan-loading">
-                    <div class="spinner"></div>
-                    <div>Scanning for networks...</div>
+                <div class="network-mode-grid">
+                    <button type="button" class="network-mode selected" id="mode-ethernet" onclick="chooseNetworkMode('ethernet')">
+                        <strong>Ethernet</strong>
+                        <span>Wired LAN</span>
+                    </button>
+                    <button type="button" class="network-mode" id="mode-wifi" onclick="chooseNetworkMode('wifi')">
+                        <strong>WiFi</strong>
+                        <span>Wireless LAN</span>
+                    </button>
                 </div>
 
-                <div id="wifi-network-list" class="network-list" style="display:none;"></div>
+                <div id="ethernet-section" class="network-setup-panel visible">
+                    <button class="btn btn-primary" onclick="useEthernet()">Next</button>
+                </div>
 
-                <div id="wifi-password-section" class="wifi-password-section">
-                    <div class="input-group">
-                        <label>Password for <strong id="wifi-selected-ssid"></strong></label>
-                        <input type="password" id="wifi-password" placeholder="Enter WiFi password"
-                               onkeydown="if(event.key==='Enter')saveWifi()">
+                <div id="wifi-section" class="network-setup-panel">
+                    <div id="wifi-scan-loading" class="scan-loading">
+                        <div class="spinner"></div>
+                        <div>Scanning for networks...</div>
                     </div>
-                    <button class="btn btn-primary" id="btn-wifi-save" onclick="saveWifi()">Next</button>
-                </div>
 
-                <button class="btn btn-secondary" onclick="scanWifi()" id="btn-rescan">
-                    Rescan Networks
-                </button>
+                    <div id="wifi-network-list" class="network-list" style="display:none;"></div>
+
+                    <div id="wifi-password-section" class="wifi-password-section">
+                        <div class="input-group">
+                            <label>Password for <strong id="wifi-selected-ssid"></strong></label>
+                            <input type="password" id="wifi-password" placeholder="Enter WiFi password"
+                                   onkeydown="if(event.key==='Enter')saveWifi()">
+                        </div>
+                        <button class="btn btn-primary" id="btn-wifi-save" onclick="saveWifi()">Next</button>
+                    </div>
+
+                    <button class="btn btn-secondary" onclick="scanWifi()" id="btn-rescan">
+                        Rescan Networks
+                    </button>
+                </div>
             </div>
         </div>
 
@@ -607,7 +661,7 @@
                     <h2>Review & Apply</h2>
 
                     <div class="review-item">
-                        <span class="review-label">WiFi Network</span>
+                        <span class="review-label">Network</span>
                         <span class="review-value" id="review-ssid"></span>
                     </div>
                     <div class="review-item">
@@ -623,7 +677,7 @@
                         <p style="color:#e94560;font-weight:600;">What happens when you tap Apply:</p>
                         <div class="warning-step">
                             <span class="warning-step-num">1.</span>
-                            Server connects to your home WiFi
+                            <span id="apply-step-network">Server keeps using Ethernet</span>
                         </div>
                         <div class="warning-step">
                             <span class="warning-step-num">2.</span>
@@ -631,12 +685,12 @@
                         </div>
                         <div class="warning-step">
                             <span class="warning-step-num">3.</span>
-                            Your phone will disconnect
+                            <span id="apply-step-phone">Your dashboard address is ready</span>
                         </div>
                         <p style="color:#fff;margin-top:12px;font-weight:500;">After that:</p>
                         <div class="warning-step">
                             <span class="warning-step-num">4.</span>
-                            Connect your phone back to your home WiFi
+                            <span id="apply-step-return">Stay on your LAN</span>
                         </div>
                         <div class="warning-step">
                             <span class="warning-step-num">5.</span>
@@ -648,7 +702,7 @@
                         Apply & Finish
                     </button>
                     <button class="btn btn-secondary" onclick="goToStep(1)">
-                        Back to WiFi
+                        Back to Network
                     </button>
                 </div>
             </div>
@@ -658,7 +712,7 @@
                 <div class="card">
                     <div class="done-icon">&#9989;</div>
                     <h1 style="text-align:center;">Setup Complete!</h1>
-                    <p style="text-align:center;">Your server is now on your home WiFi.</p>
+                    <p style="text-align:center;" id="done-network-text">Your server setup is complete.</p>
 
                     <div class="ip-display" id="done-ip-display" style="font-size:1.15rem;">
                         Connecting...
@@ -668,7 +722,7 @@
                     </div>
 
                     <p style="text-align:center;font-size:0.9rem;color:#fff;">
-                        Connect your phone to your home WiFi,<br>
+                        Open this from your LAN,<br>
                         then open the address above.
                     </p>
                     <p style="text-align:center;font-size:0.85rem;">
@@ -692,6 +746,8 @@
 
     <script>
         var currentStep = 0;
+        var networkMode = 'ethernet';
+        var wifiScanned = false;
         var selectedSSID = '';
         var savedSSID = '';
         var savedWifiPassword = '';
@@ -712,14 +768,41 @@
 
             currentStep = step;
 
-            if (step === 1) {
+            if (step === 1 && networkMode === 'wifi') {
                 scanWifi();
             }
             if (step === 3) {
                 document.getElementById('review-ssid').textContent = savedSSID;
+                updateReviewText();
                 document.getElementById('review-panel').style.display = 'block';
                 document.getElementById('done-panel').style.display = 'none';
             }
+        }
+
+        function chooseNetworkMode(mode) {
+            networkMode = mode === 'wifi' ? 'wifi' : 'ethernet';
+            document.getElementById('mode-ethernet').classList.toggle('selected', networkMode === 'ethernet');
+            document.getElementById('mode-wifi').classList.toggle('selected', networkMode === 'wifi');
+            document.getElementById('ethernet-section').classList.toggle('visible', networkMode === 'ethernet');
+            document.getElementById('wifi-section').classList.toggle('visible', networkMode === 'wifi');
+            if (networkMode === 'wifi' && !wifiScanned) {
+                scanWifi();
+            }
+        }
+
+        function useEthernet() {
+            networkMode = 'ethernet';
+            savedSSID = 'Ethernet';
+            savedWifiPassword = '';
+            goToStep(2);
+        }
+
+        function updateReviewText() {
+            var isWifi = networkMode === 'wifi';
+            document.getElementById('apply-step-network').textContent = isWifi ? 'Server connects to your home WiFi' : 'Server keeps using Ethernet';
+            document.getElementById('apply-step-phone').textContent = isWifi ? 'Your phone may disconnect' : 'Your dashboard address is ready';
+            document.getElementById('apply-step-return').textContent = isWifi ? 'Connect your phone back to your home WiFi' : 'Stay on your LAN';
+            document.getElementById('done-network-text').textContent = isWifi ? 'Your server is now on your home WiFi.' : 'Your server is ready on Ethernet.';
         }
 
         function showToast(message, type) {
@@ -766,6 +849,7 @@
             pwSection.classList.remove('visible');
             rescanBtn.disabled = true;
             selectedSSID = '';
+            wifiScanned = true;
 
             fetch(API_BASE + '/wifi/scan')
                 .then(function(res) { return res.json(); })
@@ -818,6 +902,7 @@
             el.classList.add('selected');
 
             selectedSSID = el.getAttribute('data-ssid');
+            networkMode = 'wifi';
             document.getElementById('wifi-selected-ssid').textContent = selectedSSID;
             document.getElementById('wifi-password').value = '';
 
@@ -855,6 +940,7 @@
             .then(function(res) {
                 setButtonLoading(btn, false, 'Next');
                 if (res.status === 200) {
+                    networkMode = 'wifi';
                     savedSSID = selectedSSID;
                     savedWifiPassword = password;
                     showToast('WiFi saved: ' + selectedSSID, 'success');
@@ -927,15 +1013,15 @@
         }
 
         function applySettings() {
-            /* The big moment: calls /complete which connects WiFi,
-               writes stamp, and schedules hotspot stop.
-               The phone WILL disconnect after this. */
+            /* Finish setup. WiFi mode switches networks; Ethernet mode keeps LAN. */
             var btn = document.getElementById('btn-apply');
-            setButtonLoading(btn, true, 'Connecting to WiFi...');
+            var loadingText = networkMode === 'wifi' ? 'Connecting to WiFi...' : 'Finishing setup...';
+            setButtonLoading(btn, true, loadingText);
 
             fetch(API_BASE + '/complete', {
                 method: 'POST',
-                headers: {'Content-Type': 'application/json'}
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({network_mode: networkMode})
             })
             .then(function(res) { return res.json().then(function(d) { return {status: res.status, data: d}; }); })
             .then(function(res) {
@@ -944,6 +1030,8 @@
                        User may or may not see this (hotspot is dying). */
                     var ip = res.data.ip || '';
                     var hostname = res.data.hostname || '';
+                    networkMode = res.data.network_mode || networkMode;
+                    updateReviewText();
 
                     /* Show the mDNS hostname as primary address */
                     if (hostname) {
@@ -978,6 +1066,7 @@
                     document.getElementById('done-ip-display').textContent = 'https://' + SERVER_HOSTNAME + '/';
                     document.getElementById('done-cam-address').textContent = SERVER_HOSTNAME;
                 }
+                updateReviewText();
                 document.getElementById('review-panel').style.display = 'none';
                 document.getElementById('done-panel').style.display = 'block';
             });

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -504,7 +504,7 @@ class TestSetupCompleteContract:
         )
         resp = client.post("/api/v1/setup/complete")
         data = resp.get_json()
-        _assert_has_fields(data, {"ip", "hostname"})
+        _assert_has_fields(data, {"ip", "hostname", "network_mode"})
 
     def test_error_when_no_wifi(self, app, client):
         # Reset pending WiFi

--- a/app/server/tests/integration/test_provisioning.py
+++ b/app/server/tests/integration/test_provisioning.py
@@ -273,6 +273,33 @@ class TestSetupComplete:
         assert "WiFi" in data["error"]
 
     @patch(f"{SUBPROCESS_PATCH}.run")
+    def test_ethernet_complete_does_not_require_wifi(self, mock_run, app, client):
+        """Wired setup can finish without WiFi credentials."""
+        app.provisioning_service._pending_wifi["ssid"] = ""
+        app.provisioning_service._pending_wifi["password"] = ""
+        _write_setup_hotspot_password(app)
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="eth0:ethernet:connected\n", stderr=""),
+            MagicMock(
+                returncode=0,
+                stdout="IP4.ADDRESS[1]:192.168.1.244/24\n",
+                stderr="",
+            ),
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+
+        response = client.post(
+            "/api/v1/setup/complete", json={"network_mode": "ethernet"}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["network_mode"] == "ethernet"
+        assert data["ip"] == "192.168.1.244"
+        assert os.path.isfile(os.path.join(app.config["DATA_DIR"], ".setup-done"))
+
+    @patch(f"{SUBPROCESS_PATCH}.run")
     def test_full_flow_saves_then_completes(self, mock_run, app, client):
         """Full flow: save WiFi → save admin password → complete."""
         # Step 1: Save WiFi

--- a/app/server/tests/security/test_setup_hotspot_credentials.py
+++ b/app/server/tests/security/test_setup_hotspot_credentials.py
@@ -8,6 +8,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SERVER_SCRIPT = REPO_ROOT / "app/server/config/monitor-hotspot.sh"
 CAMERA_SCRIPT = REPO_ROOT / "app/camera/config/camera-hotspot.sh"
+GPIO_TRIGGER_SCRIPT = REPO_ROOT / "app/server/config/gpio-trigger.sh"
+GPIO_TRIGGER_RECIPE = (
+    REPO_ROOT / "meta-home-monitor/recipes-core/gpio-trigger/gpio-trigger_1.0.bb"
+)
+BASE_PACKAGEGROUP = (
+    REPO_ROOT
+    / "meta-home-monitor/recipes-core/packagegroups/packagegroup-monitor-base.bb"
+)
+DEPLOY_SCRIPT = REPO_ROOT / "scripts/deploy-dev-app.sh"
 
 
 def _read(path: Path) -> str:
@@ -35,7 +44,84 @@ def test_rotated_hotspot_credentials_must_not_reuse_factory_defaults():
         assert 'wifi-sec.psk "${HOTSPOT_PASS_VALUE}"' in text
 
 
-def test_factory_reset_wifi_wipe_keeps_provisioned_setup_credential():
+def test_setup_hotspots_advertise_wpa2_ccmp_not_legacy_wpa():
+    for path in (SERVER_SCRIPT, CAMERA_SCRIPT):
+        text = _read(path)
+        assert "wifi-sec.key-mgmt wpa-psk" in text
+        assert "wifi-sec.proto rsn" in text
+        assert "wifi-sec.pairwise ccmp" in text
+        assert "wifi-sec.group ccmp" in text
+
+
+def test_dev_deploy_installs_setup_hotspot_scripts():
+    text = _read(DEPLOY_SCRIPT)
+
+    assert "app/server/config/monitor-hotspot.sh" in text
+    assert "app/server/config/monitor-hotspot.service" in text
+    assert "/opt/monitor/scripts/monitor-hotspot.sh" in text
+    assert "monitor-hotspot.service" in text
+
+    assert "app/camera/config/camera-hotspot.sh" in text
+    assert "app/camera/config/camera-hotspot.service" in text
+    assert "/opt/camera/scripts/camera-hotspot.sh" in text
+    assert "camera-hotspot.service" in text
+
+
+def test_dev_deploy_installs_camera_privileged_helper():
+    text = _read(DEPLOY_SCRIPT)
+
+    assert "app/camera/config/camera-privileged-helper.service" in text
+    assert "camera-privileged-helper.service" in text
+    assert "systemctl restart camera-privileged-helper camera-streamer" in text
+
+
+def test_hotspot_wipe_tolerates_read_only_rootfs_cleanup():
+    for path in (SERVER_SCRIPT, CAMERA_SCRIPT):
+        text = _read(path)
+        assert "Skipped read-only file" in text
+        assert "Skipped read-only wpa_supplicant.conf" in text
+
+
+def test_hotspot_led_writes_are_best_effort_under_set_e():
+    for path in (SERVER_SCRIPT, CAMERA_SCRIPT):
+        text = _read(path)
+        assert 'TARGET="${LED_PATH}/$1"' in text
+        assert 'if [ -w "$TARGET" ]; then' in text
+        assert 'printf "%s\\n" "$2" > "$TARGET" 2>/dev/null || true' in text
+
+
+def test_wifi_repair_wipe_keeps_provisioned_setup_credential():
     for path in (SERVER_SCRIPT, CAMERA_SCRIPT):
         text = _read(path)
         assert 'rm -f "$HOTSPOT_PASS_FILE"' not in text
+
+
+def test_hardware_factory_reset_removes_setup_hotspot_credentials():
+    text = _read(GPIO_TRIGGER_SCRIPT)
+    assert '"${CONFIG_DIR}/setup-hotspot.psk"' in text
+    assert '"${CONFIG_DIR}/camera-hotspot.psk"' in text
+
+
+def test_authenticated_factory_reset_preserves_setup_hotspot_credentials():
+    server_reset = _read(REPO_ROOT / "app/server/monitor/services/backup_paths.py")
+    camera_reset = _read(REPO_ROOT / "app/camera/camera_streamer/factory_reset.py")
+
+    assert (
+        "setup_hotspot_password_file"
+        not in server_reset.partition("def resettable_config_files")[2].partition(
+            "def resettable_dirs"
+        )[0]
+    )
+    assert "camera-hotspot.psk" not in camera_reset
+    assert "operator-chosen setup hotspot password" in camera_reset
+
+
+def test_gpio_trigger_is_installed_in_shared_images():
+    recipe = _read(GPIO_TRIGGER_RECIPE)
+    packagegroup = _read(BASE_PACKAGEGROUP)
+
+    assert "file://config/gpio-trigger.sh" in recipe
+    assert "file://config/gpio-trigger.service" in recipe
+    assert "/opt/scripts/gpio-trigger.sh" in recipe
+    assert "gpio-trigger.service" in recipe
+    assert "gpio-trigger" in packagegroup

--- a/app/server/tests/unit/test_privileged_helper.py
+++ b/app/server/tests/unit/test_privileged_helper.py
@@ -261,6 +261,8 @@ def test_wifi_operations_build_allowlisted_commands():
             b'{"operation":"hotspot.connect_wifi","payload":'
             b'{"ssid":"MysticNet","password":"passphrase"}}'
         )
+        helper.handle_request(b'{"operation":"hotspot.stop","payload":{}}')
+        helper.handle_request(b'{"operation":"hotspot.start","payload":{}}')
 
     assert run.call_args_list[0].args[0] == [
         "nmcli",
@@ -278,6 +280,15 @@ def test_wifi_operations_build_allowlisted_commands():
         "connect",
         "MysticNet",
         "passphrase",
+    ]
+    assert run.call_args_list[2].args[0] == [
+        "/opt/monitor/scripts/monitor-hotspot.sh",
+        "stop",
+    ]
+    assert run.call_args_list[3].args[0] == [
+        "systemctl",
+        "restart",
+        "monitor-hotspot.service",
     ]
 
 
@@ -315,7 +326,7 @@ def test_tailscale_up_rejects_bad_authkey():
         ("tailscale.down", ["tailscale", "down"]),
         ("tailscale.enable", ["systemctl", "enable", "--now", "tailscaled"]),
         ("tailscale.disable", ["systemctl", "disable", "--now", "tailscaled"]),
-        ("system.reboot", ["reboot"]),
+        ("system.reboot", ["systemctl", "reboot"]),
     ],
 )
 def test_simple_operations_build_allowlisted_commands(operation, expected):

--- a/app/server/tests/unit/test_provisioning_service.py
+++ b/app/server/tests/unit/test_provisioning_service.py
@@ -42,6 +42,7 @@ class FakeUser:
     username: str = "admin"
     password_hash: str = "oldhash"
     role: str = "admin"
+    must_change_password: bool = True
 
 
 @pytest.fixture()
@@ -321,6 +322,7 @@ class TestSetAdminPassword:
         mh.assert_called_once_with("securepassword")
         saved_user = store.save_user.call_args[0][0]
         assert saved_user.password_hash == "newhash"
+        assert saved_user.must_change_password is False
 
     def test_requires_setup_hotspot_password(self, svc):
         msg, code = svc.set_admin_password("securepassword", "")
@@ -646,3 +648,60 @@ class TestCompleteSetup:
         result, err, code = svc.complete_setup()
         assert code == 200
         assert result["ip"] == ""
+
+    @patch(SUBPROCESS_PATCH)
+    @patch("monitor.services.provisioning_service.socket")
+    def test_ethernet_mode_completes_without_wifi(
+        self, mock_socket, mock_sub, svc, tmp_path
+    ):
+        """Wired server setup should not require WiFi credentials."""
+        _fix(mock_sub)
+        _write_setup_hotspot_password(tmp_path)
+        mock_socket.gethostname.return_value = "rpi-divinu"
+        mock_sub.run.side_effect = [
+            MagicMock(returncode=0, stdout="eth0:ethernet:connected\n"),
+            MagicMock(returncode=0, stdout="IP4.ADDRESS[1]:192.168.1.244/24\n"),
+            MagicMock(returncode=0),
+        ]
+
+        result, err, code = svc.complete_setup(network_mode="ethernet")
+
+        assert code == 200
+        assert err == ""
+        assert result["network_mode"] == "ethernet"
+        assert result["ip"] == "192.168.1.244"
+        assert (tmp_path / ".setup-done").exists()
+        commands = [call.args[0] for call in mock_sub.run.call_args_list]
+        assert ["/opt/monitor/scripts/monitor-hotspot.sh", "stop"] in commands
+        assert not any(
+            cmd[:2] == ["/opt/monitor/scripts/monitor-hotspot.sh", "connect"]
+            for cmd in commands
+        )
+
+    @patch(SUBPROCESS_PATCH)
+    @patch("monitor.services.provisioning_service.socket")
+    def test_ethernet_mode_requires_connected_ip(
+        self, mock_socket, mock_sub, svc, tmp_path
+    ):
+        _fix(mock_sub)
+        _write_setup_hotspot_password(tmp_path)
+        mock_socket.gethostname.return_value = "rpi-divinu"
+        mock_sub.run.side_effect = [
+            MagicMock(returncode=0, stdout=""),
+        ]
+
+        result, err, code = svc.complete_setup(network_mode="ethernet")
+
+        assert code == 400
+        assert result is None
+        assert "Ethernet" in err
+        assert not (tmp_path / ".setup-done").exists()
+
+    def test_invalid_network_mode_returns_400(self, svc, tmp_path):
+        _write_setup_hotspot_password(tmp_path)
+
+        result, err, code = svc.complete_setup(network_mode="cellular")
+
+        assert code == 400
+        assert result is None
+        assert "Network mode" in err

--- a/app/server/tests/unit/test_svc_factory_reset.py
+++ b/app/server/tests/unit/test_svc_factory_reset.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from monitor.services import privileged
 from monitor.services.factory_reset_service import FactoryResetService
 
 
@@ -29,6 +30,7 @@ def data_dir(tmp_path):
     (tmp_path / "config" / "users.json").write_text("[]")
     (tmp_path / "config" / "settings.json").write_text("{}")
     (tmp_path / "config" / ".secret_key").write_text("abc123")
+    (tmp_path / "config" / "setup-hotspot.psk").write_text("RotatedSetup123\n")
 
     # Stamp file
     (tmp_path / ".setup-done").write_text("setup completed\n")
@@ -86,6 +88,9 @@ class TestFactoryReset:
         assert not (data_dir / "config" / "users.json").exists()
         assert not (data_dir / "config" / "settings.json").exists()
         assert not (data_dir / "config" / ".secret_key").exists()
+        assert (data_dir / "config" / "setup-hotspot.psk").read_text() == (
+            "RotatedSetup123\n"
+        )
 
     @patch(
         "monitor.services.factory_reset_service.FactoryResetService._schedule_restart"
@@ -398,3 +403,89 @@ class TestErrorHandling:
         t.start()
         t.join(timeout=5)
         assert done.is_set()  # thread completed without raising
+
+
+class TestPostResetRecovery:
+    """Reset must not strand the device without setup networking."""
+
+    @patch(
+        "monitor.services.factory_reset_service.privileged.should_use_helper",
+        return_value=True,
+    )
+    @patch(
+        "monitor.services.factory_reset_service.privileged.request",
+        return_value={"returncode": 0},
+    )
+    def test_attempt_reboot_uses_privileged_helper(
+        self, mock_request, mock_should_use_helper, tmp_path
+    ):
+        svc = FactoryResetService(MagicMock(), MagicMock(), str(tmp_path))
+
+        assert svc._attempt_reboot() is True
+
+        mock_request.assert_called_once_with("system.reboot", timeout=20)
+
+    @patch(
+        "monitor.services.factory_reset_service.privileged.should_use_helper",
+        return_value=True,
+    )
+    @patch(
+        "monitor.services.factory_reset_service.privileged.request",
+        side_effect=privileged.PrivilegedHelperError("helper denied reboot"),
+    )
+    def test_attempt_reboot_returns_false_when_helper_rejects(
+        self, mock_request, mock_should_use_helper, tmp_path
+    ):
+        svc = FactoryResetService(MagicMock(), MagicMock(), str(tmp_path))
+
+        assert svc._attempt_reboot() is False
+
+    def test_post_reset_recovery_starts_hotspot_when_reboot_fails(self, tmp_path):
+        svc = FactoryResetService(MagicMock(), MagicMock(), str(tmp_path))
+
+        with (
+            patch.object(svc, "_attempt_reboot", return_value=False) as reboot,
+            patch.object(svc, "_start_setup_hotspot", return_value=True) as hotspot,
+        ):
+            svc._run_post_reset_recovery()
+
+        reboot.assert_called_once()
+        hotspot.assert_called_once()
+
+    @patch(
+        "monitor.services.factory_reset_service.privileged.should_use_helper",
+        return_value=True,
+    )
+    @patch(
+        "monitor.services.factory_reset_service.privileged.request",
+        return_value={"returncode": 0},
+    )
+    def test_start_setup_hotspot_uses_privileged_helper(
+        self, mock_request, mock_should_use_helper, tmp_path
+    ):
+        svc = FactoryResetService(MagicMock(), MagicMock(), str(tmp_path))
+
+        assert svc._start_setup_hotspot() is True
+
+        mock_request.assert_called_once_with("hotspot.start", timeout=90)
+
+    @patch(
+        "monitor.services.factory_reset_service.privileged.should_use_helper",
+        return_value=False,
+    )
+    @patch("monitor.services.factory_reset_service.subprocess.run")
+    def test_start_setup_hotspot_restarts_systemd_without_helper(
+        self, mock_run, mock_should_use_helper, tmp_path
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        svc = FactoryResetService(MagicMock(), MagicMock(), str(tmp_path))
+
+        assert svc._start_setup_hotspot() is True
+
+        mock_run.assert_called_once_with(
+            ["systemctl", "restart", "monitor-hotspot.service"],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+        )

--- a/docs/exec-plans/2026-05-30-first-setup-factory-reset.md
+++ b/docs/exec-plans/2026-05-30-first-setup-factory-reset.md
@@ -1,0 +1,102 @@
+# First Setup And Factory Reset Recovery
+
+## Goal
+
+Make server and camera first-time setup and authenticated factory reset reliable
+on real devices without touching the operator PC's WiFi.
+
+## Non-Goals
+
+- Do not weaken authentication, signing, or pairing controls.
+- Do not add SSH or CLI backdoors for admin recovery.
+- Do not change the PC/laptop network configuration during validation.
+
+## Constraints
+
+- Authenticated GUI factory reset should return the device to setup mode using
+  the setup hotspot password the operator chose during setup.
+- Hardware GPIO reset remains the full wipe path and may remove setup hotspot
+  password files.
+- Device validation must use serial ports and device-side network paths.
+
+## Context
+
+- Branch: `codex/fix-first-setup-factory-reset`
+- Server: COM4 and LAN `192.168.1.245`
+- Camera: COM3, setup AP `HomeCam-Setup`, setup IP `10.42.0.1`
+- Key files: camera/server hotspot scripts, camera/server factory reset
+  services, provisioning setup UI, systemd helper services.
+
+## Plan
+
+1. Preserve setup hotspot PSK during authenticated factory reset.
+2. Keep hardware GPIO reset wiping setup hotspot PSKs.
+3. Update tests and docs for that contract.
+4. Deploy to server and camera.
+5. Validate reset/setup from real devices through serial/device paths.
+6. Commit, push, open PR to `main`, wait for CI, merge.
+
+## Resumption
+
+- Current status: implementation and hardware validation complete; ready for
+  final repo validation, PR, CI, and merge.
+- Last completed step: camera authenticated reset was triggered through the
+  live API, returned to `HomeCam-Setup`, accepted the operator-chosen setup
+  hotspot password, and was restored to the home WiFi.
+- Next step: run final validation gates, commit, push, open the PR, wait for
+  CI, and merge.
+- Branch / PR: `codex/fix-first-setup-factory-reset`, PR not opened yet.
+- Devices / environments: COM3 camera serial, COM4 server serial, server LAN
+  SSH for device-side validation only.
+- Commands to resume: `git status --short --branch`, then run the validation
+  listed below.
+- Open risks / blockers: full Yocto VM build may need the configured build VM.
+
+## Validation
+
+- `pytest -q app/camera/tests/unit/test_privileged_helper.py app/camera/tests/integration/test_wifi_setup.py app/camera/tests/unit/test_factory_reset.py`
+  passed on Windows.
+- Server live deploy check: `/opt/monitor/monitor/services/backup_paths.py`
+  excludes `setup-hotspot.psk` from resettable config files; server
+  `setup-hotspot.psk` remains `monitor:monitor 600`; `monitor`,
+  `monitor-privileged-helper`, and `monitor-hotspot.service` are active.
+- Camera live deploy check over `HomeCam-Setup`: setup submission returned
+  `{"status":"connecting"}` instead of the previous 500 when
+  `/data/config/camera-hotspot.psk` started root-owned.
+- Camera serial validation on COM3: after setup, `camera-privileged-helper`,
+  `camera-streamer`, and `camera-hotspot.service` were active; setup was
+  complete; `/data/config/camera-hotspot.psk` was `camera:camera 600`.
+- Camera authenticated factory reset validation: `/api/factory-reset` returned
+  success, the setup AP reappeared, `HomeCam-Setup` accepted the
+  operator-chosen password, `/api/status` showed `setup_complete: false`, and
+  `/data/config/camera-hotspot.psk` remained `camera:camera 600`.
+- Camera restore validation: setup was submitted again with `MysticNet2.4`, the
+  camera returned on LAN at `192.168.1.186`, `/api/status` showed
+  `server_connected: true`, and serial confirmed setup complete with services
+  active.
+- `pytest app/camera/tests/ -v`
+- `pytest app/server/tests/ -v`
+- `ruff check .`
+- `ruff format --check .`
+- `python tools/docs/check_doc_map.py`
+- `python scripts/ai/validate_repo_ai_setup.py`
+- `python scripts/ai/check_doc_links.py`
+- `python scripts/ai/check_shell_scripts.py`
+- `python scripts/check_version_consistency.py`
+- `python scripts/check_versioning_design.py`
+- `python -m pre_commit run --all-files`
+- hardware deploy and serial/device smoke validation for server and camera
+
+## Risks
+
+- Preserving the setup hotspot password during GUI reset is intentional, but
+  docs and tests must clearly separate it from hardware reset semantics.
+- Legacy devices without a rotated setup hotspot PSK still fall back to the
+  documented factory setup password until the first setup wizard stores one.
+
+## Completion Criteria
+
+- GUI reset on server and camera returns to setup mode and accepts the
+  operator-chosen setup hotspot password.
+- Tests and repo rule checks pass or have documented environment blockers.
+- PR to `main` is merged after CI passes.

--- a/docs/guides/hardware-setup.md
+++ b/docs/guides/hardware-setup.md
@@ -216,6 +216,12 @@ ping rpi-divinu.local
 ip addr show eth0
 ```
 
+If Ethernet is not available, connect to the setup hotspot **HomeMonitor-Setup**
+using the factory setup password `homemonitor`, then open `http://10.42.0.1`.
+During setup, choose a new setup hotspot password. Authenticated factory reset
+from the web UI preserves that password so you can re-enter setup. Hardware
+GPIO reset removes it and returns the setup hotspot to the factory password.
+
 ### 4.3 SSH In (Dev Image Only)
 
 ```bash
@@ -284,7 +290,7 @@ https://rpi-divinu.local
 ```
 
 - **Accept the self-signed certificate warning** (the system generates its own CA on first boot).
-- **Production images** will prompt a first-boot setup wizard (create admin account, set timezone, set hostname).
+- **Production images** will prompt a first-boot setup wizard. Keep the server on Ethernet when possible; WiFi is optional for the server.
 - **Dev images** have a pre-configured admin account for testing.
 
 ---
@@ -302,7 +308,7 @@ https://rpi-divinu.local
 On first boot, the camera starts a WiFi hotspot for provisioning:
 
 1. Connect your phone to WiFi: **HomeCam-Setup** using the factory setup password `homecamera`
-2. During setup, choose a new setup hotspot password. The camera stores it in `/data/config/camera-hotspot.psk` and uses it if setup mode appears again after a reset or WiFi repair.
+2. During setup, choose a new setup hotspot password. The camera stores it in `/data/config/camera-hotspot.psk` and uses it if setup mode appears again for WiFi repair or authenticated factory reset. Hardware GPIO reset removes it and returns the setup hotspot to the factory password.
 3. The setup wizard opens automatically (captive portal). If not, go to `http://10.42.0.1`
 4. Enter your **home WiFi SSID** and **password**
 5. Enter the **server address** (default: `rpi-divinu.local`)

--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -20,6 +20,7 @@ SRC_URI = " \
     file://camera_streamer/ \
     file://release_version/release_version.py \
     file://config/camera-streamer.service \
+    file://config/camera-privileged-helper.service \
     file://config/camera-hotspot.service \
     file://config/camera-hotspot.sh \
     file://config/nftables-camera.conf \
@@ -53,7 +54,7 @@ RDEPENDS:${PN} = " \
 
 inherit systemd useradd
 
-SYSTEMD_SERVICE:${PN} = "camera-streamer.service camera-hotspot.service ensure-camera-overlay.service camera-ota-installer.path camera-ota-reboot.path"
+SYSTEMD_SERVICE:${PN} = "camera-privileged-helper.service camera-streamer.service camera-hotspot.service ensure-camera-overlay.service camera-ota-installer.path camera-ota-reboot.path"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 # Create camera system user/group
@@ -89,6 +90,7 @@ do_install() {
     # Systemd services
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/config/camera-streamer.service ${D}${systemd_system_unitdir}/camera-streamer.service
+    install -m 0644 ${WORKDIR}/config/camera-privileged-helper.service ${D}${systemd_system_unitdir}/camera-privileged-helper.service
     install -m 0644 ${WORKDIR}/config/camera-hotspot.service ${D}${systemd_system_unitdir}/camera-hotspot.service
     install -m 0644 ${WORKDIR}/config/ensure-camera-overlay.service ${D}${systemd_system_unitdir}/ensure-camera-overlay.service
     install -m 0644 ${WORKDIR}/config/camera-ota-installer.service ${D}${systemd_system_unitdir}/camera-ota-installer.service
@@ -116,6 +118,7 @@ do_install() {
 FILES:${PN} = " \
     /opt/camera \
     ${bindir}/camera-ota-installer \
+    ${systemd_system_unitdir}/camera-privileged-helper.service \
     ${systemd_system_unitdir}/camera-streamer.service \
     ${systemd_system_unitdir}/camera-hotspot.service \
     ${systemd_system_unitdir}/ensure-camera-overlay.service \

--- a/meta-home-monitor/recipes-core/gpio-trigger/gpio-trigger_1.0.bb
+++ b/meta-home-monitor/recipes-core/gpio-trigger/gpio-trigger_1.0.bb
@@ -1,0 +1,32 @@
+# REQ: SWR-018, SWR-050; RISK: RISK-006, RISK-018; SEC: SC-006, SC-019; TEST: TC-015, TC-044
+SUMMARY = "Boot-time GPIO provisioning and factory reset trigger"
+DESCRIPTION = "Shared GPIO jumper detector used by server and camera images."
+LICENSE = "AGPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/AGPL-3.0-only;md5=73f1eb20517c55bf9493b7dd6e480788"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/server:"
+
+SRC_URI = " \
+    file://config/gpio-trigger.sh \
+    file://config/gpio-trigger.service \
+    "
+
+S = "${WORKDIR}"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "gpio-trigger.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}/opt/scripts
+    install -m 0755 ${WORKDIR}/config/gpio-trigger.sh ${D}/opt/scripts/gpio-trigger.sh
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/config/gpio-trigger.service ${D}${systemd_system_unitdir}/gpio-trigger.service
+}
+
+FILES:${PN} = " \
+    /opt/scripts/gpio-trigger.sh \
+    ${systemd_system_unitdir}/gpio-trigger.service \
+    "

--- a/meta-home-monitor/recipes-core/packagegroups/packagegroup-monitor-base.bb
+++ b/meta-home-monitor/recipes-core/packagegroups/packagegroup-monitor-base.bb
@@ -16,6 +16,7 @@ RDEPENDS:${PN} = " \
     tzdata \
     tailscale \
     nm-persist \
+    gpio-trigger \
     htop \
     nano \
     curl \

--- a/scripts/deploy-dev-app.sh
+++ b/scripts/deploy-dev-app.sh
@@ -172,6 +172,10 @@ deploy_server() {
     copy_file "$REPO_ROOT/app/server/config/nginx-monitor.conf" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/server/config/monitor.service" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/server/config/monitor-privileged-helper.service" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/monitor-hotspot.sh" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/monitor-hotspot.service" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/gpio-trigger.sh" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/gpio-trigger.service" "$host" "$SERVER_STAGE"
 
     log "Installing server app into /opt/monitor"
     ssh "${SSH_OPTS[@]}" "$host" "
@@ -200,8 +204,16 @@ deploy_server() {
         id -u monitor >/dev/null 2>&1 || useradd -r -d /opt/monitor -s /bin/false -U monitor
         mkdir -p /data/config /data/recordings /data/live /data/logs /data/certs
         chown -R monitor:monitor /data/config /data/recordings /data/live /data/logs /data/certs
+        mkdir -p /opt/scripts
+        mkdir -p /opt/monitor/scripts
+        cp '$SERVER_STAGE/monitor-hotspot.sh' /opt/monitor/scripts/monitor-hotspot.sh
+        chmod 0755 /opt/monitor/scripts/monitor-hotspot.sh
+        cp '$SERVER_STAGE/gpio-trigger.sh' /opt/scripts/gpio-trigger.sh
+        chmod 0755 /opt/scripts/gpio-trigger.sh
         cp '$SERVER_STAGE/monitor.service' /etc/systemd/system/monitor.service
         cp '$SERVER_STAGE/monitor-privileged-helper.service' /etc/systemd/system/monitor-privileged-helper.service
+        cp '$SERVER_STAGE/monitor-hotspot.service' /etc/systemd/system/monitor-hotspot.service
+        cp '$SERVER_STAGE/gpio-trigger.service' /etc/systemd/system/gpio-trigger.service
     "
 
     log "Applying boot optimisation overrides"
@@ -218,7 +230,7 @@ deploy_server() {
         # Mask systemd-networkd-wait-online: always times out on eth0 no-carrier
         systemctl mask systemd-networkd-wait-online.service 2>/dev/null || true
         systemctl daemon-reload
-        systemctl enable monitor-privileged-helper.service monitor.service >/dev/null 2>&1 || true
+        systemctl enable gpio-trigger.service monitor-hotspot.service monitor-privileged-helper.service monitor.service >/dev/null 2>&1 || true
     "
 
     if [ "$SKIP_RESTART" -eq 0 ]; then
@@ -247,6 +259,12 @@ deploy_camera() {
     copy_file "$REPO_ROOT/app/camera/setup.py" "$host" "$CAMERA_STAGE"
     copy_file "$REPO_ROOT/app/camera/requirements.txt" "$host" "$CAMERA_STAGE"
     copy_file "$REPO_ROOT/app/camera/config/camera.conf.default" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/app/camera/config/camera-streamer.service" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/app/camera/config/camera-privileged-helper.service" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/app/camera/config/camera-hotspot.sh" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/app/camera/config/camera-hotspot.service" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/gpio-trigger.sh" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/gpio-trigger.service" "$host" "$CAMERA_STAGE"
 
     log "Installing camera app into /opt/camera"
     ssh "${SSH_OPTS[@]}" "$host" "
@@ -268,45 +286,23 @@ deploy_camera() {
         # Pre-compile bytecode so first-request import is instant
         python3 -m compileall -q /opt/camera/camera_streamer
         chown -R camera:camera /opt/camera/camera_streamer/__pycache__ 2>/dev/null || true
+        mkdir -p /opt/scripts
+        mkdir -p /opt/camera/scripts
+        cp '$CAMERA_STAGE/camera-hotspot.sh' /opt/camera/scripts/camera-hotspot.sh
+        chmod 0755 /opt/camera/scripts/camera-hotspot.sh
+        cp '$CAMERA_STAGE/gpio-trigger.sh' /opt/scripts/gpio-trigger.sh
+        chmod 0755 /opt/scripts/gpio-trigger.sh
+        cp '$CAMERA_STAGE/gpio-trigger.service' /etc/systemd/system/gpio-trigger.service
     "
 
     log "Applying boot optimisation overrides"
     ssh "${SSH_OPTS[@]}" "$host" "
-        # Full unit file override — removes network-online.target.
-        # In hotspot/AP mode nm-online waits full 60s timeout; camera-hotspot.service
-        # completes in ~6s (or skips instantly when setup-done), which is enough.
-        cat > /etc/systemd/system/camera-streamer.service << 'SVCEOF'
-[Unit]
-Description=Camera RTSP Streamer
-After=avahi-daemon.service local-fs.target NetworkManager.service camera-hotspot.service sys-subsystem-net-devices-wlan0.device
-Wants=NetworkManager.service
-
-[Service]
-Type=simple
-User=camera
-Group=camera
-WorkingDirectory=/opt/camera
-ExecStartPre=+/bin/sh -c 'chmod 0666 /sys/class/leds/ACT/trigger /sys/class/leds/ACT/brightness /sys/class/leds/ACT/delay_on /sys/class/leds/ACT/delay_off 2>/dev/null || true'
-ExecStart=/usr/bin/python3 -m camera_streamer.main
-Restart=always
-RestartSec=5
-TimeoutStopSec=20
-KillMode=control-group
-Environment=PYTHONPATH=/opt/camera
-Environment=CAMERA_DATA_DIR=/data
-Environment=CAMERA_CONFIG_DIR=/data/config
-Environment=CAMERA_CERTS_DIR=/data/certs
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/data
-PrivateTmp=true
-SupplementaryGroups=video
-AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SYS_ADMIN
-
-[Install]
-WantedBy=multi-user.target
-SVCEOF
+        # Full unit file override from the repo. Keep this in sync with
+        # app/camera/config/camera-streamer.service so hardening exceptions
+        # such as /var/lib/camera-ota cannot drift in the deploy path.
+        cp '$CAMERA_STAGE/camera-streamer.service' /etc/systemd/system/camera-streamer.service
+        cp '$CAMERA_STAGE/camera-privileged-helper.service' /etc/systemd/system/camera-privileged-helper.service
+        cp '$CAMERA_STAGE/camera-hotspot.service' /etc/systemd/system/camera-hotspot.service
         # journald limits — prevent /run from filling up under active streaming.
         # Without explicit RuntimeMaxUse, journald's implicit cap (~7MB on a 70MB
         # /run) is not enforced tightly enough under the ~6 entries/sec picamera2
@@ -335,17 +331,18 @@ ConditionFileNotEmpty=/data/tailscale/tailscaled.state
 EOF
         fi
         systemctl daemon-reload
+        systemctl enable gpio-trigger.service camera-privileged-helper.service camera-hotspot.service camera-streamer.service >/dev/null 2>&1 || true
     "
 
     if [ "$SKIP_RESTART" -eq 0 ]; then
         log "Restarting camera service"
-        ssh "${SSH_OPTS[@]}" "$host" "systemctl restart camera-streamer && systemctl is-active camera-streamer >/dev/null"
+        ssh "${SSH_OPTS[@]}" "$host" "systemctl restart camera-privileged-helper camera-streamer && systemctl is-active camera-privileged-helper camera-streamer >/dev/null"
     fi
 
     log "Validating camera health"
     wait_for_http_status "https://${CAMERA_IP}/" "302" "200" "45"
     wait_for_http_status "https://${CAMERA_IP}/login" "200" "" "20"
-    ssh "${SSH_OPTS[@]}" "$host" "systemctl is-active camera-streamer avahi-daemon"
+    ssh "${SSH_OPTS[@]}" "$host" "systemctl is-active camera-privileged-helper camera-streamer avahi-daemon"
 
     log "Cleaning camera staging area"
     ssh "${SSH_OPTS[@]}" "$host" "rm -rf '$CAMERA_STAGE'"


### PR DESCRIPTION
﻿## Summary
- Preserve operator-chosen setup hotspot passwords during authenticated server/camera factory reset while keeping hardware GPIO reset as the full wipe path.
- Add camera privileged helper operations for root-only hotspot lifecycle and setup password writes, fixing first-time setup when `/data/config/camera-hotspot.psk` is protected.
- Update setup UI/API validation, dev deploy paths, Yocto packaging, docs, and regression coverage for server and camera reset semantics.

## Hardware validation
- Deployed to server `192.168.1.245` and camera via COM3/setup AP without changing this PC's WiFi.
- Camera setup submitted through `/api/connect` from `HomeCam-Setup` with a root-owned password file; response changed from prior 500 to `connecting`.
- Triggered authenticated camera `/api/factory-reset`; AP came back, accepted the operator-chosen setup password, and serial confirmed `camera:camera 600 /data/config/camera-hotspot.psk` with setup incomplete.
- Restored camera to `MysticNet2.4`; server sees `/api/status` with `server_connected: true`, and COM3 confirms setup complete and camera services active.
- Server live deploy check confirms reset excludes `setup-hotspot.psk`, server setup PSK remains `monitor:monitor 600`, and monitor services are active.

## Validation
- `pytest app/camera/tests/ -v` -> 856 passed
- `pytest app/server/tests/ -v` -> 2502 passed, 1 skipped
- `ruff check .`
- `ruff format --check .`
- `python tools/docs/check_doc_map.py`
- `python scripts/ai/validate_repo_ai_setup.py`
- `python scripts/ai/check_doc_links.py`
- `python scripts/ai/check_shell_scripts.py`
- `python scripts/check_version_consistency.py`
- `python scripts/check_versioning_design.py`
- `python tools/traceability/check_traceability.py`
- `python -m pre_commit run --all-files`
