### PR TITLE
[codex] Serialize server and camera OTA starts

### DIFF
--- a/app/server/monitor/api/ota.py
+++ b/app/server/monitor/api/ota.py
@@ -51,8 +51,64 @@ CAMERA_BUSY_STATES = {
     "rebooting",
     "validating",
 }
+SERVER_INSTALL_ACTIVE_STATES = {
+    "verifying",
+    "installing",
+    "rebooting",
+}
 CAMERA_LIBRARY_MANIFEST_SUFFIX = ".json"
 CAMERA_CUSTOM_MANIFEST = "manifest.json"
+
+
+def _normal_state(status):
+    return str((status or {}).get("state") or "idle").lower()
+
+
+def _active_camera_update(ota):
+    """Return the first camera update that would conflict with server install."""
+    for camera in current_app.store.get_cameras():
+        if camera.status == "pending":
+            continue
+        state = _normal_state(ota.get_status(camera.id))
+        if state in CAMERA_BUSY_STATES:
+            return camera.id, state
+    return "", ""
+
+
+def _reject_if_camera_update_active(ota):
+    camera_id, state = _active_camera_update(ota)
+    if not camera_id:
+        return None
+    return (
+        jsonify(
+            {
+                "error": (
+                    "Camera update is already running "
+                    f"({camera_id}: {state}). Wait for camera updates to "
+                    "finish before installing a server update."
+                )
+            }
+        ),
+        409,
+    )
+
+
+def _reject_if_server_install_active(ota):
+    state = _normal_state(ota.get_status("server"))
+    if state not in SERVER_INSTALL_ACTIVE_STATES:
+        return None
+    return (
+        jsonify(
+            {
+                "error": (
+                    "Server update is already running "
+                    f"({state}). Wait for the server update to finish before "
+                    "starting camera updates."
+                )
+            }
+        ),
+        409,
+    )
 
 
 def _safe_camera_id(camera_id):
@@ -547,6 +603,9 @@ def install_server_image():
         return jsonify(
             {"error": f"A server update is already in progress ({state})"}
         ), 409
+    camera_lock = _reject_if_camera_update_active(ota)
+    if camera_lock:
+        return camera_lock
 
     staging = ota.staging_dir
     if not os.path.isdir(staging):
@@ -1084,6 +1143,9 @@ def push_camera_update(camera_id):
 
     ota = current_app.ota_service
     ota.ensure_storage()
+    server_lock = _reject_if_server_install_active(ota)
+    if server_lock:
+        return server_lock
     body = request.get_json(silent=True) or {}
     requested_scope = str(body.get("scope") or "common")
     if requested_scope == "custom":
@@ -1188,6 +1250,9 @@ def push_all_eligible_cameras():
     """Push the reusable camera bundle to all online eligible cameras."""
     ota = current_app.ota_service
     ota.ensure_storage()
+    server_lock = _reject_if_server_install_active(ota)
+    if server_lock:
+        return server_lock
     record = _latest_camera_bundle(_read_camera_bundle_records(ota))
     if record is None:
         return jsonify({"error": "No reusable camera bundle uploaded"}), 409

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -2478,8 +2478,12 @@
                       x-show="ota.server.staged_filename"
                       x-text="ota.server.staged_filename"></span>
                 <button class="btn btn--primary" style="margin-left:var(--space-2);"
-                        :disabled="!ota.server.staged_filename || ota.server.busy || (ota.server.verification && ota.server.verification.install_blocked)"
+                        :disabled="!ota.server.staged_filename || ota.server.busy || serverInstallLockedByCamera() || (ota.server.verification && ota.server.verification.install_blocked)"
                         @click="installServerBundle()">Install &amp; Reboot</button>
+            </div>
+            <div class="text-small text-muted" style="margin-top:var(--space-2);"
+                 x-show="serverInstallLockedByCamera()">
+                A camera update is running. Server install is locked until camera updates finish.
             </div>
             <div x-show="ota.server.busy" style="margin-top:var(--space-3);">
                 <div class="progress-bar"><div class="progress-bar__fill" :style="'width:' + (ota.server.progress || 0) + '%'"></div></div>
@@ -2562,8 +2566,12 @@
                        accept=".swu"
                        @change="uploadCameraLibraryBundle($event.target.files[0]); $event.target.value = '';">
                 <button class="btn btn--primary ota-install-button"
-                        :disabled="!cameraCommonBundleReady() || !cameraCommonBundleEligible() || cameraAnyBusy()"
+                        :disabled="!cameraCommonBundleReady() || !cameraCommonBundleEligible() || cameraAnyBusy() || cameraInstallLockedByServer()"
                         @click="pushAllCameraBundles()">Update eligible cameras</button>
