### PR TITLE
[codex] Keep storage services synced after USB reconnect failure

### DIFF
--- a/app/server/monitor/__init__.py
+++ b/app/server/monitor/__init__.py
@@ -513,15 +513,7 @@ def _init_services(app):
     # quietly fail against a stale /data/recordings path after the operator
     # selects a USB device.
     def _on_recording_dir_change(new_dir):
-        app.streaming.update_recordings_dir(new_dir)
-        if getattr(app, "motion_clip_correlator", None) is not None:
-            app.motion_clip_correlator.set_recordings_dir(new_dir)
-        if getattr(app, "loop_recorder", None) is not None:
-            app.loop_recorder.set_base_dir(new_dir)
-        if getattr(app, "offsite_backup_service", None) is not None:
-            app.offsite_backup_service.set_recordings_dir(new_dir)
-        if getattr(app, "timestamp_backfill_service", None) is not None:
-            app.timestamp_backfill_service.set_recordings_dir(new_dir)
+        _apply_recording_dir_change(app, new_dir)
 
     app.storage_manager.set_dir_change_callback(_on_recording_dir_change)
 
@@ -559,6 +551,54 @@ def _init_services(app):
         time_health=app.time_health_service,
     )
     app.watchdog_notifier = WatchdogNotifier(probe_url=app.config["WATCHDOG_PROBE_URL"])
+
+
+def _apply_recording_dir_change(app, requested_dir):
+    """Apply a recordings-dir change and settle dependents on the final path.
+
+    Starting or restarting recorders can detect a bad USB path and ask
+    StorageService to fall back to internal storage. That fallback is re-entrant:
+    it changes StorageManager again while the original callback is still running.
+    Every dependent service must therefore sync to the effective StorageManager
+    path after StreamingService has had a chance to trigger fallback.
+    """
+    app.streaming.update_recordings_dir(requested_dir)
+    _sync_recording_dir_dependents(app, requested_dir)
+
+
+def _sync_recording_dir_dependents(app, requested_dir):
+    effective_dir = _effective_recordings_dir(app, requested_dir)
+    if _normalized_path(effective_dir) != _normalized_path(requested_dir):
+        log.info(
+            "Recordings dir settled on %s after requested %s",
+            effective_dir,
+            requested_dir,
+        )
+
+    if getattr(app.streaming, "recordings_dir", effective_dir) != effective_dir:
+        app.streaming.update_recordings_dir(effective_dir)
+    if getattr(app, "motion_clip_correlator", None) is not None:
+        app.motion_clip_correlator.set_recordings_dir(effective_dir)
+    if getattr(app, "loop_recorder", None) is not None:
+        app.loop_recorder.set_base_dir(effective_dir)
+    if getattr(app, "offsite_backup_service", None) is not None:
+        app.offsite_backup_service.set_recordings_dir(effective_dir)
+    if getattr(app, "timestamp_backfill_service", None) is not None:
+        app.timestamp_backfill_service.set_recordings_dir(effective_dir)
+
+
+def _effective_recordings_dir(app, fallback_dir):
+    storage_manager = getattr(app, "storage_manager", None)
+    effective_dir = getattr(storage_manager, "recordings_dir", "")
+    return (
+        effective_dir
+        if isinstance(effective_dir, str) and effective_dir
+        else fallback_dir
+    )
+
+
+def _normalized_path(path):
+    return os.path.normpath(str(path or ""))
 
 
 def _restore_hostname(data_dir: str):
@@ -602,10 +642,7 @@ def _startup(app):
     # searches the right tree.
     recordings_dir = _auto_mount_usb(app, app.config["RECORDINGS_DIR"])
     if recordings_dir != app.config["RECORDINGS_DIR"]:
-        app.streaming.update_recordings_dir(recordings_dir)
-        if getattr(app, "motion_clip_correlator", None) is not None:
-            app.motion_clip_correlator.set_recordings_dir(recordings_dir)
-        app.loop_recorder.set_base_dir(recordings_dir)
+        _sync_recording_dir_dependents(app, recordings_dir)
 
     app.streaming.start()
     # NOTE: app.storage_manager is NOT started. LoopRecorder (ADR-0017)
@@ -684,6 +721,15 @@ def _auto_mount_usb(app, default_recordings_dir):
             return default_recordings_dir
 
         rec_dir = usb.prepare_recordings_dir()
+        ok, probe_error = app.storage_service.verify_recordings_dir(rec_dir)
+        if not ok:
+            log.warning(
+                "Configured USB storage %s failed write check: %s - using internal storage",
+                resolved_device,
+                probe_error,
+            )
+            return default_recordings_dir
+
         app.storage_manager.set_recordings_dir(rec_dir)
         if resolved_device != usb_device or getattr(settings, "usb_uuid", "") != (
             device.get("uuid", "") or ""

--- a/app/server/monitor/services/storage_service.py
+++ b/app/server/monitor/services/storage_service.py
@@ -221,6 +221,29 @@ class StorageService:
                 500,
             )
 
