### PR TITLE
Fix time health table alignment

### DIFF
--- a/app/server/monitor/static/css/control-panel.css
+++ b/app/server/monitor/static/css/control-panel.css
@@ -3603,6 +3603,38 @@ textarea {
     overflow-wrap: anywhere;
 }
 
+.settings-page .time-health-table-wrap {
+    margin-top: var(--space-3);
+    overflow-x: auto;
+}
+
+.settings-page .time-health-table {
+    width: 100%;
+    min-width: 560px;
+}
+
+.settings-page .time-health-table th,
+.settings-page .time-health-table td {
+    padding: 12px 16px;
+    text-align: left;
+    vertical-align: middle;
+}
+
+.settings-page .time-health-table th:first-child,
+.settings-page .time-health-table td:first-child {
+    padding-left: 18px;
+}
+
+.settings-page .time-health-table th:last-child,
+.settings-page .time-health-table td:last-child {
+    padding-right: 18px;
+}
+
+.settings-page .time-health-table__action {
+    text-align: right !important;
+    white-space: nowrap;
+}
+
 @media (max-width: 980px) {
     .settings-page .page-hero {
         padding: 18px 20px;
@@ -3933,6 +3965,15 @@ textarea {
 
     .settings-page .settings-table-cards .btn {
         max-width: 100%;
+        white-space: normal;
+    }
+
+    .settings-page .time-health-table {
+        min-width: 0;
+    }
+
+    .settings-page .time-health-table__action {
+        text-align: left !important;
         white-space: normal;
     }
 

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -211,27 +211,27 @@
             <div class="text-small text-muted" x-show="timeHealth.state === 'unknown'">
                 Time health unavailable in this environment.
             </div>
-            <div style="margin-top: var(--space-3); overflow-x:auto;">
-                <table style="width:100%; border-collapse:collapse;">
+            <div class="settings-table-cards time-health-table-wrap">
+                <table class="time-health-table">
                     <thead>
                         <tr class="text-small text-muted">
-                            <th style="text-align:left; padding:0 0 var(--space-2) 0;">Camera</th>
-                            <th style="text-align:left; padding:0 0 var(--space-2) 0;">Drift</th>
-                            <th style="text-align:left; padding:0 0 var(--space-2) 0;">State</th>
-                            <th style="text-align:right; padding:0 0 var(--space-2) 0;">Action</th>
+                            <th scope="col">Camera</th>
+                            <th scope="col">Drift</th>
+                            <th scope="col">State</th>
+                            <th scope="col" class="time-health-table__action">Action</th>
                         </tr>
                     </thead>
                     <tbody>
                         <template x-for="camera in timeHealth.cameras" :key="camera.id">
                             <tr>
-                                <td style="padding:10px 0; border-top:1px solid var(--color-border);" x-text="camera.name || camera.id"></td>
-                                <td style="padding:10px 0; border-top:1px solid var(--color-border);" x-text="formatSignedSeconds(camera.drift_seconds)"></td>
-                                <td style="padding:10px 0; border-top:1px solid var(--color-border);">
+                                <td data-label="Camera" x-text="camera.name || camera.id"></td>
+                                <td data-label="Drift" x-text="formatSignedSeconds(camera.drift_seconds)"></td>
+                                <td data-label="State">
                                     <span class="badge"
                                           :style="timeHealthBadgeStyle(camera.state)"
                                           x-text="timeHealthStateLabel(camera.state)"></span>
                                 </td>
-                                <td style="padding:10px 0; border-top:1px solid var(--color-border); text-align:right;">
+                                <td data-label="Action" class="time-health-table__action">
                                     <button class="btn btn--secondary btn--small"
                                             @click="resyncTime(camera.id)"
                                             :disabled="camera.state === 'unknown' || timeHealthBusyTarget === camera.id">
@@ -241,7 +241,7 @@
                             </tr>
                         </template>
                         <tr x-show="!timeHealth.cameras.length">
-                            <td colspan="4" class="text-small text-muted" style="padding-top:10px; border-top:1px solid var(--color-border);">
+                            <td colspan="4" class="text-small text-muted">
                                 No paired cameras reporting time health yet.
                             </td>
                         </tr>

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -903,6 +903,9 @@ class TestCompleteGuiRedesignCoverage:
             "Camera defaults",
             "Server Software Update",
             "Camera Software Updates",
+            "time-health-table-wrap",
+            'data-label="Camera"',
+            'data-label="Action"',
         ]
         for expected in expected_controls:
             assert expected in body
@@ -950,5 +953,7 @@ class TestCompleteGuiRedesignCoverage:
             ".ota-job-panel",
             ".ota-device-card__controls",
             ".ota-state-pill--busy",
+            ".time-health-table",
+            ".time-health-table__action",
         ]:
             assert selector in css


### PR DESCRIPTION
## Summary
- Give the Time Health camera table a real settings-table wrapper instead of zero-padding inline table styles
- Add explicit cell padding and right-aligned action column so the rounded container no longer clips Camera/Action text
- Preserve the mobile card-table behavior with data-label attributes

## Validation
- pytest app/server/tests/integration/test_views.py -q
- ruff check app/server/tests/integration/test_views.py
- git diff --check
- python -m pre_commit run --files app/server/monitor/templates/settings.html app/server/monitor/static/css/control-panel.css app/server/tests/integration/test_views.py