+            </div>
+            <div class="text-small text-muted ota-section-note"
+                 x-show="cameraInstallLockedByServer()">
+                Server update is running. Camera installs are locked until the server update finishes.
             </div>
         </div>
         <div class="ota-camera-list" x-show="(ota.cameras || []).length > 0">
@@ -4735,6 +4743,27 @@ function settingsPage() {
             return (this.ota.cameras || []).some(this.cameraBusy);
         },
 
+        _otaStartActive(state, deviceType) {
+            state = state || 'idle';
+            if (deviceType === 'server') {
+                return state === 'verifying' || state === 'installing' || state === 'rebooting';
+            }
+            return state === 'uploading' || state === 'downloading' ||
+                state === 'verifying' || state === 'installing' ||
+                state === 'rebooting' || state === 'validating';
+        },
+
+        serverInstallLockedByCamera() {
+            var self = this;
+            return (this.ota.cameras || []).some(function(cam) {
+                return self._otaStartActive(cam && cam.state, 'camera');
+            });
+        },
+
+        cameraInstallLockedByServer() {
+            return this._otaStartActive(this.ota.server && this.ota.server.state, 'server');
+        },
+
         cameraCommonBundleReady() {
             return !!(this.ota.camera_bundle && this.ota.camera_bundle.filename && this.ota.camera_bundle.target_version);
         },