+        ok, probe_error = self.verify_recordings_dir(rec_dir)
+        if not ok:
+            active_dir = self._active_recordings_dir() or self._default_dir
+            self._log_audit(
+                "USB_STORAGE_REJECTED",
+                user,
+                ip,
+                f"device={device_path}, path={rec_dir}, error={probe_error}",
+            )
+            return (
+                {
+                    "recordings_dir": active_dir,
+                    "filesystem_status": device.get("filesystem_status", "unknown"),
+                },
+                (
+                    "USB mounted, but the recordings folder failed a write test. "
+                    "Recording remains on internal storage. Eject the USB drive "
+                    "or reformat/replace it before using it for recordings. "
+                    f"Detail: {probe_error}"
+                ),
+                409,
+            )
+
         # Switch storage manager
         if self._storage_manager:
             self._storage_manager.set_recordings_dir(rec_dir)
@@ -323,6 +346,20 @@ class StorageService:
             200,
         )
 
+    def verify_recordings_dir(self, recordings_dir: str) -> tuple[bool, str]:
+        """Return whether a candidate recordings root can safely accept clips."""
+        self._try_repair_recordings_dir(recordings_dir, "")
+        ok, error = self._probe_recording_path(recordings_dir)
+        if not ok:
+            return False, error
+
+        for camera_id in self._known_camera_ids():
+            self._try_repair_recordings_dir(recordings_dir, camera_id)
+            ok, error = self._probe_recording_path(recordings_dir, camera_id)
+            if not ok:
+                return False, f"{camera_id}: {error}"
+        return True, ""
+
     def handle_recording_storage_fault(
         self, recordings_dir: str, camera_id: str = "", error: str = ""
     ) -> str:
@@ -386,6 +423,18 @@ class StorageService:
         except privileged.PrivilegedHelperError as exc:
             log.warning("USB recording permission repair failed: %s", exc)
             return False
+
+    def _known_camera_ids(self) -> list[str]:
+        try:
+            cameras = self._store.get_cameras()
+        except Exception:
+            return []
+        ids: list[str] = []
+        for camera in cameras:
+            camera_id = getattr(camera, "id", "")
+            if isinstance(camera_id, str) and camera_id:
+                ids.append(camera_id)
+        return ids
 
     @staticmethod
     def _probe_recording_path(

--- a/app/server/tests/integration/test_api_storage.py
+++ b/app/server/tests/integration/test_api_storage.py
@@ -105,12 +105,15 @@ class TestSelectDevice:
 
         app.storage_service._storage_manager = MagicMock()
 
-        response = client.post(
-            "/api/v1/storage/select",
-            json={
-                "device_path": "/dev/sda1",
-            },
-        )
+        with patch.object(
+            app.storage_service, "verify_recordings_dir", return_value=(True, "")
+        ):
+            response = client.post(
+                "/api/v1/storage/select",
+                json={
+                    "device_path": "/dev/sda1",
+                },
+            )
         assert response.status_code == 200
         data = response.get_json()
         assert data["recordings_dir"] == "/mnt/usb/recordings"

--- a/app/server/tests/unit/test_app.py
+++ b/app/server/tests/unit/test_app.py
@@ -1,6 +1,9 @@
 # REQ: SWR-045; RISK: RISK-021; SEC: SC-021; TEST: TC-042
 """Tests for the Flask application factory."""
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 
 class TestCreateApp:
     """Test the create_app factory function."""
@@ -75,6 +78,61 @@ class TestUsbConfigResolution:
         ]
 
         assert _resolve_configured_usb(devices, "/dev/sda1", "") is None
