### PR TITLE
Fix camera WiFi scan auth handling

### DIFF
--- a/app/camera/camera_streamer/templates/status.html
+++ b/app/camera/camera_streamer/templates/status.html
@@ -1768,12 +1768,22 @@ function doUnpair() {
 // ---- WiFi ----
 function scanNetworks() {
     var btn = $("btn-scan");
+    var list = $("netlist");
     btn.disabled = true; btn.textContent = "Scanning…";
-    fetch("/api/networks").then(function(r){ return r.json(); }).then(function(d){
+    fetch("/api/networks", { credentials: "same-origin" }).then(function(r){
+        if (r.status === 401) {
+            window.location.href = "/login";
+            return null;
+        }
+        return r.json().then(function(d){
+            if (!r.ok) throw new Error((d && d.error) || "Scan failed.");
+            return d;
+        });
+    }).then(function(d){
+        if (!d) return;
         var nets = (d.networks || []).slice().sort(function(a,b){ return (b.signal||0) - (a.signal||0); });
-        var list = $("netlist");
         if (!nets.length) {
-            list.innerHTML = '<div style="padding:10px;color:var(--muted);text-align:center">No networks found</div>';
+            list.innerHTML = '<div style="padding:10px;color:var(--muted);text-align:center">No networks found. Type the WiFi name manually.</div>';
         } else {
             list.innerHTML = nets.map(function(n){
                 return '<div class="net" data-ssid="' + esc(n.ssid) + '">' +
@@ -1790,9 +1800,10 @@ function scanNetworks() {
         }
         list.hidden = false;
         btn.disabled = false; btn.textContent = "Scan for networks";
-    }).catch(function(){
+    }).catch(function(err){
         btn.disabled = false; btn.textContent = "Scan for networks";
-        setMsg("wifi-result", "err", "Scan failed.");
+        list.hidden = true;
+        setMsg("wifi-result", "err", err.message || "Scan failed.");
     });
 }
 function doWifi() {

--- a/app/camera/tests/contracts/test_api_contracts.py
+++ b/app/camera/tests/contracts/test_api_contracts.py
@@ -736,6 +736,16 @@ class TestStatusServerNoPasswordAuthContract:
 class TestStatusServerNetworksContract:
     """GET /api/networks on status server."""
 
+    def test_requires_auth(self, configured_config):
+        server = CameraStatusServer(configured_config)
+        server.start()
+        try:
+            data, status = _json_get("/api/networks", scheme="https")
+            assert status == 401
+            _assert_fields(data, {"error"})
+        finally:
+            server.stop()
+
     @patch("camera_streamer.status_server.wifi.scan_networks")
     def test_fields(self, mock_scan, configured_config):
         mock_scan.return_value = [
@@ -749,6 +759,20 @@ class TestStatusServerNetworksContract:
             )
             _assert_fields(data, {"networks"})
             assert isinstance(data["networks"], list)
+        finally:
+            server.stop()
+
+    def test_status_page_scan_distinguishes_auth_error_from_empty_scan(
+        self, configured_config
+    ):
+        server = CameraStatusServer(configured_config)
+        server.start()
+        try:
+            html, status = _html_get("/", scheme="https", headers=_auth_headers())
+            assert status == 200
+            assert 'fetch("/api/networks", { credentials: "same-origin" })' in html
+            assert "r.status === 401" in html
+            assert "No networks found. Type the WiFi name manually." in html
         finally:
             server.stop()
 


### PR DESCRIPTION
## Summary
- make the camera status WiFi scan fetch preserve same-origin credentials and treat HTTP errors explicitly
- redirect expired/unauthenticated sessions to login instead of rendering an empty network list
- keep genuine empty scans distinct with manual-SSID guidance
- add camera contract coverage for protected scan behavior and status-page JS

## Validation
- pytest -q app/camera/tests/contracts/test_api_contracts.py::TestStatusServerNetworksContract app/camera/tests/unit/test_wifi.py
- ruff check .
- ruff format --check .
- python tools/traceability/check_traceability.py
- python -m pre_commit run --all-files
- live camera OS scan on 192.168.1.186 found SSIDs including MysticNet2.4
- deployed status.html to 192.168.1.186 and verified camera-streamer remains active