### PR TITLE
[codex] Fix stale OTA staging policy

### DIFF
--- a/app/camera/camera_streamer/ota_agent.py
+++ b/app/camera/camera_streamer/ota_agent.py
@@ -162,7 +162,8 @@ class OTAAgent:
 
         ok, msg = ota_installer.stage_bundle(handler.rfile, content_length)
         if not ok:
-            self._send_json(handler, 500, {"error": msg})
+            code = 400 if msg.startswith("Rejected older update") else 500
+            self._send_json(handler, code, {"error": msg})
             return
 
         ok, trigger_msg = ota_installer.trigger_install(msg)

--- a/app/camera/camera_streamer/ota_installer.py
+++ b/app/camera/camera_streamer/ota_installer.py
@@ -39,6 +39,9 @@ import shutil
 import tempfile
 import time
 
+from camera_streamer import ota_policy
+from camera_streamer.release_version import release_version
+
 log = logging.getLogger("camera-streamer.ota-installer")
 
 SPOOL_DIR = "/var/lib/camera-ota"
@@ -325,6 +328,22 @@ def stage_bundle(src_fileobj, total_bytes, progress_cb=None):
         write_status(STATE_ERROR, error="Incomplete upload")
         return False, "Incomplete upload"
 
+    target_version = extract_bundle_version(tmp)
+    decision = ota_policy.classify_update(release_version(), target_version)
+    if decision.blocked:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        write_status(
+            STATE_ERROR,
+            error=decision.reason,
+            target_version=target_version,
+            current_version=decision.current_version,
+            update_relation=decision.relation,
+        )
+        return False, decision.reason
+
     try:
         os.replace(tmp, dst)
     except OSError as exc:
@@ -334,8 +353,13 @@ def stage_bundle(src_fileobj, total_bytes, progress_cb=None):
     # Surface the target version so the UI can render "1.0.0 → 1.1.0"
     # alongside the staged bundle. Empty string is acceptable — older
     # bundles without a version field still install.
