### PR TITLE
[codex] Fail over recorder storage on USB faults

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -345,6 +345,11 @@ def _init_services(app):
         recordings_dir=recordings_dir,
         clip_duration=app.config.get("CLIP_DURATION_SECONDS", 180),
         clip_stamp_queue=app.clip_stamp_queue,
+        storage_fault_handler=lambda recordings_dir, camera_id, error: (
+            app.storage_service.handle_recording_storage_fault(
+                recordings_dir, camera_id, error
+            )
+        ),
     )
 
     def _camera_status_fingerprint(camera_id: str) -> str:

--- a/app/server/monitor/services/privileged_helper.py
+++ b/app/server/monitor/services/privileged_helper.py
@@ -42,6 +42,7 @@ HOSTNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,62}$")
 TIMEZONE_RE = re.compile(r"^[A-Za-z0-9_+./-]{1,80}$")
 ISO_STAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")
 LABEL_RE = re.compile(r"^[A-Za-z0-9_. -]{1,32}$")
+CAMERA_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
 OTA_PUBLIC_KEY = "/etc/swupdate-public.crt"
 
 
@@ -144,6 +145,55 @@ def _ensure_monitor_can_write_mount(mount_point: str) -> None:
         raise HelperRequestError(
             f"USB mounted but {mount_point} is not writable by monitor: {exc}"
         ) from exc
+
+
+def _validate_recordings_repair_target(payload: dict[str, Any]) -> str:
+    recordings_dir = _as_text(payload.get("recordings_dir"), max_len=256)
+    recordings_dir = posixpath.normpath(recordings_dir)
+    allowed_root = posixpath.normpath(
+        posixpath.join(usb.DEFAULT_MOUNT_POINT, usb.RECORDINGS_FOLDER)
+    )
+    if recordings_dir != allowed_root:
+        raise HelperRequestError("recordings directory is not allowlisted")
+
+    camera_id = str(payload.get("camera_id") or "").strip()
+    if not camera_id:
+        return recordings_dir
+    if not CAMERA_ID_RE.fullmatch(camera_id):
+        raise HelperRequestError("camera id is invalid")
+    return posixpath.join(recordings_dir, camera_id)
+
+
+def _op_recording_storage_repair_permissions(payload: dict[str, Any]) -> dict[str, Any]:
+    target = _validate_recordings_repair_target(payload)
+    if pwd is None or grp is None:
+        raise HelperRequestError("user/group lookup unavailable")
+
+    def _raise_walk_error(exc: OSError) -> None:
+        raise exc
+
+    try:
+        uid = pwd.getpwnam("monitor").pw_uid
+        gid = grp.getgrnam("monitor").gr_gid
+        os.makedirs(target, exist_ok=True)
+        os.chown(target, uid, gid)
+        os.chmod(target, 0o775)
+        for root, dirs, files in os.walk(target, onerror=_raise_walk_error):
+            os.chown(root, uid, gid)
+            os.chmod(root, 0o775)
+            for dirname in dirs:
+                directory = posixpath.join(root, dirname)
+                os.chown(directory, uid, gid)
+                os.chmod(directory, 0o775)
+            for filename in files:
+                path = posixpath.join(root, filename)
+                os.chown(path, uid, gid)
+                os.chmod(path, 0o664)
+    except (KeyError, PermissionError, OSError) as exc:
+        raise HelperRequestError(
+            f"recording storage permission repair failed: {exc}"
+        ) from exc
+    return {"path": target}
 
 
 def _op_usb_unmount(payload: dict[str, Any]) -> dict[str, Any]:
@@ -323,6 +373,7 @@ OPERATIONS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
     "usb.mount": _op_usb_mount,
     "usb.unmount": _op_usb_unmount,
     "usb.format": _op_usb_format,
+    "recording_storage.repair_permissions": (_op_recording_storage_repair_permissions),
     "time.set_timezone": _op_time_set_timezone,
     "time.set_ntp": _op_time_set_ntp,
     "time.set_manual": _op_time_set_manual,