+
+
+class TestRecordingDirSync:
+    def _fake_app(self, active_dir="/data/recordings"):
+        return SimpleNamespace(
+            storage_manager=SimpleNamespace(recordings_dir=active_dir),
+            streaming=MagicMock(recordings_dir=active_dir),
+            motion_clip_correlator=MagicMock(),
+            loop_recorder=MagicMock(),
+            offsite_backup_service=MagicMock(),
+            timestamp_backfill_service=MagicMock(),
+        )
+
+    def test_dependents_use_effective_dir_after_reentrant_fallback(self):
+        from monitor import _apply_recording_dir_change
+
+        app = self._fake_app(active_dir="/mnt/recordings/home-monitor-recordings")
+
+        def update_recordings_dir(new_dir):
+            app.streaming.recordings_dir = new_dir
+            if new_dir == "/mnt/recordings/home-monitor-recordings":
+                app.storage_manager.recordings_dir = "/data/recordings"
+                app.streaming.recordings_dir = "/data/recordings"
+
+        app.streaming.update_recordings_dir.side_effect = update_recordings_dir
+
+        _apply_recording_dir_change(app, "/mnt/recordings/home-monitor-recordings")
+
+        app.motion_clip_correlator.set_recordings_dir.assert_called_once_with(
+            "/data/recordings"
+        )
+        app.loop_recorder.set_base_dir.assert_called_once_with("/data/recordings")
+        app.offsite_backup_service.set_recordings_dir.assert_called_once_with(
+            "/data/recordings"
+        )
+        app.timestamp_backfill_service.set_recordings_dir.assert_called_once_with(
+            "/data/recordings"
+        )
+
+    def test_dependents_use_requested_dir_when_no_fallback_occurs(self):
+        from monitor import _apply_recording_dir_change
+
+        app = self._fake_app(active_dir="/mnt/recordings/home-monitor-recordings")
+        app.streaming.update_recordings_dir.side_effect = lambda new_dir: setattr(
+            app.streaming, "recordings_dir", new_dir
+        )
+
+        _apply_recording_dir_change(app, "/mnt/recordings/home-monitor-recordings")
+
+        app.loop_recorder.set_base_dir.assert_called_once_with(
+            "/mnt/recordings/home-monitor-recordings"
+        )
+        app.timestamp_backfill_service.set_recordings_dir.assert_called_once_with(
+            "/mnt/recordings/home-monitor-recordings"
+        )
 
 
 class TestBlueprintRegistration:

--- a/app/server/tests/unit/test_storage_service.py
+++ b/app/server/tests/unit/test_storage_service.py
@@ -52,6 +52,7 @@ def _make_service(
             usb_label="",
             usb_recordings_dir="",
         )