-    target_version = extract_bundle_version(dst)
-    write_status(STATE_DOWNLOADING, progress=40, target_version=target_version)
+    write_status(
+        STATE_DOWNLOADING,
+        progress=40,
+        target_version=target_version,
+        current_version=decision.current_version,
+        update_relation=decision.relation,
+    )
     log.info(
         "Bundle staged at %s (%d bytes, version=%s)",
         dst,

--- a/app/camera/camera_streamer/ota_policy.py
+++ b/app/camera/camera_streamer/ota_policy.py
@@ -1,0 +1,187 @@
+# REQ: SWR-010, SWR-038, SWR-046; RISK: RISK-004, RISK-019; SEC: SC-003, SC-018; TEST: TC-013, TC-036, TC-043
+"""Shared OTA bundle ordering policy.
+
+The server and camera run in different Python packages, but they must
+make the same safety decision about an update bundle: never install an
+older, parseable release over a newer running image by accident.
+
+This module is copied into both package namespaces at build time:
+
+  /opt/monitor/monitor/ota_policy.py
+  /opt/camera/camera_streamer/ota_policy.py
+
+It deliberately has no Flask, requests, packaging, or filesystem
+dependencies so the Pi Zero camera path can use it too.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "UpdateDecision",
+    "classify_update",
+    "compare_versions",
+    "is_blocked_downgrade",
+]
+
+_SEMVER_RE = re.compile(
+    r"^v?"
+    r"(?P<major>0|[1-9]\d*)\."
+    r"(?P<minor>0|[1-9]\d*)\."
+    r"(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<pre>[0-9A-Za-z.-]+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?$"
+)
+_NUM_RE = re.compile(r"^(0|[1-9]\d*)$")
+
+
+@dataclass(frozen=True)
+class _ParsedVersion:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UpdateDecision:
+    """Result of comparing a staged bundle with the running image."""
+
+    relation: str
+    allowed: bool
+    current_version: str
+    target_version: str
+    reason: str = ""
+
+    @property
+    def blocked(self) -> bool:
+        return not self.allowed
+
+    def as_dict(self) -> dict[str, str | bool]:
+        return {
+            "relation": self.relation,
+            "allowed": self.allowed,
+            "current_version": self.current_version,
+            "target_version": self.target_version,
+            "reason": self.reason,
+        }
+
+
+def _parse(value: str) -> _ParsedVersion | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    match = _SEMVER_RE.match(text)
+    if not match:
+        return None
+    prerelease = tuple((match.group("pre") or "").split("."))
+    if prerelease == ("",):
+        prerelease = ()
+    return _ParsedVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=prerelease,
+    )
+
+
+def _compare_prerelease(left: tuple[str, ...], right: tuple[str, ...]) -> int:
+    # SemVer: absence of prerelease sorts after any prerelease for the
+    # same major/minor/patch (1.2.3 > 1.2.3-rc.1).
+    if not left and not right:
+        return 0
+    if not left:
+        return 1
+    if not right:
+        return -1
+
+    for l_part, r_part in zip(left, right, strict=False):
+        if l_part == r_part:
+            continue
+        l_numeric = _NUM_RE.match(l_part) is not None
+        r_numeric = _NUM_RE.match(r_part) is not None
+        if l_numeric and r_numeric:
+            l_num = int(l_part)
+            r_num = int(r_part)
+            return (l_num > r_num) - (l_num < r_num)
+        if l_numeric:
+            return -1
+        if r_numeric:
+            return 1
+        return (l_part > r_part) - (l_part < r_part)
+
+    return (len(left) > len(right)) - (len(left) < len(right))
+
+
+def compare_versions(left: str, right: str) -> int | None:
+    """Compare two SemVer-like release strings.
+
+    Returns ``-1`` when ``left < right``, ``0`` when equal, ``1`` when
+    ``left > right``. Returns ``None`` if either side is missing or not
+    parseable as ``X.Y.Z`` with an optional SemVer prerelease/build
+    suffix. Unknown versions are not ordered because forcing a decision
+    there would strand older recovery bundles.
+    """
+
+    left_parsed = _parse(left)
+    right_parsed = _parse(right)
+    if left_parsed is None or right_parsed is None:
+        return None
+
+    left_base = (left_parsed.major, left_parsed.minor, left_parsed.patch)
+    right_base = (right_parsed.major, right_parsed.minor, right_parsed.patch)
+    if left_base != right_base:
+        return (left_base > right_base) - (left_base < right_base)
+    return _compare_prerelease(left_parsed.prerelease, right_parsed.prerelease)
+
+
+def classify_update(current_version: str, target_version: str) -> UpdateDecision:
+    """Classify an OTA bundle against the running image.
+
+    Downgrades are blocked only when both versions are parseable. That
+    gives modern, correctly-versioned bundles strict protection while
+    still allowing an operator to use a legacy recovery bundle whose
+    metadata predates this policy.
+    """
+
+    current = (current_version or "").strip()
+    target = (target_version or "").strip()
+    ordering = compare_versions(target, current)
+    if ordering is None:
+        return UpdateDecision(
+            relation="unknown",
+            allowed=True,
+            current_version=current,
+            target_version=target,
+        )
+    if ordering < 0:
+        reason = (
+            f"Rejected older update {target or 'unknown'}; "
+            f"current version is {current or 'unknown'}."
+        )
+        return UpdateDecision(
+            relation="downgrade",
+            allowed=False,
+            current_version=current,
+            target_version=target,
+            reason=reason,
+        )
+    if ordering == 0:
+        return UpdateDecision(
+            relation="same",
+            allowed=True,
+            current_version=current,
+            target_version=target,
+        )
+    return UpdateDecision(
+        relation="upgrade",
+        allowed=True,
+        current_version=current,
+        target_version=target,
+    )
+
+
+def is_blocked_downgrade(current_version: str, target_version: str) -> bool:
+    return classify_update(current_version, target_version).blocked

--- a/app/camera/camera_streamer/status_server.py
+++ b/app/camera/camera_streamer/status_server.py
@@ -1264,7 +1264,8 @@ def _make_status_handler(
 
             ok, msg = ota_installer.stage_bundle(self.rfile, content_len)
             if not ok:
-                self._json_response({"error": msg}, 500)
+                code = 400 if msg.startswith("Rejected older update") else 500
+                self._json_response({"error": msg}, code)
                 return
 
             ok, msg = ota_installer.trigger_install(msg)

--- a/app/camera/tests/unit/test_ota_installer.py
+++ b/app/camera/tests/unit/test_ota_installer.py
@@ -9,6 +9,38 @@ import pytest
 from camera_streamer import ota_installer
 
 
+def _newc_entry(name: str, data: bytes) -> bytes:
+    name_bytes = name.encode("utf-8") + b"\0"
+    fields = [
+        "070701",
+        f"{1:08x}",
+        f"{0o100644:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{1:08x}",
+        f"{0:08x}",
+        f"{len(data):08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{len(name_bytes):08x}",
+        f"{0:08x}",
+    ]
+    out = "".join(fields).encode("ascii") + name_bytes
+    out += b"\0" * ((4 - len(out) % 4) % 4)
+    out += data
+    out += b"\0" * ((4 - len(out) % 4) % 4)
+    return out
+
+
+def _swu_bytes(version: str) -> bytes:
+    manifest = (
+        'software = { version = "' + version + '"; home-monitor-camera = {}; };\n'
+    ).encode("utf-8")
+    return _newc_entry("sw-description", manifest)
+
+
 @pytest.fixture
 def spool(tmp_path, monkeypatch):
     spool_dir = tmp_path / "spool"
@@ -122,6 +154,33 @@ class TestStageBundle:
         )
         assert calls, "progress_cb should fire"
         assert calls[-1] == (len(data), len(data))
+
+    def test_rejects_older_bundle(self, spool, monkeypatch):
+        monkeypatch.setattr(
+            "camera_streamer.ota_installer.release_version", lambda: "1.6.0"
+        )
+        data = _swu_bytes("1.4.1-dev")
+
+        ok, msg = ota_installer.stage_bundle(io.BytesIO(data), len(data))
+
+        assert ok is False
+        assert "Rejected older update" in msg
+        assert not os.path.exists(ota_installer.bundle_path())
+        assert ota_installer.read_status()["state"] == "error"
+
+    def test_allows_newer_bundle(self, spool, monkeypatch):
+        monkeypatch.setattr(
+            "camera_streamer.ota_installer.release_version", lambda: "1.6.0"
+        )
+        data = _swu_bytes("1.7.0")
+
+        ok, path = ota_installer.stage_bundle(io.BytesIO(data), len(data))
+
+        assert ok is True
+        assert path == ota_installer.bundle_path()
+        status = ota_installer.read_status()
+        assert status["target_version"] == "1.7.0"
+        assert status["update_relation"] == "upgrade"
 
 
 class TestTriggerInstall:

--- a/app/camera/tests/unit/test_ota_policy.py
+++ b/app/camera/tests/unit/test_ota_policy.py
@@ -1,0 +1,21 @@
+# REQ: SWR-010, SWR-038; RISK: RISK-004, RISK-019; SEC: SC-003, SC-018; TEST: TC-013, TC-036
+from camera_streamer import ota_policy
+
+
+def test_blocks_parseable_downgrade():
+    decision = ota_policy.classify_update("1.6.0", "1.4.1-dev")
+
+    assert decision.blocked is True
+    assert decision.relation == "downgrade"
+
+
+def test_allows_upgrade_and_same_version():
+    assert ota_policy.classify_update("1.6.0", "1.7.0").relation == "upgrade"
+    assert ota_policy.classify_update("1.6.0", "v1.6.0").relation == "same"
+
+
+def test_unknown_versions_are_not_ordered():
+    decision = ota_policy.classify_update("1.6.0", "")
+
+    assert decision.allowed is True
+    assert decision.relation == "unknown"

--- a/app/server/monitor/api/ota.py
+++ b/app/server/monitor/api/ota.py
@@ -25,7 +25,9 @@ import threading
 
 from flask import Blueprint, current_app, jsonify, request, session
 
+from monitor import ota_policy
 from monitor.auth import admin_required, csrf_protect, login_required
+from monitor.release_version import release_version
 from monitor.services import ota_service
 
 ota_bp = Blueprint("ota", __name__)
@@ -57,6 +59,15 @@ def _latest_camera_bundle(ota, camera_id):
     return entries[0].path, entries[0].name
 
 
+def _discard_camera_bundle(ota, camera_id, reason):
+    """Remove a staged camera bundle that failed OTA policy."""
+    try:
+        shutil.rmtree(_camera_inbox_dir(ota, camera_id), ignore_errors=True)
+    except OSError:
+        pass
+    ota.set_status(camera_id, "idle", progress=0, error=reason)
+
+
 @ota_bp.route("/status", methods=["GET"])
 @login_required
 def get_status():
@@ -67,11 +78,10 @@ def get_status():
     # Live read from /etc/os-release VERSION_ID, not the persisted
     # Settings.firmware_version (which is legacy plumbing — see
     # docs/architecture/versioning.md §C).
-    from monitor.release_version import release_version
-
+    current_server_version = release_version()
     server_status = {
-        "current_version": release_version(),
-        **ota.get_status("server"),
+        "current_version": current_server_version,
+        **ota.get_status("server", current_version=current_server_version),
     }
     server_status["verification"] = ota.get_verification_posture()
 
@@ -94,12 +104,23 @@ def get_status():
         # camera so the "Push" button can be enabled without the user
         # needing to re-upload after a page refresh.
         path, fn = _latest_camera_bundle(ota, cam.id)
+        target_version = ""
+        if path:
+            target_version = ota_service.extract_bundle_version(path)
+            decision = ota_policy.classify_update(cam.firmware_version, target_version)
+            if decision.blocked:
+                _discard_camera_bundle(ota, cam.id, decision.reason)
+                path = None
+                fn = ""
+                entry["error"] = decision.reason
+            else:
+                entry["update_relation"] = decision.relation
         entry["staged_filename"] = fn or ""
         # Read the target version off the staged bundle (if any). The
         # admin needs to see what they're about to push, not just the
         # filename — dev tagging isn't consistent enough to trust.
         if path and not entry.get("target_version"):
-            entry["target_version"] = ota_service.extract_bundle_version(path)
+            entry["target_version"] = target_version
         result["cameras"].append(entry)
 
     return jsonify(result), 200
@@ -139,7 +160,13 @@ def upload_server_image():
     except OSError as e:
         return jsonify({"error": f"Upload failed: {e}"}), 500
 
-    staged_path, err = ota.stage_bundle(tmp_path, file.filename, user=user, ip=ip)
+    staged_path, err = ota.stage_bundle(
+        tmp_path,
+        file.filename,
+        user=user,
+        ip=ip,
+        current_version=release_version(),
+    )
     if err:
         try:
             os.unlink(tmp_path)
@@ -202,9 +229,20 @@ def install_server_image():
         return jsonify({"error": "No staged update found"}), 404
     candidates.sort(reverse=True)
     bundle_path = os.path.join(staging, candidates[0][1])
+    target_version = ota_service.extract_bundle_version(bundle_path)
+    decision = ota_policy.classify_update(release_version(), target_version)
+    if decision.blocked:
+        try:
+            os.unlink(bundle_path)
+        except OSError:
+            pass
+        ota.set_status("server", "idle", progress=0, error=decision.reason)
+        return jsonify({"error": decision.reason}), 409
+
     ok, err = ota.install_bundle(bundle_path, user=user, ip=ip)
     if not ok:
         return jsonify({"error": err}), 500
+    ota.clean_staging()
 
     # The button says "Install & Reboot", so actually reboot. We flush
     # the HTTP response first (the client needs the 200 to transition
@@ -284,6 +322,14 @@ def upload_camera_image(camera_id):
         return jsonify({"error": "Uploaded file is empty"}), 400
 
     target_version = ota_service.extract_bundle_version(target_path)
+    decision = ota_policy.classify_update(camera.firmware_version, target_version)
+    if decision.blocked:
+        try:
+            os.unlink(target_path)
+        except OSError:
+            pass
+        return jsonify({"error": decision.reason}), 400
+
     ota.set_status(
         camera_id,
         "staged",
@@ -292,6 +338,7 @@ def upload_camera_image(camera_id):
         error="",
         filename=file.filename,
         target_version=target_version,
+        update_relation=decision.relation,
     )
     audit = getattr(current_app, "audit", None)
     if audit:
@@ -417,6 +464,12 @@ def push_camera_update(camera_id):
         return jsonify(
             {"error": "No bundle uploaded for this camera — upload a .swu first"}
         ), 409
+
+    target_version = ota_service.extract_bundle_version(bundle_path)
+    decision = ota_policy.classify_update(camera.firmware_version, target_version)
+    if decision.blocked:
+        _discard_camera_bundle(ota, camera_id, decision.reason)
+        return jsonify({"error": decision.reason}), 409
 
     status = ota.get_status(camera_id)
     if status.get("state") in {"uploading", "installing"}:

--- a/app/server/monitor/ota_policy.py
+++ b/app/server/monitor/ota_policy.py
@@ -1,0 +1,187 @@
+# REQ: SWR-010, SWR-038, SWR-046; RISK: RISK-004, RISK-019; SEC: SC-003, SC-018; TEST: TC-013, TC-036, TC-043
+"""Shared OTA bundle ordering policy.
+
+The server and camera run in different Python packages, but they must
+make the same safety decision about an update bundle: never install an
+older, parseable release over a newer running image by accident.
+
+This module is copied into both package namespaces at build time:
+
+  /opt/monitor/monitor/ota_policy.py
+  /opt/camera/camera_streamer/ota_policy.py
+
+It deliberately has no Flask, requests, packaging, or filesystem
+dependencies so the Pi Zero camera path can use it too.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "UpdateDecision",
+    "classify_update",
+    "compare_versions",
+    "is_blocked_downgrade",
+]
+
+_SEMVER_RE = re.compile(
+    r"^v?"
+    r"(?P<major>0|[1-9]\d*)\."
+    r"(?P<minor>0|[1-9]\d*)\."
+    r"(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<pre>[0-9A-Za-z.-]+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?$"
+)
+_NUM_RE = re.compile(r"^(0|[1-9]\d*)$")
+
+
+@dataclass(frozen=True)
+class _ParsedVersion:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UpdateDecision:
+    """Result of comparing a staged bundle with the running image."""
+
+    relation: str
+    allowed: bool
+    current_version: str
+    target_version: str
+    reason: str = ""
+
+    @property
+    def blocked(self) -> bool:
+        return not self.allowed
+
+    def as_dict(self) -> dict[str, str | bool]:
+        return {
+            "relation": self.relation,
+            "allowed": self.allowed,
+            "current_version": self.current_version,
+            "target_version": self.target_version,
+            "reason": self.reason,
+        }
+
+
+def _parse(value: str) -> _ParsedVersion | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    match = _SEMVER_RE.match(text)
+    if not match:
+        return None
+    prerelease = tuple((match.group("pre") or "").split("."))
+    if prerelease == ("",):
+        prerelease = ()
+    return _ParsedVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=prerelease,
+    )
+
+
+def _compare_prerelease(left: tuple[str, ...], right: tuple[str, ...]) -> int:
+    # SemVer: absence of prerelease sorts after any prerelease for the
+    # same major/minor/patch (1.2.3 > 1.2.3-rc.1).
+    if not left and not right:
+        return 0
+    if not left:
+        return 1
+    if not right:
+        return -1
+
+    for l_part, r_part in zip(left, right, strict=False):
+        if l_part == r_part:
+            continue
+        l_numeric = _NUM_RE.match(l_part) is not None
+        r_numeric = _NUM_RE.match(r_part) is not None
+        if l_numeric and r_numeric:
+            l_num = int(l_part)
+            r_num = int(r_part)
+            return (l_num > r_num) - (l_num < r_num)
+        if l_numeric:
+            return -1
+        if r_numeric:
+            return 1
+        return (l_part > r_part) - (l_part < r_part)
+
+    return (len(left) > len(right)) - (len(left) < len(right))
+
+
+def compare_versions(left: str, right: str) -> int | None:
+    """Compare two SemVer-like release strings.
+
+    Returns ``-1`` when ``left < right``, ``0`` when equal, ``1`` when
+    ``left > right``. Returns ``None`` if either side is missing or not
+    parseable as ``X.Y.Z`` with an optional SemVer prerelease/build
+    suffix. Unknown versions are not ordered because forcing a decision
+    there would strand older recovery bundles.
+    """
+
+    left_parsed = _parse(left)
+    right_parsed = _parse(right)
+    if left_parsed is None or right_parsed is None:
+        return None
+
+    left_base = (left_parsed.major, left_parsed.minor, left_parsed.patch)
+    right_base = (right_parsed.major, right_parsed.minor, right_parsed.patch)
+    if left_base != right_base:
+        return (left_base > right_base) - (left_base < right_base)
+    return _compare_prerelease(left_parsed.prerelease, right_parsed.prerelease)
+
+
+def classify_update(current_version: str, target_version: str) -> UpdateDecision:
+    """Classify an OTA bundle against the running image.
+
+    Downgrades are blocked only when both versions are parseable. That
+    gives modern, correctly-versioned bundles strict protection while
+    still allowing an operator to use a legacy recovery bundle whose
+    metadata predates this policy.
+    """
+
+    current = (current_version or "").strip()
+    target = (target_version or "").strip()
+    ordering = compare_versions(target, current)
+    if ordering is None:
+        return UpdateDecision(
+            relation="unknown",
+            allowed=True,
+            current_version=current,
+            target_version=target,
+        )
+    if ordering < 0:
+        reason = (
+            f"Rejected older update {target or 'unknown'}; "
+            f"current version is {current or 'unknown'}."
+        )
+        return UpdateDecision(
+            relation="downgrade",
+            allowed=False,
+            current_version=current,
+            target_version=target,
+            reason=reason,
+        )
+    if ordering == 0:
+        return UpdateDecision(
+            relation="same",
+            allowed=True,
+            current_version=current,
+            target_version=target,
+        )
+    return UpdateDecision(
+        relation="upgrade",
+        allowed=True,
+        current_version=current,
+        target_version=target,
+    )
+
+
+def is_blocked_downgrade(current_version: str, target_version: str) -> bool:
+    return classify_update(current_version, target_version).blocked

