### PR TITLE
[codex] Fix camera password confirmation and NTP status

### DIFF
--- a/app/camera/camera_streamer/templates/setup.html
+++ b/app/camera/camera_streamer/templates/setup.html
@@ -401,6 +401,8 @@ p {
       <input type="text" id="in-admin-user" value="admin" placeholder="admin">
       <label>Password</label>
       <input type="password" id="in-admin-pw" placeholder="Password (min 12 characters)">
+      <label>Confirm password</label>
+      <input type="password" id="in-admin-pw-confirm" placeholder="Confirm camera password">
       <div class="hint">You'll use these credentials to access the camera's status page and change settings later.</div>
     </div>
 
@@ -859,6 +861,7 @@ function doConnect() {
   var port = $('in-port').value.trim() || '8554';
   var adminUser = $('in-admin-user').value.trim() || 'admin';
   var adminPw = $('in-admin-pw').value;
+  var adminPwConfirm = $('in-admin-pw-confirm').value;
   var hotspotPw = $('in-hotspot-pw').value;
   var hotspotPwConfirm = $('in-hotspot-pw-confirm').value;
 
@@ -871,6 +874,10 @@ function doConnect() {
   }
   if (!adminPw || adminPw.length < 12) {
     alert('Set a password (at least 12 characters)');
+    return;
+  }
+  if (adminPw !== adminPwConfirm) {
+    alert('Camera passwords do not match');
     return;
   }
   if (!hotspotPw || hotspotPw.length < 12) {
@@ -891,6 +898,7 @@ function doConnect() {
       ssid: ssid, password: pass,
       server_ip: server, server_port: port,
       admin_username: adminUser, admin_password: adminPw,
+      admin_password_confirm: adminPwConfirm,
       setup_hotspot_password: hotspotPw
     })
   })