+        store.get_cameras.return_value = []
     if storage_manager is None:
         storage_manager = MagicMock()
     return StorageService(
@@ -216,7 +217,8 @@ class TestSelectDeviceSuccess:
         mock_usb.DEFAULT_MOUNT_POINT = "/mnt/usb"
         svc = _make_service()
 
-        result, err, status = svc.select_device("/dev/sda1")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            result, err, status = svc.select_device("/dev/sda1")
 
         assert status == 200
         assert err == ""
@@ -234,9 +236,60 @@ class TestSelectDeviceSuccess:
         mgr = MagicMock()
         svc = _make_service(storage_manager=mgr)
 
-        svc.select_device("/dev/sda1")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            svc.select_device("/dev/sda1")
 
         mgr.set_recordings_dir.assert_called_once_with("/mnt/usb/recordings")
+
+    @patch(USB_PATCH)
+    def test_unwritable_usb_does_not_switch_storage_manager(self, mock_usb):
+        mock_usb.detect_devices.return_value = [_make_device()]
+        mock_usb.mount_device.return_value = (True, "")
+        mock_usb.prepare_recordings_dir.return_value = "/mnt/usb/recordings"
+        mock_usb.DEFAULT_MOUNT_POINT = "/mnt/usb"
+        mgr = MagicMock()
+        mgr.recordings_dir = "/data/recordings"
+        store = MagicMock()
+        settings = MagicMock(
+            usb_device="", usb_uuid="", usb_label="", usb_recordings_dir=""
+        )
+        store.get_settings.return_value = settings
+        store.get_cameras.return_value = []
+        audit = MagicMock()
+        svc = _make_service(storage_manager=mgr, store=store, audit=audit)
+
+        with patch.object(
+            svc, "verify_recordings_dir", return_value=(False, "Input/output error")
+        ):
+            result, err, status = svc.select_device(
+                "/dev/sda1", user="admin", ip="10.0.0.1"
+            )
+
+        assert status == 409
+        assert result["recordings_dir"] == "/data/recordings"
+        assert "internal storage" in err
+        mgr.set_recordings_dir.assert_not_called()
+        store.save_settings.assert_not_called()
+        audit.log_event.assert_called_once()
+        assert audit.log_event.call_args[0][0] == "USB_STORAGE_REJECTED"
+
+    @patch(USB_PATCH)
+    def test_select_device_verifies_usb_before_switching(self, mock_usb):
+        mock_usb.detect_devices.return_value = [_make_device()]
+        mock_usb.mount_device.return_value = (True, "")
+        mock_usb.prepare_recordings_dir.return_value = "/mnt/usb/recordings"
+        mock_usb.DEFAULT_MOUNT_POINT = "/mnt/usb"
+        svc = _make_service()
+
+        with patch.object(
+            svc, "verify_recordings_dir", return_value=(True, "")
+        ) as verify:
+            result, err, status = svc.select_device("/dev/sda1")
+
+        assert status == 200
+        assert err == ""
+        assert result["recordings_dir"] == "/mnt/usb/recordings"
+        verify.assert_called_once_with("/mnt/usb/recordings")
 
     @patch(USB_PATCH)
     def test_success_saves_config(self, mock_usb):
@@ -251,7 +304,8 @@ class TestSelectDeviceSuccess:
         store.get_settings.return_value = settings
         svc = _make_service(store=store)
 
-        svc.select_device("/dev/sda1")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            svc.select_device("/dev/sda1")
 
         assert settings.usb_device == "/dev/sda1"
         assert settings.usb_uuid == "usb-uuid"
@@ -268,7 +322,8 @@ class TestSelectDeviceSuccess:
         audit = MagicMock()
         svc = _make_service(audit=audit)
 
-        svc.select_device("/dev/sda1", user="admin", ip="10.0.0.1")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            svc.select_device("/dev/sda1", user="admin", ip="10.0.0.1")
 
         audit.log_event.assert_called_once()
         call_args = audit.log_event.call_args
@@ -511,7 +566,8 @@ class TestAuditFailureResilience:
         audit.log_event.side_effect = RuntimeError("audit db locked")
         svc = _make_service(audit=audit)
 
-        result, err, status = svc.select_device("/dev/sda1")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            result, err, status = svc.select_device("/dev/sda1")
 
         assert status == 200
 
@@ -552,6 +608,7 @@ class TestConfigPersistenceFailure:
         store.get_settings.side_effect = OSError("disk full")
         svc = _make_service(store=store)
 
-        result, err, status = svc.select_device("/dev/sda1")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            result, err, status = svc.select_device("/dev/sda1")
 
         assert status == 200

--- a/app/server/tests/unit/test_svc_storage.py
+++ b/app/server/tests/unit/test_svc_storage.py
@@ -165,7 +165,10 @@ class TestSelectDevice:
         mock_usb.prepare_recordings_dir.return_value = "/mnt/usb/recordings"
         mock_usb.DEFAULT_MOUNT_POINT = "/mnt/usb"
 
-        result, err, status = svc.select_device("/dev/sda1", user="admin", ip="1.2.3.4")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            result, err, status = svc.select_device(
+                "/dev/sda1", user="admin", ip="1.2.3.4"
+            )
         assert status == 200
         assert err == ""
         assert result["recordings_dir"] == "/mnt/usb/recordings"
@@ -198,7 +201,8 @@ class TestSelectDevice:
         mock_usb.prepare_recordings_dir.return_value = "/mnt/usb/recordings"
         mock_usb.DEFAULT_MOUNT_POINT = "/mnt/usb"
 
-        svc.select_device("/dev/sda1")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            svc.select_device("/dev/sda1")
         store.get_settings.assert_called()
         settings = store.get_settings.return_value
         assert settings.usb_uuid == "usb-uuid"
@@ -285,7 +289,8 @@ class TestAuditFailSilent:
         mock_usb.prepare_recordings_dir.return_value = "/mnt/usb/recordings"
         mock_usb.DEFAULT_MOUNT_POINT = "/mnt/usb"
 
-        result, err, status = svc.select_device("/dev/sda1", user="admin")
+        with patch.object(svc, "verify_recordings_dir", return_value=(True, "")):
+            result, err, status = svc.select_device("/dev/sda1", user="admin")
         assert status == 200
 
     def test_no_audit_logger(self):


### PR DESCRIPTION
## Summary
- preflight USB recording roots with a write test before marking reconnect/select successful
- keep timestamp backfill, loop cleanup, offsite backup, and motion correlation synced to the final effective recordings directory after re-entrant fallback
- reject an unusable USB reconnect with a clear error while keeping recordings on internal storage

## Root cause
Reconnect selected the configured USB and fired the storage-manager callback. Streaming then detected the bad USB path and fell back to `/data/recordings`, but the original callback continued and pushed some dependent services back to the stale USB path. That left timestamp backfill and cleanup looking at `/mnt/recordings` while ffmpeg was correctly recording to `/data`.

## Validation
- `pytest app/server/tests/unit/test_app.py app/server/tests/unit/test_storage_service.py app/server/tests/integration/test_api_storage.py -q`
- `ruff check app/server/monitor/__init__.py app/server/monitor/services/storage_service.py app/server/tests/unit/test_app.py app/server/tests/unit/test_storage_service.py`
- `ruff format --check app/server/monitor/__init__.py app/server/monitor/services/storage_service.py app/server/tests/unit/test_app.py app/server/tests/unit/test_storage_service.py`
- `python -m pre_commit run --all-files`
- deployed to `192.168.1.245`; configured USB fails write preflight, active recorder stays on `/data/recordings/cam-351ad8ee`, and fresh clips continue writing