--- a/app/server/monitor/services/ota_service.py
+++ b/app/server/monitor/services/ota_service.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import threading
 
+from monitor import ota_policy
 from monitor.services import privileged
 
 log = logging.getLogger("monitor.ota-service")
@@ -115,7 +116,7 @@ class OTAService:
     def staging_dir(self):
         return os.path.join(self._data_dir, "ota", "staging")
 
-    def get_status(self, device_id="server"):
+    def get_status(self, device_id="server", current_version=""):
         """Get update status for a device.
 
         The in-memory status dict is transient — it vanishes on restart.
@@ -126,18 +127,27 @@ class OTAService:
         """
         with self._status_lock:
             status = self._status.get(device_id)
-            if status is not None:
-                return dict(status)
+            status_copy = dict(status) if status is not None else None
+        if status_copy is not None:
+            if device_id == "server":
+                return self._apply_staged_policy(status_copy, current_version)
+            return status_copy
 
         default = {"state": "idle", "version": "", "progress": 0, "error": ""}
         if device_id == "server":
             staged = self._find_staged_bundle()
             if staged:
+                staged_path = os.path.join(self.staging_dir, staged)
+                target_version = extract_bundle_version(staged_path)
+                decision = ota_policy.classify_update(current_version, target_version)
+                if decision.blocked:
+                    self._discard_staged_bundle(staged, decision.reason)
+                    default["error"] = decision.reason
+                    return default
                 default["state"] = "staged"
                 default["staged_filename"] = staged
