### PR TITLE
[codex] Fix OTA staging on data partition

### DIFF
--- a/app/camera/camera_streamer/ota_agent.py
+++ b/app/camera/camera_streamer/ota_agent.py
@@ -8,7 +8,7 @@ directly — it is unprivileged and NoNewPrivileges=true).
 
 Flow:
     POST /ota/upload
-      1. Stream body to /var/lib/camera-ota/staging/update.swu.partial
+      1. Stream body to /data/ota/camera-spool/staging/update.swu.partial
       2. Atomic rename to update.swu on complete
       3. Write trigger → systemd .path fires camera-ota-installer.service
          (root, runs `swupdate -c -i` then `swupdate -i`)

--- a/app/camera/camera_streamer/ota_installer.py
+++ b/app/camera/camera_streamer/ota_installer.py
@@ -9,8 +9,8 @@ standby slot, and fw_setenv.
 
 This module implements the client half of the split:
 
-    camera-streamer  ──write bundle──▶  /var/lib/camera-ota/staging/update.swu
-                    ──write trigger──▶  /var/lib/camera-ota/trigger
+    camera-streamer  ──write bundle──▶  /data/ota/camera-spool/staging/update.swu
+                    ──write trigger──▶  /data/ota/camera-spool/trigger
                                             │
                              (systemd .path unit fires)
                                             ▼
@@ -19,7 +19,7 @@ This module implements the client half of the split:
                                             ▼
                                 swupdate -c -i / swupdate -i
                                             │
-                    ◀── poll status.json ── /var/lib/camera-ota/status.json
+                    ◀── poll status.json ── /data/ota/camera-spool/status.json
 
 Both OTA entry points (server-push via OTAAgent on :8080 and camera
 GUI upload on :443) stage the bundle and trigger through this module
@@ -44,7 +44,7 @@ from camera_streamer.release_version import release_version
 
 log = logging.getLogger("camera-streamer.ota-installer")
 
-SPOOL_DIR = "/var/lib/camera-ota"
+SPOOL_DIR = os.environ.get("CAMERA_OTA_SPOOL_DIR", "/data/ota/camera-spool")
 STAGING_DIR = os.path.join(SPOOL_DIR, "staging")
 TRIGGER_PATH = os.path.join(SPOOL_DIR, "trigger")
 STATUS_PATH = os.path.join(SPOOL_DIR, "status.json")

--- a/app/camera/config/camera-ota-installer.path
+++ b/app/camera/config/camera-ota-installer.path
@@ -3,9 +3,9 @@ Description=Watch for camera OTA install triggers
 
 [Path]
 # Fires when the trigger file is created/modified. The unprivileged
-# camera-streamer process writes this file after staging a bundle,
+# camera-streamer process writes this file after staging a bundle on /data,
 # which activates camera-ota-installer.service (runs as root).
-PathModified=/var/lib/camera-ota/trigger
+PathModified=/data/ota/camera-spool/trigger
 Unit=camera-ota-installer.service
 
 [Install]

--- a/app/camera/config/camera-ota-installer.service
+++ b/app/camera/config/camera-ota-installer.service
@@ -1,17 +1,19 @@
 # REQ: SWR-038, SWR-050; RISK: RISK-004, RISK-018; SEC: SC-003, SC-019; TEST: TC-036, TC-044
 [Unit]
 Description=Camera OTA Installer (root-privileged swupdate wrapper)
-# Must run after /data is mounted (bundle lives under /var/lib which
-# may be bind-mounted from /data in future) and after local-fs so
-# /dev is populated for fw_setenv + partition access.
+# Must run after /data is mounted because the staged bundle and SWUpdate
+# TMPDIR live there; local-fs also guarantees /dev exists for fw_setenv
+# and partition access.
 After=local-fs.target
-ConditionPathExists=/var/lib/camera-ota/trigger
+RequiresMountsFor=/data
+ConditionPathExists=/data/ota/camera-spool/trigger
 
 [Service]
 Type=oneshot
 User=root
 Group=root
 ExecStart=/usr/bin/camera-ota-installer
+Environment=CAMERA_OTA_SPOOL_DIR=/data/ota/camera-spool
 # swupdate itself is the install — this service finishes when it
 # does, and the path unit re-arms for the next trigger.
 TimeoutStartSec=900

--- a/app/camera/config/camera-ota-tmpfiles.conf
+++ b/app/camera/config/camera-ota-tmpfiles.conf
@@ -1,15 +1,18 @@
 # REQ: SWR-038, SWR-050; RISK: RISK-004, RISK-018; SEC: SC-003, SC-019; TEST: TC-036, TC-044
-# Spool directory for the camera OTA install trigger-file protocol.
+# Persistent spool directory for the camera OTA install trigger-file protocol.
 #
-# Ownership: root:camera so the unprivileged camera-streamer can
-# write the trigger file + bundle; setgid (2) makes new files
-# inherit the camera group.
+# Ownership: camera:camera because /data itself is camera-owned on camera
+# images and systemd-tmpfiles rejects unsafe owner transitions below it.
+# The privileged installer still verifies signatures before writing slots.
 #
 # Layout:
-#   /var/lib/camera-ota/         root:camera 2775 — shared spool
-#   /var/lib/camera-ota/staging/ root:camera 2775 — bundle lives here
-#   /var/lib/camera-ota/status.json root:camera 0664 — installer-written,
-#                                                 camera-streamer-read
-d  /var/lib/camera-ota         2775 root camera -
-d  /var/lib/camera-ota/staging 2775 root camera -
-f  /var/lib/camera-ota/status.json 0664 root camera - {"state":"idle","progress":0,"error":"","updated_at":0}
+#   /data/ota/camera-spool/         camera:camera 2775 — shared spool
+#   /data/ota/camera-spool/staging/ camera:camera 2775 — uploaded bundle
+#   /data/ota/camera-spool/tmp/     camera:camera 2775 — SWUpdate TMPDIR
+#   /data/ota/camera-spool/status.json camera:camera 0664 — installer-written,
+#                                                         camera-streamer-read
+d  /data/ota                    2775 camera camera -
+d  /data/ota/camera-spool       2775 camera camera -
+d  /data/ota/camera-spool/staging 2775 camera camera -
+d  /data/ota/camera-spool/tmp   2775 camera camera -
+f  /data/ota/camera-spool/status.json 0664 camera camera - {"state":"idle","progress":0,"error":"","updated_at":0}

--- a/app/camera/config/camera-streamer.service
+++ b/app/camera/config/camera-streamer.service
@@ -28,16 +28,14 @@ Environment=CAMERA_DATA_DIR=/data
 Environment=CAMERA_CONFIG_DIR=/data/config
 Environment=CAMERA_CERTS_DIR=/data/certs
 Environment=CAMERA_PRIVILEGED_HELPER_SOCKET=/run/camera/privileged-helper.sock
+Environment=CAMERA_OTA_SPOOL_DIR=/data/ota/camera-spool
 
 # Security hardening
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
-# /data — persistent config, certs, logs (normal use).
-# /var/lib/camera-ota — OTA spool dir, shared with the privileged
-# camera-ota-installer.service via the trigger-file protocol. Without
-# this exemption ProtectSystem=strict rejects writes with EROFS.
-ReadWritePaths=/data /var/lib/camera-ota
+# /data — persistent config, certs, logs, and OTA spool.
+ReadWritePaths=/data
 PrivateTmp=true
 # Camera device access
 SupplementaryGroups=video

--- a/app/camera/scripts/camera-ota-installer.sh
+++ b/app/camera/scripts/camera-ota-installer.sh
@@ -12,11 +12,11 @@
 # This script is the privileged half of the OTA pipeline:
 #
 #   1. camera-streamer (user=camera) stages the bundle at
