### PR TITLE
[codex] Stabilize time health summary integration test

### DIFF
--- a/app/server/tests/integration/test_time_health.py
+++ b/app/server/tests/integration/test_time_health.py
@@ -32,6 +32,15 @@ class TestTimeHealthSummary:
             "rtc_time": "Sat 2026-05-04 12:00:00 UTC",
         }
         app.settings_service.get_timesync_status = lambda: {"last_sync_time": ""}
+        app.storage_manager.get_storage_stats = lambda: {
+            "percent": 10,
+            "free_gb": 90,
+            "total_gb": 100,
+            "retention_days": 7,
+            "recordings_dir": "/data/recordings",
+            "storage_health": "ok",
+            "storage_error": "",
+        }
 
         client = logged_in_client()
         response = client.get("/api/v1/system/summary")


### PR DESCRIPTION
## Summary
- isolate storage health in the time-health summary integration test so storage state does not win the deep link under CI runner filesystem conditions

## Validation
- pytest app/server/tests/integration/test_time_health.py -q
- ruff check app/server/tests/integration/test_time_health.py
- ruff format --check app/server/tests/integration/test_time_health.py
- python -m pre_commit run --all-files