-                default["target_version"] = extract_bundle_version(
-                    os.path.join(self.staging_dir, staged)
-                )
+                default["target_version"] = target_version
+                default["update_relation"] = decision.relation
         return default
 
     def is_busy(self, device_id="server"):
@@ -210,6 +220,39 @@ class OTAService:
         entries.sort(reverse=True)
         return entries[0][1]
 
+    def _apply_staged_policy(self, status, current_version=""):
+        """Apply persisted-staging safety to an in-memory status snapshot."""
+        if status.get("state") != "staged":
+            return status
+        filename = status.get("staged_filename") or self._find_staged_bundle()
+        if not filename:
+            return status
+        path = os.path.join(self.staging_dir, filename)
+        target_version = status.get("target_version") or extract_bundle_version(path)
+        decision = ota_policy.classify_update(current_version, target_version)
+        if decision.blocked:
+            self._discard_staged_bundle(filename, decision.reason)
+            self.set_status("server", "idle", error=decision.reason)
+            return {
+                "state": "idle",
+                "version": "",
+                "progress": 0,
+                "error": decision.reason,
+            }
+        status["target_version"] = target_version
+        status["update_relation"] = decision.relation
+        return status
+
+    def _discard_staged_bundle(self, filename, reason):
+        """Remove one staged server bundle that failed OTA policy."""
+        try:
+            os.unlink(os.path.join(self.staging_dir, filename))
+            log.warning("Discarded staged OTA bundle %s: %s", filename, reason)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            log.warning("Failed to discard staged OTA bundle %s: %s", filename, exc)
+
     def set_status(self, device_id, state, **kwargs):
         """Update status for a device."""
         with self._status_lock:
