### PR TITLE
[codex] Fix server security session layout

### DIFF
--- a/app/server/monitor/static/css/control-panel.css
+++ b/app/server/monitor/static/css/control-panel.css
@@ -3666,6 +3666,111 @@ textarea {
     margin-top: 0;
 }
 
+.settings-section--sessions .settings-section__body {
+    display: grid;
+    gap: 14px;
+    padding: 18px;
+}
+
+.settings-section--sessions .settings-section__intro {
+    max-width: 780px;
+    margin: 0;
+    color: #53647d;
+    font-size: 0.95rem;
+    line-height: 1.45;
+}
+
+.session-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px;
+    border: 1px solid rgba(20, 35, 61, 0.09);
+    border-radius: 18px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(245, 249, 255, 0.58));
+}
+
+.session-toolbar__copy {
+    min-width: 220px;
+    max-width: 740px;
+    line-height: 1.45;
+}
+
+.session-toolbar__controls {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.session-scope-toggle {
+    min-height: 38px;
+    margin: 0;
+    padding: 0 12px;
+    border: 1px solid rgba(20, 35, 61, 0.1);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.66);
+    color: #22314a;
+    font-size: 0.88rem;
+    font-weight: 760;
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.session-scope-toggle input {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    accent-color: var(--color-info);
+}
+
+.session-toolbar .btn {
+    white-space: nowrap;
+}
+
+.settings-section--sessions .settings-table-cards {
+    margin: 0;
+}
+
+.settings-section--sessions .session-table td[data-label="Action"] {
+    color: #50617a;
+}
+
+@media (max-width: 900px) {
+    .session-toolbar {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .session-toolbar__copy {
+        min-width: 0;
+    }
+
+    .session-toolbar__controls {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 700px) {
+    .settings-section--sessions .settings-section__body {
+        padding: 14px;
+    }
+
+    .session-toolbar {
+        padding: 12px;
+    }
+
+    .session-scope-toggle,
+    .session-toolbar .btn {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
 /* Alerts mobile should not hide filter controls off-screen. */
 @media (max-width: 760px) {
     .alerts-page .alerts-filters {

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -938,30 +938,28 @@
      ACCOUNT TAB (all users)
      ═══════════════════════════════════════════════════════════ -->
 <div x-show="tab === 'security'" x-cloak>
-    <div class="settings-section">
-        <div class="flex-between" style="align-items:flex-start; gap:var(--space-3); flex-wrap:wrap;">
-            <div>
-                <div class="settings-section__title" style="margin-bottom:0; border-bottom:none; padding-bottom:0;">Active Sessions</div>
-                <div class="text-small text-muted" style="margin-top:6px;">
-                    Review every browser currently signed in to this account and revoke any device that should no longer have access.
-                </div>
-            </div>
-            <label x-show="isAdmin" class="text-small" style="display:inline-flex; gap:8px; align-items:center; cursor:pointer; margin-top:4px;">
-                <input type="checkbox" x-model="sessions.includeAll" @change="loadSessions()">
-                <span>All users (admin)</span>
-            </label>
-        </div>
+    <div class="settings-section settings-section--sessions">
+        <div class="settings-section__title">Active Sessions</div>
+        <div class="settings-section__body">
+            <p class="settings-section__intro">
+                Review every browser currently signed in to this account and revoke any device that should no longer have access.
+            </p>
 
-        <div class="card mt-16">
-            <div style="display:flex; justify-content:space-between; gap:var(--space-3); align-items:center; flex-wrap:wrap; margin-bottom:var(--space-3);">
-                <div class="text-small text-muted">
+            <div class="session-toolbar">
+                <div class="session-toolbar__copy text-small text-muted">
                     Source IPs are visible to admins when the all-users view is enabled. Current-session detection is server-side, not IP-based.
                 </div>
-                <button class="btn btn--secondary btn--small"
-                        :disabled="sessions.loading || sessions.busy || sessionOtherCount() === 0"
-                        @click="revokeOtherSessions()">
-                    Sign out other devices
-                </button>
+                <div class="session-toolbar__controls">
+                    <label x-show="isAdmin" class="checkbox-row session-scope-toggle">
+                        <input type="checkbox" x-model="sessions.includeAll" @change="loadSessions()">
+                        <span>All users (admin)</span>
+                    </label>
+                    <button class="btn btn--secondary btn--small"
+                            :disabled="sessions.loading || sessions.busy || sessionOtherCount() === 0"
+                            @click="revokeOtherSessions()">
+                        Sign out other devices
+                    </button>
+                </div>
             </div>
 
             <template x-if="sessions.loading">


### PR DESCRIPTION
﻿## Summary
- Fixes the server Settings -> Security active sessions layout so the all-users scope toggle and sign-out action are grouped in a single toolbar.
- Removes the nested card inside the settings section and keeps the active sessions table in the normal section body.
- Adds responsive rules so the toolbar stacks cleanly on narrower screens.

## Root cause
The old markup split the section title, admin scope checkbox, helper copy, and action button across separate flex/card containers. On desktop this left the checkbox floating in the upper-right corner and made the action area look like a card inside another card.

## Deploy
- Deployed `settings.html` and `control-panel.css` to server `192.168.1.245`.
- Restarted `monitor`; service came back `active`.

## Validation
- Browser-rendered local Settings -> Security view and verified the section has the grouped toolbar and no nested card.
- `pytest -q app/server/tests/integration/test_views.py::TestAlertCenterUI::test_settings_security_tab_is_sessions_only app/server/tests/integration/test_views.py::TestCompleteGuiRedesignCoverage::test_settings_preserves_every_tab_and_admin_option_group`
- `ruff check .`
- `ruff format --check .`
- `python tools/traceability/check_traceability.py`
- `python -m pre_commit run --all-files`
