### PR TITLE
Fix camera stream failover and duplicate page initialization

### DIFF
--- a/app/camera/camera_streamer/heartbeat.py
+++ b/app/camera/camera_streamer/heartbeat.py
@@ -255,6 +255,7 @@ class HeartbeatSender:
 
         while not self._stop_event.is_set():
             try:
+                self._refresh_server_resolver("heartbeat_tick")
                 self._refresh_resolver_for_network_event()
                 response = self._send()
                 if response and response.get("pending_config"):
@@ -485,32 +486,33 @@ class HeartbeatSender:
     def _restart_stream_for_endpoint_change(
         self, previous_ip: str | None, current_ip: str
     ) -> None:
-        """Restart an active stream so FFmpeg reconnects to the preferred IP."""
+        """Notify the stream owner to reconnect to the preferred endpoint."""
         if self._stream is None:
             return
+        desired_running = False
         try:
-            if not self._stream.is_streaming:
+            desired_running = (
+                self._control is not None
+                and self._control.desired_stream_state == "running"
+            )
+        except Exception:
+            desired_running = False
+        try:
+            streaming = bool(self._stream.is_streaming)
+            if not streaming and not desired_running:
                 return
         except Exception:
+            if not desired_running:
+                return
+        notifier = getattr(self._stream, "request_endpoint_reconnect", None)
+        if callable(notifier):
+            notifier(previous_ip, current_ip, source="heartbeat")
+            if desired_running and not streaming:
+                starter = getattr(self._stream, "start", None)
+                if callable(starter):
+                    starter()
             return