--- a/app/server/monitor/services/storage_service.py
+++ b/app/server/monitor/services/storage_service.py
@@ -12,8 +12,10 @@ Design patterns:
 """
 
 import logging
+import os
+from pathlib import Path
 
-from monitor.services import usb
+from monitor.services import privileged, usb
 
 log = logging.getLogger("monitor.storage_service")
 
@@ -321,6 +323,89 @@ class StorageService:
             200,
         )
 
+    def handle_recording_storage_fault(
+        self, recordings_dir: str, camera_id: str = "", error: str = ""
+    ) -> str:
+        """Repair an external recording path or fail over to internal storage.
+
+        The saved USB selection is intentionally preserved. A faulted USB should
+        show up as configured-but-inactive so the operator can reselect,
+        reformat, or eject it deliberately; recording continuity goes to the
+        internal partition immediately.
+        """
+        active_dir = self._active_recordings_dir()
+        if active_dir and _same_path(active_dir, recordings_dir):
+            current_dir = active_dir
+        elif active_dir:
+            return active_dir
+        else:
+            current_dir = recordings_dir or self._default_dir
+
+        if _same_path(current_dir, self._default_dir):
+            log.error(
+                "Internal recording storage fault at %s for %s: %s",
+                current_dir,
+                camera_id or "unknown camera",
+                error,
+            )
+            return current_dir
+
+        repair_error = ""
+        if self._try_repair_recordings_dir(current_dir, camera_id):
+            ok, repair_error = self._probe_recording_path(current_dir, camera_id)
+            if ok:
+                self._log_audit(
+                    "USB_STORAGE_REPAIRED",
+                    "",
+                    "",
+                    f"path={current_dir}, camera={camera_id or 'all'}",
+                )
+                return current_dir
+
+        if self._storage_manager:
+            self._storage_manager.set_recordings_dir(self._default_dir)
+
+        detail = (
+            f"path={current_dir}, fallback={self._default_dir}, "
+            f"camera={camera_id or 'unknown'}, error={error or repair_error}"
+        )
+        log.warning("Recording storage fault; falling back to internal: %s", detail)
+        self._log_audit("USB_STORAGE_FALLBACK", "", "", detail)
+        return self._default_dir
+
+    def _try_repair_recordings_dir(self, recordings_dir: str, camera_id: str) -> bool:
+        if not privileged.should_use_helper():
+            return False
+        try:
+            privileged.request(
+                "recording_storage.repair_permissions",
+                {"recordings_dir": recordings_dir, "camera_id": camera_id},
+                timeout=60,
+            )
+            return True
+        except privileged.PrivilegedHelperError as exc:
+            log.warning("USB recording permission repair failed: %s", exc)
+            return False
+
+    @staticmethod
+    def _probe_recording_path(
+        recordings_dir: str, camera_id: str = ""
+    ) -> tuple[bool, str]:
+        target = Path(recordings_dir)
+        if camera_id:
+            target = target / camera_id
+        probe = target / ".home-monitor-write-test"
+        try:
+            target.mkdir(parents=True, exist_ok=True)
+            with open(probe, "ab") as f:
+                f.write(b"ok\n")
+                f.flush()
+                os.fsync(f.fileno())
+            probe.unlink(missing_ok=True)
+            return True, ""
+        except OSError as exc:
+            return False, str(exc)
+
     def _save_usb_config(
         self,
         device_path: str,
@@ -357,3 +442,7 @@ def _storage_error_message(error: str) -> str:
         "Eject the USB drive or reformat/replace it before trusting recordings. "
         f"Detail: {detail}"
     )
+
+
+def _same_path(left: str, right: str) -> bool:
+    return os.path.normpath(left or "") == os.path.normpath(right or "")

--- a/app/server/monitor/services/streaming_service.py
+++ b/app/server/monitor/services/streaming_service.py
@@ -99,11 +99,13 @@ class StreamingService:
         recordings_dir,
         clip_duration=CLIP_DURATION,
         clip_stamp_queue=None,
+        storage_fault_handler=None,
     ):
         self._live_dir = Path(live_dir)
         self._recordings_dir = Path(recordings_dir)
         self._clip_duration = clip_duration
         self._clip_stamp_queue = clip_stamp_queue
+        self._storage_fault_handler = storage_fault_handler
         self._snap_procs: dict = {}  # cam_id -> Popen (long-lived snapshot ffmpeg)
         self._rec_procs: dict = {}  # cam_id -> Popen (recorder — owned here)
         self._snap_intent: dict = {}  # cam_id -> "wanted" | "stopped"
@@ -289,9 +291,10 @@ class StreamingService:
                 return False
             self._recorder_intent[cam_id] = "wanted"
 
-        cam_rec_dir = self._recordings_dir / cam_id
-        cam_rec_dir.mkdir(parents=True, exist_ok=True)
-        segments_log = cam_rec_dir / ".segments.log"
+        paths = self._prepare_recorder_paths(cam_id)
+        if paths is None:
+            return False
+        cam_rec_dir, segments_log = paths
 
         cmd = [
             "ffmpeg",
@@ -348,6 +351,45 @@ class StreamingService:
             log.info("Recorder started for %s (PID %d)", cam_id, proc.pid)
             return True
         return False
+
+    def _prepare_recorder_paths(self, cam_id):
+        """Return writable per-camera recording paths, failing over once."""
+        first_error = None
+        for attempt in range(2):
+            cam_rec_dir = self._recordings_dir / cam_id
+            try:
+                _assert_recording_dir_writable(cam_rec_dir)
+                return cam_rec_dir, cam_rec_dir / ".segments.log"
+            except OSError as exc:
+                first_error = exc
+                if attempt > 0 or self._storage_fault_handler is None:
+                    break
+                fallback_dir = self._handle_storage_fault(cam_id, exc)
+                if not fallback_dir:
+                    break
+                self._recordings_dir = Path(fallback_dir)
+
+        log.error(
+            "Recorder storage unavailable for %s at %s: %s",
+            cam_id,
+            self._recordings_dir,
+            first_error,
+        )
+        return None
+
+    def _handle_storage_fault(self, cam_id, exc):
+        try:
+            return self._storage_fault_handler(
+                str(self._recordings_dir), cam_id, str(exc)
+            )
+        except Exception as handler_exc:  # pragma: no cover - defensive boundary
+            log.warning(
+                "Storage fault handler failed for %s at %s: %s",
+                cam_id,
+                self._recordings_dir,
+                handler_exc,
+            )
+            return None
 
     # --- Recorder finalizer (rename .mp4.part → .mp4 on segment close) ----
 
@@ -563,3 +605,14 @@ def create_recording_dirs(recordings_dir, cam_id):
     path = Path(recordings_dir) / cam_id
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def _assert_recording_dir_writable(path: Path) -> None:
+    """Create and fsync a small probe file in the recorder output directory."""
+    path.mkdir(parents=True, exist_ok=True)
+    probe = path / ".home-monitor-write-test"
+    with open(probe, "ab") as f:
+        f.write(b"ok\n")
+        f.flush()
+        os.fsync(f.fileno())
+    probe.unlink(missing_ok=True)

--- a/app/server/tests/unit/test_privileged_helper.py
+++ b/app/server/tests/unit/test_privileged_helper.py
@@ -128,6 +128,62 @@ def test_helper_mount_ownership_covers_recordings_folder():
     chmod.assert_any_call(f"/mnt/recordings/{helper.usb.RECORDINGS_FOLDER}", 0o775)
 
 
+def test_recording_storage_repair_rejects_non_allowlisted_path():
+    request = (
+        b'{"operation":"recording_storage.repair_permissions","payload":'
+        b'{"recordings_dir":"/etc","camera_id":"cam-x"}}'
+    )
+    with pytest.raises(helper.HelperRequestError, match="allowlisted"):
+        helper.handle_request(request)
+
+
+def test_recording_storage_repair_rejects_bad_camera_id():
+    request = (
+        b'{"operation":"recording_storage.repair_permissions","payload":'
+        b'{"recordings_dir":"/mnt/recordings/home-monitor-recordings",'
+        b'"camera_id":"../bad"}}'
+    )
+    with pytest.raises(helper.HelperRequestError, match="camera id"):
+        helper.handle_request(request)
+
+
+def test_recording_storage_repair_chowns_camera_tree():
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value.pw_uid = 996
+    fake_grp = MagicMock()
+    fake_grp.getgrnam.return_value.gr_gid = 994
+    root = "/mnt/recordings/home-monitor-recordings/cam-x"
+
+    with (
+        patch.object(helper, "pwd", fake_pwd),
+        patch.object(helper, "grp", fake_grp),
+        patch.object(helper.os, "makedirs") as makedirs,
+        patch.object(
+            helper.os,
+            "walk",
+            return_value=[
+                (root, ["2026-05-30"], [".segments.log"]),
+                (f"{root}/2026-05-30", [], ["clip.mp4"]),
+            ],
+        ),
+        patch.object(helper.os, "chown", create=True) as chown,
+        patch.object(helper.os, "chmod") as chmod,
+    ):
+        data = helper.handle_request(
+            b'{"operation":"recording_storage.repair_permissions","payload":'
+            b'{"recordings_dir":"/mnt/recordings/home-monitor-recordings",'
+            b'"camera_id":"cam-x"}}'
+        )
+
+    assert data == {"path": root}
+    makedirs.assert_called_once_with(root, exist_ok=True)
+    chown.assert_any_call(root, 996, 994)
+    chown.assert_any_call(f"{root}/.segments.log", 996, 994)
+    chown.assert_any_call(f"{root}/2026-05-30/clip.mp4", 996, 994)
+    chmod.assert_any_call(root, 0o775)
+    chmod.assert_any_call(f"{root}/.segments.log", 0o664)
+
+
 def test_usb_unmount_and_format_delegate_to_usb_module():
     with patch.object(helper.usb, "unmount_device", return_value=(True, "")) as unmount:
         assert helper.handle_request(b'{"operation":"usb.unmount","payload":{}}') == {}

--- a/app/server/tests/unit/test_storage_service.py
+++ b/app/server/tests/unit/test_storage_service.py
@@ -430,7 +430,73 @@ class TestEject:
 
 
 # ---------------------------------------------------------------------------
-# 7. Audit failure resilience
+# 7. Runtime recording storage faults
+# ---------------------------------------------------------------------------
+
+
+class TestRecordingStorageFault:
+    def test_external_fault_falls_back_without_clearing_usb_config(self):
+        mgr = MagicMock()
+        mgr.recordings_dir = "/mnt/recordings/home-monitor-recordings"
+        store = MagicMock()
+        settings = MagicMock(
+            usb_device="/dev/sda1",
+            usb_uuid="usb-uuid",
+            usb_label="HomeMonitor",
+            usb_recordings_dir="/mnt/recordings/home-monitor-recordings",
+        )
+        store.get_settings.return_value = settings
+        audit = MagicMock()
+        svc = _make_service(storage_manager=mgr, store=store, audit=audit)
+
+        with patch.object(svc, "_try_repair_recordings_dir", return_value=False):
+            result = svc.handle_recording_storage_fault(
+                "/mnt/recordings/home-monitor-recordings",
+                "cam-x",
+                "Permission denied",
+            )
+
+        assert result == "/data/recordings"
+        mgr.set_recordings_dir.assert_called_once_with("/data/recordings")
+        store.save_settings.assert_not_called()
+        audit.log_event.assert_called_once()
+        assert audit.log_event.call_args[0][0] == "USB_STORAGE_FALLBACK"
+
+    def test_external_fault_uses_repaired_usb_when_probe_passes(self):
+        mgr = MagicMock()
+        mgr.recordings_dir = "/mnt/recordings/home-monitor-recordings"
+        svc = _make_service(storage_manager=mgr)
+
+        with (
+            patch.object(svc, "_try_repair_recordings_dir", return_value=True),
+            patch.object(svc, "_probe_recording_path", return_value=(True, "")),
+        ):
+            result = svc.handle_recording_storage_fault(
+                "/mnt/recordings/home-monitor-recordings",
+                "cam-x",
+                "Permission denied",
+            )
+
+        assert result == "/mnt/recordings/home-monitor-recordings"
+        mgr.set_recordings_dir.assert_not_called()
+
+    def test_internal_fault_does_not_recurse_into_fallback(self):
+        mgr = MagicMock()
+        mgr.recordings_dir = "/data/recordings"
+        svc = _make_service(storage_manager=mgr)
+
+        result = svc.handle_recording_storage_fault(
+            "/data/recordings",
+            "cam-x",
+            "Input/output error",
+        )
+
+        assert result == "/data/recordings"
+        mgr.set_recordings_dir.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 8. Audit failure resilience
 # ---------------------------------------------------------------------------
 
 
@@ -471,7 +537,7 @@ class TestAuditFailureResilience:
 
 
 # ---------------------------------------------------------------------------
-# 8. Config persistence failure resilience
+# 9. Config persistence failure resilience
 # ---------------------------------------------------------------------------
 
 

--- a/app/server/tests/unit/test_streaming.py
+++ b/app/server/tests/unit/test_streaming.py
@@ -152,6 +152,88 @@ class TestRecorderPipeline:
         assert svc.is_recording("cam-x") is True
         svc.stop()
 
+    @patch("subprocess.Popen")
+    def test_start_recorder_falls_back_when_storage_unwritable(
+        self, mock_popen, tmp_path
+    ):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.poll.return_value = None
+        mock_popen.return_value = proc
+        bad_dir = tmp_path / "usb"
+        bad_dir.mkdir()
+        (bad_dir / "cam-x").write_text("not a directory")
+        fallback_dir = tmp_path / "recordings"
+        faults = []
+
+        def handle_fault(recordings_dir, camera_id, error):
+            faults.append((recordings_dir, camera_id, error))
+            return str(fallback_dir)
+
+        svc = StreamingService(
+            str(tmp_path / "live"),
+            str(bad_dir),
+            storage_fault_handler=handle_fault,
+        )
+        svc.start()
+
+        assert svc.start_recorder("cam-x", f"{MEDIAMTX_URL}/cam-x") is True
+
+        cmd = mock_popen.call_args[0][0]
+        assert faults
+        assert faults[0][0] == str(bad_dir)
+        assert faults[0][1] == "cam-x"
+        assert cmd[-1] == str(fallback_dir / "cam-x" / "%Y%m%d_%H%M%S.mp4")
+        svc.stop()
+
+    @patch("subprocess.Popen")
+    def test_start_recorder_allows_storage_handler_to_repair_same_path(
+        self, mock_popen, tmp_path
+    ):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.poll.return_value = None
+        mock_popen.return_value = proc
+        rec_dir = tmp_path / "usb"
+        rec_dir.mkdir()
+        broken_cam_path = rec_dir / "cam-x"
+        broken_cam_path.write_text("not a directory")
+
+        def handle_fault(recordings_dir, camera_id, error):
+            broken_cam_path.unlink()
+            broken_cam_path.mkdir()
+            return recordings_dir
+
+        svc = StreamingService(
+            str(tmp_path / "live"),
+            str(rec_dir),
+            storage_fault_handler=handle_fault,
+        )
+        svc.start()
+
+        assert svc.start_recorder("cam-x", f"{MEDIAMTX_URL}/cam-x") is True
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[-1] == str(rec_dir / "cam-x" / "%Y%m%d_%H%M%S.mp4")
+        svc.stop()
+
+    @patch("subprocess.Popen")
+    def test_start_recorder_returns_false_when_storage_cannot_recover(
+        self, mock_popen, tmp_path
+    ):
+        bad_dir = tmp_path / "usb"
+        bad_dir.mkdir()
+        (bad_dir / "cam-x").write_text("not a directory")
+        svc = StreamingService(
+            str(tmp_path / "live"),
+            str(bad_dir),
+            storage_fault_handler=lambda _dir, _cam, _error: "",
+        )
+        svc.start()
+
+        assert svc.start_recorder("cam-x", f"{MEDIAMTX_URL}/cam-x") is False
+        mock_popen.assert_not_called()
+        svc.stop()
+
 
 class TestWatchdogIntent:
     """Deliberately-stopped processes are NOT restarted by the watchdog."""


### PR DESCRIPTION
## Summary
- add a recorder write probe before ffmpeg launches so broken recording roots are detected before restart loops
- repair allowlisted USB recording camera folders through the privileged helper when permissions are the problem
- automatically fail over active recording services to internal `/data/recordings` when USB remains unwritable, while preserving the saved USB config as configured-but-inactive

## Root cause
The server only fell back to internal storage during startup mount failure or manual USB eject. Once a USB mount was selected, the recorder watchdog blindly restarted ffmpeg against that path. On the live server, the configured USB camera directory was root-owned and returning `Input/output error`, so ffmpeg could read the camera stream but could not open `.segments.log` and kept dying.

## Validation
- `pytest app/server/tests/unit/test_streaming.py app/server/tests/unit/test_storage_service.py app/server/tests/unit/test_privileged_helper.py app/server/tests/integration/test_api_storage.py -q`
- `ruff check .`
- `ruff format --check .`
- `python -m pre_commit run --all-files`
- `python tools/docs/check_doc_map.py`
- `python scripts/ai/validate_repo_ai_setup.py`
- deployed to `192.168.1.245`; monitor fell back from `/mnt/recordings/home-monitor-recordings` to `/data/recordings`, ffmpeg is running against `/data/recordings/cam-351ad8ee`, and new MP4 files are being written there

Note: `pytest app/server/tests/ -q` was attempted but exceeded the 5 minute local timeout, so the targeted server/unit/integration set above is the passing validation for this fix.