@@ -238,7 +281,7 @@ class OTAService:
         except OSError as e:
             return False, 0, str(e)
 
-    def stage_bundle(self, source_path, filename, user="", ip=""):
+    def stage_bundle(self, source_path, filename, user="", ip="", current_version=""):
         """Stage a .swu bundle for installation.
 
         Validates file extension and size, moves to staging directory.
@@ -276,6 +319,11 @@ class OTAService:
                 f"Insufficient disk space (free: {free}, need: {size + MIN_FREE_SPACE})",
             )
 
+        target_version = extract_bundle_version(source_path)
+        decision = ota_policy.classify_update(current_version, target_version)
+        if decision.blocked:
+            return None, decision.reason
+
         # Create staging directory
         os.makedirs(self.staging_dir, exist_ok=True)
         staged_path = os.path.join(self.staging_dir, filename)
@@ -299,7 +347,6 @@ class OTAService:
                 pass
             return None, f"Failed to stage file: {e}"
 
-        target_version = extract_bundle_version(staged_path)
         self.set_status(
             "server",
             "staged",
@@ -308,6 +355,7 @@ class OTAService:
             error="",
             staged_filename=filename,
             target_version=target_version,
+            update_relation=decision.relation,
         )
         self._log_audit(
             "OTA_STAGED",

--- a/app/server/tests/integration/test_api_ota.py
+++ b/app/server/tests/integration/test_api_ota.py
@@ -2,15 +2,53 @@
 """Tests for the OTA update API."""
 
 import io
+import os
 
 from monitor.models import Camera
 
 
-def _add_camera(app, camera_id="cam-001", status="online"):
+def _add_camera(app, camera_id="cam-001", status="online", firmware_version=""):
     """Helper: add camera."""
     app.store.save_camera(
-        Camera(id=camera_id, name="Test", status=status, ip="192.168.1.50")
+        Camera(
+            id=camera_id,
+            name="Test",
+            status=status,
+            ip="192.168.1.50",
+            firmware_version=firmware_version,
+        )
     )
+
+
+def _newc_entry(name: str, data: bytes) -> bytes:
+    name_bytes = name.encode("utf-8") + b"\0"
+    fields = [
+        "070701",
+        f"{1:08x}",
+        f"{0o100644:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{1:08x}",
+        f"{0:08x}",
+        f"{len(data):08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{len(name_bytes):08x}",
+        f"{0:08x}",
+    ]
+    out = "".join(fields).encode("ascii") + name_bytes
+    out += b"\0" * ((4 - len(out) % 4) % 4)
+    out += data
+    out += b"\0" * ((4 - len(out) % 4) % 4)
+    return out
+
+
+def _swu_bytes(version: str, target: str = "server") -> bytes:
+    selector = "raspberrypi4-64" if target == "server" else "home-monitor-camera"
+    manifest = f'software = {{ version = "{version}"; {selector} = {{}}; }};\n'
+    return _newc_entry("sw-description", manifest.encode("utf-8"))
 
 
 class TestOTAStatus:
@@ -71,6 +109,21 @@ class TestOTAStatus:
         data = client.get("/api/v1/ota/status").get_json()
         assert len(data["cameras"]) == 0
 
+    def test_status_discards_stale_camera_bundle(self, app, logged_in_client):
+        client = logged_in_client()
+        _add_camera(app, "cam-001", "online", firmware_version="1.6.0")
+        inbox = os.path.join(app.ota_service.inbox_dir, "camera-cam-001")
+        os.makedirs(inbox, exist_ok=True)
+        with open(os.path.join(inbox, "old.swu"), "wb") as f:
+            f.write(_swu_bytes("1.4.1-dev", target="camera"))
+
+        data = client.get("/api/v1/ota/status").get_json()
+
+        cam = next(c for c in data["cameras"] if c["id"] == "cam-001")
+        assert cam["staged_filename"] == ""
+        assert "Rejected older update" in cam["error"]
+        assert not os.path.exists(inbox)
+
 
 class TestServerUpload:
     """Test POST /api/v1/ota/server/upload."""
@@ -111,6 +164,18 @@ class TestServerUpload:
         )
         status = app.ota_service.get_status("server")
         assert status["state"] == "staged"
+
+    def test_rejects_older_server_bundle(self, monkeypatch, logged_in_client):
+        monkeypatch.setattr("monitor.api.ota.release_version", lambda: "1.6.0")
+        client = logged_in_client()
+        data = {"file": (io.BytesIO(_swu_bytes("1.4.1-dev")), "old.swu")}
+
+        response = client.post(
+            "/api/v1/ota/server/upload", data=data, content_type="multipart/form-data"
+        )
+
+        assert response.status_code == 400
+        assert "Rejected older update" in response.get_json()["error"]
 
 
 class TestCameraPush:
@@ -261,6 +326,19 @@ class TestCameraUpload:
         cam = next(c for c in status["cameras"] if c["id"] == "cam-001")
         assert cam["staged_filename"] == "new.swu"
 
+    def test_rejects_older_camera_bundle(self, app, logged_in_client):
+        client = logged_in_client()
+        _add_camera(app, "cam-001", "online", firmware_version="1.6.0")
+
+        resp = client.post(
+            "/api/v1/ota/camera/cam-001/upload",
+            data={"file": (io.BytesIO(_swu_bytes("1.4.1-dev", "camera")), "old.swu")},
+            content_type="multipart/form-data",
+        )
+
+        assert resp.status_code == 400
+        assert "Rejected older update" in resp.get_json()["error"]
+
 
 class TestCameraLiveStatus:
     """Test GET /api/v1/ota/camera/<id>/live-status."""
@@ -359,7 +437,7 @@ class TestServerUploadEdgeCases:
         import os
         import tempfile
 
-        def _fake_stage(source_path, filename, user="", ip=""):
+        def _fake_stage(source_path, filename, user="", ip="", current_version=""):
             fd, p = tempfile.mkstemp(suffix=".swu")
             os.write(fd, b"fake")
             os.close(fd)
@@ -385,7 +463,7 @@ class TestServerUploadEdgeCases:
         import os
         import tempfile
 
-        def _fake_stage(source_path, filename, user="", ip=""):
+        def _fake_stage(source_path, filename, user="", ip="", current_version=""):
             fd, p = tempfile.mkstemp(suffix=".swu")
             os.write(fd, b"fake")
             os.close(fd)
@@ -477,6 +555,26 @@ class TestServerInstall:
         resp = client.post("/api/v1/ota/server/install")
         assert resp.status_code == 200
         assert "reboot" in resp.get_json()["message"].lower()
+        assert os.path.isdir(staging)
+        assert not [p for p in os.listdir(staging) if p.endswith(".swu")]
+
+    def test_rejects_stale_bundle_at_install_time(
+        self, monkeypatch, app, logged_in_client
+    ):
+        client = logged_in_client()
+        monkeypatch.setattr("monitor.api.ota.release_version", lambda: "1.6.0")
+
+        staging = app.ota_service.staging_dir
+        os.makedirs(staging, exist_ok=True)
+        bundle = os.path.join(staging, "old.swu")
+        with open(bundle, "wb") as fh:
+            fh.write(_swu_bytes("1.4.1-dev"))
+
+        resp = client.post("/api/v1/ota/server/install")
+
+        assert resp.status_code == 409
+        assert "Rejected older update" in resp.get_json()["error"]
+        assert not os.path.exists(bundle)
 
 
 class TestCameraUploadEdgeCases:

--- a/app/server/tests/unit/test_ota_policy.py
+++ b/app/server/tests/unit/test_ota_policy.py
@@ -1,0 +1,27 @@
+# REQ: SWR-010, SWR-046; RISK: RISK-004, RISK-019; SEC: SC-003, SC-018; TEST: TC-013, TC-043
+from monitor import ota_policy
+
+
+def test_blocks_parseable_downgrade():
+    decision = ota_policy.classify_update("1.6.0", "1.4.1-dev")
+
+    assert decision.blocked is True
+    assert decision.relation == "downgrade"
+    assert "current version is 1.6.0" in decision.reason
+
+
+def test_allows_upgrade_and_same_version():
+    assert ota_policy.classify_update("1.6.0", "1.7.0").relation == "upgrade"
+    assert ota_policy.classify_update("1.6.0", "v1.6.0").relation == "same"
+
+
+def test_unknown_versions_are_not_ordered():
+    decision = ota_policy.classify_update("1.6.0", "")
+
+    assert decision.allowed is True
+    assert decision.relation == "unknown"
+
+
+def test_semver_prerelease_ordering():
+    assert ota_policy.compare_versions("1.6.0-rc.1", "1.6.0") == -1
+    assert ota_policy.compare_versions("1.6.0-rc.2", "1.6.0-rc.1") == 1

--- a/app/server/tests/unit/test_svc_ota.py
+++ b/app/server/tests/unit/test_svc_ota.py
@@ -9,6 +9,39 @@ import pytest
 from monitor.services.ota_service import MAX_BUNDLE_SIZE, OTAService
 
 
+def _newc_entry(name: str, data: bytes) -> bytes:
+    name_bytes = name.encode("utf-8") + b"\0"
+    fields = [
+        "070701",
+        f"{1:08x}",
+        f"{0o100644:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{1:08x}",
+        f"{0:08x}",
+        f"{len(data):08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{0:08x}",
+        f"{len(name_bytes):08x}",
+        f"{0:08x}",
+    ]
+    out = "".join(fields).encode("ascii") + name_bytes
+    out += b"\0" * ((4 - len(out) % 4) % 4)
+    out += data
+    out += b"\0" * ((4 - len(out) % 4) % 4)
+    return out
+
+
+def _write_swu(path: str, version: str) -> None:
+    manifest = (
+        'software = { version = "' + version + '"; raspberrypi4-64 = {}; };\n'
+    ).encode("utf-8")
+    with open(path, "wb") as f:
+        f.write(_newc_entry("sw-description", manifest))
+
+
 @pytest.fixture
 def data_dir(tmp_path):
     """Create temp data directory structure."""
@@ -57,6 +90,26 @@ class TestGetSetStatus:
         svc.set_status("cam-001", "pending")
         assert svc.get_status("server")["state"] == "installing"
         assert svc.get_status("cam-001")["state"] == "pending"
+
+    def test_discards_stale_staged_server_bundle_from_disk(self, svc, data_dir):
+        staged = os.path.join(data_dir, "ota", "staging", "old.swu")
+        _write_swu(staged, "1.4.1-dev")
+
+        status = svc.get_status("server", current_version="1.6.0")
+
+        assert status["state"] == "idle"
+        assert "Rejected older update" in status["error"]
+        assert not os.path.exists(staged)
+
+    def test_keeps_current_staged_server_bundle_from_disk(self, svc, data_dir):
+        staged = os.path.join(data_dir, "ota", "staging", "same.swu")
+        _write_swu(staged, "1.6.0")
+
+        status = svc.get_status("server", current_version="1.6.0")
+
+        assert status["state"] == "staged"
+        assert status["staged_filename"] == "same.swu"
+        assert status["update_relation"] == "same"
 
 
 class TestCheckSpace:
@@ -135,6 +188,27 @@ class TestStageBundle:
             f.write(b"x" * 100)
         svc.stage_bundle(src, "update.swu")
         assert svc.get_status("server")["state"] == "staged"
+
+    def test_rejects_older_version_when_current_is_known(self, svc, data_dir):
+        src = os.path.join(data_dir, "ota", "inbox", "old.swu")
+        _write_swu(src, "1.4.1-dev")
+
+        path, err = svc.stage_bundle(src, "old.swu", current_version="1.6.0")
+
+        assert path is None
+        assert "Rejected older update" in err
+        assert not os.path.exists(os.path.join(data_dir, "ota", "staging", "old.swu"))
+
+    def test_allows_newer_version_when_current_is_known(self, svc, data_dir):
+        src = os.path.join(data_dir, "ota", "inbox", "new.swu")
+        _write_swu(src, "1.7.0")
+
+        path, err = svc.stage_bundle(src, "new.swu", current_version="1.6.0")
+
+        assert err == ""
+        assert path is not None
+        status = svc.get_status("server", current_version="1.6.0")
+        assert status["update_relation"] == "upgrade"
 
 
 class TestVerifyBundle:

--- a/app/shared/ota_policy/ota_policy.py
+++ b/app/shared/ota_policy/ota_policy.py
@@ -1,0 +1,187 @@
+# REQ: SWR-010, SWR-038, SWR-046; RISK: RISK-004, RISK-019; SEC: SC-003, SC-018; TEST: TC-013, TC-036, TC-043
+"""Shared OTA bundle ordering policy.
+
+The server and camera run in different Python packages, but they must
+make the same safety decision about an update bundle: never install an
+older, parseable release over a newer running image by accident.
+
+This module is copied into both package namespaces at build time:
+
+  /opt/monitor/monitor/ota_policy.py
+  /opt/camera/camera_streamer/ota_policy.py
+
+It deliberately has no Flask, requests, packaging, or filesystem
+dependencies so the Pi Zero camera path can use it too.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "UpdateDecision",
+    "classify_update",
+    "compare_versions",
+    "is_blocked_downgrade",
+]
+
+_SEMVER_RE = re.compile(
+    r"^v?"
+    r"(?P<major>0|[1-9]\d*)\."
+    r"(?P<minor>0|[1-9]\d*)\."
+    r"(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<pre>[0-9A-Za-z.-]+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?$"
+)
+_NUM_RE = re.compile(r"^(0|[1-9]\d*)$")
+
+
+@dataclass(frozen=True)
+class _ParsedVersion:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UpdateDecision:
+    """Result of comparing a staged bundle with the running image."""
+
+    relation: str
+    allowed: bool
+    current_version: str
+    target_version: str
+    reason: str = ""
+
+    @property
+    def blocked(self) -> bool:
+        return not self.allowed
+
+    def as_dict(self) -> dict[str, str | bool]:
+        return {
+            "relation": self.relation,
+            "allowed": self.allowed,
+            "current_version": self.current_version,
+            "target_version": self.target_version,
+            "reason": self.reason,
+        }
+
+
+def _parse(value: str) -> _ParsedVersion | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    match = _SEMVER_RE.match(text)
+    if not match:
+        return None
+    prerelease = tuple((match.group("pre") or "").split("."))
+    if prerelease == ("",):
+        prerelease = ()
+    return _ParsedVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=prerelease,
+    )
+
+
+def _compare_prerelease(left: tuple[str, ...], right: tuple[str, ...]) -> int:
+    # SemVer: absence of prerelease sorts after any prerelease for the
+    # same major/minor/patch (1.2.3 > 1.2.3-rc.1).
+    if not left and not right:
+        return 0
+    if not left:
+        return 1
+    if not right:
+        return -1
+
+    for l_part, r_part in zip(left, right, strict=False):
+        if l_part == r_part:
+            continue
+        l_numeric = _NUM_RE.match(l_part) is not None
+        r_numeric = _NUM_RE.match(r_part) is not None
+        if l_numeric and r_numeric:
+            l_num = int(l_part)
+            r_num = int(r_part)
+            return (l_num > r_num) - (l_num < r_num)
+        if l_numeric:
+            return -1
+        if r_numeric:
+            return 1
+        return (l_part > r_part) - (l_part < r_part)
+
+    return (len(left) > len(right)) - (len(left) < len(right))
+
+
+def compare_versions(left: str, right: str) -> int | None:
+    """Compare two SemVer-like release strings.
+
+    Returns ``-1`` when ``left < right``, ``0`` when equal, ``1`` when
+    ``left > right``. Returns ``None`` if either side is missing or not
+    parseable as ``X.Y.Z`` with an optional SemVer prerelease/build
+    suffix. Unknown versions are not ordered because forcing a decision
+    there would strand older recovery bundles.
+    """
+
+    left_parsed = _parse(left)
+    right_parsed = _parse(right)
+    if left_parsed is None or right_parsed is None:
+        return None
+
+    left_base = (left_parsed.major, left_parsed.minor, left_parsed.patch)
+    right_base = (right_parsed.major, right_parsed.minor, right_parsed.patch)
+    if left_base != right_base:
+        return (left_base > right_base) - (left_base < right_base)
+    return _compare_prerelease(left_parsed.prerelease, right_parsed.prerelease)
+
+
+def classify_update(current_version: str, target_version: str) -> UpdateDecision:
+    """Classify an OTA bundle against the running image.
+
+    Downgrades are blocked only when both versions are parseable. That
+    gives modern, correctly-versioned bundles strict protection while
+    still allowing an operator to use a legacy recovery bundle whose
+    metadata predates this policy.
+    """
+
+    current = (current_version or "").strip()
+    target = (target_version or "").strip()
+    ordering = compare_versions(target, current)
+    if ordering is None:
+        return UpdateDecision(
+            relation="unknown",
+            allowed=True,
+            current_version=current,
+            target_version=target,
+        )
+    if ordering < 0:
+        reason = (
+            f"Rejected older update {target or 'unknown'}; "
+            f"current version is {current or 'unknown'}."
+        )
+        return UpdateDecision(
+            relation="downgrade",
+            allowed=False,
+            current_version=current,
+            target_version=target,
+            reason=reason,
+        )
+    if ordering == 0:
+        return UpdateDecision(
+            relation="same",
+            allowed=True,
+            current_version=current,
+            target_version=target,
+        )
+    return UpdateDecision(
+        relation="upgrade",
+        allowed=True,
+        current_version=current,
+        target_version=target,
+    )
+
+
+def is_blocked_downgrade(current_version: str, target_version: str) -> bool:
+    return classify_update(current_version, target_version).blocked