-#      /var/lib/camera-ota/staging/update.swu
-#   2. camera-streamer writes /var/lib/camera-ota/trigger
+#      /data/ota/camera-spool/staging/update.swu
+#   2. camera-streamer writes /data/ota/camera-spool/trigger
 #   3. camera-ota-installer.path detects the trigger
 #   4. camera-ota-installer.service runs THIS script as root
-#   5. Progress is reported back via /var/lib/camera-ota/status.json
+#   5. Progress is reported back via /data/ota/camera-spool/status.json
 #
 # State file format (status.json):
 #   {"state": "idle|verifying|installing|installed|error",
@@ -33,8 +33,9 @@ set -eu
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
-SPOOL=/var/lib/camera-ota
+SPOOL=${CAMERA_OTA_SPOOL_DIR:-/data/ota/camera-spool}
 STAGING="$SPOOL/staging"
+OTA_TMP="$SPOOL/tmp"
 TRIGGER="$SPOOL/trigger"
 STATUS="$SPOOL/status.json"
 LOG="$SPOOL/install.log"
@@ -44,7 +45,7 @@ LEDCTL=/usr/bin/home-monitor-ledctl
 AUTO_REBOOT=0
 
 log() {
-    printf '%s %s\n' "$(date -Iseconds)" "$*" | tee -a "$LOG"
+    printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "$LOG"
 }
 
 set_led() {
@@ -117,6 +118,13 @@ cleanup() {
     fi
 }
 trap cleanup EXIT
+
+# Ensure the persistent /data-backed spool exists even on older images
+# whose tmpfiles rules created the legacy /var/lib path.
+mkdir -p "$STAGING" "$OTA_TMP"
+chown camera:camera "$SPOOL" "$STAGING" "$OTA_TMP" 2>/dev/null || true
+chmod 2775 "$SPOOL" "$STAGING" "$OTA_TMP" 2>/dev/null || true
+export TMPDIR="$OTA_TMP"
 
 # Path unit fires on trigger creation. If trigger is missing (race
 # with a previous run), nothing to do.
@@ -192,7 +200,7 @@ fi
 # Zeroing the superblock guarantees the post-swupdate mount is of
 # the NEW filesystem, not the ghost of a broken one.
 log "Zeroing standby partition superblock to clear any stale FS"
-dd if=/dev/zero of="$STANDBY" bs=1M count=16 status=none 2>&1 | tee -a "$LOG" || true
+dd if=/dev/zero of="$STANDBY" bs=1048576 count=16 2>&1 | tee -a "$LOG" || true
 sync
 
 # Phase 1: verify signature (if a key is available).

--- a/app/camera/tests/integration/test_ota_agent.py
+++ b/app/camera/tests/integration/test_ota_agent.py
@@ -30,7 +30,7 @@ def config(tmp_path):
 @pytest.fixture
 def spool(tmp_path, monkeypatch):
     """Redirect the installer spool to a tmp dir so tests don't touch
-    /var/lib/camera-ota."""
+    the production /data OTA spool."""
     spool_dir = tmp_path / "spool"
     staging = spool_dir / "staging"
     staging.mkdir(parents=True)

--- a/app/camera/tests/unit/test_systemd_hardening.py
+++ b/app/camera/tests/unit/test_systemd_hardening.py
@@ -3,20 +3,19 @@
 
 Filed in response to a 1.4.0 → 1.4.1 OTA blocker on three cameras
 stuck on 1.3.0. Their `camera-streamer.service` shipped with
-``ProtectSystem=strict`` and ``ReadWritePaths=/data`` only — no
-``/var/lib/camera-ota`` — which made the systemd namespace see the
-OTA spool directory as read-only even though the underlying
-filesystem was rw. The dashboard's `/api/ota/upload` handler then
-failed every upload with::
+``ProtectSystem=strict`` and a writable-path list that did not match
+the OTA spool, which made the systemd namespace see the spool
+directory as read-only even though the underlying filesystem was rw.
+The dashboard's `/api/ota/upload` handler then failed every upload with::
 
     {"error": "Write failed: [Errno 30] Read-only file system:
-              '/var/lib/camera-ota/staging/update.swu.partial'"}
+              '/data/ota/camera-spool/staging/update.swu.partial'"}
 
 The fix is one line in the unit. The CHALLENGE is preventing the
-class of regression from coming back: a future PR could quietly
-remove ``/var/lib/camera-ota`` from ``ReadWritePaths``, or move the
-spool dir, and the only surface that would catch it is hardware
-verification — which is too late.
+class of regression from coming back: a future PR could quietly move
+the spool dir outside ``/data`` while leaving ``ReadWritePaths`` behind,
+and the only surface that would catch it is hardware verification —
+which is too late.
 
 This test parses ``app/camera/config/camera-streamer.service`` at
 build time and asserts the hardening directives MATCH the set of
@@ -62,12 +61,6 @@ REQUIRED_WRITABLE_PATHS: dict[str, str] = {
         "camera_streamer.factory_reset, recordings, certs, motion log, "
         "wifi profiles. Persists across A/B OTA. The most fundamental "
         "writable path; without this nothing works."
-    ),
-    "/var/lib/camera-ota": (
-        "USED BY: camera_streamer.ota_installer, status_server's "
-        "/api/ota/upload handler, camera-ota-installer.service spool. "
-        "Hosts the trigger file, staged bundle, install status JSON. "
-        "Missing this → 1.3.0 OTA-stuck regression — see CHANGELOG 1.4.2."
     ),
 }
 

--- a/app/server/monitor/services/ota_service.py
+++ b/app/server/monitor/services/ota_service.py
@@ -178,8 +178,18 @@ class OTAService:
         return os.path.join(self.ota_dir, "staging")
 
     @property
+    def swupdate_tmp_dir(self):
+        return os.path.join(self.ota_dir, "tmp")
+
+    @property
     def camera_staging_dir(self):
         return os.path.join(self.ota_dir, "camera-library")
+
+    def _swupdate_env(self):
+        os.makedirs(self.swupdate_tmp_dir, exist_ok=True)
+        env = os.environ.copy()
+        env["TMPDIR"] = self.swupdate_tmp_dir
+        return env
 
     def ensure_storage(self):
         """Create and repair OTA storage directories.
@@ -214,13 +224,19 @@ class OTAService:
         try:
             os.makedirs(self.inbox_dir, exist_ok=True)
             os.makedirs(self.staging_dir, exist_ok=True)
+            os.makedirs(self.swupdate_tmp_dir, exist_ok=True)
             os.makedirs(self.camera_staging_dir, exist_ok=True)
             return ""
         except OSError as exc:
             return str(exc)
 
     def _probe_storage_writable(self):
-        for directory in (self.inbox_dir, self.staging_dir, self.camera_staging_dir):
+        for directory in (
+            self.inbox_dir,
+            self.staging_dir,
+            self.swupdate_tmp_dir,
+            self.camera_staging_dir,
+        ):
             err = self._probe_directory_writable(directory)
             if err:
                 return err
@@ -568,6 +584,7 @@ class OTAService:
                     capture_output=True,
                     text=True,
                     timeout=60,
+                    env=self._swupdate_env(),
                 )
                 returncode = result.returncode
                 stderr = result.stderr
@@ -659,6 +676,7 @@ class OTAService:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
+                    env=self._swupdate_env(),
                 )
                 try:
                     _stdout, stderr = proc.communicate(timeout=600)