@@ -4765,6 +4794,7 @@ function settingsPage() {
         },
 
         cameraCanInstall(cam) {
+            if (this.cameraInstallLockedByServer()) return false;
             if (!cam || !cam.online || this.cameraBusy(cam)) return false;
             if (!cam.target_version || !cam.staged_filename) return false;
             if (cam.update_relation === 'same' || cam.update_relation === 'blocked' || cam.update_relation === 'downgrade') return false;
@@ -4773,6 +4803,7 @@ function settingsPage() {
 
         cameraInstallLabel(cam) {
             if (!cam) return 'Install';
+            if (this.cameraInstallLockedByServer()) return 'Server updating';
             if (this.cameraBusy(cam)) return this.otaStateLabel(cam.state);
             if (!cam.online) return 'Offline';
             if (cam.update_relation === 'same') return 'Already current';
@@ -5041,6 +5072,10 @@ function settingsPage() {
                 window.HM.toast(posture.warning || 'OTA verification is blocked', 'error');
                 return;
             }
+            if (this.serverInstallLockedByCamera()) {
+                window.HM.toast('Camera update is running; wait before installing a server update.', 'error');
+                return;
+            }
             var prompt = 'Install this update? The server will reboot into the new partition.';
             if (posture.warning) {
                 prompt = posture.warning + '\n\n' + prompt;
@@ -5177,6 +5212,7 @@ function settingsPage() {
 
         async pushCameraBundle(cam) {
             if (!cam.online) { window.HM.toast('Camera is offline', 'error'); return; }
+            if (this.cameraInstallLockedByServer()) { window.HM.toast('Server update is running; wait before starting camera updates.', 'error'); return; }
             if (!this.cameraCanInstall(cam)) { window.HM.toast('No eligible bundle for this camera', 'error'); return; }
             var scope = cam.bundle_scope === 'custom' ? 'custom' : 'common';
             if (!confirm('Push ' + (scope === 'custom' ? 'the custom bundle' : 'the selected bundle') + ' to ' + (cam.name || cam.id) + '? The camera will reboot into the new partition.')) return;
@@ -5204,6 +5240,10 @@ function settingsPage() {
             }
             if (!this.cameraCommonBundleEligible()) {
                 window.HM.toast('No online cameras need this bundle', 'info');
+                return;
+            }
+            if (this.cameraInstallLockedByServer()) {
+                window.HM.toast('Server update is running; wait before starting camera updates.', 'error');
                 return;
             }
             if (!confirm('Update all eligible online cameras to ' + (this.ota.camera_bundle.target_version || 'the selected version') + '? Each camera will reboot itself after installation.')) return;

--- a/app/server/tests/integration/test_api_ota.py
+++ b/app/server/tests/integration/test_api_ota.py
@@ -197,6 +197,20 @@ class TestServerUpload:
         assert response.status_code == 400
         assert "Rejected older update" in response.get_json()["error"]
 
+    def test_upload_allowed_while_camera_update_active(self, app, logged_in_client):
+        client = logged_in_client()
+        _add_camera(app, "cam-001", "online")
+        app.ota_service.set_status("cam-001", "uploading", progress=20, error="")
+
+        response = client.post(
+            "/api/v1/ota/server/upload",
+            data={"file": (io.BytesIO(b"fake-swu-content"), "update.swu")},
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 200
+        assert "staged" in response.get_json()["message"].lower()
+
 
 class TestCameraPush:
     """Test POST /api/v1/ota/camera/<id>/push."""
@@ -222,6 +236,16 @@ class TestCameraPush:
         response = client.post("/api/v1/ota/camera/cam-001/push")
         assert response.status_code == 409
         assert "upload" in response.get_json()["error"].lower()
+
+    def test_push_blocked_while_server_install_active(self, app, logged_in_client):
+        client = logged_in_client()
+        _add_camera(app, "cam-001", "online", firmware_version="1.6.0")
+        app.ota_service.set_status("server", "installing", progress=50, error="")
+
+        response = client.post("/api/v1/ota/camera/cam-001/push")
+
+        assert response.status_code == 409
+        assert "Server update is already running" in response.get_json()["error"]
 
     def test_pushes_update(self, monkeypatch, app, logged_in_client):
         client = logged_in_client()
@@ -366,6 +390,27 @@ class TestCameraPush:
             "cam-offline",
         }
 
+    def test_push_all_blocked_while_server_install_active(self, app, logged_in_client):
+        client = logged_in_client()
+        _add_camera(app, "cam-old", "online", firmware_version="1.6.0")
+        upload = client.post(
+            "/api/v1/ota/camera-library/upload",
+            data={
+                "file": (
+                    io.BytesIO(_swu_bytes("1.6.2", "camera")),
+                    "common.swu",
+                )
+            },
+            content_type="multipart/form-data",
+        )
+        assert upload.status_code == 200
+        app.ota_service.set_status("server", "rebooting", progress=100, error="")
+
+        response = client.post("/api/v1/ota/cameras/push", json={})
+
+        assert response.status_code == 409
+        assert "Server update is already running" in response.get_json()["error"]
+
 
 class TestCameraUpload:
     """Test POST /api/v1/ota/camera/<id>/upload."""
@@ -466,6 +511,26 @@ class TestCameraUpload:
         assert data["camera_bundle"]["target_version"] == "1.6.2"
         assert data["camera_bundle"]["eligible_count"] == 1
         assert data["camera_bundle"]["already_current_count"] == 1
+
+    def test_common_camera_bundle_upload_allowed_while_server_installing(
+        self, app, logged_in_client
+    ):
+        client = logged_in_client()
+        app.ota_service.set_status("server", "installing", progress=50, error="")
+
+        response = client.post(
+            "/api/v1/ota/camera-library/upload",
+            data={
+                "file": (
+                    io.BytesIO(_swu_bytes("1.6.2", "camera")),
+                    "common.swu",
+                )
+            },
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["target_version"] == "1.6.2"
 
     def test_custom_camera_bundle_is_not_saved_to_common_library(
         self, app, logged_in_client
@@ -729,6 +794,24 @@ class TestServerInstall:
         assert resp.status_code == 409
         assert "Rejected older update" in resp.get_json()["error"]
         assert not os.path.exists(bundle)
+
+    def test_blocks_install_while_camera_update_active(self, app, logged_in_client):
+        client = logged_in_client()
+        _add_camera(app, "cam-001", "online")
+
+        staging = app.ota_service.staging_dir
+        os.makedirs(staging, exist_ok=True)
+        bundle = os.path.join(staging, "update.swu")
+        with open(bundle, "wb") as fh:
+            fh.write(b"fake-bundle")
+        app.ota_service.set_status("cam-001", "uploading", progress=20, error="")
+
+        response = client.post("/api/v1/ota/server/install")
+
+        assert response.status_code == 409
+        error = response.get_json()["error"]
+        assert "Camera update is already running" in error
+        assert "cam-001" in error
 
 
 class TestCameraUploadEdgeCases:

--- a/app/server/tests/unit/test_static_app_js.py
+++ b/app/server/tests/unit/test_static_app_js.py
@@ -70,3 +70,21 @@ def test_common_camera_bundle_picker_cannot_be_left_disabled():
     assert 'style="position:absolute;left:-10000px;' in common_picker_block
     assert ":disabled=" not in common_picker_block
     assert "input.disabled = false;" in text
+
+
+def test_ota_install_buttons_lock_across_server_and_camera_updates():
+    """Install starts are mutually exclusive; staging uploads remain separate."""
+    text = SETTINGS_HTML.read_text(encoding="utf-8")
+
+    for expected in [
+        "serverInstallLockedByCamera",
+        "cameraInstallLockedByServer",
+        "A camera update is running. Server install is locked",
+        "Server update is running. Camera installs are locked",
+        "wait before installing a server update",
+        "wait before starting camera updates",
+        "serverInstallLockedByCamera() ||",
+        "cameraAnyBusy() || cameraInstallLockedByServer()",
+        "if (this.cameraInstallLockedByServer()) return false;",
+    ]:
+        assert expected in text

--- a/docs/guides/hardware-setup.md
+++ b/docs/guides/hardware-setup.md
@@ -539,7 +539,10 @@ and is deleted after a successful install.
 The system uses A/B partitions with automatic rollback if the new image fails
 to boot. Cameras own their own activation reboot after the inactive slot is
 written, and the server reports success only when the camera comes back on the
-expected target version.
+expected target version. Uploading/staging bundles is allowed during other
+maintenance, but starting installs is serialized across device classes: a server
+install waits for active camera updates to finish, and camera installs wait for
+an active server update to finish.
 
 ### 8.4 Maintenance Restarts
 

--- a/docs/history/adr/0020-dual-transport-ota.md
+++ b/docs/history/adr/0020-dual-transport-ota.md
@@ -65,7 +65,7 @@ The user's practical ask is "I should be able to update both boxes from one scre
 | GET | `/api/v1/ota/usb/scan` | admin | find .swu on mounted USBs |
 | POST | `/api/v1/ota/usb/import` | admin+CSRF | import USB bundle |
 
-`push` returns 202 immediately and runs the actual upload on a background thread — a 150 MB bundle over 2.4 GHz WiFi is ~40 s, well past gunicorn's default worker timeout. The UI polls `/api/v1/ota/status` at 1.5 s while anything is in flight, 5 s when idle.
+`push` returns 202 immediately and runs the actual upload on a background thread — a 150 MB bundle over 2.4 GHz WiFi is ~40 s, well past gunicorn's default worker timeout. The UI polls `/api/v1/ota/status` at 1.5 s while anything is in flight, 5 s when idle. Server install and camera install starts are mutually exclusive: the operator can still upload/stage bundles, but cannot start a server update while any camera update is transferring/installing/rebooting, and cannot start camera updates while the server is verifying/installing/rebooting.
 
 ### UI
 
@@ -215,3 +215,13 @@ can retry or explicitly discard it. The status policy also treats runtime
 versions such as `1.6.10` as matching bundle labels such as
 `v1.6.10-dev`, so completed lab/dev updates settle to "already current"
 instead of staying in "installed; waiting for version refresh".
+
+**9. Cross-device update start lock.** The server Settings UI and OTA API now
+separate staging from activation. Uploading a server bundle, a reusable common
+camera bundle, or a one-shot custom camera bundle remains allowed during other
+maintenance. Starting an install does not: server self-update is refused while
+any camera update is transferring, verifying, installing, validating, or
+rebooting, and camera update starts are refused while the server is verifying,
+installing, or rebooting. This prevents the server from rebooting out from under
+active camera pushes and prevents camera updates from starting while the server
+is in the middle of its own activation.


### PR DESCRIPTION
## Goal
Prevent server OTA activation and camera OTA activation from racing each other while still allowing operators to upload and stage bundles.

## Changes
- Add server-side OTA start guards: server install returns 409 while any camera update is active, and camera push/bulk push returns 409 while the server is verifying/installing/rebooting.
- Keep upload/staging paths open so server bundles, common camera bundles, and custom camera bundles can still be prepared during maintenance.
- Add Settings UI lock messages and disabled install buttons that mirror the backend guard.
- Update OTA ADR and hardware setup docs with the staging-vs-activation rule.

## Validation
- pytest app/server/tests/integration/test_api_ota.py -q
- pytest app/server/tests/unit/test_static_app_js.py -q
- pytest app/server/tests/integration/test_views.py -q
- pytest app/server/tests/unit -q
- pytest app/server/tests/integration -q
- pytest app/server/tests/contracts -q
- ruff check .
- ruff format --check .
- python tools/docs/check_doc_map.py
- python scripts/ai/validate_repo_ai_setup.py
- python scripts/ai/check_doc_links.py
- python scripts/ai/check_shell_scripts.py
- python scripts/check_version_consistency.py
- python scripts/check_versioning_design.py
- python tools/traceability/check_traceability.py
- python -m pre_commit run --all-files

## Notes
A single combined `pytest app/server/tests/ -q` local run exceeded the command timeout because the complete server suite runs longer than the timeout window on this host. The same server suite passed when split into unit, integration, and contract lanes.