### PR TITLE
Fix live stream recovery after LAN changes

### DIFF
--- a/app/server/config/monitor-avahi-pin.service
+++ b/app/server/config/monitor-avahi-pin.service
@@ -2,8 +2,8 @@
 [Unit]
 Description=Pin Home Monitor mDNS identity
 Documentation=https://github.com/vinu-dev/rpi-home-monitor
-After=local-fs.target NetworkManager.service
-Wants=NetworkManager.service
+After=local-fs.target NetworkManager.service systemd-networkd.service
+Wants=NetworkManager.service systemd-networkd.service
 Before=avahi-daemon.service
 RequiresMountsFor=/data
 
@@ -12,7 +12,6 @@ Type=oneshot
 Environment=PYTHONPATH=/opt/monitor
 Environment=MONITOR_AVAHI_CONFIG=/data/config/avahi-daemon.conf
 ExecStart=/usr/bin/python3 -m monitor.services.avahi_pin
-RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/app/server/config/monitor-avahi-pin.timer
+++ b/app/server/config/monitor-avahi-pin.timer
@@ -1,0 +1,13 @@
+# REQ: SWR-024, SWR-050; RISK: RISK-010, RISK-012; SEC: SC-012; TEST: TC-023
+[Unit]
+Description=Reconcile Home Monitor mDNS identity after LAN changes
+Documentation=https://github.com/vinu-dev/rpi-home-monitor
+
+[Timer]
+OnBootSec=20s
+OnUnitInactiveSec=30s
+AccuracySec=5s
+Unit=monitor-avahi-pin.service
+
+[Install]
+WantedBy=timers.target

--- a/app/server/config/monitor-network-dispatcher.sh
+++ b/app/server/config/monitor-network-dispatcher.sh
@@ -22,5 +22,3 @@ fi
 PYTHONPATH=/opt/monitor \
 MONITOR_AVAHI_CONFIG=/data/config/avahi-daemon.conf \
     /usr/bin/python3 -m monitor.services.avahi_pin >/dev/null 2>&1 || true
-
-systemctl try-restart avahi-daemon.service >/dev/null 2>&1 || true