--- a/app/server/monitor/services/privileged_helper.py
+++ b/app/server/monitor/services/privileged_helper.py
@@ -98,6 +98,7 @@ def _run_command(
     *,
     timeout: int = 30,
     nonzero_ok: bool = False,
+    env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     try:
         result = subprocess.run(
@@ -106,6 +107,7 @@ def _run_command(
             text=True,
             timeout=timeout,
             check=False,
+            env=env,
         )
     except FileNotFoundError as exc:
         raise HelperRequestError(f"{cmd[0]} not found") from exc
@@ -374,7 +376,7 @@ def _op_ota_verify(payload: dict[str, Any]) -> dict[str, Any]:
     public_key = _validate_ota_public_key_path(payload.get("public_key_path"))
     if public_key:
         cmd.extend(["-k", public_key])
-    return _run_command(cmd, timeout=60, nonzero_ok=True)
+    return _run_command(cmd, timeout=60, nonzero_ok=True, env=_swupdate_env())
 
 
 def _op_ota_install(payload: dict[str, Any]) -> dict[str, Any]:
@@ -382,7 +384,29 @@ def _op_ota_install(payload: dict[str, Any]) -> dict[str, Any]:
     public_key = _validate_ota_public_key_path(payload.get("public_key_path"))
     if public_key:
         cmd.extend(["-k", public_key])
-    return _run_command(cmd, timeout=600, nonzero_ok=True)
+    return _run_command(cmd, timeout=600, nonzero_ok=True, env=_swupdate_env())
+
+
+def _swupdate_env() -> dict[str, str]:
+    tmpdir = posixpath.join(OTA_DIR, "tmp")
+    _ensure_monitor_owned_dir(OTA_DIR)
+    _ensure_monitor_owned_dir(tmpdir)
+    env = os.environ.copy()
+    env["TMPDIR"] = tmpdir
+    return env
+
+
+def _ensure_monitor_owned_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+    if pwd is None or grp is None:
+        return
+    try:
+        uid = pwd.getpwnam("monitor").pw_uid
+        gid = grp.getgrnam("monitor").gr_gid
+        os.chown(path, uid, gid)
+        os.chmod(path, 0o755)
+    except (KeyError, PermissionError, OSError) as exc:
+        raise HelperRequestError(f"OTA temp directory repair failed: {exc}") from exc
 
 
 def _op_ota_repair_storage(payload: dict[str, Any]) -> dict[str, Any]:
@@ -397,6 +421,7 @@ def _op_ota_repair_storage(payload: dict[str, Any]) -> dict[str, Any]:
         gid = grp.getgrnam("monitor").gr_gid
         os.makedirs(posixpath.join(OTA_DIR, "inbox"), exist_ok=True)
         os.makedirs(posixpath.join(OTA_DIR, "staging"), exist_ok=True)
+        os.makedirs(posixpath.join(OTA_DIR, "tmp"), exist_ok=True)
         os.makedirs(posixpath.join(OTA_DIR, "camera-library"), exist_ok=True)
 
         for root, dirs, files in os.walk(

--- a/app/server/tests/unit/test_privileged_helper.py
+++ b/app/server/tests/unit/test_privileged_helper.py
@@ -451,7 +451,10 @@ def test_ota_verify_without_public_key_omits_key_argument():
     request = (
         b'{"operation":"ota.verify","payload":{"bundle_path":"/data/ota/update.swu"}}'
     )
-    with patch.object(helper, "_run_command", return_value={"returncode": 0}) as run:
+    with (
+        patch.object(helper, "_swupdate_env", return_value={"TMPDIR": "/data/ota/tmp"}),
+        patch.object(helper, "_run_command", return_value={"returncode": 0}) as run,
+    ):
         data = helper.handle_request(request)
 
     assert data == {"returncode": 0}
@@ -459,6 +462,7 @@ def test_ota_verify_without_public_key_omits_key_argument():
         ["swupdate", "-c", "-i", "/data/ota/update.swu"],
         timeout=60,
         nonzero_ok=True,
+        env={"TMPDIR": "/data/ota/tmp"},
     )
 
 
@@ -468,7 +472,10 @@ def test_ota_verify_accepts_production_public_key():
         b'{"bundle_path":"/data/ota/update.swu",'
         b'"public_key_path":"/etc/swupdate-public.crt"}}'
     )
-    with patch.object(helper, "_run_command", return_value={"returncode": 0}) as run:
+    with (
+        patch.object(helper, "_swupdate_env", return_value={"TMPDIR": "/data/ota/tmp"}),
+        patch.object(helper, "_run_command", return_value={"returncode": 0}) as run,
+    ):
         data = helper.handle_request(request)
 
     assert data == {"returncode": 0}
@@ -483,6 +490,7 @@ def test_ota_verify_accepts_production_public_key():
         ],
         timeout=60,
         nonzero_ok=True,
+        env={"TMPDIR": "/data/ota/tmp"},
     )
 
 
@@ -492,7 +500,10 @@ def test_ota_install_accepts_production_public_key():
         b'{"bundle_path":"/data/ota/update.swu",'
         b'"public_key_path":"/etc/swupdate-public.crt"}}'
     )
-    with patch.object(helper, "_run_command", return_value={"returncode": 0}) as run:
+    with (
+        patch.object(helper, "_swupdate_env", return_value={"TMPDIR": "/data/ota/tmp"}),
+        patch.object(helper, "_run_command", return_value={"returncode": 0}) as run,
+    ):
         data = helper.handle_request(request)
 
     assert data == {"returncode": 0}
@@ -506,7 +517,33 @@ def test_ota_install_accepts_production_public_key():
         ],
         timeout=600,
         nonzero_ok=True,
+        env={"TMPDIR": "/data/ota/tmp"},
     )
+
+
+def test_swupdate_env_keeps_root_created_tmp_writable_by_monitor(monkeypatch):
+    fake_pwd = MagicMock()
+    fake_pwd.getpwnam.return_value.pw_uid = 996
+    fake_grp = MagicMock()
+    fake_grp.getgrnam.return_value.gr_gid = 994
+    monkeypatch.setattr(helper, "pwd", fake_pwd)
+    monkeypatch.setattr(helper, "grp", fake_grp)
+    monkeypatch.setattr(helper, "OTA_DIR", "/data/ota")
+
+    with (
+        patch.object(helper.os, "makedirs") as makedirs,
+        patch.object(helper.os, "chown", create=True) as chown,
+        patch.object(helper.os, "chmod") as chmod,
+    ):
+        env = helper._swupdate_env()
+
+    assert env["TMPDIR"] == "/data/ota/tmp"
+    makedirs.assert_any_call("/data/ota", exist_ok=True)
+    makedirs.assert_any_call("/data/ota/tmp", exist_ok=True)
+    chown.assert_any_call("/data/ota", 996, 994)
+    chown.assert_any_call("/data/ota/tmp", 996, 994)
+    chmod.assert_any_call("/data/ota", 0o755)
+    chmod.assert_any_call("/data/ota/tmp", 0o755)
 
 
 def test_ota_repair_storage_repairs_allowlisted_tree(monkeypatch):
@@ -543,6 +580,7 @@ def test_ota_repair_storage_repairs_allowlisted_tree(monkeypatch):
     assert data == {"path": "/data/ota"}
     makedirs.assert_any_call("/data/ota/inbox", exist_ok=True)
     makedirs.assert_any_call("/data/ota/staging", exist_ok=True)
+    makedirs.assert_any_call("/data/ota/tmp", exist_ok=True)
     makedirs.assert_any_call("/data/ota/camera-library", exist_ok=True)
     chown.assert_any_call("/data/ota", 996, 994)
     chown.assert_any_call("/data/ota/inbox/camera.swu", 996, 994)

--- a/app/server/tests/unit/test_svc_ota.py
+++ b/app/server/tests/unit/test_svc_ota.py
@@ -404,6 +404,9 @@ class TestVerifyBundle:
         valid, err = svc.verify_bundle(bundle)
         assert valid is False
         assert "bad signature" in err
+        assert mock_run.call_args.kwargs["env"]["TMPDIR"] == os.path.join(
+            data_dir, "ota", "tmp"
+        )
 
     @patch("monitor.services.ota_service.subprocess.run")
     def test_swupdate_not_found(self, mock_run, svc, data_dir):