--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -19,6 +19,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/camera:${THISDIR}/../../../a
 SRC_URI = " \
     file://camera_streamer/ \
     file://release_version/release_version.py \
+    file://ota_policy/ota_policy.py \
     file://config/camera-streamer.service \
     file://config/camera-privileged-helper.service \
     file://config/camera-hotspot.service \
@@ -74,6 +75,12 @@ do_install() {
     # The file:// fetcher preserves the subdir name under WORKDIR.
     install -m 0644 ${WORKDIR}/release_version/release_version.py \
         ${D}/opt/camera/camera_streamer/release_version.py
+
+    # Shared OTA policy helper: downgrade/stale-bundle decisions must
+    # match monitor-server exactly so server-pushed and direct-camera
+    # updates fail closed the same way.
+    install -m 0644 ${WORKDIR}/ota_policy/ota_policy.py \
+        ${D}/opt/camera/camera_streamer/ota_policy.py
 
     # Default config (copied to /data on first boot)
     install -m 0644 ${WORKDIR}/config/camera.conf.default ${D}/opt/camera/camera.conf.default

--- a/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
+++ b/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
@@ -19,6 +19,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/../../../app/server:${THISDIR}/../../../a
 SRC_URI = " \
     file://monitor/ \
     file://release_version/release_version.py \
+    file://ota_policy/ota_policy.py \
     file://config/monitor.service \
     file://config/monitor-privileged-helper.service \
     file://config/monitor-avahi-pin.service \
@@ -76,6 +77,11 @@ do_install() {
     # The file:// fetcher preserves the subdir name under WORKDIR.
     install -m 0644 ${WORKDIR}/release_version/release_version.py \
         ${D}/opt/monitor/monitor/release_version.py