-
-        def _restart() -> None:
-            try:
-                log.info(
-                    "Restarting stream for server endpoint change: %s -> %s",
-                    previous_ip or "(none)",
-                    current_ip,
-                )
-                self._stream.stop()
-                self._stream.start()
-            except Exception as exc:
-                log.warning("Failed to restart stream after endpoint change: %s", exc)
-
-        threading.Thread(
-            target=_restart,
-            daemon=True,
-            name="stream-endpoint-restart",
-        ).start()
+        log.warning("Stream manager cannot reconnect for server endpoint change")
 
     def _handle_server_unpair(self) -> None:
         """Wipe local pairing state and exit so systemd restarts us into PAIRING.

--- a/app/camera/camera_streamer/lifecycle.py
+++ b/app/camera/camera_streamer/lifecycle.py
@@ -160,8 +160,8 @@ class _ServerResolver:
         if not self._address:
             return False
         try:
-            ip = socket.gethostbyname(self._address)
-        except socket.gaierror as exc:
+            ip = self._resolve_address()
+        except (OSError, subprocess.SubprocessError, socket.gaierror) as exc:
             log.debug(
                 "ServerResolver: refresh from %s failed for %s: %s",
                 source,
@@ -170,6 +170,39 @@ class _ServerResolver:
             )
             return False
         return self._set_resolved_ip(ip, source=source)
+
+    def _resolve_address(self) -> str:
+        """Resolve the configured server address to an IPv4 LAN endpoint."""
+        address = self._address.strip()
+        if address.lower().endswith(".local"):
+            avahi_ip = self._resolve_with_avahi(address)
+            if avahi_ip:
+                return avahi_ip
+        return socket.gethostbyname(address)
+
+    @staticmethod
+    def _resolve_with_avahi(address: str) -> str | None:
+        """Resolve a ``.local`` name through Avahi's direct CLI helper."""
+        try:
+            result = subprocess.run(
+                ["avahi-resolve", "-n", address],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (FileNotFoundError, OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        for token in result.stdout.replace("\t", " ").split():
+            try:
+                parsed = ipaddress.ip_address(token)
+            except ValueError:
+                continue
+            if parsed.version == 4 and parsed.is_private:
+                return str(parsed)
+        return None
 
     def _set_resolved_ip(self, ip: str, source: str) -> bool:
         try:
@@ -235,8 +268,8 @@ class _ServerResolver:
         while not self._stop.is_set() and time.monotonic() < deadline:
             attempts += 1
             try:
-                ip = socket.gethostbyname(self._address)
-            except socket.gaierror as e:
+                ip = self._resolve_address()
+            except (OSError, subprocess.SubprocessError, socket.gaierror) as e:
                 log.debug(
                     "Resolution attempt %d for '%s' failed: %s — retry in %.1fs",
                     attempts,

--- a/app/camera/camera_streamer/picam_backend.py
+++ b/app/camera/camera_streamer/picam_backend.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import os
+import signal
 import subprocess
 import threading
 import time
@@ -110,6 +111,8 @@ LORES_WIDTH = 320
 LORES_HEIGHT = 240
 LORES_FPS = 5
 MIN_RETAIN_BYTES = 32 * 1024
+FFMPEG_TERM_TIMEOUT = 2
+FFMPEG_KILL_TIMEOUT = 1
 
 
 class PicameraH264Backend:
@@ -182,7 +185,12 @@ class PicameraH264Backend:
             self.stop_pre_rolled_recording("aborted")
         except Exception:  # pragma: no cover - defensive cleanup
             log.debug("pre-roll teardown failed", exc_info=True)
-        # Encoder + picam first so frames stop flowing before we close ffmpeg's stdin.
+        # Kill the publisher first. On server endpoint loss, ffmpeg can be stuck
+        # in the RTSPS output path; leaving it alive while stopping Picamera2 can
+        # block the encoder output cleanup and prevent the reconnect loop from
+        # ever starting a publisher for the new server IP.
+        self._stop_ffmpeg()
+
         try:
             if self._picam2 is not None:
                 try:
@@ -201,21 +209,42 @@ class PicameraH264Backend:
             self._lores_thread.join(timeout=5)
         self._lores_thread = None
 
-        if self._ffmpeg is not None:
+        log.info("PicameraH264Backend stopped")
+
+    def _stop_ffmpeg(self) -> None:
+        proc = self._ffmpeg
+        self._ffmpeg = None
+        if proc is None:
+            return
+        try:
+            self._signal_ffmpeg(proc, signal.SIGTERM)
             try:
-                # Closing stdin lets ffmpeg finish its muxer cleanup.
-                if self._ffmpeg.stdin and not self._ffmpeg.stdin.closed:
-                    self._ffmpeg.stdin.close()
-                self._ffmpeg.terminate()
-                try:
-                    self._ffmpeg.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    self._ffmpeg.kill()
-                    self._ffmpeg.wait(timeout=2)
+                proc.wait(timeout=FFMPEG_TERM_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                self._signal_ffmpeg(proc, signal.SIGKILL)
+                proc.wait(timeout=FFMPEG_KILL_TIMEOUT)
+        except OSError:
+            pass
+        try:
+            if proc.stdin and not proc.stdin.closed:
+                proc.stdin.close()
+        except (OSError, ValueError):
+            pass
+
+    @staticmethod
+    def _signal_ffmpeg(proc, sig: int) -> None:
+        """Signal ffmpeg's process group, falling back to the process itself."""
+        pid = getattr(proc, "pid", None)
+        if pid and hasattr(os, "getpgid"):
+            try:
+                os.killpg(os.getpgid(pid), sig)
+                return
             except OSError:
                 pass
-            self._ffmpeg = None
-        log.info("PicameraH264Backend stopped")
+        if sig == signal.SIGTERM:
+            proc.terminate()
+        else:
+            proc.kill()
 
     @property
     def is_streaming(self) -> bool:

--- a/app/camera/camera_streamer/stream.py
+++ b/app/camera/camera_streamer/stream.py
@@ -30,6 +30,7 @@ Features:
 
 import logging
 import os
+import signal
 import subprocess
 import threading
 import time
@@ -50,6 +51,9 @@ MAX_BACKOFF = 60
 MOTION_LORES_WIDTH = 320
 MOTION_LORES_HEIGHT = 240
 MOTION_LORES_FPS = 5
+STALE_PUBLISHER_TERM_TIMEOUT = 2.0
+STALE_PUBLISHER_KILL_TIMEOUT = 1.0
+ENDPOINT_RECONNECT_EXIT_TIMEOUT = 12.0
 
 
 class StreamManager:
@@ -75,8 +79,12 @@ class StreamManager:
         self._libcamera_proc = None
         self._running = False
         self._thread = None
+        self._retry_event = threading.Event()
         self._backoff = INITIAL_BACKOFF
         self._consecutive_failures = 0
+        self._active_stream_url: str | None = None
+        self._endpoint_reconnect_requested = False
+        self._endpoint_reconnect_generation = 0
         self._lock = threading.Lock()
         self._motion_runner = None
         # Picamera2 backend (preferred path). None means we're on the
@@ -118,13 +126,56 @@ class StreamManager:
             log.warning("Server not configured — streaming disabled")
             return False
 
-        self._running = True
-        self._thread = threading.Thread(
-            target=self._stream_loop, daemon=True, name="stream-loop"
-        )
-        self._thread.start()
+        with self._lock:
+            if self._running and self._thread and self._thread.is_alive():
+                self._retry_event.set()
+                log.info("Stream manager already running; retry requested")
+                return True
+
+            self._running = True
+            self._retry_event.clear()
+            self._endpoint_reconnect_requested = False
+            self._thread = threading.Thread(
+                target=self._stream_loop, daemon=True, name="stream-loop"
+            )
+            thread = self._thread
+
+        thread.start()
         log.info("Stream manager started")
         return True
+
+    def request_endpoint_reconnect(
+        self,
+        previous_ip: str | None = None,
+        current_ip: str | None = None,
+        *,
+        source: str = "resolver",
+    ) -> None:
+        """Ask the stream loop to reconnect to the current resolved endpoint.
+
+        Heartbeat/network observers must not call stop()+start() directly:
+        that creates a second lifecycle owner and can leave an old ffmpeg
+        publisher alive on a stale server IP. This method only marks intent
+        and wakes the single stream loop that owns process teardown/startup.
+        """
+        with self._lock:
+            self._endpoint_reconnect_requested = True
+            self._endpoint_reconnect_generation += 1
+            generation = self._endpoint_reconnect_generation
+        self._retry_event.set()
+        log.info(
+            "Stream endpoint reconnect requested by %s: %s -> %s",
+            source,
+            previous_ip or "(none)",
+            current_ip or "(current)",
+        )
+        watchdog = threading.Timer(
+            ENDPOINT_RECONNECT_EXIT_TIMEOUT,
+            self._exit_if_endpoint_reconnect_stuck,
+            args=(generation,),
+        )
+        watchdog.daemon = True
+        watchdog.start()
 
     def _motion_enabled(self) -> bool:
         """True iff config wants motion detection AND wiring is in place."""
@@ -218,11 +269,15 @@ class StreamManager:
     def stop(self):
         """Stop streaming and tear down whichever backend is active."""
         self._running = False
+        self._retry_event.set()
+        with self._lock:
+            self._endpoint_reconnect_requested = False
         self._teardown_picam_backend()
         self._kill_ffmpeg()
         self._stop_motion_runner()
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=10)
+        self._retry_event.clear()
         log.info("Stream manager stopped")
 
     def _teardown_picam_backend(self):
@@ -231,12 +286,14 @@ class StreamManager:
         with self._lock:
             backend = self._picam_backend
             self._picam_backend = None
+            self._active_stream_url = None
         if backend is not None:
             try:
                 backend.stop()
             except Exception:
                 log.exception("Picamera backend stop failed")
         self._stop_motion_runner()
+        self._terminate_stale_stream_publishers(reason="picamera teardown")
 
     def _stop_motion_runner(self):
         if self._motion_runner is not None:
@@ -269,10 +326,16 @@ class StreamManager:
         while self._running:
             try:
                 if use_picam:
+                    self._terminate_stale_stream_publishers(
+                        reason="before picamera start"
+                    )
                     if self._start_picam_backend():
                         self._monitor_picam_backend()
                     self._teardown_picam_backend()
                 else:
+                    self._terminate_stale_stream_publishers(
+                        reason="before ffmpeg start"
+                    )
                     self._start_ffmpeg()
                     self._monitor_ffmpeg()
             except Exception:
@@ -280,6 +343,12 @@ class StreamManager:
 
             if not self._running:
                 break
+
+            if self._consume_endpoint_reconnect_requested():
+                self._consecutive_failures = 0
+                self._backoff = INITIAL_BACKOFF
+                log.info("Stream endpoint changed; reconnecting immediately")
+                continue
 
             # Reconnect with backoff
             self._consecutive_failures += 1
@@ -291,11 +360,12 @@ class StreamManager:
                 self._consecutive_failures,
                 wait,
             )
-            # Sleep in small increments so we can stop quickly
-            for _ in range(int(wait * 10)):
-                if not self._running:
-                    return
-                time.sleep(0.1)
+            if self._retry_event.wait(timeout=wait):
+                self._retry_event.clear()
+                if self._running:
+                    log.info("Stream retry requested; reconnecting now")
+            if not self._running:
+                return
 
     @property
     def _use_mtls(self):
@@ -324,6 +394,36 @@ class StreamManager:
         if self._use_mtls:
             return self._config.rtsps_url
         return self._config.rtsp_url
+
+    def _set_active_stream_url(self) -> str:
+        """Remember the endpoint used by the currently running pipeline."""
+        url = self._stream_url
+        with self._lock:
+            self._active_stream_url = url
+        return url
+
+    def _clear_active_stream_url(self) -> None:
+        with self._lock:
+            self._active_stream_url = None
+
+    def _request_endpoint_reconnect_if_changed(self) -> bool:
+        current_url = self._stream_url
+        with self._lock:
+            active_url = self._active_stream_url
+            if self._endpoint_reconnect_requested:
+                return True
+            if not active_url or current_url == active_url:
+                return False
+            self._endpoint_reconnect_requested = True
+        log.info("Stream target changed: %s -> %s", active_url, current_url)
+        return True
+
+    def _consume_endpoint_reconnect_requested(self) -> bool:
+        with self._lock:
+            requested = self._endpoint_reconnect_requested
+            self._endpoint_reconnect_requested = False
+            self._active_stream_url = None
+        return requested
 
     def _tls_flags(self):
         """Return ffmpeg TLS flags for mTLS client cert authentication.
@@ -531,15 +631,18 @@ class StreamManager:
             motion_enabled=motion_enabled,
             server_resolver=self._server_resolver,
         )
+        target_url = self._set_active_stream_url()
         if not backend.start():
             log.error("Picamera backend failed to start")
+            self._clear_active_stream_url()
             self._stop_motion_runner()
             return False
         with self._lock:
             self._picam_backend = backend
         log.info(
-            "Streaming via Picamera2 backend (motion=%s)",
+            "Streaming via Picamera2 backend (motion=%s target=%s)",
             motion_enabled,
+            target_url,
         )
         return True
 
@@ -549,6 +652,8 @@ class StreamManager:
         if backend is None:
             return
         while self._running and backend.is_streaming:
+            if self._request_endpoint_reconnect_if_changed():
+                break
             time.sleep(1.0)
         log.info("Picamera backend no longer streaming")
 
@@ -556,6 +661,7 @@ class StreamManager:
         """Launch the streaming pipeline."""
         import shutil
 
+        target_url = self._set_active_stream_url()
         log.info(
             "Stream config: device=%s resolution=%dx%d fps=%d "
             "server=%s:%s camera_id=%s",
@@ -567,14 +673,16 @@ class StreamManager:
             self._config.server_port,
             self._config.camera_id,
         )
-        log.info("Stream target URL: %s (mTLS=%s)", self._stream_url, self._use_mtls)
+        log.info("Stream target URL: %s (mTLS=%s)", target_url, self._use_mtls)
 
         # Check if video device exists before starting
         if not os.path.exists(self._camera_device):
+            self._clear_active_stream_url()
             log.error("%s not found — camera not detected", self._camera_device)
             return
 
         if not shutil.which("ffmpeg"):
+            self._clear_active_stream_url()
             log.error("ffmpeg binary not found in PATH — cannot stream")
             return
 
@@ -611,6 +719,7 @@ class StreamManager:
             time.sleep(5)
 
             if self._libcamera_proc.poll() is not None:
+                self._clear_active_stream_url()
                 log.error(
                     "libcamera-vid exited early (code %d)",
                     self._libcamera_proc.returncode,
@@ -631,7 +740,7 @@ class StreamManager:
             log.info(
                 "ffmpeg started (PID %d), streaming to %s",
                 self._process.pid,
-                self._config.rtsp_url,
+                target_url,
             )
         else:
             # Direct ffmpeg v4l2 capture (camera outputs H.264 natively)
@@ -676,13 +785,26 @@ class StreamManager:
         stderr_thread = threading.Thread(target=_read_stderr, daemon=True)
         stderr_thread.start()
 
-        # Wait for process to exit
-        proc.wait()
+        endpoint_reconnect = False
+        while self._running and proc.poll() is None:
+            if self._request_endpoint_reconnect_if_changed():
+                endpoint_reconnect = True
+                self._kill_ffmpeg()
+                break
+            time.sleep(1.0)
+
+        if proc.poll() is None:
+            proc.wait()
         stderr_thread.join(timeout=2)
 
         returncode = proc.returncode
         with self._lock:
-            self._process = None
+            if self._process is proc:
+                self._process = None
+
+        if endpoint_reconnect:
+            log.info("ffmpeg stopped for server endpoint change")
+            return
 
         if returncode == 0:
             # Clean exit (shouldn't happen during normal streaming)
@@ -725,3 +847,139 @@ class StreamManager:
         # ffmpeg exit — the reconnect loop will _start_ffmpeg() again
         # and allocate a fresh pipe.
         self._stop_motion_runner()
+
+    def _terminate_stale_stream_publishers(self, *, reason: str) -> None:
+        """Kill leftover ffmpeg publishers for this camera stream.
+
+        The normal owner is ``self._process`` or the Picamera backend's
+        private ffmpeg. This sweep is a safety net for races during endpoint
+        changes or abrupt backend teardown: no camera should keep publishing
+        to two server IPs, and no stale publisher should keep a dead IP alive.
+        """
+        self._terminate_stream_publishers(reason=reason, include_known=False)
+
+    def _terminate_stream_publishers(self, *, reason: str, include_known: bool) -> None:
+        pids = self._find_stream_publisher_pids(include_known=include_known)
+        if not pids:
+            return
+        log.warning(
+            "Terminating ffmpeg publisher(s) for %s after %s: %s",
+            self._stream_path,
+            reason,
+            ", ".join(str(pid) for pid in pids),
+        )
+        for pid in pids:
+            self._terminate_pid(pid)
+
+    def _exit_if_endpoint_reconnect_stuck(self, generation: int) -> None:
+        with self._lock:
+            still_stuck = (
+                self._endpoint_reconnect_requested
+                and generation == self._endpoint_reconnect_generation
+            )
+        if not still_stuck:
+            return
+        log.error(
+            "Endpoint reconnect did not complete within %.0fs; "
+            "terminating stream publishers and restarting camera-streamer",
+            ENDPOINT_RECONNECT_EXIT_TIMEOUT,
+        )
+        self._terminate_stream_publishers(
+            reason="endpoint reconnect watchdog",
+            include_known=True,
+        )
+        os._exit(0)
+
+    @property
+    def _stream_path(self) -> str:
+        return self._config.camera_id or self._config.stream_name
+
+    def _known_stream_pids(self) -> set[int]:
+        known: set[int] = set()
+        with self._lock:
+            proc = self._process
+            backend = self._picam_backend
+        if proc is not None and getattr(proc, "pid", None):
+            known.add(int(proc.pid))
+        backend_proc = (
+            getattr(backend, "_ffmpeg", None) if backend is not None else None
+        )
+        if backend_proc is not None and getattr(backend_proc, "pid", None):
+            known.add(int(backend_proc.pid))
+        return known
+
+    def _find_stream_publisher_pids(self, *, include_known: bool) -> list[int]:
+        if not os.path.isdir("/proc"):
+            return []
+        stream_path = self._stream_path
+        own_pid = os.getpid()
+        known = self._known_stream_pids()
+        pids: list[int] = []
+        try:
+            entries = os.listdir("/proc")
+        except OSError:
+            return []
+        for entry in entries:
+            if not entry.isdigit():
+                continue
+            pid = int(entry)
+            if pid == own_pid or (not include_known and pid in known):
+                continue
+            try:
+                with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                    parts = [
+                        p.decode("utf-8", "replace")
+                        for p in fh.read().split(b"\0")
+                        if p
+                    ]
+            except OSError:
+                continue
+            if self._cmdline_targets_stream(parts, stream_path):
+                pids.append(pid)
+        return pids
+
+    @staticmethod
+    def _cmdline_targets_stream(parts: list[str], stream_path: str) -> bool:
+        if not parts:
+            return False
+        exe = os.path.basename(parts[0])
+        if exe != "ffmpeg":
+            return False
+        suffix = f"/{stream_path}"
+        for arg in parts:
+            if (arg.startswith("rtsp://") or arg.startswith("rtsps://")) and (
+                arg == suffix or arg.endswith(suffix)
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _terminate_pid(pid: int) -> None:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except OSError as exc:
+            log.debug("Failed to terminate stale ffmpeg pid %d: %s", pid, exc)
+            return
+        deadline = time.monotonic() + STALE_PUBLISHER_TERM_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.1)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        except OSError as exc:
+            log.debug("Failed to kill stale ffmpeg pid %d: %s", pid, exc)
+            return
+        deadline = time.monotonic() + STALE_PUBLISHER_KILL_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.1)

--- a/app/camera/tests/unit/test_heartbeat.py
+++ b/app/camera/tests/unit/test_heartbeat.py
@@ -460,29 +460,93 @@ class TestHeartbeatSender:
             stream_manager=stream,
             server_resolver=resolver,
         )
-        started = []
 
-        class FakeThread:
-            def __init__(self, target=None, **_kwargs):
-                self._target = target
-
-            def start(self):
-                started.append(True)
-                self._target()
-
-        with patch("camera_streamer.heartbeat.threading.Thread", FakeThread):
-            sender._apply_server_endpoint(
-                {
-                    "server_endpoint": {
-                        "stream_host": "192.168.1.244",
-                        "source": "route_iface",
-                    }
+        sender._apply_server_endpoint(
+            {
+                "server_endpoint": {
+                    "stream_host": "192.168.1.244",
+                    "source": "route_iface",
                 }
-            )
+            }
+        )
 
-        assert started == [True]
-        stream.stop.assert_called_once()
+        stream.request_endpoint_reconnect.assert_called_once_with(
+            "192.168.1.245", "192.168.1.244", source="heartbeat"
+        )
+        stream.stop.assert_not_called()
+        stream.start.assert_not_called()
+
+    def test_server_endpoint_change_retries_desired_running_inactive_stream(self):
+        cfg = _make_config(server_ip="homemonitor.local")
+        resolver = MagicMock()
+        resolver.resolved_ip = "192.168.1.244"
+
+        def update_ip(ip, source="server_endpoint"):
+            resolver.resolved_ip = ip
+            return True
+
+        resolver.update_preferred_ip.side_effect = update_ip
+        stream = MagicMock()
+        stream.is_streaming = False
+        handler = MagicMock()
+        handler.desired_stream_state = "running"
+        sender = HeartbeatSender(
+            cfg,
+            _make_pairing(),
+            stream_manager=stream,
+            control_handler=handler,
+            server_resolver=resolver,
+        )
+
+        sender._apply_server_endpoint(
+            {
+                "server_endpoint": {
+                    "stream_host": "192.168.1.245",
+                    "source": "route_iface",
+                }
+            }
+        )
+
+        stream.request_endpoint_reconnect.assert_called_once_with(
+            "192.168.1.244", "192.168.1.245", source="heartbeat"
+        )
+        stream.stop.assert_not_called()
         stream.start.assert_called_once()
+
+    def test_server_endpoint_change_ignores_inactive_stopped_stream(self):
+        cfg = _make_config(server_ip="homemonitor.local")
+        resolver = MagicMock()
+        resolver.resolved_ip = "192.168.1.244"
+
+        def update_ip(ip, source="server_endpoint"):
+            resolver.resolved_ip = ip
+            return True
+
+        resolver.update_preferred_ip.side_effect = update_ip
+        stream = MagicMock()
+        stream.is_streaming = False
+        handler = MagicMock()
+        handler.desired_stream_state = "stopped"
+        sender = HeartbeatSender(
+            cfg,
+            _make_pairing(),
+            stream_manager=stream,
+            control_handler=handler,
+            server_resolver=resolver,
+        )
+
+        sender._apply_server_endpoint(
+            {
+                "server_endpoint": {
+                    "stream_host": "192.168.1.245",
+                    "source": "route_iface",
+                }
+            }
+        )
+
+        stream.request_endpoint_reconnect.assert_not_called()
+        stream.stop.assert_not_called()
+        stream.start.assert_not_called()
 
     def test_network_failures_force_resolver_refresh(self):
         cfg = _make_config(server_ip="homemonitor.local")

--- a/app/camera/tests/unit/test_lifecycle_resolver.py
+++ b/app/camera/tests/unit/test_lifecycle_resolver.py
@@ -73,15 +73,47 @@ class TestResolverHappyPath:
         )
         resolver._resolved_ip = "192.168.1.245"
 
-        with patch(
-            "camera_streamer.lifecycle.socket.gethostbyname",
-            return_value="192.168.1.244",
+        with (
+            patch(
+                "camera_streamer.lifecycle._ServerResolver._resolve_with_avahi",
+                return_value=None,
+            ),
+            patch(
+                "camera_streamer.lifecycle.socket.gethostbyname",
+                return_value="192.168.1.244",
+            ),
         ):
             assert resolver.refresh_now(source="heartbeat_failure") is True
 
         assert resolver.resolved_ip == "192.168.1.244"
         cached = json.loads(cache_path.read_text(encoding="utf-8"))
         assert cached["ip"] == "192.168.1.244"
+
+    def test_refresh_now_prefers_direct_avahi_for_local_names(self, tmp_path):
+        cache_path = tmp_path / "server_resolved_ip"
+        resolver = _ServerResolver(
+            "homemonitor.local",
+            capture_manager=MagicMock(),
+            cache_path=str(cache_path),
+        )
+        resolver._resolved_ip = "192.168.1.244"
+
+        with (
+            patch(
+                "camera_streamer.lifecycle._ServerResolver._resolve_with_avahi",
+                return_value="192.168.1.245",
+            ),
+            patch(
+                "camera_streamer.lifecycle.socket.gethostbyname",
+                return_value="192.168.1.244",
+            ) as socket_lookup,
+        ):
+            assert resolver.refresh_now(source="heartbeat_tick") is True
+
+        assert resolver.resolved_ip == "192.168.1.245"
+        socket_lookup.assert_not_called()
+        cached = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert cached["ip"] == "192.168.1.245"
 
     def test_success_persists_cache_atomically(self, tmp_path):
         cache_path = tmp_path / "server_resolved_ip"

--- a/app/camera/tests/unit/test_picam_backend.py
+++ b/app/camera/tests/unit/test_picam_backend.py
@@ -125,6 +125,41 @@ class TestStartEncoder:
         assert isinstance(backend._encoder.output, FakeFileOutput)
         assert backend._pre_roll_output is None
 
+    def test_stop_terminates_ffmpeg_before_picam_recording(self, camera_config):
+        calls = []
+
+        class FakeProc:
+            pid = 1234
+            stdin = io.BytesIO()
+
+            def terminate(self):
+                calls.append("ffmpeg.terminate")
+
+            def wait(self, timeout=None):
+                calls.append(f"ffmpeg.wait:{timeout}")
+
+            def kill(self):
+                calls.append("ffmpeg.kill")
+
+        class StopAwarePicam:
+            def stop_recording(self):
+                calls.append("picam.stop_recording")
+
+            def close(self):
+                calls.append("picam.close")
+
+        backend = PicameraH264Backend(camera_config)
+        backend._ffmpeg = FakeProc()
+        backend._picam2 = StopAwarePicam()
+
+        backend.stop()
+
+        assert calls[:2] == ["ffmpeg.terminate", "ffmpeg.wait:2"]
+        assert "picam.stop_recording" in calls
+        assert calls.index("ffmpeg.terminate") < calls.index("picam.stop_recording")
+        assert backend._ffmpeg is None
+        assert backend._picam2 is None
+
 
 class TestPreRollRecording:
     def test_start_and_stop_finalize_buffered_then_live_bytes(

--- a/app/camera/tests/unit/test_stream.py
+++ b/app/camera/tests/unit/test_stream.py
@@ -37,6 +37,139 @@ class TestStreamManager:
             time.sleep(0.2)
             mgr.stop()
 
+    def test_start_while_running_requests_retry_without_new_thread(self, camera_config):
+        """Repeated start requests must wake the loop, not spawn contenders."""
+        mgr = StreamManager(camera_config)
+        thread = MagicMock()
+        thread.is_alive.return_value = True
+        mgr._running = True
+        mgr._thread = thread
+
+        with patch("camera_streamer.stream.threading.Thread") as thread_factory:
+            assert mgr.start() is True
+
+        thread_factory.assert_not_called()
+        assert mgr._retry_event.is_set()
+
+    def test_running_stream_reconnects_when_resolved_endpoint_changes(
+        self, camera_config
+    ):
+        """A live stream must not stay pinned to a stale server IP."""
+        resolver = MagicMock()
+        resolver.resolved_ip = "192.168.1.244"
+        mgr = StreamManager(camera_config, server_resolver=resolver)
+        mgr._running = True
+        mgr._active_stream_url = mgr._stream_url
+        backend = MagicMock()
+        backend.is_streaming = True
+        mgr._picam_backend = backend
+
+        resolver.resolved_ip = "192.168.1.245"
+        mgr._monitor_picam_backend()
+
+        assert mgr._consume_endpoint_reconnect_requested() is True
+
+    def test_external_endpoint_reconnect_request_is_owned_by_stream_loop(
+        self, camera_config, monkeypatch
+    ):
+        """Observers signal endpoint changes; the stream loop performs teardown."""
+        timers = []
+
+        class FakeTimer:
+            daemon = False
+
+            def __init__(self, timeout, target, args=()):
+                self.timeout = timeout
+                self.target = target
+                self.args = args
+                timers.append(self)
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr("camera_streamer.stream.threading.Timer", FakeTimer)
+        mgr = StreamManager(camera_config)
+        mgr._running = True
+        mgr._active_stream_url = mgr._stream_url
+        backend = MagicMock()
+        backend.is_streaming = True
+        mgr._picam_backend = backend
+
+        mgr.request_endpoint_reconnect("192.168.1.244", "192.168.1.245", source="test")
+        mgr._monitor_picam_backend()
+
+        assert mgr._consume_endpoint_reconnect_requested() is True
+        assert mgr._retry_event.is_set()
+        assert timers
+        assert timers[0].daemon is True
+
+    def test_stale_ffmpeg_detection_matches_only_this_stream(self, camera_config):
+        """Stale cleanup should only target ffmpeg publishers for this camera ID."""
+        mgr = StreamManager(camera_config)
+
+        assert mgr._cmdline_targets_stream(
+            [
+                "ffmpeg",
+                "-f",
+                "rtsp",
+                "rtsps://192.168.1.244:8322/cam-test001",
+            ],
+            mgr._stream_path,
+        )
+        assert not mgr._cmdline_targets_stream(
+            [
+                "ffmpeg",
+                "-f",
+                "rtsp",
+                "rtsps://192.168.1.244:8322/cam-other",
+            ],
+            mgr._stream_path,
+        )
+        assert not mgr._cmdline_targets_stream(
+            ["python3", "-m", "camera_streamer.main"],
+            mgr._stream_path,
+        )
+
+    def test_endpoint_reconnect_watchdog_exits_when_stuck(
+        self, camera_config, monkeypatch
+    ):
+        """A hung reconnect must let systemd restart the streamer."""
+        mgr = StreamManager(camera_config)
+        mgr._endpoint_reconnect_requested = True
+        mgr._endpoint_reconnect_generation = 7
+        killed = []
+        exits = []
+        monkeypatch.setattr(
+            mgr,
+            "_terminate_stream_publishers",
+            lambda **kwargs: killed.append(kwargs),
+        )
+        monkeypatch.setattr(
+            "camera_streamer.stream.os._exit", lambda code: exits.append(code)
+        )
+
+        mgr._exit_if_endpoint_reconnect_stuck(7)
+
+        assert killed == [
+            {"reason": "endpoint reconnect watchdog", "include_known": True}
+        ]
+        assert exits == [0]
+
+    def test_endpoint_reconnect_watchdog_ignores_completed_generation(
+        self, camera_config, monkeypatch
+    ):
+        mgr = StreamManager(camera_config)
+        mgr._endpoint_reconnect_requested = False
+        mgr._endpoint_reconnect_generation = 7
+        exits = []
+        monkeypatch.setattr(
+            "camera_streamer.stream.os._exit", lambda code: exits.append(code)
+        )
+
+        mgr._exit_if_endpoint_reconnect_stuck(7)
+
+        assert exits == []
+
     def test_build_ffmpeg_only_cmd(self, camera_config):
         """Should build correct ffmpeg command."""
         mgr = StreamManager(camera_config)

--- a/app/server/monitor/services/storage_manager.py
+++ b/app/server/monitor/services/storage_manager.py
@@ -111,8 +111,13 @@ class StorageManager:
             self._thread.join(timeout=10)
         log.info("Storage manager stopped")
 
-    def get_storage_stats(self) -> dict:
-        """Get storage usage stats for the current recordings location."""
+    def get_storage_stats(self, *, include_tree: bool = True) -> dict:
+        """Get storage usage stats for the current recordings location.
+
+        ``include_tree=False`` is the dashboard-fast path: it reports disk
+        usage without recursively walking the recordings tree. Detailed views
+        keep the default so they still get clip counts and oldest/newest data.
+        """
         rec_dir = self._recordings_dir
         storage_health = "ok"
         storage_error = ""
@@ -140,8 +145,34 @@ class StorageManager:
                 "threshold_percent": self._threshold_percent,
                 "oldest_segment": None,
                 "newest_segment": None,
+                "tree_scanned": False,
                 "storage_health": "unavailable",
                 "storage_error": _storage_error_message(exc),
+            }
+
+        base_stats = {
+            "total_gb": total_gb,
+            "used_gb": used_gb,
+            "free_gb": free_gb,
+            "percent": percent,
+            "recordings_dir": str(rec_dir),
+            "is_usb": self._is_usb_path(rec_dir),
+            "reserve_mb": self._reserve_mb,
+            "threshold_percent": self._threshold_percent,
+            "storage_health": storage_health,
+            "storage_error": storage_error,
+        }
+
+        if not include_tree:
+            return {
+                **base_stats,
+                "recordings_mb": 0,
+                "camera_count": 0,
+                "clip_count": 0,
+                "per_camera": {},
+                "oldest_segment": None,
+                "newest_segment": None,
+                "tree_scanned": False,
             }
 
         # Count clips per camera; track oldest/newest mtime across all clips
@@ -196,20 +227,14 @@ class StorageManager:
             recordings_bytes += cam_bytes
 
         return {
-            "total_gb": total_gb,
-            "used_gb": used_gb,
-            "free_gb": free_gb,
-            "percent": percent,
+            **base_stats,
             "recordings_mb": round(recordings_bytes / (1024 * 1024), 1),
             "camera_count": len(camera_stats),
             "clip_count": total_clips,
             "per_camera": camera_stats,
-            "recordings_dir": str(rec_dir),
-            "is_usb": self._is_usb_path(rec_dir),
-            "reserve_mb": self._reserve_mb,
-            "threshold_percent": self._threshold_percent,
             "oldest_segment": _epoch_to_iso(oldest_mtime),
             "newest_segment": _epoch_to_iso(newest_mtime),
+            "tree_scanned": True,
             "storage_health": storage_health,
             "storage_error": storage_error,
         }

--- a/app/server/monitor/services/system_summary_service.py
+++ b/app/server/monitor/services/system_summary_service.py
@@ -317,7 +317,7 @@ class SystemSummaryService:
 
     def _storage_state(self) -> tuple[str, dict, str]:
         try:
-            stats = self._storage.get_storage_stats()
+            stats = self._get_storage_stats_for_summary()
         except Exception as exc:
             log.warning("summary: get_storage_stats failed: %s", exc)
             return (
@@ -341,11 +341,10 @@ class SystemSummaryService:
         else:
             state = "green"
 
-        retention = (
-            None
-            if state == "red" and storage_error
-            else self._estimate_retention_days(stats)
-        )
+        tree_scanned = bool(stats.get("tree_scanned", True))
+        retention = None
+        if not (state == "red" and storage_error) and tree_scanned:
+            retention = self._estimate_retention_days(stats)
         detail = {
             "percent": round(percent, 1),
             "retention_days": retention,
@@ -355,6 +354,15 @@ class SystemSummaryService:
             "storage_error": storage_error,
         }
         return state, detail, "/settings#storage"
+
+    def _get_storage_stats_for_summary(self) -> dict:
+        """Read dashboard storage stats without expensive clip-tree walks."""
+        try:
+            return self._storage.get_storage_stats(include_tree=False)
+        except TypeError:
+            # Backward-compatible for tests or adapters with the older
+            # no-argument storage interface.
+            return self._storage.get_storage_stats()
 
     def _estimate_retention_days(self, stats: dict) -> float | None:
         """Retention = free_bytes / bytes_written_per_day (7-day trailing).

--- a/app/server/monitor/templates/alerts.html
+++ b/app/server/monitor/templates/alerts.html
@@ -4,7 +4,7 @@
 {% block title %}Alerts - Home Monitor{% endblock %}
 
 {% block content %}
-<div x-data="alertsPage()" class="alerts-page">
+<div x-data="alertsPage()" x-init="boot()" class="alerts-page">
 
 <section class="page-hero page-hero--compact">
     <div>
@@ -159,7 +159,7 @@ function alertsPage() {
         markingId: '',
         markingAll: false,
 
-        async init() {
+        async boot() {
             await this.reload();
         },
 

--- a/app/server/monitor/templates/alerts.html
+++ b/app/server/monitor/templates/alerts.html
@@ -4,7 +4,7 @@
 {% block title %}Alerts - Home Monitor{% endblock %}
 
 {% block content %}
-<div x-data="alertsPage()" x-init="init()" class="alerts-page">
+<div x-data="alertsPage()" class="alerts-page">
 
 <section class="page-hero page-hero--compact">
     <div>

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -4,7 +4,7 @@
 {% block title %}Dashboard - Home Monitor{% endblock %}
 
 {% block content %}
-<div x-data="dashboardPage()" class="dashboard-page">
+<div x-data="dashboardPage()" x-init="boot()" class="dashboard-page">
 
 <!--
   Tier 1 — Status strip (ADR-0018)
@@ -1682,7 +1682,7 @@ function dashboardPage() {
             return '';
         },
 
-        init() {
+        boot() {
             this.loadCurrentUser();
             this.loadEncoderPresets();
             this.loadSummary();

--- a/app/server/monitor/templates/dashboard.html
+++ b/app/server/monitor/templates/dashboard.html
@@ -4,7 +4,7 @@
 {% block title %}Dashboard - Home Monitor{% endblock %}
 
 {% block content %}
-<div x-data="dashboardPage()" x-init="init()" class="dashboard-page">
+<div x-data="dashboardPage()" class="dashboard-page">
 
 <!--
   Tier 1 — Status strip (ADR-0018)

--- a/app/server/monitor/templates/events.html
+++ b/app/server/monitor/templates/events.html
@@ -4,7 +4,7 @@
 {% block title %}Events - Home Monitor{% endblock %}
 
 {% block content %}
-<div x-data="eventsPage()">
+<div x-data="eventsPage()" x-init="boot()">
 
 <section class="page-hero page-hero--compact">
     <div>
@@ -141,7 +141,7 @@ function eventsPage() {
         error: '',
         playingKey: '',
 
-        async init() {
+        async boot() {
             // Default to last 7 days so the page isn't a firehose on
             // first load. Operators can clear the dates to see all.
             var today = new Date();

--- a/app/server/monitor/templates/events.html
+++ b/app/server/monitor/templates/events.html
@@ -4,7 +4,7 @@
 {% block title %}Events - Home Monitor{% endblock %}
 
 {% block content %}
-<div x-data="eventsPage()" x-init="init()">
+<div x-data="eventsPage()">
 
 <section class="page-hero page-hero--compact">
     <div>

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -4,7 +4,7 @@
 {% block title %}Settings - Home Monitor{% endblock %}
 
 {% block content %}
-<div x-data="settingsPage()" x-init="init()" class="settings-page">
+<div x-data="settingsPage()" class="settings-page">
 <section class="page-hero page-hero--compact">
     <div>
         <div class="page-hero__eyebrow">System control</div>

--- a/app/server/monitor/templates/settings.html
+++ b/app/server/monitor/templates/settings.html
@@ -4,7 +4,7 @@
 {% block title %}Settings - Home Monitor{% endblock %}
 
 {% block content %}
-<div x-data="settingsPage()" class="settings-page">
+<div x-data="settingsPage()" x-init="boot()" class="settings-page">
 <section class="page-hero page-hero--compact">
     <div>
         <div class="page-hero__eyebrow">System control</div>
@@ -2945,7 +2945,7 @@ function settingsPage() {
             return false;
         },
 
-        async init() {
+        async boot() {
             try {
                 await window.HM.auth.getMe();
                 this.currentUser = window.HM.auth.getUser();

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -725,6 +725,12 @@ class TestCompleteGuiRedesignCoverage:
             assert title in body
             assert supporting_text in body
 
+    def test_alpine_pages_do_not_double_initialize_pollers(self, client):
+        """Alpine auto-calls an init() method; x-init="init()" calls it again."""
+        for path in ["/dashboard", "/settings", "/events", "/alerts"]:
+            body = self._get_body(client, path)
+            assert 'x-init="init()"' not in body
+
     def test_dashboard_preserves_all_camera_roll_call_actions(self, client):
         body = self._get_body(client, "/dashboard")
         for text in [

--- a/app/server/tests/integration/test_views.py
+++ b/app/server/tests/integration/test_views.py
@@ -726,10 +726,18 @@ class TestCompleteGuiRedesignCoverage:
             assert supporting_text in body
 
     def test_alpine_pages_do_not_double_initialize_pollers(self, client):
-        """Alpine auto-calls an init() method; x-init="init()" calls it again."""
-        for path in ["/dashboard", "/settings", "/events", "/alerts"]:
+        """Explicit boot() avoids Alpine auto-calling init() plus x-init."""
+        pages = {
+            "/dashboard": "dashboardPage",
+            "/settings": "settingsPage",
+            "/events": "eventsPage",
+            "/alerts": "alertsPage",
+        }
+        for path, component in pages.items():
             body = self._get_body(client, path)
             assert 'x-init="init()"' not in body
+            assert 'x-init="boot()"' in body
+            assert f'x-data="{component}()"' in body
 
     def test_dashboard_preserves_all_camera_roll_call_actions(self, client):
         body = self._get_body(client, "/dashboard")

--- a/app/server/tests/unit/test_storage_manager.py
+++ b/app/server/tests/unit/test_storage_manager.py
@@ -261,6 +261,18 @@ class TestGetStorageStats:
         ):
             assert key in stats, f"Missing key: {key}"
 
+    def test_fast_path_skips_recording_tree_walk(self, tmp_path):
+        mgr, rec_dir = _make_manager(tmp_path)
+        _make_clip(rec_dir, "cam-001", "2026-04-01", "08-00-00")
+
+        with patch("pathlib.Path.iterdir", side_effect=AssertionError("no scan")):
+            stats = mgr.get_storage_stats(include_tree=False)
+
+        assert stats["tree_scanned"] is False
+        assert stats["clip_count"] == 0
+        assert stats["camera_count"] == 0
+        assert stats["per_camera"] == {}
+
     def test_counts_clips_per_camera(self, tmp_path):
         mgr, rec_dir = _make_manager(tmp_path)
         _make_clip(rec_dir, "cam-001", "2026-04-01", "08-00-00")

--- a/app/server/tests/unit/test_svc_system_summary.py
+++ b/app/server/tests/unit/test_svc_system_summary.py
@@ -93,7 +93,7 @@ def _build(**overrides):
         },
     )
 
-    return SystemSummaryService(
+    service = SystemSummaryService(
         store=store,
         storage_manager=storage,
         audit=audit,
@@ -101,6 +101,16 @@ def _build(**overrides):
         health_module=health,
         time_health=time_health,
     )
+    if overrides.get("return_deps"):
+        return service, SimpleNamespace(
+            store=store,
+            storage=storage,
+            audit=audit,
+            recordings=rec_svc,
+            health=health,
+            time_health=time_health,
+        )
+    return service
 
 
 def _iso_ago(seconds: float) -> str:
@@ -127,6 +137,11 @@ class TestGreenBaseline:
         assert out["details"]["cameras"]["online"] == 1
         assert out["details"]["cameras"]["total"] == 1
         assert out["details"]["recent_errors"] == 0
+
+    def test_summary_uses_fast_storage_stats(self):
+        svc, deps = _build(return_deps=True)
+        svc.compute_summary()
+        deps.storage.get_storage_stats.assert_called_once_with(include_tree=False)
 
     def test_pending_cameras_excluded_from_totals(self):
         svc = _build(


### PR DESCRIPTION
## Summary
- make the camera stream loop own server endpoint reconnects instead of heartbeat calling stop/start directly
- prefer direct Avahi resolution for `.local` server names and refresh the resolver on heartbeat ticks
- terminate blocked/stale ffmpeg publishers safely so cameras do not stay pinned to a dead server IP
- prevent Alpine pages from double-calling `init()` and starting duplicate dashboard/settings pollers
- add focused unit and view coverage for Ethernet/WiFi endpoint changes, hung reconnect recovery, and duplicate Alpine init prevention

## Validation
- python -m pytest app/camera/tests/unit/test_picam_backend.py app/camera/tests/unit/test_stream.py app/camera/tests/unit/test_heartbeat.py app/camera/tests/unit/test_lifecycle_resolver.py -q
- ruff check app/camera/camera_streamer/picam_backend.py app/camera/camera_streamer/stream.py app/camera/camera_streamer/heartbeat.py app/camera/camera_streamer/lifecycle.py app/camera/tests/unit/test_picam_backend.py app/camera/tests/unit/test_stream.py app/camera/tests/unit/test_heartbeat.py app/camera/tests/unit/test_lifecycle_resolver.py
- ruff format --check app/camera/camera_streamer/picam_backend.py app/camera/camera_streamer/stream.py app/camera/camera_streamer/heartbeat.py app/camera/camera_streamer/lifecycle.py app/camera/tests/unit/test_picam_backend.py app/camera/tests/unit/test_stream.py app/camera/tests/unit/test_heartbeat.py app/camera/tests/unit/test_lifecycle_resolver.py
- python -m pytest app/server/tests/integration/test_views.py -q
- ruff check app/server/tests/integration/test_views.py
- ruff format --check app/server/tests/integration/test_views.py

## Hardware verification
- deployed dev app to cameras 192.168.1.186, 192.168.1.115, and 192.168.1.148
- Ethernet connected: all camera resolver caches and ffmpeg publishers used server Ethernet IP 192.168.1.244 with zero camera-streamer restarts
- Ethernet removed: all cameras switched active ffmpeg publishers to server WiFi IP 192.168.1.245 and remained stable with zero camera-streamer restarts
- deployed dev app to server 192.168.1.245 and confirmed installed templates no longer contain `x-init=init()`