@@ -535,6 +538,9 @@ class TestInstallBundle:
             "-k",
             key,
         ]
+        assert mock_popen.call_args.kwargs["env"]["TMPDIR"] == os.path.join(
+            data_dir, "ota", "tmp"
+        )
 
     @patch("monitor.services.ota_service.subprocess.Popen")
     def test_install_failure(self, mock_popen, svc, data_dir):
@@ -556,6 +562,9 @@ class TestInstallBundle:
             "-k",
             key,
         ]
+        assert mock_popen.call_args.kwargs["env"]["TMPDIR"] == os.path.join(
+            data_dir, "ota", "tmp"
+        )
 
     @patch("monitor.services.ota_service.subprocess.Popen")
     def test_install_without_key_uses_plain_command(self, mock_popen, svc, data_dir):
@@ -568,6 +577,9 @@ class TestInstallBundle:
         assert ok is True
         assert err == ""
         assert mock_popen.call_args[0][0] == ["swupdate", "-i", bundle]
+        assert mock_popen.call_args.kwargs["env"]["TMPDIR"] == os.path.join(
+            data_dir, "ota", "tmp"
+        )
 
     @patch("monitor.services.ota_service.subprocess.Popen")
     def test_install_swupdate_not_found(self, mock_popen, svc, data_dir):

