### PR TITLE
[codex] Fix USB storage filesystem detection

### DIFF
--- a/app/server/monitor/services/storage_service.py
+++ b/app/server/monitor/services/storage_service.py
@@ -126,9 +126,24 @@ class StorageService:
 
         # Check filesystem
         if not device["supported"]:
+            if not device.get("fstype"):
+                return (
+                    {
+                        "needs_format": False,
+                        "filesystem_status": device.get("filesystem_status", "unknown"),
+                        "fstype": "",
+                    },
+                    (
+                        "Filesystem could not be identified. "
+                        "Rescan the USB device or unplug and reconnect it before "
+                        "selecting it for recordings."
+                    ),
+                    409,
+                )
             return (
                 {
                     "needs_format": True,
+                    "filesystem_status": device.get("filesystem_status", "unsupported"),
                     "fstype": device["fstype"],
                 },
                 (

--- a/app/server/monitor/services/usb.py
+++ b/app/server/monitor/services/usb.py
@@ -34,7 +34,7 @@ def detect_devices() -> list[dict]:
                 "-J",
                 "-b",
                 "-o",
-                "NAME,PATH,SIZE,FSTYPE,MOUNTPOINT,MODEL,LABEL,TRAN,TYPE",
+                "NAME,PATH,SIZE,FSTYPE,MOUNTPOINT,MOUNTPOINTS,MODEL,LABEL,UUID,TRAN,TYPE",
             ],
             capture_output=True,
             text=True,
@@ -71,22 +71,30 @@ def _device_info(part, parent):
     """Build device info dict from lsblk JSON."""
     fstype = part.get("fstype") or ""
     device_path = part.get("path", f"/dev/{part.get('name', '')}")
+    label = part.get("label") or ""
+    uuid = part.get("uuid") or ""
 
     # lsblk may not report fstype for non-root users — fall back to blkid
-    if not fstype and device_path:
-        fstype = _get_fstype_blkid(device_path)
+    if device_path and (not fstype or not label or not uuid):
+        props = _get_blkid_properties(device_path)
+        fstype = fstype or props.get("TYPE", "")
+        label = label or props.get("LABEL", "")
+        uuid = uuid or props.get("UUID", "")
 
     size_bytes = int(part.get("size") or 0)
+    filesystem_status = _filesystem_status(fstype)
     return {
         "name": part.get("name", ""),
         "path": device_path,
         "size": _human_size(size_bytes),
         "size_bytes": size_bytes,
         "fstype": fstype,
-        "mountpoint": part.get("mountpoint") or "",
+        "mountpoint": _mountpoint(part),
         "model": (parent.get("model") or "USB Drive").strip(),
-        "label": part.get("label") or "",
-        "supported": fstype.lower() in SUPPORTED_FS,
+        "label": label,
+        "uuid": uuid,
+        "filesystem_status": filesystem_status,
+        "supported": filesystem_status == "supported",
     }
 
 
@@ -95,18 +103,59 @@ def _get_fstype_blkid(device_path):
 
     Falls back gracefully if blkid is unavailable or fails.
     """
-    try:
-        result = subprocess.run(
-            ["blkid", "-s", "TYPE", "-o", "value", device_path],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
+    return _get_blkid_properties(device_path).get("TYPE", "")
+
+
+def _get_blkid_properties(device_path):
+    """Return blkid metadata for a device using cache and direct probing."""
+    for cmd in (
+        ["blkid", "-o", "export", device_path],
+        ["blkid", "-p", "-o", "export", device_path],
+    ):
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            continue
         if result.returncode == 0:
-            return result.stdout.strip()
-    except (subprocess.TimeoutExpired, OSError):
-        pass
+            props = _parse_blkid_export(result.stdout)
+            if props:
+                return props
+    return {}
+
+
+def _parse_blkid_export(output):
+    props = {}
+    for raw_line in output.splitlines():
+        if "=" not in raw_line:
+            continue
+        key, value = raw_line.split("=", 1)
+        props[key.strip()] = value.strip()
+    return props
+
+
+def _mountpoint(part):
+    mountpoint = part.get("mountpoint") or ""
+    mountpoints = part.get("mountpoints")
+    if mountpoint:
+        return mountpoint
+    if isinstance(mountpoints, list):
+        return next((mp for mp in mountpoints if mp), "")
+    if isinstance(mountpoints, str):
+        return mountpoints.strip()
     return ""
+
+
+def _filesystem_status(fstype):
+    if not fstype:
+        return "unknown"
+    if fstype.lower() in SUPPORTED_FS:
+        return "supported"
+    return "unsupported"
 
 
 def _human_size(nbytes):

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -1420,9 +1420,10 @@
                             <div class="text-small text-muted">
                                 <span x-text="d.path"></span> &middot;
                                 <span x-text="d.size"></span> &middot;
-                                <span x-text="d.fstype || 'unformatted'"></span>
+                                <span x-text="d.fstype || 'unknown filesystem'"></span>
                                 <span x-show="d.supported" style="color:#4ade80;"> Compatible</span>
-                                <span x-show="!d.supported" style="color:#f87171;"> Needs format</span>
+                                <span x-show="!d.supported && d.fstype" style="color:#f87171;"> Needs format</span>
+                                <span x-show="!d.supported && !d.fstype" style="color:#f59e0b;"> Rescan or reconnect before use</span>
                                 <span x-show="d.configured_inactive"> &middot; not active right now</span>
                             </div>
                         </div>
@@ -1433,7 +1434,8 @@
                             <span x-show="d.in_use" class="text-small text-muted">Active</span>
                             <!-- Issue #107: Reformat available for all device states.
                                  In-use drives auto-eject first via showFormat(). -->
-                            <button x-show="!d.supported" class="btn btn--secondary btn--small" @click="showFormat(d)">Format</button>
+                            <button x-show="!d.supported && d.fstype" class="btn btn--secondary btn--small" @click="showFormat(d)">Format</button>
+                            <button x-show="!d.supported && !d.fstype" class="btn btn--secondary btn--small" @click="scanUsb()">Rescan</button>
                             <button x-show="d.supported" class="btn btn--secondary btn--small" @click="showFormat(d)">Reformat</button>
                         </div>
                     </div>
@@ -1454,7 +1456,7 @@
                 <p style="margin:12px 0;">
                     Device <strong x-text="storage.formatDevice.model || '--'"></strong>
                     (<span x-text="storage.formatDevice.path || '--'"></span>,
-                    <span x-text="storage.formatDevice.fstype || 'unformatted'"></span>).
+                    <span x-text="storage.formatDevice.fstype || 'unknown filesystem'"></span>).
                     Format to ext4?
                 </p>
                 <button class="btn btn--danger btn--small" @click="formatUsb()" :disabled="storage.formatting">

--- a/app/server/tests/contracts/test_api_contracts.py
+++ b/app/server/tests/contracts/test_api_contracts.py
@@ -1688,6 +1688,7 @@ class TestStorageDevicesContract:
                 "model": "USB",
                 "size": "64G",
                 "fstype": "ext4",
+                "filesystem_status": "supported",
                 "supported": True,
             },
         ]
@@ -1699,7 +1700,14 @@ class TestStorageDevicesContract:
             dev = data["devices"][0]
             _assert_has_fields(
                 dev,
-                {"path", "model", "size", "fstype", "supported"},
+                {
+                    "path",
+                    "model",
+                    "size",
+                    "fstype",
+                    "filesystem_status",
+                    "supported",
+                },
             )
 
 

--- a/app/server/tests/integration/test_api_storage.py
+++ b/app/server/tests/integration/test_api_storage.py
@@ -150,7 +150,7 @@ class TestSelectDevice:
     @patch(USB_PATCH)
     def test_unsupported_filesystem(self, mock_usb, logged_in_client):
         client = logged_in_client()
-        device = _make_device("/dev/sda1", fstype="ntfs", supported=False)
+        device = _make_device("/dev/sda1", fstype="btrfs", supported=False)
         mock_usb.detect_devices.return_value = [device]
 
         response = client.post(
@@ -162,7 +162,26 @@ class TestSelectDevice:
         assert response.status_code == 400
         data = response.get_json()
         assert data["needs_format"] is True
-        assert data["fstype"] == "ntfs"
+        assert data["fstype"] == "btrfs"
+
+    @patch(USB_PATCH)
+    def test_unknown_filesystem_asks_for_rescan_not_format(
+        self, mock_usb, logged_in_client
+    ):
+        client = logged_in_client()
+        device = _make_device("/dev/sda1", fstype="", supported=False)
+        mock_usb.detect_devices.return_value = [device]
+
+        response = client.post(
+            "/api/v1/storage/select",
+            json={
+                "device_path": "/dev/sda1",
+            },
+        )
+        assert response.status_code == 409
+        data = response.get_json()
+        assert data["needs_format"] is False
+        assert data["filesystem_status"] == "unknown"
 
     @patch(USB_PATCH)
     def test_mount_failure(self, mock_usb, logged_in_client):

--- a/app/server/tests/unit/test_storage_service.py
+++ b/app/server/tests/unit/test_storage_service.py
@@ -136,7 +136,7 @@ class TestSelectDeviceValidation:
     @patch(USB_PATCH)
     def test_unsupported_filesystem_returns_400_with_needs_format(self, mock_usb):
         mock_usb.detect_devices.return_value = [
-            _make_device(fstype="ntfs", supported=False),
+            _make_device(fstype="btrfs", supported=False),
         ]
         svc = _make_service()
 
@@ -144,8 +144,22 @@ class TestSelectDeviceValidation:
 
         assert status == 400
         assert result["needs_format"] is True
-        assert result["fstype"] == "ntfs"
+        assert result["fstype"] == "btrfs"
         assert "not supported" in err
+
+    @patch(USB_PATCH)
+    def test_unknown_filesystem_returns_rescan_error_not_format_prompt(self, mock_usb):
+        mock_usb.detect_devices.return_value = [
+            _make_device(fstype="", supported=False),
+        ]
+        svc = _make_service()
+
+        result, err, status = svc.select_device("/dev/sda1")
+
+        assert status == 409
+        assert result["needs_format"] is False
+        assert result["filesystem_status"] == "unknown"
+        assert "Rescan" in err
 
     @patch(USB_PATCH)
     def test_mount_failure_returns_500(self, mock_usb):

--- a/app/server/tests/unit/test_svc_storage.py
+++ b/app/server/tests/unit/test_svc_storage.py
@@ -112,12 +112,23 @@ class TestSelectDevice:
     @patch(USB_PATCH)
     def test_unsupported_filesystem(self, mock_usb, svc):
         mock_usb.detect_devices.return_value = [
-            _make_device(fstype="ntfs", supported=False)
+            _make_device(fstype="btrfs", supported=False)
         ]
         result, err, status = svc.select_device("/dev/sda1")
         assert status == 400
         assert result["needs_format"] is True
-        assert result["fstype"] == "ntfs"
+        assert result["fstype"] == "btrfs"
+
+    @patch(USB_PATCH)
+    def test_unknown_filesystem_does_not_claim_format_is_required(self, mock_usb, svc):
+        mock_usb.detect_devices.return_value = [
+            _make_device(fstype="", supported=False)
+        ]
+        result, err, status = svc.select_device("/dev/sda1")
+        assert status == 409
+        assert result["needs_format"] is False
+        assert result["filesystem_status"] == "unknown"
+        assert "Rescan" in err
 
     @patch(USB_PATCH)
     def test_mount_failure(self, mock_usb, svc):

--- a/app/server/tests/unit/test_usb.py
+++ b/app/server/tests/unit/test_usb.py
@@ -276,10 +276,38 @@ def test_device_info_builds_dict():
     assert info["mountpoint"] == "/mnt/usb"
     assert info["model"] == "SanDisk"
     assert info["label"] == "DATA"
+    assert info["filesystem_status"] == "supported"
     assert info["supported"] is True
 
 
-def test_device_info_missing_fields():
+@patch("monitor.services.usb._get_blkid_properties")
+def test_device_info_uses_blkid_export_when_lsblk_metadata_is_missing(mock_blkid):
+    mock_blkid.return_value = {
+        "TYPE": "ext4",
+        "LABEL": "HomeMonitor",
+        "UUID": "e9a698af",
+    }
+    part = {
+        "name": "sda1",
+        "path": "/dev/sda1",
+        "size": 1073741824,
+        "fstype": "",
+        "mountpoint": "",
+        "label": "",
+    }
+    parent = {"model": "Storage Device"}
+
+    info = _device_info(part, parent)
+
+    assert info["fstype"] == "ext4"
+    assert info["label"] == "HomeMonitor"
+    assert info["uuid"] == "e9a698af"
+    assert info["filesystem_status"] == "supported"
+    assert info["supported"] is True
+
+
+@patch("monitor.services.usb._get_blkid_properties", return_value={})
+def test_device_info_missing_fields(mock_blkid):
     """Missing or None fields get safe defaults."""
     part = {"name": "sdb1"}
     parent = {}
@@ -292,10 +320,12 @@ def test_device_info_missing_fields():
     assert info["mountpoint"] == ""
     assert info["model"] == "USB Drive"
     assert info["label"] == ""
+    assert info["filesystem_status"] == "unknown"
     assert info["supported"] is False
 
 
-def test_device_info_null_mountpoint():
+@patch("monitor.services.usb._get_blkid_properties", return_value={})
+def test_device_info_null_mountpoint(mock_blkid):
     """None mountpoint converts to empty string."""
     part = {
         "name": "sda1",


### PR DESCRIPTION
﻿## Summary
- improve USB filesystem detection by falling back from incomplete `lsblk` metadata to `blkid -o export` and direct `blkid -p` probing
- include USB `uuid` and `filesystem_status` in device responses
- stop treating an unidentified filesystem as “unformatted / needs format” in the settings UI; prompt the operator to rescan or reconnect instead
- return a 409 rescan/reconnect response when selecting a USB device whose filesystem cannot be identified

## Root cause
The live USB partition was actually `ext4` (`/dev/sda1`, label `HomeMonitor`), but the UI rendered any empty `fstype` as `unformatted` and immediately showed `Needs format`. That is unsafe because a transient metadata miss can look like a destructive formatting recommendation.

## Live verification
- Server `192.168.1.245` now has the updated files deployed and `monitor` restarted
- Live scan reports `/dev/sda1` as `ext4`, `filesystem_status: supported`, label `HomeMonitor`, UUID `e9a698af-117c-4005-9b08-0d20978bf4fe`

## Validation
- `pytest -q app/server/tests/unit/test_usb.py app/server/tests/unit/test_storage_service.py app/server/tests/unit/test_svc_storage.py app/server/tests/integration/test_api_storage.py app/server/tests/contracts/test_api_contracts.py::TestStorageDevicesContract` (133 passed)
- `ruff check .`
- `ruff format --check .`