--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -1365,6 +1365,7 @@ details[open] summary {
     <div class="details-body">
       <div class="field"><label>Current password</label><input class="input" id="pw-cur" type="password"></div>
       <div class="field"><label>New password</label><input class="input" id="pw-new" type="password" placeholder="At least 12 characters"></div>
+      <div class="field"><label>Confirm new password</label><input class="input" id="pw-confirm" type="password" placeholder="Repeat new password"></div>
       <button class="btn btn--primary btn--full" id="btn-pw" onclick="doPassword()">Save password</button>
       <div id="pw-result"></div>
     </div>
@@ -1820,9 +1821,10 @@ function doWifi() {
 
 // ---- Password ----
 function doPassword() {
-    var cur = $("pw-cur").value, nw = $("pw-new").value;
+    var cur = $("pw-cur").value, nw = $("pw-new").value, confirmPw = $("pw-confirm").value;
     if (!cur) return setMsg("pw-result", "err", "Enter your current password.");
     if (!nw || nw.length < 12) return setMsg("pw-result", "err", "New password must be at least 12 characters.");
+    if (nw !== confirmPw) return setMsg("pw-result", "err", "New passwords do not match.");
     setBusy("btn-pw", true, "Saving…");
     setMsg("pw-result", "", "");
     fetch("/api/password", {
@@ -1834,7 +1836,7 @@ function doPassword() {
         if (d.error) setMsg("pw-result", "err", d.error);
         else {
             setMsg("pw-result", "ok", "Password changed.");
-            $("pw-cur").value = ""; $("pw-new").value = "";
+            $("pw-cur").value = ""; $("pw-new").value = ""; $("pw-confirm").value = "";
         }
     }).catch(function(){
         setBusy("btn-pw", false, "Save password");

--- a/app/camera/camera_streamer/wifi_setup.py
+++ b/app/camera/camera_streamer/wifi_setup.py
@@ -432,6 +432,7 @@ def _make_handler(config, setup_server):
                     server_port = data.get("server_port", "8554").strip()
                     admin_username = data.get("admin_username", "admin").strip()
                     admin_password = data.get("admin_password", "")
+                    admin_password_confirm = data.get("admin_password_confirm")
                     setup_hotspot_password = data.get("setup_hotspot_password", "")
 
                     if not ssid:
@@ -457,6 +458,15 @@ def _make_handler(config, setup_server):
                                 "error": "Password required "
                                 f"(min {MIN_ADMIN_PASSWORD_LENGTH} characters)"
                             },
+                            400,
+                        )
+                        return
+                    if (
+                        admin_password_confirm is not None
+                        and admin_password != admin_password_confirm
+                    ):
+                        self._json_response(
+                            {"error": "Camera passwords do not match"},
                             400,
                         )
                         return

--- a/app/camera/tests/contracts/test_api_contracts.py
+++ b/app/camera/tests/contracts/test_api_contracts.py
@@ -361,6 +361,7 @@ class TestSetupStatusContract:
             assert status == 200
             assert "Reach this camera" in html
             assert "/static/qrcode.min.js" in html
+            assert 'id="in-admin-pw-confirm"' in html
         finally:
             server.stop()
 
@@ -382,6 +383,7 @@ class TestSetupConnectContract:
                     "server_ip": "192.168.1.100",
                     "admin_username": "admin",
                     "admin_password": "testpass12345",
+                    "admin_password_confirm": "testpass12345",
                     "setup_hotspot_password": "CameraSetupPass123",
                 },
             )
@@ -409,6 +411,32 @@ class TestSetupConnectContract:
             assert status == 400
             _assert_fields(data, {"error"})
             assert "12" in data["error"]
+        finally:
+            server.stop()
+
+    @patch("camera_streamer.wifi.scan_networks", return_value=[])
+    @patch("camera_streamer.wifi.start_hotspot", return_value=True)
+    def test_rejects_mismatched_admin_password_confirm(
+        self, mock_hotspot, mock_scan, setup_config
+    ):
+        server = WifiSetupServer(setup_config)
+        server.start()
+        try:
+            data, status = _json_post(
+                "/api/connect",
+                {
+                    "ssid": "TestNet",
+                    "password": "pass123",
+                    "server_ip": "192.168.1.100",
+                    "admin_username": "admin",
+                    "admin_password": "testpass12345",
+                    "admin_password_confirm": "different12345",
+                    "setup_hotspot_password": "CameraSetupPass123",
+                },
+            )
+            assert status == 400
+            _assert_fields(data, {"error"})
+            assert "do not match" in data["error"]
         finally:
             server.stop()
 
@@ -643,6 +671,7 @@ class TestStatusServerApiStatusContract:
                 'id="btn-scan"',
                 'id="wifi-ssid"',
                 'id="btn-wifi"',
+                'id="pw-confirm"',
                 'id="btn-pw"',
                 'id="btn-stream-edit"',
                 'id="se-res"',

--- a/app/server/monitor/services/settings_service.py
+++ b/app/server/monitor/services/settings_service.py
@@ -30,16 +30,36 @@ def _trim_command_error(result, fallback: str) -> str:
     return text[:256] or fallback
 
 
-def _extract_last_sync_time(output: str) -> str:
-    """Best-effort parse of a timedatectl timesync-status timestamp line."""
+def _parse_timesync_status(output: str) -> dict:
+    """Best-effort parse of `timedatectl timesync-status` output."""
+    info = {
+        "last_sync_time": "",
+        "server": "",
+        "packet_count": None,
+        "has_sync_evidence": False,
+    }
     for raw_line in output.splitlines():
         line = raw_line.strip()
-        lowered = line.lower()
-        if lowered.startswith("last synchronized:") or lowered.startswith(
-            "last synchronization:"
-        ):
-            return line.split(":", 1)[1].strip()
-    return ""
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if key == "server":
+            info["server"] = value
+        elif key == "packet count":
+            try:
+                info["packet_count"] = int(value)
+            except ValueError:
+                info["packet_count"] = None
+        elif key in {"last synchronized", "last synchronization"}:
+            info["last_sync_time"] = value
+
+    packet_count = info["packet_count"]
+    info["has_sync_evidence"] = bool(
+        info["last_sync_time"] or (info["server"] and (packet_count or 0) > 0)
+    )
+    return info
 
 
 def _live_firmware_version() -> str:
@@ -321,11 +341,20 @@ class SettingsService:
                     info["rtc_time"] = v
         except (OSError, subprocess.SubprocessError) as e:
             log.warning("Failed to read time status: %s", e)
+        if info["ntp_active"] and not info["ntp_synchronized"]:
+            timesync = self.get_timesync_status()
+            if timesync.get("has_sync_evidence"):
+                info["ntp_synchronized"] = True
         return info
 
     def get_timesync_status(self) -> dict:
         """Return best-effort last-sync metadata from timedatectl."""
-        info = {"last_sync_time": ""}
+        info = {
+            "last_sync_time": "",
+            "server": "",
+            "packet_count": None,
+            "has_sync_evidence": False,
+        }
         try:
             result = subprocess.run(
                 ["timedatectl", "timesync-status", "--no-pager"],
@@ -334,7 +363,7 @@ class SettingsService:
                 timeout=5,
                 check=False,
             )
-            info["last_sync_time"] = _extract_last_sync_time(result.stdout or "")
+            info.update(_parse_timesync_status(result.stdout or ""))
         except (OSError, subprocess.SubprocessError) as e:
             log.info("Failed to read timesync status: %s", e)
         return info

--- a/app/server/tests/unit/test_settings_service.py
+++ b/app/server/tests/unit/test_settings_service.py
@@ -800,6 +800,29 @@ class TestTimeHelpers:
         assert info["ntp_synchronized"] is True
         assert "2026-04-18" in info["system_time"]
 
+    def test_get_time_status_uses_timesync_evidence_when_boolean_lags(self):
+        svc, _ = _make_service()
+        show = (
+            "Timezone=Europe/Dublin\n"
+            "NTP=yes\n"
+            "NTPSynchronized=no\n"
+            "TimeUSec=Sat 2026-05-30 10:20:32 IST\n"
+            "RTCTimeUSec=\n"
+        )
+        timesync = (
+            "Server: 216.239.35.8 (time.google.com)\n"
+            "Packet count: 7\n"
+            "Offset: +14.200ms\n"
+        )
+        with patch("monitor.services.settings_service.subprocess.run") as run:
+            run.side_effect = [
+                SimpleNamespace(returncode=0, stdout=show, stderr=""),
+                SimpleNamespace(returncode=0, stdout=timesync, stderr=""),
+            ]
+            info = svc.get_time_status()
+        assert info["ntp_active"] is True
+        assert info["ntp_synchronized"] is True
+
     def test_get_timesync_status_parses_last_sync_line(self):
         svc, _ = _make_service()
         fake = (
@@ -809,6 +832,8 @@ class TestTimeHelpers:
             run.return_value = SimpleNamespace(returncode=0, stdout=fake, stderr="")
             info = svc.get_timesync_status()
         assert info["last_sync_time"] == "Sat 2026-04-18 10:00:00 UTC"
+        assert info["server"] == "ntp.example.net"
+        assert info["has_sync_evidence"] is True
 
     def test_restart_timesyncd_invokes_systemctl(self):
         svc, _ = _make_service()


### PR DESCRIPTION
﻿## Summary
- add confirmation fields for camera setup password changes and logged-in camera password changes
- reject mismatched camera admin password confirmation during first-time setup
- make server time status use `timedatectl timesync-status` evidence when `NTPSynchronized` lags behind the active NTP daemon

## Root cause
- the camera setup UI only confirmed the setup-hotspot password, not the camera admin password
- the server settings page trusted `timedatectl show`'s boolean even when `systemd-timesyncd` already had server/packet sync evidence

## Deployment
- deployed server change to `192.168.1.245`, restarted `monitor`, verified live service returns `ntp_synchronized: true`
- deployed camera changes to `192.168.1.186`, restarted `camera-streamer`, verified service active and camera API still reports streaming/server connected

## Validation
- `pytest -q app/camera/tests/contracts/test_api_contracts.py::TestSetupStatusContract app/camera/tests/contracts/test_api_contracts.py::TestSetupConnectContract app/camera/tests/contracts/test_api_contracts.py::TestStatusServerApiStatusContract::test_status_page_renders_local_control_panel`
- `pytest -q app/server/tests/unit/test_settings_service.py::TestTimeHelpers`
- `ruff check .`
- `ruff format --check .`
- `pytest -q app/camera/tests/ --ignore=app/camera/tests/integration/test_ensure_camera_overlay.py` (844 passed; ignored overlay script tests fail on Windows because `bash.exe` receives raw `D:\...` paths)
- `pytest -q app/server/tests/unit/` (1497 passed, 1 skipped)
- `pytest -q app/server/tests/integration/test_api_settings.py app/server/tests/integration/test_time_health.py` (45 passed)

## Notes
- Full `pytest app/camera/tests/ -v` only failed in `test_ensure_camera_overlay.py` due the existing Windows shell path issue: `/bin/bash: D:Codex...ensure-camera-overlay.sh: No such file or directory`.
- Full `pytest -q app/server/tests/` exceeded the 10 minute local timeout, so the server unit suite and settings/time integration slice were run separately.