+
+    # Shared OTA policy helper: server-side staging and camera-side
+    # receiver code must make the same downgrade/stale-bundle decision.
+    install -m 0644 ${WORKDIR}/ota_policy/ota_policy.py \
+        ${D}/opt/monitor/monitor/ota_policy.py
 
     # Create data directories (will be on /data partition in production)
     install -d ${D}/opt/monitor/data/recordings

--- a/scripts/check_versioning_design.py
+++ b/scripts/check_versioning_design.py
@@ -125,6 +125,41 @@ def check_release_version_helper_canonical() -> list[str]:
     return failures
 
 
+def check_ota_policy_helper_canonical() -> list[str]:
+    """The OTA downgrade/stale-bundle policy must be identical in
+    server, camera, and the canonical shared source.
+    """
+    failures: list[str] = []
+    canonical = REPO_ROOT / "app" / "shared" / "ota_policy" / "ota_policy.py"
+    camera_copy = REPO_ROOT / "app" / "camera" / "camera_streamer" / "ota_policy.py"
+    server_copy = REPO_ROOT / "app" / "server" / "monitor" / "ota_policy.py"
+    for p in (canonical, camera_copy, server_copy):
+        if not p.is_file():
+            failures.append(f"missing ota_policy helper: {p}")
+    if failures:
+        return failures
+    h_canonical = _sha256(canonical)
+    h_camera = _sha256(camera_copy)
+    h_server = _sha256(server_copy)
+    if h_camera != h_canonical:
+        failures.append(
+            f"ota_policy drift: camera copy diverged from canonical\n"
+            f"  canonical: {canonical}  sha256={h_canonical}\n"
+            f"  camera:    {camera_copy}  sha256={h_camera}\n"
+            "Re-copy from canonical: cp app/shared/ota_policy/ota_policy.py "
+            "app/camera/camera_streamer/ota_policy.py"
+        )
+    if h_server != h_canonical:
+        failures.append(
+            f"ota_policy drift: server copy diverged from canonical\n"
+            f"  canonical: {canonical}  sha256={h_canonical}\n"
+            f"  server:    {server_copy}  sha256={h_server}\n"
+            "Re-copy from canonical: cp app/shared/ota_policy/ota_policy.py "
+            "app/server/monitor/ota_policy.py"
+        )
+    return failures
+
+
 # --- Check 3 — no app code reads /etc/sw-versions ------------------
 
 
