### PR TITLE
Fix camera settings sync and time resync

### DIFF
--- a/app/camera/camera_streamer/control.py
+++ b/app/camera/camera_streamer/control.py
@@ -324,19 +324,6 @@ class ControlHandler:
         if request_id and request_id <= self._last_request_id:
             return None, "Stale request_id (replay rejected)", 409
 
-        schedule_only = set(params.keys()) == {"restart_schedule"}
-
-        # Rate limiting
-        now = time.monotonic()
-        elapsed = now - self._last_change_time
-        if (
-            self._last_change_time > 0
-            and elapsed < RATE_LIMIT_SECONDS
-            and not schedule_only
-        ):
-            wait = RATE_LIMIT_SECONDS - elapsed
-            return None, f"Rate limited, retry after {wait:.0f}s", 429
-
         if not params:
             return None, "No parameters provided", 400
 
@@ -358,6 +345,21 @@ class ControlHandler:
                 "",
                 200,
             )
+
+        schedule_only = set(changes.keys()) == {"restart_schedule"}
+
+        # Rate-limit real changes, but let full desired-state replays that
+        # collapse to no-op above succeed. The server deliberately sends full
+        # state for convergence after either side changes settings.
+        now = time.monotonic()
+        elapsed = now - self._last_change_time
+        if (
+            self._last_change_time > 0
+            and elapsed < RATE_LIMIT_SECONDS
+            and not schedule_only
+        ):
+            wait = RATE_LIMIT_SECONDS - elapsed
+            return None, f"Rate limited, retry after {wait:.0f}s", 429
 
         # Apply changes to config
         config_updates = {}

--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -26,6 +26,7 @@ import time
 import urllib.error
 import urllib.request
 
+from camera_streamer import privileged
 from camera_streamer.control import ControlHandler, parse_control_request
 from camera_streamer.health import read_throttle_state as _read_throttle_state
 from camera_streamer.restart_schedule_model import normalise_restart_schedule
@@ -52,6 +53,15 @@ UNPAIR_401_THRESHOLD = 5
 
 def _restart_timesyncd() -> None:
     # REQ: SWR-025; RISK: RISK-015; SEC: SC-002; TEST: TC-030
+    if privileged.should_use_helper():
+        try:
+            privileged.request("time.restart_timesyncd", timeout=10)
+        except privileged.PrivilegedHelperError as exc:
+            log.warning("Failed to restart systemd-timesyncd via helper: %s", exc)
+            return
+        log.info("Restarted systemd-timesyncd after server-requested time resync")
+        return
+
     try:
         result = subprocess.run(
             ["systemctl", "restart", "systemd-timesyncd"],

--- a/app/camera/camera_streamer/privileged_helper.py
+++ b/app/camera/camera_streamer/privileged_helper.py
@@ -271,6 +271,10 @@ def _op_system_reboot(payload: dict[str, Any]) -> dict[str, Any]:
     return _run_command(["systemctl", "reboot"], timeout=15)
 
 
+def _op_time_restart_timesyncd(payload: dict[str, Any]) -> dict[str, Any]:
+    return _run_command(["systemctl", "restart", "systemd-timesyncd"], timeout=10)
+
+
 OPERATIONS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
     "hotspot.connect": _op_hotspot_connect,
     "hotspot.set_password": _op_hotspot_set_password,
@@ -280,6 +284,7 @@ OPERATIONS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
     "hostname.set": _op_hostname_set,
     "led.set": _op_led_set,
     "system.reboot": _op_system_reboot,
+    "time.restart_timesyncd": _op_time_restart_timesyncd,
 }
 
 

--- a/app/camera/tests/unit/test_control.py
+++ b/app/camera/tests/unit/test_control.py
@@ -359,6 +359,16 @@ class TestRateLimiting:
         assert status == 429
         assert "Rate limited" in err
 
+    def test_allows_unchanged_full_state_during_cooldown(self, control):
+        control.set_config({"fps": 15})
+        desired_state = control.get_config()
+
+        result, err, status = control.set_config(desired_state)
+
+        assert status == 200, err
+        assert result["status"] == "unchanged"
+        assert result["applied"] == {}
+
     def test_allows_after_cooldown(self, control):
         control.set_config({"fps": 15})
         # Manually reset the timer

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -627,6 +627,10 @@ class TestHeartbeatSender:
 
         with (
             patch(
+                "camera_streamer.heartbeat.privileged.should_use_helper",
+                return_value=False,
+            ),
+            patch(
                 "camera_streamer.heartbeat.subprocess.run",
                 return_value=MagicMock(returncode=0, stdout="", stderr=""),
             ) as mock_run,
@@ -643,6 +647,27 @@ class TestHeartbeatSender:
         )
         mock_handler_cls.assert_not_called()
 
+    def test_apply_pending_config_restarts_timesyncd_via_helper_when_unprivileged(
+        self,
+    ):
+        cfg = _make_config()
+        sender = HeartbeatSender(cfg, _make_pairing())
+
+        with (
+            patch(
+                "camera_streamer.heartbeat.privileged.should_use_helper",
+                return_value=True,
+            ),
+            patch("camera_streamer.heartbeat.privileged.request") as mock_request,
+            patch("camera_streamer.heartbeat.subprocess.run") as mock_run,
+            patch("camera_streamer.heartbeat.ControlHandler") as mock_handler_cls,
+        ):
+            sender._apply_pending_config({"time_resync": True})
+
+        mock_request.assert_called_once_with("time.restart_timesyncd", timeout=10)
+        mock_run.assert_not_called()
+        mock_handler_cls.assert_not_called()
+
     def test_apply_pending_config_handles_time_resync_and_stream_config(self):
         cfg = _make_config()
         sender = HeartbeatSender(cfg, _make_pairing())
