### PR TITLE
[codex] Fix camera OTA confirmation and boot wait-online

### DIFF
--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -30,7 +30,7 @@ import urllib.error
 import urllib.request
 from datetime import UTC, datetime
 
-from camera_streamer import led
+from camera_streamer import led, ota_installer
 from camera_streamer.capture import CaptureManager
 from camera_streamer.control import (
     DEFAULT_STREAM_STATE_PATH,
@@ -732,6 +732,7 @@ class CameraLifecycle:
         self._health.start()
 
         led.connected()
+        ota_installer.reconcile_after_boot()
         if self._notifier is not None:
             self._notifier.mark_ready()
         log.info("Camera streamer running (camera=%s)", self._config.camera_id)

--- a/app/camera/camera_streamer/ota_installer.py
+++ b/app/camera/camera_streamer/ota_installer.py
@@ -80,6 +80,14 @@ OTA_PROTOCOL_VERSION = 2
 # isn't enabled or spool dir permissions are broken.
 TRIGGER_START_TIMEOUT = 30  # seconds
 
+# `rebooting` is intentionally persisted before systemctl reboot so the
+# server can show the correct state while the camera disappears. Once a
+# new camera-streamer process is running after that point, the old status
+# must no longer block future uploads.
+_PROCESS_STARTED_AT = int(time.time())
+POST_BOOT_BUSY_GRACE_SECONDS = 15
+STALE_BUSY_STATUS_SECONDS = 10 * 60
+
 
 def bundle_path():
     """Canonical absolute path of the staged bundle."""
@@ -205,6 +213,52 @@ def extract_bundle_version(swu_path):
     return m.group(1) if m else ""
 
 
+def _int_or_zero(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _is_stale_post_boot_busy_status(data, activation):
+    state = data.get("state", STATE_IDLE)
+    if state not in (STATE_REBOOTING, STATE_VALIDATING):
+        return False
+    if activation:
+        return False
+    if os.path.exists(TRIGGER_PATH):
+        return False
+
+    updated_at = _int_or_zero(data.get("updated_at"))
+    if updated_at <= 0:
+        return True
+
+    # If this process started after the status was written, the camera
+    # has already come back from the reboot window that wrote it.
+    if updated_at < (_PROCESS_STARTED_AT - POST_BOOT_BUSY_GRACE_SECONDS):
+        return True
+
+    # Also keep self-healing if camera-streamer is restarted without a
+    # board reboot while an old status file is still present.
+    return (time.time() - updated_at) > STALE_BUSY_STATUS_SECONDS
+
+
+def _normalize_status(data, activation):
+    data.setdefault("state", STATE_IDLE)
+    data.setdefault("progress", 0)
+    data.setdefault("error", "")
+
+    if _is_stale_post_boot_busy_status(data, activation):
+        previous_state = data.get("state", "")
+        data["state"] = STATE_IDLE
+        data["progress"] = 0
+        data["error"] = ""
+        data["stale_state_cleared"] = True
+        data["previous_state"] = previous_state
+
+    return data
+
+
 def read_status():
     """Read the installer's status JSON. Returns a dict with defaults
     if the file is missing/unreadable.
@@ -214,12 +268,10 @@ def read_status():
             data = json.load(f)
         if not isinstance(data, dict):
             raise ValueError("status.json is not an object")
-        data.setdefault("state", STATE_IDLE)
-        data.setdefault("progress", 0)
-        data.setdefault("error", "")
+        activation = status_led.read_activation("camera")
+        data = _normalize_status(data, activation)
         data["protocol_version"] = OTA_PROTOCOL_VERSION
         data["current_version"] = release_version()
-        activation = status_led.read_activation("camera")
         if activation:
             data["activation"] = activation
             if data.get("state") == STATE_IDLE:
@@ -240,6 +292,31 @@ def read_status():
             "activation": activation,
             "verification": verification_posture(),
         }
+
+
+def reconcile_after_boot():
+    """Persist cleanup of stale reboot/validation state after boot.
+
+    `read_status()` already treats stale post-boot states as idle for
+    callers. This helper makes that cleanup durable so the status file
+    no longer surprises older tools or shell diagnostics.
+    """
+    status = read_status()
+    previous_state = (
+        status.get("previous_state") if status.get("stale_state_cleared") else ""
+    )
+    if not previous_state:
+        return False
+
+    write_status(
+        STATE_IDLE,
+        progress=0,
+        error="",
+        previous_state=previous_state,
+        current_version=release_version(),
+    )
+    log.info("Cleared stale OTA %s state after boot", previous_state)
+    return True
 
 
 def write_status(state, progress=0, error="", **extra):

--- a/app/camera/tests/unit/test_ota_installer.py
+++ b/app/camera/tests/unit/test_ota_installer.py
@@ -2,6 +2,7 @@
 """Unit tests for camera-side OTA installer client."""
 
 import io
+import json
 import os
 
 import pytest
@@ -119,6 +120,51 @@ class TestIsBusy:
     def test_installed_state_is_not_busy(self, spool):
         ota_installer.write_status("installed", progress=100)
         assert ota_installer.is_busy() is False
+
+    def test_stale_rebooting_state_is_not_busy(self, spool, monkeypatch):
+        monkeypatch.setattr(ota_installer, "_PROCESS_STARTED_AT", 1000)
+        monkeypatch.setattr(ota_installer.time, "time", lambda: 1000)
+        monkeypatch.setattr(ota_installer.status_led, "read_activation", lambda _: {})
+        with open(ota_installer.STATUS_PATH, "w") as f:
+            json.dump(
+                {"state": "rebooting", "progress": 100, "updated_at": 900},
+                f,
+            )
+
+        status = ota_installer.read_status()
+
+        assert status["state"] == "idle"
+        assert status["stale_state_cleared"] is True
+        assert ota_installer.is_busy() is False
+
+    def test_recent_rebooting_state_stays_busy(self, spool, monkeypatch):
+        monkeypatch.setattr(ota_installer, "_PROCESS_STARTED_AT", 1000)
+        monkeypatch.setattr(ota_installer.time, "time", lambda: 1000)
+        monkeypatch.setattr(ota_installer.status_led, "read_activation", lambda _: {})
+        with open(ota_installer.STATUS_PATH, "w") as f:
+            json.dump(
+                {"state": "rebooting", "progress": 100, "updated_at": 995},
+                f,
+            )
+
+        assert ota_installer.read_status()["state"] == "rebooting"
+        assert ota_installer.is_busy() is True
+
+    def test_reconcile_after_boot_persists_idle_status(self, spool, monkeypatch):
+        monkeypatch.setattr(ota_installer, "_PROCESS_STARTED_AT", 1000)
+        monkeypatch.setattr(ota_installer.time, "time", lambda: 1000)
+        monkeypatch.setattr(ota_installer.status_led, "read_activation", lambda _: {})
+        with open(ota_installer.STATUS_PATH, "w") as f:
+            json.dump(
+                {"state": "validating", "progress": 95, "updated_at": 900},
+                f,
+            )
+
+        assert ota_installer.reconcile_after_boot() is True
+        with open(ota_installer.STATUS_PATH) as f:
+            raw = json.load(f)
+        assert raw["state"] == "idle"
+        assert raw["previous_state"] == "validating"
 
 
 class TestStageBundle:

--- a/app/server/monitor/services/camera_ota_client.py
+++ b/app/server/monitor/services/camera_ota_client.py
@@ -26,6 +26,7 @@ import http.client
 import json
 import logging
 import os
+import re
 import ssl
 import time
 
@@ -58,6 +59,26 @@ STATUS_TIMEOUT = 10
 # Pi Zero 2W can take ~3 min — we cap at 15 min with a 5 s poll.
 INSTALL_POLL_INTERVAL = 5
 INSTALL_POLL_TIMEOUT = 900
+BUSY_STATES = {"downloading", "verifying", "installing", "rebooting", "validating"}
+_BUILD_PROFILE_VERSION_RE = re.compile(
+    r"^(?P<base>v?\d+\.\d+\.\d+)-(?P<profile>dev|prod)$"
+)
+
+
+def _strip_build_profile_suffix(version: str) -> str:
+    """Remove a dev/prod build-profile suffix from a plain release version.
+
+    Runtime firmware reports /etc/os-release VERSION_ID (for example,
+    ``1.6.5``). Some staged bundles still carry the build profile in
+    their target label (``v1.6.5-dev``). For activation confirmation,
+    those represent the same running image; real prereleases such as
+    ``1.6.5-dev.20260531`` are left untouched.
+    """
+
+    match = _BUILD_PROFILE_VERSION_RE.match((version or "").strip())
+    if not match:
+        return version
+    return match.group("base")
 
 
 def _version_matches(actual, expected):
@@ -65,10 +86,35 @@ def _version_matches(actual, expected):
     expected = str(expected or "")
     if not expected:
         return False
-    if actual == expected:
-        return True
-    ordering = ota_policy.compare_versions(actual, expected)
-    return ordering == 0
+    candidates = (
+        (actual, expected),
+        (_strip_build_profile_suffix(actual), _strip_build_profile_suffix(expected)),
+    )
+    for actual_candidate, expected_candidate in candidates:
+        if actual_candidate == expected_candidate:
+            return True
+        ordering = ota_policy.compare_versions(actual_candidate, expected_candidate)
+        if ordering == 0:
+            return True
+    return False
+
+
+def _busy_status_message(status):
+    state = str(status.get("state") or "unknown")
+    progress = status.get("progress", 0)
+    current = str(status.get("current_version") or "")
+    target = str(status.get("target_version") or "")
+    detail = f"Camera OTA is already in progress ({state}"
+    try:
+        detail += f", {int(progress)}%"
+    except (TypeError, ValueError):
+        pass
+    detail += ")"
+    if current or target:
+        detail += f"; current={current or 'unknown'}"
+        if target:
+            detail += f", target={target}"
+    return detail
 
 
 class CameraOTAClient:
@@ -158,6 +204,20 @@ class CameraOTAClient:
         if total <= 0:
             return False, "Bundle is empty"
 
+        if expected_version:
+            preflight_status, _preflight_err = self.get_status(camera_ip)
+            if preflight_status is not None:
+                current_version = str(preflight_status.get("current_version") or "")
+                if _version_matches(current_version, expected_version):
+                    log.info(
+                        "OTA push to %s skipped: camera already reports %s",
+                        camera_ip,
+                        current_version,
+                    )
+                    return True, "Installed"
+                if preflight_status.get("state") in BUSY_STATES:
+                    return False, _busy_status_message(preflight_status)
+
         try:
             ctx = self._ssl_context()
         except (FileNotFoundError, ssl.SSLError, OSError) as exc:
@@ -213,6 +273,9 @@ class CameraOTAClient:
             log.warning("OTA push to %s TLS error: %s", camera_ip, exc)
             return False, f"TLS error: {exc}"
         except OSError as exc:
+            status, _status_err = self.get_status(camera_ip)
+            if status is not None and status.get("state") in BUSY_STATES:
+                return False, _busy_status_message(status)
             log.warning("OTA push to %s I/O error: %s", camera_ip, exc)
             return False, f"I/O error: {exc}"
         except http.client.HTTPException as exc:

--- a/app/server/tests/unit/test_boot_units.py
+++ b/app/server/tests/unit/test_boot_units.py
@@ -1,0 +1,36 @@
+# REQ: SWR-050; RISK: RISK-018; SEC: SC-019; TEST: TC-044
+"""Boot dependency policy tests for image-level systemd units."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def test_mediamtx_does_not_wait_for_network_online():
+    text = _read("meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx.service")
+
+    assert "network-online.target" not in text
+    assert "After=network.target" in text
+    assert "Before=monitor.service" in text
+
+
+def test_tailscale_daemon_does_not_pull_wait_online():
+    text = _read(
+        "meta-home-monitor/recipes-connectivity/tailscale/files/tailscaled.service"
+    )
+
+    assert "network-online.target" not in text
+    assert "NetworkManager-wait-online.service" not in text
+    assert "After=NetworkManager.service network.target local-fs.target" in text
+    assert "RequiresMountsFor=/data" in text
+
+
+def test_image_masks_unused_systemd_networkd_wait_online():
+    text = _read("meta-home-monitor/recipes-core/systemd/systemd-conf_%.bbappend")
+
+    assert "systemd-networkd-wait-online.service" in text
+    assert "ln -sf /dev/null" in text

--- a/app/server/tests/unit/test_camera_ota_client.py
+++ b/app/server/tests/unit/test_camera_ota_client.py
@@ -159,6 +159,72 @@ class TestPushBundle:
         assert ok is False
         assert "connection refused" in msg.lower()
 
+    def test_preflight_busy_status_returns_meaningful_error(self, client, tmp_path):
+        p = tmp_path / "bundle.swu"
+        p.write_bytes(b"data")
+
+        with (
+            patch.object(
+                client,
+                "get_status",
+                return_value=(
+                    {
+                        "state": "rebooting",
+                        "progress": 100,
+                        "current_version": "1.6.4",
+                        "target_version": "1.6.5-dev",
+                    },
+                    "",
+                ),
+            ),
+            patch(
+                "monitor.services.camera_ota_client.http.client.HTTPSConnection"
+            ) as conn_cls,
+        ):
+            ok, msg = client.push_bundle(
+                "10.0.0.1",
+                str(p),
+                expected_version="1.6.5-dev",
+            )
+
+        assert ok is False
+        assert "Camera OTA is already in progress (rebooting, 100%)" in msg
+        assert "current=1.6.4, target=1.6.5-dev" in msg
+        conn_cls.assert_not_called()
+
+    def test_preflight_skips_when_runtime_matches_build_profile_target(
+        self, client, tmp_path
+    ):
+        p = tmp_path / "bundle.swu"
+        p.write_bytes(b"data")
+
+        with (
+            patch.object(
+                client,
+                "get_status",
+                return_value=(
+                    {
+                        "state": "idle",
+                        "progress": 0,
+                        "current_version": "1.6.5",
+                    },
+                    "",
+                ),
+            ),
+            patch(
+                "monitor.services.camera_ota_client.http.client.HTTPSConnection"
+            ) as conn_cls,
+        ):
+            ok, msg = client.push_bundle(
+                "10.0.0.1",
+                str(p),
+                expected_version="v1.6.5-dev",
+            )
+
+        assert ok is True
+        assert msg == "Installed"
+        conn_cls.assert_not_called()
+
     def test_tls_setup_failure_returns_error(self, client, tmp_path):
         p = tmp_path / "bundle.swu"
         p.write_bytes(b"data")
@@ -220,6 +286,10 @@ class TestPushBundle:
         fake_conn = MagicMock()
         fake_conn.getresponse.return_value = upload_resp
         status_sequence = [
+            (
+                {"state": "idle", "progress": 0, "current_version": "1.6.0"},
+                "",
+            ),
             (
                 {
                     "state": "installing",
@@ -323,6 +393,10 @@ class TestPushBundle:
         fake_conn = MagicMock()
         fake_conn.getresponse.return_value = upload_resp
         status_sequence = [
+            (
+                {"state": "idle", "progress": 0, "current_version": "1.6.0"},
+                "",
+            ),
             (
                 {"state": "validating", "progress": 95, "current_version": "1.6.1-dev"},
                 "",
@@ -428,4 +502,8 @@ class TestGetStatus:
 
 def test_version_matches_accepts_equivalent_v_prefix_and_rejects_empty_expected():
     assert _version_matches("v1.6.1-dev", "1.6.1-dev") is True
+    assert _version_matches("1.6.5", "v1.6.5-dev") is True
+    assert _version_matches("1.6.5", "1.6.5-prod") is True
+    assert _version_matches("1.6.5-dev.20260531", "1.6.5") is False
+    assert _version_matches("1.6.4", "v1.6.5-dev") is False
     assert _version_matches("1.6.1", "") is False

--- a/meta-home-monitor/recipes-connectivity/tailscale/files/tailscaled.service
+++ b/meta-home-monitor/recipes-connectivity/tailscale/files/tailscaled.service
@@ -2,8 +2,9 @@
 [Unit]
 Description=Tailscale node agent
 Documentation=https://tailscale.com/kb/
-Wants=network-online.target
-After=network-online.target NetworkManager-wait-online.service
+Wants=NetworkManager.service
+After=NetworkManager.service network.target local-fs.target
+RequiresMountsFor=/data
 
 [Service]
 ExecStartPre=/bin/mkdir -p /data/tailscale

--- a/meta-home-monitor/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/meta-home-monitor/recipes-core/systemd/systemd-conf_%.bbappend
@@ -9,6 +9,18 @@ do_install:append() {
     # Install as drop-in override (does not conflict with systemd package)
     install -d ${D}${sysconfdir}/systemd/timesyncd.conf.d
     install -m0644 ${WORKDIR}/timesyncd.conf ${D}${sysconfdir}/systemd/timesyncd.conf.d/00-home-monitor.conf
+
+    # Home Monitor uses NetworkManager as the appliance network manager.
+    # systemd-networkd-wait-online.service can be pulled in indirectly by
+    # generic network-online.target dependencies and then times out on
+    # no-carrier interfaces, leaving OTA boots degraded. Mask the unused
+    # wait unit at image build time; services that need networking should
+    # depend on network.target and tolerate link changes.
+    install -d ${D}${sysconfdir}/systemd/system
+    ln -sf /dev/null ${D}${sysconfdir}/systemd/system/systemd-networkd-wait-online.service
 }
 
-FILES:${PN} += "${sysconfdir}/systemd/timesyncd.conf.d/00-home-monitor.conf"
+FILES:${PN} += " \
+    ${sysconfdir}/systemd/timesyncd.conf.d/00-home-monitor.conf \
+    ${sysconfdir}/systemd/system/systemd-networkd-wait-online.service \
+"

--- a/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx.service
+++ b/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx.service
@@ -1,8 +1,9 @@
 # REQ: SWR-006, SWR-031, SWR-050; RISK: RISK-001, RISK-017; SEC: SC-016, SC-019; TEST: TC-001, TC-028, TC-044
 [Unit]
 Description=MediaMTX RTSP Server
-After=network-online.target
-Wants=network-online.target
+# MediaMTX binds local ports and tolerates network changes; waiting for
+# internet/LAN carrier delays camera/server boot when WiFi or Ethernet is down.
+After=network.target
 Before=monitor.service
 
 [Service]

--- a/scripts/deploy-dev-app.sh
+++ b/scripts/deploy-dev-app.sh
@@ -180,6 +180,8 @@ deploy_server() {
     copy_file "$REPO_ROOT/app/shared/status_led/home-monitor-ledctl" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/shared/status_led/home-monitor-led-init.service" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/meta-home-monitor/recipes-support/swupdate/files/swupdate-check.sh" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-multimedia/mediamtx/files/mediamtx.service" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-connectivity/tailscale/files/tailscaled.service" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/meta-home-monitor/recipes-core/first-boot/files/luks-first-boot.sh" "$host" "$SERVER_STAGE"
 
@@ -229,6 +231,10 @@ deploy_server() {
         cp '$SERVER_STAGE/monitor-hotspot.service' /etc/systemd/system/monitor-hotspot.service
         cp '$SERVER_STAGE/gpio-trigger.service' /etc/systemd/system/gpio-trigger.service
         cp '$SERVER_STAGE/home-monitor-led-init.service' /etc/systemd/system/home-monitor-led-init.service
+        cp '$SERVER_STAGE/mediamtx.service' /etc/systemd/system/mediamtx.service
+        if command -v tailscaled >/dev/null 2>&1; then
+            cp '$SERVER_STAGE/tailscaled.service' /etc/systemd/system/tailscaled.service
+        fi
     "
 
     log "Applying boot optimisation overrides"
@@ -240,10 +246,13 @@ deploy_server() {
         cp '$SERVER_STAGE/monitor.service' /etc/systemd/system/monitor.service
         cp '$SERVER_STAGE/monitor-privileged-helper.service' /etc/systemd/system/monitor-privileged-helper.service
         # mediamtx: same — only listens on local RTSP port, no internet needed
-        sed 's|After=network-online.target|After=network.target|;s|Wants=network-online.target||' \
-            /usr/lib/systemd/system/mediamtx.service > /etc/systemd/system/mediamtx.service
+        cp '$SERVER_STAGE/mediamtx.service' /etc/systemd/system/mediamtx.service
+        if command -v tailscaled >/dev/null 2>&1; then
+            cp '$SERVER_STAGE/tailscaled.service' /etc/systemd/system/tailscaled.service
+        fi
         # Mask systemd-networkd-wait-online: always times out on eth0 no-carrier
         systemctl mask systemd-networkd-wait-online.service 2>/dev/null || true
+        systemctl reset-failed systemd-networkd-wait-online.service 2>/dev/null || true
         systemctl daemon-reload
         systemctl enable home-monitor-led-init.service gpio-trigger.service monitor-hotspot.service monitor-privileged-helper.service monitor.service >/dev/null 2>&1 || true
     "
@@ -288,6 +297,7 @@ deploy_camera() {
     copy_file "$REPO_ROOT/app/shared/status_led/home-monitor-ledctl" "$host" "$CAMERA_STAGE"
     copy_file "$REPO_ROOT/app/shared/status_led/home-monitor-led-init.service" "$host" "$CAMERA_STAGE"
     copy_file "$REPO_ROOT/meta-home-monitor/recipes-support/swupdate/files/swupdate-check.sh" "$host" "$CAMERA_STAGE"
+    copy_file "$REPO_ROOT/meta-home-monitor/recipes-connectivity/tailscale/files/tailscaled.service" "$host" "$CAMERA_STAGE"
     copy_file "$REPO_ROOT/meta-home-monitor/recipes-core/first-boot/files/first-boot-setup.sh" "$host" "$CAMERA_STAGE"
     copy_file "$REPO_ROOT/meta-home-monitor/recipes-core/first-boot/files/luks-first-boot.sh" "$host" "$CAMERA_STAGE"
 
@@ -330,6 +340,9 @@ deploy_camera() {
         cp '$CAMERA_STAGE/camera-ota-installer.sh' /usr/bin/camera-ota-installer
         chmod 0755 /usr/bin/camera-ota-installer
         cp '$CAMERA_STAGE/gpio-trigger.service' /etc/systemd/system/gpio-trigger.service
+        if command -v tailscaled >/dev/null 2>&1; then
+            cp '$CAMERA_STAGE/tailscaled.service' /etc/systemd/system/tailscaled.service
+        fi
     "
 
     log "Applying boot optimisation overrides"
@@ -343,6 +356,11 @@ deploy_camera() {
         cp '$CAMERA_STAGE/home-monitor-led-init.service' /etc/systemd/system/home-monitor-led-init.service
         cp '$CAMERA_STAGE/camera-ota-installer.service' /etc/systemd/system/camera-ota-installer.service
         cp '$CAMERA_STAGE/camera-ota-installer.path' /etc/systemd/system/camera-ota-installer.path
+        if command -v tailscaled >/dev/null 2>&1; then
+            cp '$CAMERA_STAGE/tailscaled.service' /etc/systemd/system/tailscaled.service
+        fi
+        systemctl mask systemd-networkd-wait-online.service 2>/dev/null || true
+        systemctl reset-failed systemd-networkd-wait-online.service 2>/dev/null || true
         systemctl disable --now camera-ota-reboot.path camera-ota-reboot.service >/dev/null 2>&1 || true
         rm -f /etc/systemd/system/camera-ota-reboot.path /etc/systemd/system/camera-ota-reboot.service
         cp '$CAMERA_STAGE/camera-ota-tmpfiles.conf' /etc/tmpfiles.d/camera-ota.conf


### PR DESCRIPTION
﻿## Summary
- Clears stale camera OTA `rebooting`/`validating` state after the camera has actually booted, so future uploads are not rejected as busy.
- Treats `vX.Y.Z-dev` / `X.Y.Z-prod` bundle targets as matching runtime `X.Y.Z` during camera OTA activation confirmation, without weakening real prerelease comparisons.
- Removes product unit dependencies on `network-online.target` and masks the unused `systemd-networkd-wait-online.service` so OTA boots do not sit degraded waiting on systemd-networkd.
- Extends the dev deploy workflow to apply the same boot-unit cleanup on lab hardware.

## Root Cause
Camera OTA status persisted `rebooting` before reboot so the UI could show the expected transition, but the next camera process still treated that old state as busy. The server also compared the camera runtime version (`1.6.5`) against the bundle label (`v1.6.5-dev`) too literally, so a successful update could time out waiting for a version string that will never appear in `/etc/os-release`.

The boot delay came from generic network-online dependencies pulling `systemd-networkd-wait-online.service` on images that use NetworkManager, leaving boot degraded when unused/no-carrier links timed out.

## Validation
- `pytest app/server/tests/ -q` -> 2618 passed, 1 skipped
- `pytest app/camera/tests/ -q` with Git Bash first in PATH -> 865 passed
- `pytest app/server/tests/unit/test_camera_ota_client.py app/server/tests/unit/test_boot_units.py -q` -> 25 passed
- `pytest app/camera/tests/unit/test_ota_installer.py -q` -> 22 passed
- `ruff check .`
- `ruff format --check .`
- `python tools/docs/check_doc_map.py`
- `python scripts/ai/validate_repo_ai_setup.py`
- `python -m pre_commit run --all-files`
- `bash -n scripts/deploy-dev-app.sh`

## Hardware Validation
- Deployed branch app to server `192.168.1.245` and camera `192.168.1.186`.
- Server and camera both report `systemctl is-system-running = running`.
- `systemctl --failed --no-legend` is empty on both devices.
- `systemd-networkd-wait-online.service` is masked on both devices.
- Camera OTA status reconciled from stale `rebooting` to `idle` with `current_version: 1.6.5`.
- Server-side camera OTA push check for `v1.6.5-dev` returned `True Installed` immediately without re-uploading the bundle.
