### PR TITLE
[codex] Fix Yocto parallel install races

### DIFF
--- a/meta-home-monitor/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-home-monitor/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,3 @@
+# wpa_supplicant installs multiple binaries into BINDIR, and parallel
+# do_install can race while creating that directory.
+PARALLEL_MAKEINST = ""

--- a/meta-home-monitor/recipes-support/lvm2/lvm2_%.bbappend
+++ b/meta-home-monitor/recipes-support/lvm2/lvm2_%.bbappend
@@ -1,0 +1,3 @@
+# lvm2 installs several plugin/pkgconfig paths in parallel; serialize
+# do_install to avoid races while creating shared destination directories.
+PARALLEL_MAKEINST = ""


### PR DESCRIPTION
## Summary

- Add a `wpa-supplicant` bbappend to serialize `do_install` and avoid parallel creation races under `usr/sbin`.
- Add an `lvm2` bbappend to serialize `do_install` and avoid parallel creation races under plugin/pkgconfig install paths.

## Root Cause

The VM Yocto builds exposed nondeterministic upstream recipe install races when `make install` ran with high parallelism. Both failures were directory-creation races during `do_install`, not application code failures.

## Validation

- Rebuilt server dev image and OTA bundle on the GCP VM.
- Rebuilt camera dev image and OTA bundle on the GCP VM.
- Rebuilt server prod image and OTA bundle on the GCP VM.
- Rebuilt camera prod image and OTA bundle on the GCP VM.
- Verified dev SWU bundles are CMS signed against the OTA signing certificate.