@@ -650,6 +675,10 @@ class TestHeartbeatSender:
         mock_handler.set_config.return_value = ({"applied": True}, "", 200)
 
         with (
+            patch(
+                "camera_streamer.heartbeat.privileged.should_use_helper",
+                return_value=False,
+            ),
             patch(
                 "camera_streamer.heartbeat.subprocess.run",
                 return_value=MagicMock(returncode=0, stdout="", stderr=""),

--- a/app/camera/tests/unit/test_privileged_helper.py
+++ b/app/camera/tests/unit/test_privileged_helper.py
@@ -223,6 +223,22 @@ def test_system_reboot_uses_systemctl_reboot():
     )
 
 
+def test_time_restart_timesyncd_uses_systemctl_restart():
+    with patch("camera_streamer.privileged_helper.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        data = privileged_helper._op_time_restart_timesyncd({})
+
+    assert data["returncode"] == 0
+    mock_run.assert_called_once_with(
+        ["systemctl", "restart", "systemd-timesyncd"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
 def test_rejects_unknown_operation():
     with pytest.raises(privileged_helper.HelperRequestError, match="not allowed"):
         privileged_helper._handle_request(b'{"operation":"not.allowed","payload":{}}')

--- a/app/server/monitor/services/camera_service.py
+++ b/app/server/monitor/services/camera_service.py
@@ -1140,8 +1140,13 @@ class CameraService:
 
         if "name" in data:
             name = data["name"]
-            if not isinstance(name, str) or len(name) < 1 or len(name) > 64:
-                return "name must be 1-64 characters"
+            if not isinstance(name, str) or len(name) > 64:
+                return "name must be 64 characters or fewer"
+
+        if "location" in data:
+            location = data["location"]
+            if not isinstance(location, str) or len(location) > 64:
+                return "location must be 64 characters or fewer"
 
         if "width" in data and (
             not isinstance(data["width"], int) or data["width"] < 1

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -1576,16 +1576,7 @@ function dashboardPage() {
             this.savingStream = true;
             this.streamSaveMsg = '';
             var parts = this.editForm.resolution.split('x');
-            // Validate name client-side before the round-trip so a trivial
-            // empty-field typo surfaces immediately (backend enforces
-            // 1-64 chars and will 400 otherwise).
             var name = (this.editForm.name || '').trim();
-            if (!name) {
-                this.streamSaveOk = false;
-                this.streamSaveMsg = 'Name is required (1-64 characters).';
-                this.savingStream = false;
-                return;
-            }
             var payload = {
                 name: name,
                 location: (this.editForm.location || '').trim(),

--- a/app/server/tests/unit/test_camera_service.py
+++ b/app/server/tests/unit/test_camera_service.py
@@ -534,14 +534,24 @@ class TestUpdate:
         assert status == 400
         assert "name" in error
 
-    def test_rejects_empty_name(self):
+    def test_allows_empty_name_to_clear_display_name(self):
         cam = _make_camera()
         store = MagicMock()
         store.get_camera.return_value = cam
         svc = CameraService(store)
         error, status = svc.update("cam-001", {"name": ""})
+        assert status == 200
+        assert error == ""
+        assert cam.name == ""
+
+    def test_rejects_location_longer_than_64_chars(self):
+        cam = _make_camera()
+        store = MagicMock()
+        store.get_camera.return_value = cam
+        svc = CameraService(store)
+        error, status = svc.update("cam-001", {"location": "x" * 65})
         assert status == 400
-        assert "name" in error
+        assert "location" in error
 
     def test_mode_change_off_to_continuous_no_direct_streaming_call(self):
         """ADR-0017: pipeline changes are driven by RecordingScheduler, not here."""


### PR DESCRIPTION
## Summary
- allow blank camera display names so cards can fall back to camera ID
- keep full-state camera settings convergence, but avoid rate-limiting unchanged full-state replays
- route camera time resync through the camera privileged helper instead of direct unprivileged systemctl

## Validation
- \pytest app/camera/tests/unit/test_privileged_helper.py app/camera/tests/unit/test_heartbeat.py app/camera/tests/unit/test_control.py -q\
- \pytest app/server/tests/unit/test_camera_service.py -q\
- \uff check app/camera/camera_streamer/heartbeat.py app/camera/camera_streamer/privileged_helper.py app/camera/camera_streamer/control.py app/server/monitor/services/camera_service.py app/camera/tests/unit/test_heartbeat.py app/camera/tests/unit/test_privileged_helper.py app/camera/tests/unit/test_control.py app/server/tests/unit/test_camera_service.py\
- deployed app changes to server \192.168.1.245\ and cameras \192.168.1.186\, \192.168.1.115\, \192.168.1.148\
- verified all three cameras heartbeat HTTP 200 after deploy
- verified camera privileged helper \	ime.restart_timesyncd\ as user \camera\
- verified API blank-name save and repeated full settings save return 200