--- a/app/server/monitor/api/on_demand.py
+++ b/app/server/monitor/api/on_demand.py
@@ -1,18 +1,18 @@
 # REQ: SWR-052; RISK: RISK-001, RISK-017; SEC: SC-016; TEST: TC-001, TC-028
 """
-On-demand coordinator (ADR-0017) — localhost-only Flask blueprint.
+On-demand coordinator (ADR-0017) - localhost-only Flask blueprint.
 
 MediaMTX invokes this via a shell wrapper on `runOnDemand` /
 `runOnDemandCloseAfter`. The coordinator is the single "does anyone still
 need this stream?" gate:
 
     POST /internal/on-demand/<camera_id>/start
-        - If camera.desired_stream_state == "running" → no-op (200).
-        - Else → control_client.start_stream(ip), persist, return {"ok": true}.
+        - If desired and observed stream state are both running: no-op (200).
+        - Else: control_client.start_stream(ip), persist, return {"ok": true}.
 
     POST /internal/on-demand/<camera_id>/stop
-        - If RecordingScheduler.needs_stream(cam) → no-op (200, kept_running).
-        - Else → control_client.stop_stream(ip), persist, return {"ok": true}.
+        - If RecordingScheduler.needs_stream(cam): no-op (200, kept_running).
+        - Else: control_client.stop_stream(ip), persist, return {"ok": true}.
 
 Auth: 127.0.0.1 / ::1 only (localhost trust). No session / CSRF.
 CSRF is not applied (blueprint is not under /api/v1).
@@ -44,14 +44,17 @@ def _require_localhost():
 
 @on_demand_bp.route("/<camera_id>/start", methods=["POST"])
 def on_demand_start(camera_id: str):
-    """Viewer arrived — make sure the camera is streaming."""
+    """Viewer arrived - make sure the camera is streaming."""
     camera = current_app.store.get_camera(camera_id)
     if camera is None:
         return jsonify({"error": "Camera not found"}), 404
 
-    if camera.desired_stream_state == "running":
+    observed_running = bool(getattr(camera, "streaming", False))
+    if camera.desired_stream_state == "running" and observed_running:
         log.debug("on-demand start %s: already running", camera_id)
         return jsonify({"ok": True, "already_running": True}), 200
+
+    reconciling = camera.desired_stream_state == "running" and not observed_running
 
     if not camera.ip:
         return jsonify({"error": "Camera IP unknown"}), 409
@@ -67,12 +70,12 @@ def on_demand_start(camera_id: str):
 
     camera.desired_stream_state = "running"
     current_app.store.save_camera(camera)
-    return jsonify({"ok": True, "started": True}), 200
+    return jsonify({"ok": True, "started": True, "reconciled": reconciling}), 200
 
 
 @on_demand_bp.route("/<camera_id>/stop", methods=["POST"])
 def on_demand_stop(camera_id: str):
-    """Viewer left — stop the camera stream unless the scheduler still wants it."""
+    """Viewer left - stop the camera stream unless the scheduler still wants it."""
     camera = current_app.store.get_camera(camera_id)
     if camera is None:
         return jsonify({"error": "Camera not found"}), 404

--- a/app/server/monitor/services/avahi_pin.py
+++ b/app/server/monitor/services/avahi_pin.py
@@ -40,6 +40,7 @@ SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
 PINNED_KEY_RE = re.compile(r"^\s*#?\s*(host-name|allow-interfaces)\s*=")
 
 CommandRunner = Callable[[list[str]], str]
+CommandStatusRunner = Callable[[list[str]], int]
 
 
 def _command_output(argv: list[str]) -> str:
@@ -58,6 +59,21 @@ def _command_output(argv: list[str]) -> str:
         log.debug("Command failed for Avahi pinning: %s (%s)", argv, result.stderr)
         return ""
     return result.stdout
+
+
+def _command_status(argv: list[str]) -> int:
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        log.debug("Command unavailable for Avahi pinning: %s (%s)", argv, exc)
+        return 1
+    return int(result.returncode)
 
 
 def _normalise_hostname(host_name: str) -> str:
@@ -260,11 +276,26 @@ def apply_avahi_pin(
     return changed, interface_csv
 
 
+def restart_avahi_if_active(run: CommandStatusRunner = _command_status) -> bool:
+    """Restart Avahi only when it is already running."""
+    active = run(["systemctl", "is-active", "--quiet", "avahi-daemon.service"])
+    if active != 0:
+        return False
+    restarted = run(["systemctl", "try-restart", "avahi-daemon.service"])
+    return restarted == 0
+
+
 def main() -> int:
     changed, interface = apply_avahi_pin()
+    restarted = restart_avahi_if_active() if changed else False
     action = "updated" if changed else "already pinned"
+    restart = " restarted avahi" if restarted else ""
     log.warning(
-        "Avahi mDNS identity %s: %s.local on %s", action, SERVER_HOSTNAME, interface
+        "Avahi mDNS identity %s: %s.local on %s%s",
+        action,
+        SERVER_HOSTNAME,
+        interface,
+        restart,
     )
     return 0
 

--- a/app/server/tests/integration/test_on_demand_flow.py
+++ b/app/server/tests/integration/test_on_demand_flow.py
@@ -88,12 +88,30 @@ class TestOnDemandFlow:
 
         client.post("/internal/on-demand/cam-a/start")
         fake.calls.clear()
+        cam = app.store.get_camera("cam-a")
+        cam.streaming = True
+        app.store.save_camera(cam)
 
         # Second start call should be a no-op.
         r = client.post("/internal/on-demand/cam-a/start")
         assert r.status_code == 200
         assert fake.calls == []
         assert r.get_json().get("already_running") is True
+
+    def test_start_reconciles_desired_running_when_stream_not_observed(self, staged):
+        app, fake = staged
+        client = app.test_client()
+
+        cam = app.store.get_camera("cam-a")
+        cam.desired_stream_state = "running"
+        cam.streaming = False
+        app.store.save_camera(cam)
+
+        r = client.post("/internal/on-demand/cam-a/start")
+        assert r.status_code == 200
+        assert fake.calls == [("start", "10.0.0.7", "cam-a")]
+        assert r.get_json().get("reconciled") is True
+        assert app.store.get_camera("cam-a").desired_stream_state == "running"
 
 
 class TestOnDemandEdgeCases:

--- a/app/server/tests/unit/test_avahi_pin.py
+++ b/app/server/tests/unit/test_avahi_pin.py
@@ -302,6 +302,43 @@ def test_main_logs_pinned_identity():
         assert avahi_pin.main() == 0
 
 
+def test_main_restarts_active_avahi_when_pin_changes():
+    with (
+        patch.object(avahi_pin, "apply_avahi_pin", return_value=(True, "eth0")),
+        patch.object(
+            avahi_pin, "restart_avahi_if_active", return_value=True
+        ) as restart,
+    ):
+        assert avahi_pin.main() == 0
+
+    restart.assert_called_once_with()
+
+
+def test_restart_avahi_if_active_skips_inactive_daemon():
+    calls = []
+
+    def fake_status(argv):
+        calls.append(argv)
+        return 3 if "is-active" in argv else 0
+
+    assert avahi_pin.restart_avahi_if_active(run=fake_status) is False
+    assert calls == [["systemctl", "is-active", "--quiet", "avahi-daemon.service"]]
+
+
+def test_restart_avahi_if_active_restarts_running_daemon():
+    calls = []
+
+    def fake_status(argv):
+        calls.append(argv)
+        return 0
+
+    assert avahi_pin.restart_avahi_if_active(run=fake_status) is True
+    assert calls == [
+        ["systemctl", "is-active", "--quiet", "avahi-daemon.service"],
+        ["systemctl", "try-restart", "avahi-daemon.service"],
+    ]
+
+
 def test_avahi_unit_drop_in_uses_generated_data_config():
     drop_in = REPO_ROOT / "app" / "server" / "config" / "avahi-daemon-home-monitor.conf"
     text = drop_in.read_text(encoding="utf-8")
@@ -327,11 +364,14 @@ def test_monitor_server_recipe_installs_avahi_pin_unit():
     )
 
     assert "file://config/monitor-avahi-pin.service" in text
+    assert "file://config/monitor-avahi-pin.timer" in text
     assert "file://config/avahi-daemon-home-monitor.conf" in text
     assert "file://config/monitor-network-dispatcher.sh" in text
     assert "monitor-avahi-pin.service" in services
+    assert "monitor-avahi-pin.timer" in services
     assert "monitor.service" in services
     assert "avahi-daemon.service.d/10-home-monitor.conf" in text
+    assert "${systemd_system_unitdir}/monitor-avahi-pin.timer" in text
     assert "NetworkManager/dispatcher.d/20-home-monitor-lan-identity" in text
 
 
@@ -341,5 +381,24 @@ def test_monitor_network_dispatcher_reapplies_avahi_identity():
     ).read_text(encoding="utf-8")
 
     assert "monitor.services.avahi_pin" in script
-    assert "try-restart avahi-daemon.service" in script
     assert "dhcp4-change" in script
+
+
+def test_avahi_pin_service_is_rerunnable_for_reconciliation_timer():
+    service = (
+        REPO_ROOT / "app" / "server" / "config" / "monitor-avahi-pin.service"
+    ).read_text(encoding="utf-8")
+
+    assert "Type=oneshot" in service
+    assert "RemainAfterExit" not in service
+    assert "systemd-networkd.service" in service
+
+
+def test_avahi_pin_timer_reconciles_networkd_managed_links():
+    timer = (
+        REPO_ROOT / "app" / "server" / "config" / "monitor-avahi-pin.timer"
+    ).read_text(encoding="utf-8")
+
+    assert "Unit=monitor-avahi-pin.service" in timer
+    assert "OnBootSec=20s" in timer
+    assert "OnUnitInactiveSec=30s" in timer

--- a/app/server/tests/unit/test_on_demand_coordinator.py
+++ b/app/server/tests/unit/test_on_demand_coordinator.py
@@ -34,6 +34,7 @@ class TestOnDemandStart:
         body = resp.get_json()
         assert body["ok"] is True
         assert body.get("started") is True
+        assert body.get("reconciled") is False
         app.camera_control_client.start_stream.assert_called_once_with(
             "192.0.2.50",
             camera_id="cam-x",
@@ -45,6 +46,7 @@ class TestOnDemandStart:
         app = app_with_cam
         cam = app.store.get_camera("cam-x")
         cam.desired_stream_state = "running"
+        cam.streaming = True
         app.store.save_camera(cam)
 
         client = app.test_client()
@@ -54,6 +56,29 @@ class TestOnDemandStart:
         assert body["ok"] is True
         assert body.get("already_running") is True
         app.camera_control_client.start_stream.assert_not_called()
+
+    def test_start_reconciles_when_desired_running_but_not_streaming(
+        self, app_with_cam
+    ):
+        app = app_with_cam
+        cam = app.store.get_camera("cam-x")
+        cam.desired_stream_state = "running"
+        cam.streaming = False
+        app.store.save_camera(cam)
+
+        client = app.test_client()
+        resp = client.post("/internal/on-demand/cam-x/start")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body.get("started") is True
+        assert body.get("reconciled") is True
+        app.camera_control_client.start_stream.assert_called_once_with(
+            "192.0.2.50",
+            camera_id="cam-x",
+        )
+        cam = app.store.get_camera("cam-x")
+        assert cam.desired_stream_state == "running"
 
     def test_start_404_unknown_camera(self, app_with_cam):
         client = app_with_cam.test_client()

--- a/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
+++ b/meta-home-monitor/recipes-monitor/monitor-server/monitor-server_1.0.bb
@@ -26,6 +26,7 @@ SRC_URI = " \
     file://config/monitor.service \
     file://config/monitor-privileged-helper.service \
     file://config/monitor-avahi-pin.service \
+    file://config/monitor-avahi-pin.timer \
     file://config/monitor-hotspot.service \
     file://config/monitor-hotspot.sh \
     file://config/monitor-network-dispatcher.sh \
@@ -61,7 +62,7 @@ RDEPENDS:${PN} = " \
 
 inherit systemd useradd
 
-SYSTEMD_SERVICE:${PN} = "home-monitor-led-init.service monitor-avahi-pin.service monitor-privileged-helper.service monitor.service monitor-hotspot.service"
+SYSTEMD_SERVICE:${PN} = "home-monitor-led-init.service monitor-avahi-pin.service monitor-avahi-pin.timer monitor-privileged-helper.service monitor.service monitor-hotspot.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 # Create monitor system user/group
@@ -109,6 +110,7 @@ do_install() {
     install -m 0644 ${WORKDIR}/config/monitor.service ${D}${systemd_system_unitdir}/monitor.service
     install -m 0644 ${WORKDIR}/config/monitor-privileged-helper.service ${D}${systemd_system_unitdir}/monitor-privileged-helper.service
     install -m 0644 ${WORKDIR}/config/monitor-avahi-pin.service ${D}${systemd_system_unitdir}/monitor-avahi-pin.service
+    install -m 0644 ${WORKDIR}/config/monitor-avahi-pin.timer ${D}${systemd_system_unitdir}/monitor-avahi-pin.timer
     install -m 0644 ${WORKDIR}/config/monitor-hotspot.service ${D}${systemd_system_unitdir}/monitor-hotspot.service
     install -m 0644 ${WORKDIR}/status_led/home-monitor-led-init.service ${D}${systemd_system_unitdir}/home-monitor-led-init.service
 
@@ -144,6 +146,7 @@ FILES:${PN} = " \
     ${systemd_system_unitdir}/monitor.service \
     ${systemd_system_unitdir}/monitor-privileged-helper.service \
     ${systemd_system_unitdir}/monitor-avahi-pin.service \
+    ${systemd_system_unitdir}/monitor-avahi-pin.timer \
     ${systemd_system_unitdir}/monitor-hotspot.service \
     ${systemd_system_unitdir}/avahi-daemon.service.d/10-home-monitor.conf \
     ${sysconfdir}/nginx/sites-enabled/monitor.conf \

--- a/scripts/deploy-dev-app.sh
+++ b/scripts/deploy-dev-app.sh
@@ -172,6 +172,8 @@ deploy_server() {
     copy_file "$REPO_ROOT/app/server/config/nginx-monitor.conf" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/server/config/monitor.service" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/server/config/monitor-privileged-helper.service" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/monitor-avahi-pin.service" "$host" "$SERVER_STAGE"
+    copy_file "$REPO_ROOT/app/server/config/monitor-avahi-pin.timer" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/server/config/monitor-hotspot.sh" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/server/config/monitor-hotspot.service" "$host" "$SERVER_STAGE"
     copy_file "$REPO_ROOT/app/server/config/monitor-network-dispatcher.sh" "$host" "$SERVER_STAGE"
@@ -231,6 +233,8 @@ deploy_server() {
         chmod 0755 /usr/bin/home-monitor-ledctl
         cp '$SERVER_STAGE/monitor.service' /etc/systemd/system/monitor.service
         cp '$SERVER_STAGE/monitor-privileged-helper.service' /etc/systemd/system/monitor-privileged-helper.service
+        cp '$SERVER_STAGE/monitor-avahi-pin.service' /etc/systemd/system/monitor-avahi-pin.service
+        cp '$SERVER_STAGE/monitor-avahi-pin.timer' /etc/systemd/system/monitor-avahi-pin.timer
         cp '$SERVER_STAGE/monitor-hotspot.service' /etc/systemd/system/monitor-hotspot.service
         mkdir -p /etc/NetworkManager/conf.d
         cp '$SERVER_STAGE/10-home-monitor-hostname.conf' /etc/NetworkManager/conf.d/10-home-monitor-hostname.conf
@@ -265,7 +269,9 @@ deploy_server() {
         systemctl mask systemd-networkd-wait-online.service 2>/dev/null || true
         systemctl reset-failed systemd-networkd-wait-online.service 2>/dev/null || true
         systemctl daemon-reload
-        systemctl enable home-monitor-led-init.service gpio-trigger.service monitor-hotspot.service monitor-privileged-helper.service monitor.service >/dev/null 2>&1 || true
+        systemctl enable home-monitor-led-init.service gpio-trigger.service monitor-hotspot.service monitor-avahi-pin.timer monitor-privileged-helper.service monitor.service >/dev/null 2>&1 || true
+        systemctl start monitor-avahi-pin.timer >/dev/null 2>&1 || true
+        systemctl restart monitor-avahi-pin.service >/dev/null 2>&1 || true
     "
 
     if [ "$SKIP_RESTART" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Reconcile on-demand stream starts when the server still wants a camera running but the latest heartbeat says it is not publishing.
- Add a rerunnable Avahi pin timer so the server mDNS identity follows Ethernet/WiFi changes even when Ethernet is managed by systemd-networkd instead of NetworkManager.
- Deploy the Avahi pin service/timer in Yocto and dev deploys, with unit tests covering the behavior.

## Validation
- python -m pytest app/server/tests/unit/test_avahi_pin.py app/server/tests/unit/test_on_demand_coordinator.py app/server/tests/integration/test_on_demand_flow.py -v
- ruff check app/server/monitor/services/avahi_pin.py app/server/monitor/api/on_demand.py app/server/tests/unit/test_avahi_pin.py app/server/tests/unit/test_on_demand_coordinator.py app/server/tests/integration/test_on_demand_flow.py
- ruff format --check app/server/monitor/services/avahi_pin.py app/server/monitor/api/on_demand.py app/server/tests/unit/test_avahi_pin.py app/server/tests/unit/test_on_demand_coordinator.py app/server/tests/integration/test_on_demand_flow.py

## Device check
- Deployed to server 192.168.1.245.
- After Ethernet reconnect, eth0 is 192.168.1.244 with lower route metric than WiFi, Avahi is pinned to eth0, and monitor-avahi-pin.timer is active.
- Internal on-demand starts for cam-351ad8ee and cam-2b6a727c return already_running after reconnect.