### PR TITLE
[codex] Fix USB storage fault handling

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -651,6 +651,7 @@ def _auto_mount_usb(app, default_recordings_dir):
     try:
         settings = app.store.get_settings()
         usb_device = getattr(settings, "usb_device", "")
+        usb_uuid = getattr(settings, "usb_uuid", "")
         usb_rec_dir = getattr(settings, "usb_recordings_dir", "")
 
         if not usb_device or not usb_rec_dir:
@@ -659,31 +660,56 @@ def _auto_mount_usb(app, default_recordings_dir):
         from monitor.services import usb
 
         devices = usb.detect_devices()
-        found = any(d["path"] == usb_device for d in devices)
-        if not found:
+        device = _resolve_configured_usb(devices, usb_device, usb_uuid)
+        if not device:
             log.warning(
                 "Configured USB device %s not found — using internal storage",
                 usb_device,
             )
             return default_recordings_dir
+        resolved_device = device["path"]
 
-        ok, err = usb.mount_device(usb_device)
+        ok, err = usb.mount_device(resolved_device)
         if not ok:
             log.error(
                 "Failed to auto-mount USB %s: %s — using internal storage",
-                usb_device,
+                resolved_device,
                 err,
             )
             return default_recordings_dir
 
         rec_dir = usb.prepare_recordings_dir()
         app.storage_manager.set_recordings_dir(rec_dir)
-        log.info("Auto-mounted USB storage: %s -> %s", usb_device, rec_dir)
+        if resolved_device != usb_device or getattr(settings, "usb_uuid", "") != (
+            device.get("uuid", "") or ""
+        ):
+            settings.usb_device = resolved_device
+            settings.usb_uuid = device.get("uuid", "") or ""
+            settings.usb_label = device.get("label", "") or ""
+            settings.usb_recordings_dir = rec_dir
+            app.store.save_settings(settings)
+        log.info("Auto-mounted USB storage: %s -> %s", resolved_device, rec_dir)
         return rec_dir
 
     except Exception as e:
         log.error("USB auto-mount failed: %s", e)
         return default_recordings_dir
+
+
+def _resolve_configured_usb(devices, configured_path: str, configured_uuid: str):
+    """Find a configured USB device even if /dev/sdX changed."""
+    if configured_uuid:
+        for device in devices:
+            if device.get("uuid") == configured_uuid:
+                return device
+    for device in devices:
+        if device.get("path") == configured_path:
+            return device
+    if configured_path and not configured_uuid and len(devices) == 1:
+        device = devices[0]
+        if device.get("supported"):
+            return device
+    return None
 
 
 def _start_staleness_checker(app):

--- a/app/server/monitor/models.py
+++ b/app/server/monitor/models.py
@@ -263,6 +263,8 @@ class Settings:
     firmware_version: str = "1.0.0"
     # USB storage — set when user selects a USB device for recordings
     usb_device: str = ""  # e.g. /dev/sda1 (empty = internal)
+    usb_uuid: str = ""  # stable filesystem UUID for remount after /dev/sdX changes
+    usb_label: str = ""  # human label shown during storage recovery
     usb_recordings_dir: str = ""  # e.g. /mnt/recordings/home-monitor-recordings
     # Tailscale VPN configuration
     tailscale_enabled: bool = False  # enable/disable tailscaled daemon

--- a/app/server/monitor/services/offsite_backup.py
+++ b/app/server/monitor/services/offsite_backup.py
@@ -424,7 +424,11 @@ class OffsiteBackupService:
 
     def _discover_finalized_clips(self, settings: Settings) -> dict[str, dict]:
         root = Path(self._recordings_dir)
-        if not root.is_dir():
+        try:
+            if not root.is_dir():
+                return {}
+        except OSError as exc:
+            log.warning("Offsite backup storage unavailable: %s", exc)
             return {}
 
         prefix = settings.offsite_backup_prefix
@@ -437,37 +441,42 @@ class OffsiteBackupService:
             return {}
 
         for cam_dir in children:
-            if not cam_dir.is_dir() or not _CAMERA_ID_RE.match(cam_dir.name):
+            try:
+                if not cam_dir.is_dir() or not _CAMERA_ID_RE.match(cam_dir.name):
+                    continue
+                mp4s = cam_dir.rglob("*.mp4")
+                for mp4 in mp4s:
+                    try:
+                        stat = mp4.stat()
+                    except OSError:
+                        continue
+                    if now - stat.st_mtime < _ACTIVE_WRITE_SECONDS:
+                        continue
+                    clip_date, _start_time = _parse_clip_date_time(mp4)
+                    if not clip_date:
+                        continue
+                    clip_id = f"{cam_dir.name}/{clip_date}/{mp4.name}"
+                    discovered[clip_id] = {
+                        "clip_id": clip_id,
+                        "camera_id": cam_dir.name,
+                        "date": clip_date,
+                        "filename": mp4.name,
+                        "path": str(mp4),
+                        "size_bytes": stat.st_size,
+                        "object_key": self._build_object_key(
+                            prefix,
+                            cam_dir.name,
+                            clip_date,
+                            mp4.name,
+                        ),
+                        "enqueued_at": _iso_now(),
+                        "attempts": 0,
+                        "next_attempt_at": "",
+                        "last_error": "",
+                    }
+            except OSError as exc:
+                log.warning("Offsite backup skipped unreadable camera dir: %s", exc)
                 continue
-            for mp4 in cam_dir.rglob("*.mp4"):
-                try:
-                    stat = mp4.stat()
-                except OSError:
-                    continue
-                if now - stat.st_mtime < _ACTIVE_WRITE_SECONDS:
-                    continue
-                clip_date, _start_time = _parse_clip_date_time(mp4)
-                if not clip_date:
-                    continue
-                clip_id = f"{cam_dir.name}/{clip_date}/{mp4.name}"
-                discovered[clip_id] = {
-                    "clip_id": clip_id,
-                    "camera_id": cam_dir.name,
-                    "date": clip_date,
-                    "filename": mp4.name,
-                    "path": str(mp4),
-                    "size_bytes": stat.st_size,
-                    "object_key": self._build_object_key(
-                        prefix,
-                        cam_dir.name,
-                        clip_date,
-                        mp4.name,
-                    ),
-                    "enqueued_at": _iso_now(),
-                    "attempts": 0,
-                    "next_attempt_at": "",
-                    "last_error": "",
-                }
         return discovered
 
     def _drop_missing_entries(self, state: dict, discovered_ids: set[str]) -> None:
@@ -475,7 +484,16 @@ class OffsiteBackupService:
         for item in state["pending"]:
             clip_id = item.get("clip_id", "")
             path = item.get("path", "")
-            if clip_id in discovered_ids or (path and Path(path).exists()):
+            try:
+                path_exists = bool(path and Path(path).exists())
+            except OSError:
+                pending.append(item)
+                self._mark_error(
+                    state,
+                    f"Local storage unavailable while checking backup item: {clip_id}",
+                )
+                continue
+            if clip_id in discovered_ids or path_exists:
                 pending.append(item)
                 continue
             self._mark_error(
@@ -494,7 +512,12 @@ class OffsiteBackupService:
         for item in state["failed"]:
             clip_id = item.get("clip_id", "")
             path = item.get("path", "")
-            if clip_id in discovered_ids or (path and Path(path).exists()):
+            try:
+                path_exists = bool(path and Path(path).exists())
+            except OSError:
+                failed.append(item)
+                continue
+            if clip_id in discovered_ids or path_exists:
                 failed.append(item)
         state["failed"] = failed[-self.MAX_FAILED_ITEMS :]
 
@@ -552,7 +575,21 @@ class OffsiteBackupService:
             uploads_this_cycle += 1
             clip_id = item.get("clip_id", "")
             path = item.get("path", "")
-            if not path or not Path(path).is_file():
+            try:
+                local_file_ready = bool(path and Path(path).is_file())
+            except OSError as exc:
+                log.warning(
+                    "Offsite backup local clip check failed for %s: %s",
+                    clip_id,
+                    exc,
+                )
+                self._handle_upload_failure(
+                    state,
+                    item,
+                    "Local recordings storage is unavailable",
+                )
+                continue
+            if not local_file_ready:
                 state["pending"].remove(item)
                 self._mark_error(state, f"Local clip unavailable: {clip_id}")
                 self._log_audit(
@@ -573,7 +610,11 @@ class OffsiteBackupService:
                     settings.offsite_backup_bandwidth_cap_mbps,
                 )
             except Exception as exc:
-                friendly = _friendly_remote_error(exc)
+                friendly = (
+                    "Local recordings storage is unavailable"
+                    if isinstance(exc, OSError)
+                    else _friendly_remote_error(exc)
+                )
                 log.warning(
                     "Offsite backup upload failed for %s: %s",
                     clip_id,

--- a/app/server/monitor/services/storage_manager.py
+++ b/app/server/monitor/services/storage_manager.py
@@ -114,6 +114,8 @@ class StorageManager:
     def get_storage_stats(self) -> dict:
         """Get storage usage stats for the current recordings location."""
         rec_dir = self._recordings_dir
+        storage_health = "ok"
+        storage_error = ""
         try:
             usage = shutil.disk_usage(str(rec_dir))
             total_gb = round(usage.total / (1024**3), 2)
@@ -122,18 +124,24 @@ class StorageManager:
             percent = (
                 round(usage.used / usage.total * 100, 1) if usage.total > 0 else 0.0
             )
-        except OSError:
+        except OSError as exc:
             return {
                 "total_gb": 0,
                 "used_gb": 0,
                 "free_gb": 0,
                 "percent": 0.0,
+                "recordings_mb": 0,
                 "camera_count": 0,
                 "clip_count": 0,
+                "per_camera": {},
                 "recordings_dir": str(rec_dir),
                 "is_usb": self._is_usb_path(rec_dir),
+                "reserve_mb": self._reserve_mb,
+                "threshold_percent": self._threshold_percent,
                 "oldest_segment": None,
                 "newest_segment": None,
+                "storage_health": "unavailable",
+                "storage_error": _storage_error_message(exc),
             }
 
         # Count clips per camera; track oldest/newest mtime across all clips
@@ -143,10 +151,23 @@ class StorageManager:
         recordings_bytes = 0
         oldest_mtime: float | None = None
         newest_mtime: float | None = None
-        if rec_dir.is_dir():
-            for cam_dir in rec_dir.iterdir():
+        try:
+            cam_dirs = list(rec_dir.iterdir()) if rec_dir.is_dir() else []
+        except OSError as exc:
+            storage_health = "unavailable"
+            storage_error = _storage_error_message(exc)
+            cam_dirs = []
+
+        for cam_dir in cam_dirs:
+            try:
                 if not cam_dir.is_dir():
                     continue
+            except OSError as exc:
+                storage_health = "degraded"
+                storage_error = storage_error or _storage_error_message(exc)
+                continue
+
+            try:
                 count = 0
                 cam_bytes = 0
                 for mp4 in cam_dir.rglob("*.mp4"):
@@ -160,13 +181,19 @@ class StorageManager:
                         if newest_mtime is None or mtime > newest_mtime:
                             newest_mtime = mtime
                     except OSError:
+                        storage_health = "degraded"
                         pass
-                camera_stats[cam_dir.name] = {
-                    "clips": count,
-                    "size_mb": round(cam_bytes / (1024 * 1024), 1),
-                }
-                total_clips += count
-                recordings_bytes += cam_bytes
+            except OSError as exc:
+                storage_health = "degraded"
+                storage_error = storage_error or _storage_error_message(exc)
+                continue
+
+            camera_stats[cam_dir.name] = {
+                "clips": count,
+                "size_mb": round(cam_bytes / (1024 * 1024), 1),
+            }
+            total_clips += count
+            recordings_bytes += cam_bytes
 
         return {
             "total_gb": total_gb,
@@ -183,6 +210,8 @@ class StorageManager:
             "threshold_percent": self._threshold_percent,
             "oldest_segment": _epoch_to_iso(oldest_mtime),
             "newest_segment": _epoch_to_iso(newest_mtime),
+            "storage_health": storage_health,
+            "storage_error": storage_error,
         }
 
     def needs_cleanup(self) -> bool:
@@ -288,6 +317,14 @@ def _epoch_to_iso(epoch: float | None) -> str | None:
     if epoch is None:
         return None
     return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _storage_error_message(exc: OSError) -> str:
+    return (
+        "Recording storage cannot be read. "
+        "Eject the USB drive or reformat/replace it before trusting recordings. "
+        f"Detail: {exc}"
+    )
 
 
 def create_recording_dirs(recordings_dir, cam_id):

--- a/app/server/monitor/services/storage_service.py
+++ b/app/server/monitor/services/storage_service.py
@@ -48,7 +48,11 @@ class StorageService:
         """
         if not self._storage_manager:
             return None, "Storage manager not initialized"
-        stats = self._storage_manager.get_storage_stats()
+        try:
+            stats = self._storage_manager.get_storage_stats()
+        except OSError as exc:
+            log.warning("Storage status unavailable: %s", exc)
+            stats = self._unavailable_stats(str(exc))
         return stats, ""
 
     def list_devices(self) -> list[dict]:
@@ -63,15 +67,52 @@ class StorageService:
         devices = usb.detect_devices()
         rec_dir = self._active_recordings_dir()
         configured_device = self._configured_usb_device()
+        configured_uuid = self._configured_usb_uuid()
+        configured_present = any(d.get("path") == configured_device for d in devices)
+        legacy_single_candidate = (
+            bool(configured_device)
+            and not configured_uuid
+            and not configured_present
+            and len(devices) == 1
+            and bool(devices[0].get("supported"))
+        )
         for d in devices:
             is_active = bool(rec_dir) and self._device_backs_dir(d, rec_dir)
             is_configured = (
-                bool(configured_device) and d.get("path") == configured_device
+                (bool(configured_device) and d.get("path") == configured_device)
+                or (bool(configured_uuid) and d.get("uuid") == configured_uuid)
+                or legacy_single_candidate
             )
             d["in_use"] = is_active
             d["configured"] = is_configured
             d["configured_inactive"] = is_configured and not is_active
+            d["configured_path_changed"] = (
+                is_configured
+                and bool(configured_device)
+                and d.get("path") != configured_device
+            )
         return devices
+
+    def _unavailable_stats(self, error: str) -> dict:
+        rec_dir = self._active_recordings_dir() or self._default_dir
+        return {
+            "total_gb": 0,
+            "used_gb": 0,
+            "free_gb": 0,
+            "percent": 0.0,
+            "recordings_mb": 0,
+            "camera_count": 0,
+            "clip_count": 0,
+            "per_camera": {},
+            "recordings_dir": rec_dir,
+            "is_usb": not rec_dir.startswith("/data"),
+            "reserve_mb": 0,
+            "threshold_percent": None,
+            "oldest_segment": None,
+            "newest_segment": None,
+            "storage_health": "unavailable",
+            "storage_error": _storage_error_message(error),
+        }
 
     def _active_recordings_dir(self) -> str:
         if not self._storage_manager:
@@ -87,6 +128,14 @@ class StorageService:
         except Exception:
             return ""
         value = getattr(settings, "usb_device", "")
+        return value if isinstance(value, str) else ""
+
+    def _configured_usb_uuid(self) -> str:
+        try:
+            settings = self._store.get_settings()
+        except Exception:
+            return ""
+        value = getattr(settings, "usb_uuid", "")
         return value if isinstance(value, str) else ""
 
     @staticmethod
@@ -175,7 +224,12 @@ class StorageService:
             self._storage_manager.set_recordings_dir(rec_dir)
 
         # Persist config
-        self._save_usb_config(device_path, rec_dir)
+        self._save_usb_config(
+            device_path,
+            rec_dir,
+            uuid=device.get("uuid", ""),
+            label=device.get("label", ""),
+        )
 
         self._log_audit(
             "USB_STORAGE_SELECTED",
@@ -267,11 +321,20 @@ class StorageService:
             200,
         )
 
-    def _save_usb_config(self, device_path: str, recordings_dir: str):
+    def _save_usb_config(
+        self,
+        device_path: str,
+        recordings_dir: str,
+        *,
+        uuid: str = "",
+        label: str = "",
+    ):
         """Persist USB storage selection in settings.json."""
         try:
             settings = self._store.get_settings()
             settings.usb_device = device_path
+            settings.usb_uuid = uuid
+            settings.usb_label = label
             settings.usb_recordings_dir = recordings_dir
             self._store.save_settings(settings)
         except Exception as e:
@@ -285,3 +348,12 @@ class StorageService:
             self._audit.log_event(event, user=user, ip=ip, detail=detail)
         except Exception as e:
             log.warning("Audit log failed: %s", e)
+
+
+def _storage_error_message(error: str) -> str:
+    detail = (error or "unknown storage error").strip()
+    return (
+        "Recording storage cannot be read. "
+        "Eject the USB drive or reformat/replace it before trusting recordings. "
+        f"Detail: {detail}"
+    )

--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -320,22 +320,39 @@ class SystemSummaryService:
             stats = self._storage.get_storage_stats()
         except Exception as exc:
             log.warning("summary: get_storage_stats failed: %s", exc)
-            return "green", {"percent": 0.0, "retention_days": None}, "/settings"
+            return (
+                "red",
+                {
+                    "percent": 0.0,
+                    "retention_days": None,
+                    "storage_health": "unavailable",
+                    "storage_error": str(exc),
+                },
+                "/settings#storage",
+            )
 
         percent = float(stats.get("percent", 0.0) or 0.0)
-        if percent >= DISK_RED_PERCENT:
+        storage_health = stats.get("storage_health", "ok") or "ok"
+        storage_error = stats.get("storage_error", "") or ""
+        if storage_health != "ok" or storage_error or percent >= DISK_RED_PERCENT:
             state = "red"
         elif percent >= DISK_AMBER_PERCENT:
             state = "amber"
         else:
             state = "green"
 
-        retention = self._estimate_retention_days(stats)
+        retention = (
+            None
+            if state == "red" and storage_error
+            else self._estimate_retention_days(stats)
+        )
         detail = {
             "percent": round(percent, 1),
             "retention_days": retention,
             "free_gb": stats.get("free_gb", 0),
             "total_gb": stats.get("total_gb", 0),
+            "storage_health": storage_health,
+            "storage_error": storage_error,
         }
         return state, detail, "/settings#storage"
 
@@ -367,21 +384,29 @@ class SystemSummaryService:
         from pathlib import Path
 
         root = Path(rec_dir)
-        if not root.is_dir():
+        try:
+            if not root.is_dir():
+                return None
+        except OSError as exc:
+            log.warning("summary: retention root unavailable %s: %s", root, exc)
             return None
 
         cutoff = time.time() - RETENTION_SAMPLE_DAYS * 86400
         earliest = time.time()
         bytes_in_window = 0
-        for mp4 in root.rglob("*.mp4"):
-            try:
-                st = mp4.stat()
-            except OSError:
-                continue
-            if st.st_mtime >= cutoff:
-                bytes_in_window += st.st_size
-                if st.st_mtime < earliest:
-                    earliest = st.st_mtime
+        try:
+            for mp4 in root.rglob("*.mp4"):
+                try:
+                    st = mp4.stat()
+                except OSError:
+                    continue
+                if st.st_mtime >= cutoff:
+                    bytes_in_window += st.st_size
+                    if st.st_mtime < earliest:
+                        earliest = st.st_mtime
+        except OSError as exc:
+            log.warning("summary: retention scan failed for %s: %s", root, exc)
+            return None
 
         age_hours = (time.time() - earliest) / 3600
         if bytes_in_window <= 0 or age_hours < 24:

--- a/app/server/monitor/services/timestamp_backfill_service.py
+++ b/app/server/monitor/services/timestamp_backfill_service.py
@@ -99,6 +99,7 @@ class TimestampBackfillService:
             current_camera = self._current_camera
             started_at = self._started_at
         summary = self._timestamp_summary()
+        storage_error = summary.get("storage_error", "")
         return {
             "state": state,
             "processed": processed,
@@ -106,6 +107,7 @@ class TimestampBackfillService:
             "current_camera": current_camera,
             "started_at": started_at,
             "ffmpeg_available": self._stamper.tools_available(),
+            "storage_error": storage_error,
             "summary": summary,
         }
 
@@ -172,19 +174,43 @@ class TimestampBackfillService:
         cameras: list[dict] = []
         stamped_total = 0
         unstamped_total = 0
-        if not self._recordings_dir.is_dir():
-            return {"stamped": 0, "unstamped": 0, "cameras": cameras}
+        storage_error = ""
+        try:
+            if not self._recordings_dir.is_dir():
+                return {
+                    "stamped": 0,
+                    "unstamped": 0,
+                    "cameras": cameras,
+                    "storage_error": "",
+                }
+            cam_dirs = sorted(self._recordings_dir.iterdir())
+        except OSError as exc:
+            return {
+                "stamped": 0,
+                "unstamped": 0,
+                "cameras": cameras,
+                "storage_error": _storage_error_message(self._recordings_dir, exc),
+            }
 
-        for cam_dir in sorted(self._recordings_dir.iterdir()):
-            if not cam_dir.is_dir() or not _CAMERA_ID_RE.match(cam_dir.name):
+        for cam_dir in cam_dirs:
+            try:
+                is_dir = cam_dir.is_dir()
+            except OSError as exc:
+                storage_error = storage_error or _storage_error_message(cam_dir, exc)
+                continue
+            if not is_dir or not _CAMERA_ID_RE.match(cam_dir.name):
                 continue
             stamped = 0
             unstamped = 0
-            for clip_path in cam_dir.rglob("*.mp4"):
-                if stamp_sentinel_path(clip_path).exists():
-                    stamped += 1
-                else:
-                    unstamped += 1
+            try:
+                for clip_path in cam_dir.rglob("*.mp4"):
+                    if stamp_sentinel_path(clip_path).exists():
+                        stamped += 1
+                    else:
+                        unstamped += 1
+            except OSError as exc:
+                storage_error = storage_error or _storage_error_message(cam_dir, exc)
+                continue
             if stamped == 0 and unstamped == 0:
                 continue
             camera = self._store.get_camera(cam_dir.name)
@@ -202,6 +228,7 @@ class TimestampBackfillService:
             "stamped": stamped_total,
             "unstamped": unstamped_total,
             "cameras": cameras,
+            "storage_error": storage_error,
         }
 
     def _log_audit(self, event: str, *, detail: str) -> None:
@@ -211,3 +238,10 @@ class TimestampBackfillService:
             self._audit.log_event(event, detail=detail)
         except Exception:
             log.debug("timestamp_backfill: audit log failed for %s", event)
+
+
+def _storage_error_message(path: Path, exc: OSError) -> str:
+    return (
+        f"Recording storage at {path} cannot be scanned: {exc}. "
+        "Eject the USB drive or reformat/replace it before backfilling timestamps."
+    )

--- a/app/server/monitor/services/usb.py
+++ b/app/server/monitor/services/usb.py
@@ -180,6 +180,30 @@ def is_mounted(mount_point=DEFAULT_MOUNT_POINT) -> bool:
         return False
 
 
+def mounted_source(mount_point=DEFAULT_MOUNT_POINT) -> str:
+    """Return the block device currently mounted at mount_point, if any."""
+    try:
+        with open("/proc/mounts", encoding="utf-8") as mounts:
+            for line in mounts:
+                parts = line.split()
+                if len(parts) >= 2 and parts[1] == mount_point:
+                    return parts[0]
+    except OSError:
+        return ""
+    return ""
+
+
+def _same_block_device(left: str, right: str) -> bool:
+    if not left or not right:
+        return False
+    if left == right:
+        return True
+    try:
+        return os.stat(left).st_rdev == os.stat(right).st_rdev
+    except OSError:
+        return False
+
+
 # REQ: SWR-027; RISK: RISK-013; SEC: SC-013; TEST: TC-024
 def mount_device(device_path, mount_point=DEFAULT_MOUNT_POINT) -> tuple[bool, str]:
     """Mount a USB device at the given mount point.
@@ -199,9 +223,24 @@ def mount_device(device_path, mount_point=DEFAULT_MOUNT_POINT) -> tuple[bool, st
         os.makedirs(mount_point, exist_ok=True)
 
         # Check if already mounted
-        if is_mounted(mount_point):
-            log.info("Mount point %s already mounted", mount_point)
-            return True, ""
+        current_source = mounted_source(mount_point)
+        if current_source:
+            if _same_block_device(current_source, device_path):
+                log.info("Mount point %s already mounted", mount_point)
+                return True, ""
+            log.warning(
+                "Mount point %s is mounted from %s; unmounting before mounting %s",
+                mount_point,
+                current_source,
+                device_path,
+            )
+            ok, err = unmount_device(mount_point)
+            if not ok:
+                return (
+                    False,
+                    f"Mount point {mount_point} is already mounted from "
+                    f"{current_source}; unmount failed: {err}",
+                )
 
         # Detect filesystem to set proper mount options
         fstype = _get_fstype_blkid(device_path)

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -1336,9 +1336,12 @@
             </div>
             <div class="info-row" style="border-bottom:none;">
                 <span class="info-row__label">Loop Recording</span>
-                <span class="info-row__value" style="color:#4ade80;">Active (FIFO)</span>
+                <span class="info-row__value"
+                      :style="{ color: storage.health === 'ok' ? '#4ade80' : '#f59e0b' }"
+                      x-text="storage.health === 'ok' ? 'Active (FIFO)' : 'Storage fault'"></span>
             </div>
         </div>
+        <div class="msg msg--warn" x-show="storage.error" style="margin-top:12px;" x-text="storage.error"></div>
 
         <div class="card mt-16">
             <div class="flex-between" style="margin-bottom:12px;">
@@ -1379,7 +1382,12 @@
                 <span class="info-row__label">Started</span>
                 <span class="info-row__value" x-text="formatLocalTime(storage.timestamps.startedAt)"></span>
             </div>
-            <div class="msg msg--warn" x-show="!storage.timestamps.ffmpegAvailable" style="margin-top:12px;">
+            <div class="msg msg--warn" x-show="storage.timestamps.statusError || storage.timestamps.storageError" style="margin-top:12px;">
+                <span x-text="storage.timestamps.storageError || storage.timestamps.statusError"></span>
+            </div>
+            <div class="msg msg--warn"
+                 x-show="!storage.timestamps.statusError && !storage.timestamps.storageError && !storage.timestamps.ffmpegAvailable"
+                 style="margin-top:12px;">
                 ffmpeg/ffprobe are not available on this host. New clips remain downloadable, but embedded timestamps cannot be added until the image is fixed.
             </div>
             <div style="margin-top:12px;" x-show="storage.timestamps.cameras.length > 0">
@@ -1423,6 +1431,7 @@
                                 <span x-show="!d.supported && d.fstype" style="color:#f87171;"> Needs format</span>
                                 <span x-show="!d.supported && !d.fstype" style="color:#f59e0b;"> Rescan or reconnect before use</span>
                                 <span x-show="d.configured_inactive"> &middot; not active right now</span>
+                                <span x-show="d.configured_path_changed"> &middot; device path changed</span>
                             </div>
                         </div>
                         <div style="display:flex; gap:6px; flex-wrap:wrap; align-items:center;">
@@ -2384,6 +2393,8 @@ function settingsPage() {
             space: '',
             clips: '',
             isUsb: false,
+            health: 'ok',
+            error: '',
             devices: [],
             scanned: false,
             scanning: false,
@@ -2407,6 +2418,8 @@ function settingsPage() {
                 stamped: 0,
                 unstamped: 0,
                 cameras: [],
+                storageError: '',
+                statusError: '',
                 busy: false,
                 pollTimer: null
             }
@@ -3757,6 +3770,8 @@ function settingsPage() {
                 this.storage.space = (data.total_gb || 0) + ' GB / ' + (data.free_gb || 0) + ' GB free';
                 this.storage.clips = (data.clip_count || 0) + ' clips across ' + (data.camera_count || 0) + ' cameras';
                 this.storage.isUsb = data.is_usb;
+                this.storage.health = data.storage_health || (data.storage_error ? 'degraded' : 'ok');
+                this.storage.error = data.storage_error || '';
                 // ADR-0017 fields — tolerate older servers that don't send them.
                 this.storage.mountPath = data.mount_path || data.recordings_path || '';
                 var used = (data.used_gb !== undefined) ? data.used_gb : ((data.total_gb || 0) - (data.free_gb || 0));
@@ -3787,12 +3802,14 @@ function settingsPage() {
                 this.storage.timestamps.total = data.total || 0;
                 this.storage.timestamps.currentCamera = data.current_camera || '';
                 this.storage.timestamps.startedAt = data.started_at || '';
+                this.storage.timestamps.storageError = data.storage_error || (data.summary && data.summary.storage_error) || '';
+                this.storage.timestamps.statusError = '';
                 var summary = data.summary || {};
                 this.storage.timestamps.stamped = summary.stamped || 0;
                 this.storage.timestamps.unstamped = summary.unstamped || 0;
                 this.storage.timestamps.cameras = summary.cameras || [];
             } catch(e) {
-                this.storage.timestamps.ffmpegAvailable = false;
+                this.storage.timestamps.statusError = e.message || 'Timestamp status is unavailable.';
             }
             if (this.storage.timestamps.pollTimer) {
                 clearTimeout(this.storage.timestamps.pollTimer);

--- a/app/server/tests/integration/test_api_timestamp_backfill.py
+++ b/app/server/tests/integration/test_api_timestamp_backfill.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 
 from monitor.models import Camera
 from monitor.services.clip_stamper import StampResult, stamp_sentinel_path
@@ -65,6 +66,31 @@ def test_cancel_when_idle_returns_status(app, logged_in_client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["state"] == "idle"
+
+
+def test_status_reports_storage_error_without_claiming_ffmpeg_missing(
+    app, logged_in_client, monkeypatch
+):
+    app.clip_stamper.tools_available = lambda: True
+    recordings_dir = Path(app.config["RECORDINGS_DIR"])
+    real_iterdir = Path.iterdir
+
+    def broken_iterdir(path):
+        if path == recordings_dir:
+            raise OSError(5, "Input/output error")
+        return real_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", broken_iterdir)
+    client = logged_in_client()
+
+    resp = client.get("/api/v1/recordings/timestamp-backfill/status")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ffmpeg_available"] is True
+    assert "Input/output error" in data["storage_error"]
+    assert data["summary"]["stamped"] == 0
+    assert data["summary"]["unstamped"] == 0
 
 
 def test_backfill_recovers_from_stamp_exception(app, logged_in_client):

--- a/app/server/tests/unit/test_app.py
+++ b/app/server/tests/unit/test_app.py
@@ -43,6 +43,40 @@ class TestCreateApp:
         assert app.config["CERTS_DIR"] == str(data_dir / "certs")
 
 
+class TestUsbConfigResolution:
+    def test_prefers_uuid_when_device_path_changes(self):
+        from monitor import _resolve_configured_usb
+
+        devices = [
+            {"path": "/dev/sdb1", "uuid": "same-usb", "supported": True},
+        ]
+
+        resolved = _resolve_configured_usb(devices, "/dev/sda1", "same-usb")
+
+        assert resolved == devices[0]
+
+    def test_legacy_path_only_config_uses_single_supported_device(self):
+        from monitor import _resolve_configured_usb
+
+        devices = [
+            {"path": "/dev/sdb1", "uuid": "new-uuid", "supported": True},
+        ]
+
+        resolved = _resolve_configured_usb(devices, "/dev/sda1", "")
+
+        assert resolved == devices[0]
+
+    def test_legacy_path_only_config_does_not_guess_multiple_devices(self):
+        from monitor import _resolve_configured_usb
+
+        devices = [
+            {"path": "/dev/sdb1", "uuid": "one", "supported": True},
+            {"path": "/dev/sdc1", "uuid": "two", "supported": True},
+        ]
+
+        assert _resolve_configured_usb(devices, "/dev/sda1", "") is None
+
+
 class TestBlueprintRegistration:
     """Test that all API blueprints are registered."""
 

--- a/app/server/tests/unit/test_models.py
+++ b/app/server/tests/unit/test_models.py
@@ -86,6 +86,8 @@ class TestSettings:
         assert s.hostname == "home-monitor"
         assert s.setup_completed is False
         assert s.firmware_version == "1.0.0"
+        assert s.usb_uuid == ""
+        assert s.usb_label == ""
         assert s.offsite_backup_enabled is False
         assert s.offsite_backup_retention_days == 30
         assert s.offsite_backup_bandwidth_cap_mbps is None
@@ -99,10 +101,10 @@ class TestSettings:
         d = asdict(Settings())
         assert d["timezone"] == "Europe/Dublin"
         assert isinstance(d, dict)
-        # 9 base + 5 tailscale + 2 ADR-0017 watermarks + 1 ADR-0019 ntp_mode
+        # 11 base + 5 tailscale + 2 ADR-0017 watermarks + 1 ADR-0019 ntp_mode
         # + 1 motion post-roll + 1 TOTP 2FA policy + 8 offsite-backup fields
         # + 2 outbound webhook settings + 1 backup snapshot-retention setting
-        assert len(d) == 30
+        assert len(d) == 32
         assert d["ntp_mode"] == "auto"
         assert d["loop_low_watermark_percent"] == 10
         assert d["loop_hysteresis_percent"] == 5

--- a/app/server/tests/unit/test_offsite_backup_service.py
+++ b/app/server/tests/unit/test_offsite_backup_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from monitor.models import Settings
@@ -191,6 +192,49 @@ class TestSync:
         assert state["pending"][0]["attempts"] == 1
         assert state["pending"][0]["next_attempt_at"] != ""
         assert "credentials" in state["last_error"].lower()
+
+    def test_discovery_skips_unavailable_recordings_root(self, tmp_path, monkeypatch):
+        service, store, recordings_dir = _make_service(
+            tmp_path,
+            settings=_configured_settings(),
+        )
+        original_is_dir = Path.is_dir
+
+        def _is_dir(path):
+            if path == recordings_dir:
+                raise OSError("input/output error")
+            return original_is_dir(path)
+
+        monkeypatch.setattr(Path, "is_dir", _is_dir)
+
+        assert service._discover_finalized_clips(store.get_settings()) == {}
+
+    def test_local_storage_fault_retries_without_crashing(self, tmp_path, monkeypatch):
+        service, store, _recordings_dir = _make_service(
+            tmp_path,
+            settings=_configured_settings(),
+        )
+        state = service._state_template()
+        state["pending"] = [
+            {
+                "clip_id": "cam-001/2026-05-04/20260504_101500.mp4",
+                "path": "/mnt/recordings/cam-001/20260504_101500.mp4",
+                "object_key": "backups/home-monitor/cam-001/20260504_101500.mp4",
+                "attempts": 0,
+                "next_attempt_at": "",
+            }
+        ]
+
+        def _is_file(_path):
+            raise OSError("input/output error")
+
+        monkeypatch.setattr(Path, "is_file", _is_file)
+
+        service._process_pending_uploads(state, store.get_settings())
+
+        assert len(state["pending"]) == 1
+        assert state["pending"][0]["attempts"] == 1
+        assert "local recordings storage" in state["last_error"].lower()
 
     def test_run_once_prunes_old_remote_objects_on_retention_sweep(self, tmp_path):
         deleted = []

--- a/app/server/tests/unit/test_storage_manager.py
+++ b/app/server/tests/unit/test_storage_manager.py
@@ -280,6 +280,24 @@ class TestGetStorageStats:
             stats = mgr.get_storage_stats()
         assert stats["total_gb"] == 0
         assert stats["used_gb"] == 0
+        assert stats["storage_health"] == "unavailable"
+        assert "Recording storage cannot be read" in stats["storage_error"]
+
+    def test_directory_scan_oserror_returns_degraded_status(self, tmp_path):
+        mgr, rec_dir = _make_manager(tmp_path)
+        real_iterdir = type(rec_dir).iterdir
+
+        def broken_iterdir(path):
+            if path == rec_dir:
+                raise OSError(5, "Input/output error")
+            return real_iterdir(path)
+
+        with patch("pathlib.Path.iterdir", broken_iterdir):
+            stats = mgr.get_storage_stats()
+
+        assert stats["total_gb"] > 0
+        assert stats["storage_health"] == "unavailable"
+        assert "Input/output error" in stats["storage_error"]
 
     def test_is_usb_false_for_internal_path(self, tmp_path):
         mgr, _ = _make_manager(tmp_path)

--- a/app/server/tests/unit/test_storage_service.py
+++ b/app/server/tests/unit/test_storage_service.py
@@ -20,7 +20,13 @@ USB_PATCH = "monitor.services.storage_service.usb"
 
 
 def _make_device(
-    path="/dev/sda1", model="USB Stick", size="32G", fstype="ext4", supported=True
+    path="/dev/sda1",
+    model="USB Stick",
+    size="32G",
+    fstype="ext4",
+    supported=True,
+    uuid="usb-uuid",
+    label="HomeMonitor",
 ):
     """Build a fake USB device dict matching usb.detect_devices() output."""
     return {
@@ -29,6 +35,8 @@ def _make_device(
         "size": size,
         "fstype": fstype,
         "supported": supported,
+        "uuid": uuid,
+        "label": label,
     }
 
 
@@ -40,6 +48,8 @@ def _make_service(
         store = MagicMock()
         store.get_settings.return_value = MagicMock(
             usb_device="",
+            usb_uuid="",
+            usb_label="",
             usb_recordings_dir="",
         )
     if storage_manager is None:
@@ -105,6 +115,23 @@ class TestListDevices:
         svc = _make_service()
 
         assert svc.list_devices() == []
+
+    @patch(USB_PATCH)
+    def test_marks_configured_by_uuid_after_device_path_changes(self, mock_usb):
+        device = _make_device(path="/dev/sdb1", uuid="same-usb")
+        mock_usb.detect_devices.return_value = [device]
+        store = MagicMock()
+        store.get_settings.return_value = MagicMock(
+            usb_device="/dev/sda1",
+            usb_uuid="same-usb",
+            usb_recordings_dir="/mnt/recordings/home-monitor-recordings",
+        )
+        svc = _make_service(store=store)
+
+        result = svc.list_devices()
+
+        assert result[0]["configured"] is True
+        assert result[0]["configured_path_changed"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -218,13 +245,17 @@ class TestSelectDeviceSuccess:
         mock_usb.prepare_recordings_dir.return_value = "/mnt/usb/recordings"
         mock_usb.DEFAULT_MOUNT_POINT = "/mnt/usb"
         store = MagicMock()
-        settings = MagicMock(usb_device="", usb_recordings_dir="")
+        settings = MagicMock(
+            usb_device="", usb_uuid="", usb_label="", usb_recordings_dir=""
+        )
         store.get_settings.return_value = settings
         svc = _make_service(store=store)
 
         svc.select_device("/dev/sda1")
 
         assert settings.usb_device == "/dev/sda1"
+        assert settings.usb_uuid == "usb-uuid"
+        assert settings.usb_label == "HomeMonitor"
         assert settings.usb_recordings_dir == "/mnt/usb/recordings"
         store.save_settings.assert_called_once_with(settings)
 
@@ -357,13 +388,20 @@ class TestEject:
     def test_eject_clears_usb_config(self, mock_usb):
         mock_usb.unmount_device.return_value = (True, "")
         store = MagicMock()
-        settings = MagicMock(usb_device="/dev/sda1", usb_recordings_dir="/mnt/usb/rec")
+        settings = MagicMock(
+            usb_device="/dev/sda1",
+            usb_uuid="usb-uuid",
+            usb_label="HomeMonitor",
+            usb_recordings_dir="/mnt/usb/rec",
+        )
         store.get_settings.return_value = settings
         svc = _make_service(store=store)
 
         svc.eject()
 
         assert settings.usb_device == ""
+        assert settings.usb_uuid == ""
+        assert settings.usb_label == ""
         assert settings.usb_recordings_dir == ""
         store.save_settings.assert_called_once()
 

--- a/app/server/tests/unit/test_svc_storage.py
+++ b/app/server/tests/unit/test_svc_storage.py
@@ -17,6 +17,8 @@ def _make_device(
     fstype="ext4",
     supported=True,
     mountpoint="",
+    uuid="usb-uuid",
+    label="HomeMonitor",
 ):
     return {
         "path": path,
@@ -25,6 +27,8 @@ def _make_device(
         "fstype": fstype,
         "supported": supported,
         "mountpoint": mountpoint,
+        "uuid": uuid,
+        "label": label,
     }
 
 
@@ -94,6 +98,21 @@ class TestListDevices:
         assert result[0]["configured"] is True
         assert result[0]["configured_inactive"] is False
         assert result[0]["in_use"] is True
+
+    @patch(USB_PATCH)
+    def test_marks_configured_usb_when_device_path_changes(self, mock_usb, svc, deps):
+        sm, store, _ = deps
+        sm.recordings_dir = "/data/recordings"
+        store.get_settings.return_value.usb_device = "/dev/sda1"
+        store.get_settings.return_value.usb_uuid = "same-usb"
+        mock_usb.detect_devices.return_value = [
+            _make_device(path="/dev/sdb1", uuid="same-usb")
+        ]
+
+        result = svc.list_devices()
+
+        assert result[0]["configured"] is True
+        assert result[0]["configured_path_changed"] is True
 
 
 class TestSelectDevice:
@@ -181,6 +200,9 @@ class TestSelectDevice:
 
         svc.select_device("/dev/sda1")
         store.get_settings.assert_called()
+        settings = store.get_settings.return_value
+        assert settings.usb_uuid == "usb-uuid"
+        assert settings.usb_label == "HomeMonitor"
         store.save_settings.assert_called()
 
 
@@ -246,6 +268,8 @@ class TestEject:
         svc.eject()
         settings = store.get_settings.return_value
         assert settings.usb_device == ""
+        assert settings.usb_uuid == ""
+        assert settings.usb_label == ""
         assert settings.usb_recordings_dir == ""
         store.save_settings.assert_called()
 

--- a/app/server/tests/unit/test_svc_system_summary.py
+++ b/app/server/tests/unit/test_svc_system_summary.py
@@ -198,6 +198,22 @@ class TestStorageStateTransitions:
         assert out["state"] == "red"
         assert out["deep_link"].startswith("/settings")
 
+    def test_storage_unavailable_is_red(self):
+        svc = _build(
+            stats={
+                "percent": 0,
+                "free_gb": 0,
+                "total_gb": 0,
+                "recordings_dir": "/mnt/recordings/home-monitor-recordings",
+                "storage_health": "unavailable",
+                "storage_error": "Storage directory is unavailable",
+            }
+        )
+        out = svc.compute_summary()
+        assert out["state"] == "red"
+        assert out["details"]["storage"]["storage_health"] == "unavailable"
+        assert "unavailable" in out["details"]["storage"]["storage_error"]
+
 
 # ---------------------------------------------------------------------------
 # Camera thresholds

--- a/app/server/tests/unit/test_usb.py
+++ b/app/server/tests/unit/test_usb.py
@@ -428,10 +428,10 @@ def test_is_mounted_os_error(mock_run):
 
 
 @patch("monitor.services.usb._get_fstype_blkid", return_value="ext4")
-@patch("monitor.services.usb.is_mounted", return_value=False)
+@patch("monitor.services.usb.mounted_source", return_value="")
 @patch("monitor.services.usb.subprocess.run")
 @patch("monitor.services.usb.os.makedirs")
-def test_mount_device_success(mock_makedirs, mock_run, mock_is_mounted, mock_fstype):
+def test_mount_device_success(mock_makedirs, mock_run, mock_mounted, mock_fstype):
     mock_run.return_value = _make_run_result(returncode=0)
     ok, err = mount_device("/dev/sda1", "/mnt/usb")
 
@@ -440,19 +440,20 @@ def test_mount_device_success(mock_makedirs, mock_run, mock_is_mounted, mock_fst
     mock_makedirs.assert_called_once_with("/mnt/usb", exist_ok=True)
 
 
-@patch("monitor.services.usb.is_mounted", return_value=True)
+@patch("monitor.services.usb._same_block_device", return_value=True)
+@patch("monitor.services.usb.mounted_source", return_value="/dev/sda1")
 @patch("monitor.services.usb.os.makedirs")
-def test_mount_device_already_mounted(mock_makedirs, mock_is_mounted):
+def test_mount_device_already_mounted(mock_makedirs, mock_mounted, mock_same):
     ok, err = mount_device("/dev/sda1", "/mnt/usb")
     assert ok is True
     assert err == ""
 
 
 @patch("monitor.services.usb._get_fstype_blkid", return_value="ext4")
-@patch("monitor.services.usb.is_mounted", return_value=False)
+@patch("monitor.services.usb.mounted_source", return_value="")
 @patch("monitor.services.usb.subprocess.run")
 @patch("monitor.services.usb.os.makedirs")
-def test_mount_device_failure(mock_makedirs, mock_run, mock_is_mounted, mock_fstype):
+def test_mount_device_failure(mock_makedirs, mock_run, mock_mounted, mock_fstype):
     mock_run.return_value = _make_run_result(
         returncode=1, stderr="mount: permission denied"
     )
@@ -463,11 +464,11 @@ def test_mount_device_failure(mock_makedirs, mock_run, mock_is_mounted, mock_fst
 
 
 @patch("monitor.services.usb._get_fstype_blkid", return_value="ext4")
-@patch("monitor.services.usb.is_mounted", return_value=False)
+@patch("monitor.services.usb.mounted_source", return_value="")
 @patch("monitor.services.usb.subprocess.run")
 @patch("monitor.services.usb.os.makedirs")
 def test_mount_device_failure_empty_stderr(
-    mock_makedirs, mock_run, mock_is_mounted, mock_fstype
+    mock_makedirs, mock_run, mock_mounted, mock_fstype
 ):
     """Empty stderr falls back to 'Mount failed'."""
     mock_run.return_value = _make_run_result(returncode=1, stderr="")
@@ -477,10 +478,10 @@ def test_mount_device_failure_empty_stderr(
 
 
 @patch("monitor.services.usb._get_fstype_blkid", return_value="ext4")
-@patch("monitor.services.usb.is_mounted", return_value=False)
+@patch("monitor.services.usb.mounted_source", return_value="")
 @patch("monitor.services.usb.subprocess.run")
 @patch("monitor.services.usb.os.makedirs")
-def test_mount_device_timeout(mock_makedirs, mock_run, mock_is_mounted, mock_fstype):
+def test_mount_device_timeout(mock_makedirs, mock_run, mock_mounted, mock_fstype):
     mock_run.side_effect = subprocess.TimeoutExpired(cmd="mount", timeout=30)
     ok, err = mount_device("/dev/sda1")
     assert ok is False
@@ -496,11 +497,11 @@ def test_mount_device_makedirs_os_error(mock_makedirs):
 
 
 @patch("monitor.services.usb._get_fstype_blkid", return_value="ext4")
-@patch("monitor.services.usb.is_mounted", return_value=False)
+@patch("monitor.services.usb.mounted_source", return_value="")
 @patch("monitor.services.usb.subprocess.run")
 @patch("monitor.services.usb.os.makedirs")
 def test_mount_device_default_mount_point(
-    mock_makedirs, mock_run, mock_is_mounted, mock_fstype
+    mock_makedirs, mock_run, mock_mounted, mock_fstype
 ):
     mock_run.return_value = _make_run_result(returncode=0)
     ok, err = mount_device("/dev/sda1")
@@ -509,11 +510,11 @@ def test_mount_device_default_mount_point(
 
 
 @patch("monitor.services.usb._get_fstype_blkid", return_value="exfat")
-@patch("monitor.services.usb.is_mounted", return_value=False)
+@patch("monitor.services.usb.mounted_source", return_value="")
 @patch("monitor.services.usb.subprocess.run")
 @patch("monitor.services.usb.os.makedirs")
 def test_mount_device_exfat_uses_uid_gid(
-    mock_makedirs, mock_run, mock_is_mounted, mock_fstype
+    mock_makedirs, mock_run, mock_mounted, mock_fstype
 ):
     """exFAT mount includes uid/gid/umask options."""
     mock_run.return_value = _make_run_result(returncode=0)
@@ -525,6 +526,28 @@ def test_mount_device_exfat_uses_uid_gid(
     opts = call_args[call_args.index("-o") + 1]
     assert "uid=" in opts
     assert "umask=0002" in opts
+
+
+@patch("monitor.services.usb._get_fstype_blkid", return_value="ext4")
+@patch("monitor.services.usb.unmount_device", return_value=(True, ""))
+@patch("monitor.services.usb._same_block_device", return_value=False)
+@patch("monitor.services.usb.mounted_source", return_value="/dev/sda1")
+@patch("monitor.services.usb.subprocess.run")
+@patch("monitor.services.usb.os.makedirs")
+def test_mount_device_unmounts_stale_mount_before_new_device(
+    mock_makedirs,
+    mock_run,
+    mock_mounted,
+    mock_same,
+    mock_unmount,
+    mock_fstype,
+):
+    mock_run.return_value = _make_run_result(returncode=0)
+    ok, err = mount_device("/dev/sdb1", "/mnt/usb")
+
+    assert ok is True
+    assert err == ""
+    mock_unmount.assert_called_once_with("/mnt/usb")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Persist USB filesystem UUID/label and resolve configured storage after `/dev/sdX` changes.
- Unmount stale mount sources before mounting the configured USB device.
- Return degraded storage status instead of crashing when recordings storage throws `EIO`.
- Keep timestamp backfill, system summary, and offsite backup from misclassifying local storage faults as missing tools or remote failures.
- Update Settings storage panel to show storage faults clearly without changing the broader GUI design.

## Root Cause
The server persisted the volatile block path (`/dev/sda1`) as the selected USB device. After the same drive re-enumerated as `/dev/sdb1`, `/mnt/recordings` still pointed at a stale/bad mount and filesystem reads returned `Input/output error`. Several status paths assumed recordings directory scans could not fail, so the UI reported misleading symptoms such as missing ffmpeg.

## Validation
- `pytest -q app/server/tests/unit/test_app.py app/server/tests/unit/test_svc_system_summary.py app/server/tests/unit/test_usb.py app/server/tests/unit/test_storage_service.py app/server/tests/unit/test_svc_storage.py app/server/tests/unit/test_storage_manager.py app/server/tests/unit/test_offsite_backup_service.py app/server/tests/integration/test_api_timestamp_backfill.py app/server/tests/unit/test_models.py app/server/tests/integration/test_api_storage.py`
- `ruff check .`
- `ruff format --check .`
- `python tools/traceability/check_traceability.py`
- `git diff --check`
- Deployed to server `192.168.1.245`; `monitor` active and recent logs show no fresh storage summary/timestamp/offsite tracebacks.