--- a/app/server/tests/unit/test_swu_storage_design.py
+++ b/app/server/tests/unit/test_swu_storage_design.py
@@ -1,0 +1,75 @@
+# REQ: SWR-010, SWR-038, SWR-046; RISK: RISK-004, RISK-018, RISK-019; SEC: SC-003; TEST: TC-013, TC-036, TC-044
+"""Static guards for OTA storage and SWUpdate streaming design."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_swu_rootfs_images_stream_directly_to_inactive_slot():
+    """Rootfs payloads must not be extracted into /tmp before flashing."""
+
+    for template in (
+        REPO_ROOT / "swupdate" / "sw-description.server",
+        REPO_ROOT / "swupdate" / "sw-description.camera",
+    ):
+        text = template.read_text(encoding="utf-8")
+        assert 'filename = "rootfs.ext4.gz";' in text
+        assert 'type = "raw";' in text
+        assert 'device = "/dev/monitor_standby";' in text
+        assert "installed-directly = true;" in text
+
+    build_script = (REPO_ROOT / "scripts" / "build-swu.sh").read_text(encoding="utf-8")
+    assert "installed-directly" in build_script
+
+
+def test_camera_ota_spool_is_data_backed():
+    """Camera uploads must land on persistent /data, not rootfs or tmpfs."""
+
+    expected = "/data/ota/camera-spool"
+    files = (
+        REPO_ROOT / "app" / "camera" / "camera_streamer" / "ota_installer.py",
+        REPO_ROOT / "app" / "camera" / "scripts" / "camera-ota-installer.sh",
+        REPO_ROOT / "app" / "camera" / "config" / "camera-ota-installer.path",
+        REPO_ROOT / "app" / "camera" / "config" / "camera-ota-installer.service",
+        REPO_ROOT / "app" / "camera" / "config" / "camera-ota-tmpfiles.conf",
+    )
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        assert expected in text
+        assert "/var/lib/camera-ota" not in text
+
+
+def test_camera_installer_is_busybox_safe_and_uses_data_tmpdir():
+    text = (
+        REPO_ROOT / "app" / "camera" / "scripts" / "camera-ota-installer.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "date -Iseconds" not in text
+    assert "status=none" not in text
+    assert 'export TMPDIR="$OTA_TMP"' in text
+    assert "SPOOL=${CAMERA_OTA_SPOOL_DIR:-/data/ota/camera-spool}" in text
+    assert 'OTA_TMP="$SPOOL/tmp"' in text
+
+
+def test_partition_growth_has_findmnt_fallbacks():
+    for script in (
+        REPO_ROOT
+        / "meta-home-monitor"
+        / "recipes-core"
+        / "first-boot"
+        / "files"
+        / "first-boot-setup.sh",
+        REPO_ROOT
+        / "meta-home-monitor"
+        / "recipes-support"
+        / "swupdate"
+        / "files"
+        / "swupdate-check.sh",
+    ):
+        text = script.read_text(encoding="utf-8")
+        assert "mount_source()" in text
+        assert "/proc/mounts" in text
+        assert "findmnt -n -o SOURCE" in text

--- a/docs/ai/execution-rules.md
+++ b/docs/ai/execution-rules.md
@@ -209,11 +209,10 @@ service unit:
    "Sensitive-Area Rules" section above: trust boundaries shifting (which
    is what a systemd namespace is) require explicit review.
 
-Why this matters: 1.4.0 cameras stuck on a 1.3.0 hardening regression
-(`ReadWritePaths=/data` only, omitting `/var/lib/camera-ota`) couldn't OTA
-out via the user-facing path — every upload failed with EROFS even though
-`/var/lib/camera-ota` was writable on the underlying ext4. Recovery
-required a manual systemd drop-in over SSH followed by an unsigned
-migration SWU build, all because a single-line miss in a `ReadWritePaths=`
-escaped review and the build pipeline. The static test in 1.4.2 prevents
-that class of regression. See CHANGELOG `[1.4.2]`.
+Why this matters: 1.4.0 cameras stuck on a 1.3.0 hardening regression where
+the OTA spool and `ReadWritePaths=` disagreed. Every upload failed with
+EROFS even though the underlying storage was writable. Recovery required a
+manual systemd drop-in over SSH followed by an unsigned migration SWU build,
+all because a single-line miss in a `ReadWritePaths=` escaped review and
+the build pipeline. The static test in 1.4.2 prevents that class of
+regression. See CHANGELOG `[1.4.2]`.

--- a/docs/architecture/versioning.md
+++ b/docs/architecture/versioning.md
@@ -175,7 +175,7 @@ $ ./scripts/release.sh build 1.5.0     # on the build host
 
 ### OTA install (on-device)
 
-The existing `/var/lib/camera-ota/post-update.sh` (server side) and equivalent on camera get a tiny extension:
+The existing SWUpdate post-update script (server side) and equivalent on camera get a tiny extension:
 
 ```sh
 # After successful slot write, before reboot, write the new version

--- a/docs/history/adr/0008-swupdate-ab-rollback.md
+++ b/docs/history/adr/0008-swupdate-ab-rollback.md
@@ -30,9 +30,9 @@ Both devices use 64 GB SD cards with the following layout:
 | boot | 512 MB | vfat | U-Boot, kernel, DTBs, config.txt, U-Boot env |
 | rootfsA | 8 GB | ext4 | Active root filesystem |
 | rootfsB | 8 GB | ext4 | Standby (OTA target) |
-| data | ~47 GB (`--grow`) | ext4 (LUKS in prod) | Recordings, config, certs, logs, updates |
+| data | ~47 GB (`--grow`) | ext4 (LUKS in prod) | Recordings, config, certs, logs, OTA staging/tmp |
 
-Rootfs images are built at content size (~600 MB server, ~400 MB camera) and expanded via `resize2fs` on first boot. OTA `.swu` bundles contain the compact image, not the full 8 GB.
+Rootfs images are built at content size (~600 MB server, ~400 MB camera) and expanded via `resize2fs` on first boot and after OTA activation. OTA `.swu` bundles contain the compact image, not the full 8 GB. Rootfs artifacts are marked `installed-directly = true` so SWUpdate streams them into the inactive slot instead of first extracting them into `/tmp`; this is mandatory on the camera because `/tmp` is RAM-backed and much smaller than the SD card.
 
 ### Design goals
 1. An update engine that writes to the inactive partition without touching the running system.
@@ -118,7 +118,7 @@ hm-server-pi4-full-2.1.0.swu
 
 Camera: `hm-camera-zero2w-full-0.9.0.swu` (~80-100 MB compressed).
 
-The rootfs image is built at content size. After SWUpdate writes it to the inactive slot, a first-boot service runs `resize2fs` to fill the 8 GB partition.
+The rootfs image is built at content size. SWUpdate streams the compressed rootfs directly to the inactive slot. After the updated slot boots, `swupdate-check.service` runs `resize2fs` to fill the 8 GB partition.
 
 #### 2b. App-only bundle (`.tar.zst` + detached signature)
 
@@ -198,7 +198,7 @@ All delivery modes feed into the same directory structure:
 
 **Server and camera:**
 ```
-/data/update/
+/data/ota/
 ├── inbox/      # untrusted — raw uploads, USB copies, SCP drops, downloads
 ├── staging/    # verified — signature valid, metadata checked, installable
 └── history/    # audit trail — manifests, results, logs, rollback refs
@@ -226,7 +226,7 @@ For offline updates, field service, lab use.
 2. Server detects mount (udev rule)
 3. Scans one predictable path: /media/<label>/updates/manifest.json
 4. Dashboard shows available updates from manifest
-5. Admin selects → copy to /data/update/inbox/
+5. Admin selects → copy to /data/ota/inbox/
 6. Verification pipeline runs
 7. Never auto-installs on insert
 ```
@@ -254,7 +254,7 @@ Existing `POST /api/v1/ota/server/upload` enhanced:
 
 ```
 1. Admin uploads bundle via dashboard
-2. File saved to /data/update/inbox/
+2. File saved to /data/ota/inbox/
 3. Verification: signature → metadata → compatibility → space check
 4. Valid → moved to staging, dashboard shows "ready to install"
 5. Admin confirms → install begins
@@ -265,7 +265,7 @@ Existing `POST /api/v1/ota/server/upload` enhanced:
 ```
 1. Admin triggers from dashboard: POST /api/v1/ota/camera/<id>/push
 2. Server pushes bundle to camera OTA agent over mTLS (ADR-0009, port 8080)
-3. Camera saves to /data/update/inbox/ (47 GB available — plenty of room)
+3. Camera saves to `/data/ota/camera-spool/staging/update.swu`
 4. Camera verifies: signature, metadata, compatibility
 5. Moves to staging, installs from staging
 6. Reboot, U-Boot boots updated slot
@@ -276,7 +276,7 @@ Existing `POST /api/v1/ota/server/upload` enhanced:
 #### 6d. SSH/SCP developer push (dev builds only)
 
 ```
-1. Developer: scp bundle root@device:/data/update/inbox/
+1. Developer: scp bundle root@device:/data/ota/inbox/
 2. Update agent detects new file in inbox (inotify or polled)
 3. Same verification pipeline — no shortcuts
 4. Dev mode: can auto-trigger install after verification
@@ -303,7 +303,7 @@ Designed into the pipeline from day one. Implementation deferred.
 
 **Server self-update:**
 ```
- 1. Bundle arrives in /data/update/inbox/ (via any delivery mode)
+ 1. Bundle arrives in /data/ota/inbox/ (via any delivery mode)
  2. Verification:
     a. CMS signature on sw-description
     b. Metadata: target_device == server-pi4
@@ -311,9 +311,9 @@ Designed into the pipeline from day one. Implementation deferred.
     d. version > current AND version >= min_base_version
     e. channel matches device config
     f. Space check: /data free > 2 GB after staging
- 3. Move to /data/update/staging/
+ 3. Move to /data/ota/staging/
  4. Admin confirms install (auto in dev mode)
- 5. swupdate -i /data/update/staging/<bundle>.swu -e stable,<inactive-slot>
+ 5. swupdate -i /data/ota/staging/<bundle>.swu -e stable,<inactive-slot>
     - SWUpdate verifies hashes, streams rootfs image to inactive partition
     - No intermediate unpack — handler writes directly to block device
  6. fw_setenv upgrade_available 1
@@ -329,7 +329,7 @@ Designed into the pipeline from day one. Implementation deferred.
     - fw_setenv upgrade_available 0
     - fw_setenv boot_count 0
     - resize2fs /dev/mmcblk0p<N> (expand rootfs to fill 8 GB)
-    - Archive result to /data/update/history/
+    - Archive result to /data/ota/history/
     - Audit log: OTA_COMPLETED
 11. On FAILURE:
     - `swupdate-check.sh` leaves `upgrade_available=1` intact
@@ -344,9 +344,9 @@ Designed into the pipeline from day one. Implementation deferred.
 ```
  1. Admin triggers: POST /api/v1/ota/camera/<id>/push
  2. Server sends .swu to camera OTA agent over mTLS (port 8080)
- 3. Camera saves to /data/update/inbox/
+ 3. Camera saves to /data/ota/camera-spool/staging/update.swu
  4. Camera verifies: signature, metadata, compatibility
- 5. Moves to /data/update/staging/
+ 5. Installs from /data/ota/camera-spool/staging/
  6. swupdate writes rootfs to inactive slot
  7. fw_setenv upgrade_available 1, boot_count 0
  8. Reboot
@@ -425,7 +425,7 @@ No reboot. Rollback is instant (symlink swap + service restart).
 The `OTAAgent` class in `camera_streamer/ota_agent.py`:
 - HTTP server on port 8080 (nftables: server IP only)
 - Requires mTLS — verifies server cert against CA (ADR-0009)
-- `POST /update`: receives bundle, saves to `/data/update/inbox/`
+- `POST /update`: receives bundle, saves to `/data/ota/camera-spool/staging/update.swu`
 - `GET /update/status`: returns install state and progress
 - Same verification pipeline as all other delivery modes
 - Memory-safe: streams upload to disk, never loads full bundle into RAM

--- a/docs/history/adr/0020-dual-transport-ota.md
+++ b/docs/history/adr/0020-dual-transport-ota.md
@@ -120,12 +120,12 @@ as the `camera` user with `NoNewPrivileges=true`. SWUpdate needs root
 (`/dev/monitor_standby` symlink refresh, ext4 mount of the standby
 slot, `fw_setenv`), so `camera-streamer` cannot exec it directly.
 Implemented as a file-IPC protocol: camera-streamer stages the bundle
-at `/var/lib/camera-ota/staging/update.swu` and writes
-`/var/lib/camera-ota/trigger`. A systemd `.path` unit
+at `/data/ota/camera-spool/staging/update.swu` and writes
+`/data/ota/camera-spool/trigger`. A systemd `.path` unit
 (`camera-ota-installer.path`) watches the trigger and fires the
 root-owned `camera-ota-installer.service` oneshot, which is the only
 place `swupdate -i` runs on the camera. Status and progress flow back
-through `status.json` in the same spool. Alternative A from the
+through `status.json` in the same `/data`-backed spool. Alternative A from the
 original ADR (camera-direct upload on :443) also uses this protocol —
 the upload handler stages and triggers, then returns immediately.
 

--- a/docs/history/baseline/architecture.md
+++ b/docs/history/baseline/architecture.md
@@ -669,23 +669,25 @@ unprivileged user with `NoNewPrivileges=true`, so it cannot exec
 
 ```
 camera-streamer (user=camera)
-  ├─ writes bundle → /var/lib/camera-ota/staging/update.swu
-  └─ writes trigger → /var/lib/camera-ota/trigger
+  ├─ writes bundle → /data/ota/camera-spool/staging/update.swu
+  └─ writes trigger → /data/ota/camera-spool/trigger
                               │
           systemd camera-ota-installer.path fires
                               ▼
 camera-ota-installer.service (root, oneshot)
   ├─ refreshes /dev/monitor_standby from fw_printenv boot_slot
   ├─ swupdate -c (signature verify) + swupdate -i (install)
-  └─ writes progress → /var/lib/camera-ota/status.json
+  └─ writes progress → /data/ota/camera-spool/status.json
                               │
                               ▼
 camera-streamer proxies status.json back to browser / to server poll.
 ```
 
-The spool directory is `2775 root:camera` (setgid on group `camera`) so
-the unprivileged streamer can stage bundles and write triggers without
-privilege escalation.
+The spool directory is `2775 camera:camera` (setgid on group `camera`) under
+`/data` so the unprivileged streamer can stage bundles and write triggers
+without privilege escalation while avoiding rootfs and RAM-backed `/tmp`
+pressure. The root installer treats the staged bundle as untrusted and verifies
+the SWUpdate signature before writing either A/B slot.
 
 **Upload handshake is async on both camera paths.** Path B and Path C
 both return HTTP 202 as soon as the trigger file is written — they do

--- a/docs/history/specs/160-motion-mode-pre-roll.md
+++ b/docs/history/specs/160-motion-mode-pre-roll.md
@@ -78,7 +78,7 @@ Existing code this change builds on, not replaces.
   (`MOTION_PREROLL_ENABLED`, `MOTION_PREROLL_SECONDS`). Same
   `DEFAULTS` pattern as every other camera config knob.
 - `app/camera/config/camera-streamer.service:39` —
-  `ReadWritePaths=/data /var/lib/camera-ota`. The merged clip
+  `ReadWritePaths=/data`. The merged clip
   writes under `/data` (camera-local recordings staging dir), so
   no new path needs to be added. The existing systemd-hardening
   unit test (`app/camera/tests/unit/test_systemd_hardening.py`)

--- a/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
+++ b/meta-home-monitor/recipes-camera/camera-streamer/camera-streamer_1.0.bb
@@ -109,7 +109,7 @@ do_install() {
     install -m 0644 ${WORKDIR}/config/camera-ota-installer.path ${D}${systemd_system_unitdir}/camera-ota-installer.path
     install -m 0644 ${WORKDIR}/status_led/home-monitor-led-init.service ${D}${systemd_system_unitdir}/home-monitor-led-init.service
 
-    # tmpfiles.d rule that creates the /var/lib/camera-ota spool
+    # tmpfiles.d rule that creates the /data-backed camera OTA spool
     install -d ${D}${sysconfdir}/tmpfiles.d
     install -m 0644 ${WORKDIR}/config/camera-ota-tmpfiles.conf ${D}${sysconfdir}/tmpfiles.d/camera-ota.conf
 

--- a/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
+++ b/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh
@@ -11,6 +11,50 @@ set -e
 
 STAMP="/data/.first-boot-done"
 
+mount_source() {
+    target="$1"
+    if command -v findmnt >/dev/null 2>&1; then
+        found=$(findmnt -n -o SOURCE "$target" 2>/dev/null || true)
+        if [ -n "$found" ]; then
+            echo "$found"
+            return 0
+        fi
+    fi
+    awk -v target="$target" '$2 == target { print $1; exit }' /proc/mounts
+}
+
+split_partition_device() {
+    PART_DISK=""
+    PART_NUM=""
+    dev="$1"
+    case "$dev" in
+        /dev/mmcblk*p[0-9]*)
+            PART_DISK=$(echo "$dev" | sed 's/p[0-9][0-9]*$//')
+            PART_NUM=$(echo "$dev" | sed 's/^.*p//')
+            ;;
+        /dev/[sv]d*[0-9]*)
+            PART_DISK=$(echo "$dev" | sed 's/[0-9][0-9]*$//')
+            PART_NUM=$(echo "$dev" | sed 's/^.*[^0-9]//')
+            ;;
+    esac
+}
+
+grow_partition_to_end() {
+    disk="$1"
+    partnum="$2"
+    if [ -z "$disk" ] || [ -z "$partnum" ]; then
+        return 0
+    fi
+    if command -v growpart >/dev/null 2>&1; then
+        growpart "$disk" "$partnum" || true
+    elif command -v parted >/dev/null 2>&1; then
+        # GNU parted asks for confirmation when resizing mounted partitions.
+        printf 'Yes\n' | parted ---pretend-input-tty "$disk" resizepart "$partnum" 100% || true
+    fi
+    partprobe "$disk" 2>/dev/null || true
+    blockdev --rereadpt "$disk" 2>/dev/null || true
+}
+
 if [ -f "$STAMP" ]; then
     echo "First boot setup already completed."
     exit 0
@@ -34,29 +78,32 @@ else
 fi
 
 # --- Expand data partition to fill SD card ---
-DATA_DEV=$(findmnt -n -o SOURCE /data 2>/dev/null || true)
+DATA_DEV=$(mount_source /data 2>/dev/null || true)
 if [ -n "$DATA_DEV" ]; then
-    # Get the disk and partition number (e.g., /dev/mmcblk0p4 -> /dev/mmcblk0, 4)
-    DISK=$(echo "$DATA_DEV" | sed 's/p[0-9]*$//')
-    PARTNUM=$(echo "$DATA_DEV" | grep -o '[0-9]*$')
+    GROW_DEV="$DATA_DEV"
+    RESIZE_DEV="$DATA_DEV"
+    if echo "$DATA_DEV" | grep -q '^/dev/mapper/' && command -v cryptsetup >/dev/null 2>&1; then
+        MAP_NAME=$(basename "$DATA_DEV")
+        BACKING_DEV=$(cryptsetup status "$MAP_NAME" 2>/dev/null | awk '/device:/ { print $2; exit }')
+        if [ -n "$BACKING_DEV" ]; then
+            GROW_DEV="$BACKING_DEV"
+        fi
+    fi
 
-    if [ -n "$DISK" ] && [ -n "$PARTNUM" ]; then
-        echo "Expanding data partition ${DATA_DEV} (${DISK} part ${PARTNUM})..."
+    split_partition_device "$GROW_DEV"
+    if [ -n "$PART_DISK" ] && [ -n "$PART_NUM" ]; then
+        echo "Expanding data partition ${GROW_DEV} (${PART_DISK} part ${PART_NUM})..."
 
-        # Grow partition to fill remaining disk space
-        if command -v growpart >/dev/null 2>&1; then
-            growpart "$DISK" "$PARTNUM" || true
-        elif command -v parted >/dev/null 2>&1; then
-            # parted -s won't auto-confirm on mounted partitions;
-            # pipe Yes to ---pretend-input-tty to handle the prompt.
-            echo Yes | parted ---pretend-input-tty "$DISK" resizepart "$PARTNUM" 100% || true
-            partprobe "$DISK" 2>/dev/null || true
+        grow_partition_to_end "$PART_DISK" "$PART_NUM"
+
+        if echo "$DATA_DEV" | grep -q '^/dev/mapper/' && command -v cryptsetup >/dev/null 2>&1; then
+            cryptsetup resize "$MAP_NAME" 2>/dev/null || true
         fi
 
         # Resize filesystem to match partition
         if command -v resize2fs >/dev/null 2>&1; then
-            resize2fs "$DATA_DEV" 2>/dev/null || true
-            NEW_SIZE=$(df -h "$DATA_DEV" 2>/dev/null | tail -1 | awk '{print $2}')
+            resize2fs "$RESIZE_DEV" 2>/dev/null || true
+            NEW_SIZE=$(df -h /data 2>/dev/null | tail -1 | awk '{print $2}')
             echo "Data partition expanded to ${NEW_SIZE}"
         fi
     fi

--- a/meta-home-monitor/recipes-core/first-boot/files/luks-first-boot.sh
+++ b/meta-home-monitor/recipes-core/first-boot/files/luks-first-boot.sh
@@ -68,6 +68,38 @@ log() {
     echo "luks-first-boot: $1"
 }
 
+split_partition_device() {
+    PART_DISK=""
+    PART_NUM=""
+    dev="$1"
+    case "$dev" in
+        /dev/mmcblk*p[0-9]*)
+            PART_DISK=$(echo "$dev" | sed 's/p[0-9][0-9]*$//')
+            PART_NUM=$(echo "$dev" | sed 's/^.*p//')
+            ;;
+        /dev/[sv]d*[0-9]*)
+            PART_DISK=$(echo "$dev" | sed 's/[0-9][0-9]*$//')
+            PART_NUM=$(echo "$dev" | sed 's/^.*[^0-9]//')
+            ;;
+    esac
+}
+
+grow_raw_data_partition() {
+    split_partition_device "$DATA_DEV"
+    if [ -z "$PART_DISK" ] || [ -z "$PART_NUM" ]; then
+        log "Could not parse data partition device $DATA_DEV; leaving size unchanged"
+        return 0
+    fi
+    log "Expanding raw data partition $DATA_DEV (${PART_DISK} part ${PART_NUM})"
+    if command -v growpart >/dev/null 2>&1; then
+        growpart "$PART_DISK" "$PART_NUM" || true
+    elif command -v parted >/dev/null 2>&1; then
+        printf 'Yes\n' | parted ---pretend-input-tty "$PART_DISK" resizepart "$PART_NUM" 100% || true
+    fi
+    partprobe "$PART_DISK" 2>/dev/null || true
+    blockdev --rereadpt "$PART_DISK" 2>/dev/null || true
+}
+
 # --- Detect device type ---
 is_server() {
     # Server has monitor-server package installed
@@ -79,6 +111,8 @@ is_camera() {
     [ -f /opt/camera/camera_streamer/__init__.py ] || \
     systemctl list-unit-files camera-streamer.service >/dev/null 2>&1
 }
+
+grow_raw_data_partition
 
 # --- Check if already LUKS-formatted ---
 if cryptsetup isLuks "$DATA_DEV" 2>/dev/null; then
@@ -101,6 +135,8 @@ if cryptsetup isLuks "$DATA_DEV" 2>/dev/null; then
         mount /dev/mapper/"$DM_NAME" "$MOUNT_POINT"
         log "Mounted encrypted /data"
     fi
+    cryptsetup resize "$DM_NAME" 2>/dev/null || true
+    resize2fs /dev/mapper/"$DM_NAME" 2>/dev/null || true
     led_off
     exit 0
 fi

--- a/meta-home-monitor/recipes-support/swupdate/files/swupdate-check.sh
+++ b/meta-home-monitor/recipes-support/swupdate/files/swupdate-check.sh
@@ -22,6 +22,60 @@ log() {
     echo "$LOG_TAG: $1"
 }
 
+mount_source() {
+    target="$1"
+    if command -v findmnt >/dev/null 2>&1; then
+        found=$(findmnt -n -o SOURCE "$target" 2>/dev/null || true)
+        if [ -n "$found" ]; then
+            echo "$found"
+            return 0
+        fi
+    fi
+    awk -v target="$target" '$2 == target { print $1; exit }' /proc/mounts
+}
+
+cmdline_root_device() {
+    for arg in $(cat /proc/cmdline 2>/dev/null); do
+        case "$arg" in
+            root=/dev/*)
+                echo "${arg#root=}"
+                return 0
+                ;;
+        esac
+    done
+}
+
+split_partition_device() {
+    PART_DISK=""
+    PART_NUM=""
+    dev="$1"
+    case "$dev" in
+        /dev/mmcblk*p[0-9]*)
+            PART_DISK=$(echo "$dev" | sed 's/p[0-9][0-9]*$//')
+            PART_NUM=$(echo "$dev" | sed 's/^.*p//')
+            ;;
+        /dev/[sv]d*[0-9]*)
+            PART_DISK=$(echo "$dev" | sed 's/[0-9][0-9]*$//')
+            PART_NUM=$(echo "$dev" | sed 's/^.*[^0-9]//')
+            ;;
+    esac
+}
+
+grow_partition_to_end() {
+    disk="$1"
+    partnum="$2"
+    if [ -z "$disk" ] || [ -z "$partnum" ]; then
+        return 0
+    fi
+    if command -v growpart >/dev/null 2>&1; then
+        growpart "$disk" "$partnum" || true
+    elif command -v parted >/dev/null 2>&1; then
+        printf 'Yes\n' | parted ---pretend-input-tty "$disk" resizepart "$partnum" 100% || true
+    fi
+    partprobe "$disk" 2>/dev/null || true
+    blockdev --rereadpt "$disk" 2>/dev/null || true
+}
+
 request_retry_reboot() {
     log "Requesting reboot so U-Boot can retry or roll back the failed OTA"
     sync || true
@@ -35,10 +89,47 @@ request_retry_reboot() {
 
 # --- Always expand rootfs to fill partition (idempotent) ---
 expand_rootfs() {
-    ROOT_DEV=$(findmnt -n -o SOURCE / 2>/dev/null || true)
+    ROOT_DEV=$(mount_source / 2>/dev/null || true)
+    if [ "$ROOT_DEV" = "/dev/root" ] || [ -z "$ROOT_DEV" ]; then
+        CMDLINE_ROOT=$(cmdline_root_device 2>/dev/null || true)
+        if [ -n "$CMDLINE_ROOT" ]; then
+            ROOT_DEV="$CMDLINE_ROOT"
+        fi
+    fi
     if [ -n "$ROOT_DEV" ]; then
         # resize2fs is a no-op if already at full size
         resize2fs "$ROOT_DEV" 2>/dev/null || true
+    fi
+}
+
+# --- Always expand /data to fill the SD card tail (idempotent) ---
+expand_data() {
+    DATA_DEV=$(mount_source /data 2>/dev/null || true)
+    if [ -z "$DATA_DEV" ]; then
+        return 0
+    fi
+
+    GROW_DEV="$DATA_DEV"
+    RESIZE_DEV="$DATA_DEV"
+    if echo "$DATA_DEV" | grep -q '^/dev/mapper/' && command -v cryptsetup >/dev/null 2>&1; then
+        MAP_NAME=$(basename "$DATA_DEV")
+        BACKING_DEV=$(cryptsetup status "$MAP_NAME" 2>/dev/null | awk '/device:/ { print $2; exit }')
+        if [ -n "$BACKING_DEV" ]; then
+            GROW_DEV="$BACKING_DEV"
+        fi
+    fi
+
+    split_partition_device "$GROW_DEV"
+    if [ -n "$PART_DISK" ] && [ -n "$PART_NUM" ]; then
+        grow_partition_to_end "$PART_DISK" "$PART_NUM"
+    fi
+
+    if echo "$DATA_DEV" | grep -q '^/dev/mapper/' && command -v cryptsetup >/dev/null 2>&1; then
+        cryptsetup resize "$MAP_NAME" 2>/dev/null || true
+    fi
+
+    if command -v resize2fs >/dev/null 2>&1; then
+        resize2fs "$RESIZE_DEV" 2>/dev/null || true
     fi
 }
 
@@ -137,6 +228,7 @@ log "Starting post-boot check (upgrade_available=${UPGRADE_AVAILABLE})"
 
 # Always expand rootfs
 expand_rootfs
+expand_data
 
 if [ "$UPGRADE_AVAILABLE" != "1" ]; then
     log "No pending upgrade — nothing to confirm"

--- a/scripts/build-swu.sh
+++ b/scripts/build-swu.sh
@@ -167,6 +167,12 @@ if grep -q '@@[A-Za-z0-9_]*@@' "$WORK_DIR/sw-description"; then
     grep -n '@@[A-Za-z0-9_]*@@' "$WORK_DIR/sw-description" >&2
     exit 1
 fi
+if ! grep -q 'installed-directly[[:space:]]*=[[:space:]]*true;' "$WORK_DIR/sw-description"; then
+    echo ""
+    echo "ABORT: rootfs image must declare installed-directly = true." >&2
+    echo "       Otherwise SWUpdate extracts rootfs.ext4.gz into /tmp before flashing." >&2
+    exit 1
+fi
 
 # 3. Sign sw-description if requested (CMS/PKCS7 for SWUpdate)
 if [ "$SIGN" = true ]; then

--- a/scripts/deploy-dev-app.sh
+++ b/scripts/deploy-dev-app.sh
@@ -179,6 +179,9 @@ deploy_server() {
     copy_file "$REPO_ROOT/app/shared/status_led/status_led.py" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/shared/status_led/home-monitor-ledctl" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/shared/status_led/home-monitor-led-init.service" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-support/swupdate/files/swupdate-check.sh" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-core/first-boot/files/luks-first-boot.sh" "$host" "$SERVER_STAGE"
 
     log "Installing server app into /opt/monitor"
     ssh "${SSH_OPTS[@]}" "$host" "
@@ -211,6 +214,10 @@ deploy_server() {
         mkdir -p /opt/monitor/scripts
         cp '$SERVER_STAGE/monitor-hotspot.sh' /opt/monitor/scripts/monitor-hotspot.sh
         chmod 0755 /opt/monitor/scripts/monitor-hotspot.sh
+        cp '$SERVER_STAGE/swupdate-check.sh' /opt/monitor/scripts/swupdate-check.sh
+        cp '$SERVER_STAGE/first-boot-setup.sh' /opt/monitor/scripts/first-boot-setup.sh
+        cp '$SERVER_STAGE/luks-first-boot.sh' /opt/monitor/scripts/luks-first-boot.sh
+        chmod 0755 /opt/monitor/scripts/swupdate-check.sh /opt/monitor/scripts/first-boot-setup.sh /opt/monitor/scripts/luks-first-boot.sh
         cp '$SERVER_STAGE/gpio-trigger.sh' /opt/scripts/gpio-trigger.sh
         chmod 0755 /opt/scripts/gpio-trigger.sh
         cp '$SERVER_STAGE/status_led.py' /opt/monitor/monitor/status_led.py
@@ -280,6 +287,9 @@ deploy_camera() {
     copy_file "$REPO_ROOT/app/shared/status_led/status_led.py" "$host" "$CAMERA_STAGE"
     copy_file "$REPO_ROOT/app/shared/status_led/home-monitor-ledctl" "$host" "$CAMERA_STAGE"
     copy_file "$REPO_ROOT/app/shared/status_led/home-monitor-led-init.service" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-support/swupdate/files/swupdate-check.sh" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-core/first-boot/files/luks-first-boot.sh" "$host" "$CAMERA_STAGE"
 
     log "Installing camera app into /opt/camera"
     ssh "${SSH_OPTS[@]}" "$host" "
@@ -303,6 +313,11 @@ deploy_camera() {
         chown -R camera:camera /opt/camera/camera_streamer/__pycache__ 2>/dev/null || true
         mkdir -p /opt/scripts
         mkdir -p /opt/camera/scripts
+        mkdir -p /opt/monitor/scripts
+        cp '$CAMERA_STAGE/swupdate-check.sh' /opt/monitor/scripts/swupdate-check.sh
+        cp '$CAMERA_STAGE/first-boot-setup.sh' /opt/monitor/scripts/first-boot-setup.sh
+        cp '$CAMERA_STAGE/luks-first-boot.sh' /opt/monitor/scripts/luks-first-boot.sh
+        chmod 0755 /opt/monitor/scripts/swupdate-check.sh /opt/monitor/scripts/first-boot-setup.sh /opt/monitor/scripts/luks-first-boot.sh
         cp '$CAMERA_STAGE/camera-hotspot.sh' /opt/camera/scripts/camera-hotspot.sh
         chmod 0755 /opt/camera/scripts/camera-hotspot.sh
         cp '$CAMERA_STAGE/gpio-trigger.sh' /opt/scripts/gpio-trigger.sh
@@ -321,7 +336,7 @@ deploy_camera() {
     ssh "${SSH_OPTS[@]}" "$host" "
         # Full unit file override from the repo. Keep this in sync with
         # app/camera/config/camera-streamer.service so hardening exceptions
-        # such as /var/lib/camera-ota cannot drift in the deploy path.
+        # and the /data-backed camera OTA spool cannot drift in deploys.
         cp '$CAMERA_STAGE/camera-streamer.service' /etc/systemd/system/camera-streamer.service
         cp '$CAMERA_STAGE/camera-privileged-helper.service' /etc/systemd/system/camera-privileged-helper.service
         cp '$CAMERA_STAGE/camera-hotspot.service' /etc/systemd/system/camera-hotspot.service
@@ -361,6 +376,8 @@ EOF
         fi
         systemctl daemon-reload
         systemctl enable home-monitor-led-init.service gpio-trigger.service camera-privileged-helper.service camera-hotspot.service camera-streamer.service camera-ota-installer.path >/dev/null 2>&1 || true
+        systemctl reset-failed camera-ota-installer.service >/dev/null 2>&1 || true
+        systemctl restart camera-ota-installer.path >/dev/null 2>&1 || true
     "
 
     if [ "$SKIP_RESTART" -eq 0 ]; then

--- a/swupdate/sw-description.camera
+++ b/swupdate/sw-description.camera
@@ -9,6 +9,7 @@ software =
                 type = "raw";
                 device = "/dev/monitor_standby";
                 compressed = "zlib";
+                installed-directly = true;
                 sha256 = "@@ROOTFS_SHA256@@";
             }
         );

--- a/swupdate/sw-description.server
+++ b/swupdate/sw-description.server
@@ -9,6 +9,7 @@ software =
                 type = "raw";
                 device = "/dev/monitor_standby";
                 compressed = "zlib";
+                installed-directly = true;
                 sha256 = "@@ROOTFS_SHA256@@";
             }
         );


### PR DESCRIPTION
﻿## What changed

- Move camera OTA spool, installer temp, and trigger/status files onto `/data/ota/camera-spool`.
- Set server SWUpdate `TMPDIR` to `/data/ota/tmp` in both the app service path and privileged helper path.
- Add `installed-directly = true` to server and camera SWUpdate descriptors, plus a build-time guard so rootfs payloads are streamed to the inactive slot instead of extracted into `/tmp`.
- Make first-boot and post-OTA partition growth work without `findmnt`, including `/dev/root` resolution and `/data` expansion on camera images.
- Update OTA docs/ADRs and add regression tests for the storage design.

## Root cause

Camera OTA updates were staging under the root filesystem and SWUpdate was extracting the compressed rootfs into `/tmp`. On the camera image, `/tmp` is a small tmpfs and `/data` had not expanded because the image scripts assumed `findmnt` existed. The update could write much of the inactive slot, then time out before activation.

## Validation

- Deployed dev app to server `192.168.1.245` and camera `192.168.1.186` with `scripts/deploy-dev-app.sh`.
- Verified live server services active and `/data/ota/tmp` owned by `monitor`.
- Verified live camera services active, `/data/ota/camera-spool` owned by `camera`, `/data` expanded to 37.7G, and `/tmp` clean.
- `python -m pytest app/server/tests/unit -q` -> 1600 passed, 1 skipped.
- `python -m pytest app/server/tests/unit/test_privileged_helper.py app/server/tests/unit/test_svc_ota.py app/server/tests/unit/test_swu_storage_design.py -q` -> 115 passed.
- `python -m pytest app/camera/tests/unit/test_ota_installer.py app/camera/tests/unit/test_systemd_hardening.py app/camera/tests/integration/test_ota_agent.py -q` -> 44 passed.
- `ruff check .` and `ruff format --check .` passed.
- `python -m pre_commit run --all-files` passed.