@@ -320,6 +355,10 @@ CHECKS = [
     (
         "release_version helper byte-identical in 3 places",
         check_release_version_helper_canonical,
+    ),
+    (
+        "ota_policy helper byte-identical in 3 places",
+        check_ota_policy_helper_canonical,
     ),
     ("no app code reads /etc/sw-versions", check_no_app_reads_sw_versions),
     (


### PR DESCRIPTION
﻿## What changed

- Added a shared OTA version-ordering policy copied into both server and camera packages.
- Blocks parseable downgrade/stale bundles before server upload, server install, camera staging, camera upload, and camera push.
- Cleans persisted stale server/camera staged bundles from status paths so the UI no longer offers old files after refresh or reboot.
- Cleans server OTA staging after a successful install before reboot.
- Packages the shared OTA policy helper into both Yocto app recipes and extends the versioning guard to catch helper drift.

## Why

A stale `server-update-1.4.1-dev.swu` was still staged on a server already running `1.6.0`, so the Settings UI kept offering an old downgrade file. The durable fix is to make bundle ordering part of the OTA lifecycle, not just the GUI.

## Validation

- `pytest -q app/server/tests/` -> 2518 passed, 1 skipped
- `pytest -q app/server/tests/unit/test_ota_policy.py app/server/tests/unit/test_svc_ota.py app/server/tests/integration/test_api_ota.py` -> 112 passed
- `pytest -q app/camera/tests/unit/test_ota_policy.py app/camera/tests/unit/test_ota_installer.py app/camera/tests/integration/test_ota_agent.py` -> 40 passed
- `ruff check .` -> passed
- `ruff format --check .` -> passed
- `python scripts/check_versioning_design.py` -> passed
- `python tools/docs/check_doc_map.py` -> passed
- `python scripts/ai/validate_repo_ai_setup.py` -> passed
- `python -m pre_commit run --all-files` -> passed

## Hardware deploy check

Hot-deployed the Python app changes to:

- server `192.168.1.245`
- camera `192.168.1.186`

The server classified the staged `server-update-1.4.1-dev.swu` as older than current `1.6.0` and removed it through the new policy. Both services remained active after restart.

## Known local validation gap

- Local `bitbake -p` was not available on this Windows workstation; Yocto parse should be covered by CI/build VM.
- Full camera suite had 848 passing tests and 13 failures in `test_ensure_camera_overlay.py` caused by the known Windows bash path translation issue (`D:Codex...ensure-camera-overlay.sh` not found), unrelated to OTA.
